### PR TITLE
kubernetes-yaml: add websocket routes annotation

### DIFF
--- a/kubernetes-lokodash.yaml
+++ b/kubernetes-lokodash.yaml
@@ -55,6 +55,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
     kubernetes.io/ingress.class: contour
+    contour.heptio.com/websocket-routes: "/"
 spec:
   tls:
   - secretName: lokodash


### PR DESCRIPTION
We need it so contour handles websocket connections, which we use for
getting logs, exec-ing into a pod and getting traces from Inspektor
Gadget.