### PR TITLE
app: Build also Linux ARM versions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,8 +24,22 @@
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
     "linux": {
       "target": [
-        "AppImage",
-        "tar.gz"
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "armv7l",
+            "arm64"
+          ]
+        },
+        {
+          "target": "tar.gz",
+          "arch": [
+            "x64",
+            "armv7l",
+            "arm64"
+          ]
+        }
       ],
       "executableName": "headlamp",
       "maintainer": "Kinvolk <hello@kinvolk.io>",

--- a/app/scripts/build-backend.js
+++ b/app/scripts/build-backend.js
@@ -6,6 +6,8 @@ exports.default = async context => {
   let arch = context.arch;
   if (arch === 'x64') {
     arch = 'amd64';
+  } else if (arch === 'armv7l') {
+    arch = 'arm';
   }
 
   let osName = '';


### PR DESCRIPTION
I have tested the 32bit version on my Raspberry Pi and it works great. I think the 64bit version should have no problems as well (an earlier build had been tested before and worked fine).