### PR TITLE
Rename backend server to headlamp-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-backend/server
-backend/server.exe
+backend/headlamp-server
+backend/headlamp-server.exe
 backend/tools
 app/electron/src/*
 docs/development/storybook/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./backend /headlamp/backend
 
 WORKDIR /headlamp
 
-RUN cd ./backend && go build -o ./server ./cmd/
+RUN cd ./backend && go build -o ./headlamp-server ./cmd/
 
 # Keep npm install separated so source changes don't trigger install
 FROM base-build AS frontendinstall
@@ -42,9 +42,12 @@ RUN for i in $(find ./.plugins/*/main.js); do plugin_name=$(echo $i|cut -d'/' -f
 
 FROM $IMAGE_BASE
 
-COPY --from=backend /headlamp/backend/server /headlamp/server
+COPY --from=backend /headlamp/backend/headlamp-server /headlamp/headlamp-server
 COPY --from=frontend /headlamp/frontend/build /headlamp/frontend
 COPY --from=frontend /headlamp/plugins /headlamp/plugins
+# Create a symlink so we support any attempts to run "/headlamp/server", from before we
+# renamed it as "headlamp-server".
+RUN cd /headlamp && ln -s ./headlamp-server ./server
 
 EXPOSE 4466
-ENTRYPOINT ["/headlamp/server", "-html-static-dir", "/headlamp/frontend"]
+ENTRYPOINT ["/headlamp/headlamp-server", "-html-static-dir", "/headlamp/frontend"]

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ app-mac: app-build
 
 .PHONY: backend
 backend:
-	cd backend && go build -o ./server${SERVER_EXE_EXT} ./cmd
+	cd backend && go build -o ./headlamp-server${SERVER_EXE_EXT} ./cmd
 
 frontend-install:
 	cd frontend && npm install
@@ -53,7 +53,7 @@ frontend-build:
 	cd frontend && npm run build
 
 run-backend:
-	./backend/server -dev
+	./backend/headlamp-server -dev
 
 run-frontend:
 	cd frontend && npm start

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -37,8 +37,8 @@ const useExternalServer = process.env.EXTERNAL_SERVER || false;
 
 function startServer(flags: string[] = []): ChildProcessWithoutNullStreams {
   const serverFilePath = isDev
-    ? path.resolve('../backend/server')
-    : path.join(process.resourcesPath, './server');
+    ? path.resolve('../backend/headlamp-server')
+    : path.join(process.resourcesPath, './headlamp-server');
 
   const options = { shell: true, detached: false };
   if (process.platform !== 'win32' && !isDev) {

--- a/app/package.json
+++ b/app/package.json
@@ -49,7 +49,7 @@
       "category": "Network",
       "extraResources": [
         {
-          "from": "../backend/server"
+          "from": "../backend/headlamp-server"
         }
       ]
     },
@@ -69,7 +69,7 @@
       "entitlementsInherit": "mac/entitlements.mac.plist",
       "extraResources": [
         {
-          "from": "../backend/server"
+          "from": "../backend/headlamp-server"
         }
       ]
     },
@@ -79,7 +79,7 @@
       ],
       "extraResources": [
         {
-          "from": "../backend/server.exe"
+          "from": "../backend/headlamp-server.exe"
         }
       ]
     },

--- a/docs/development/_index.md
+++ b/docs/development/_index.md
@@ -95,7 +95,7 @@ folders - you may need to add other folders if your config refers
 to more folders.
 
 ```bash
-docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube ghcr.io/kinvolk/headlamp:latest /headlamp/server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
+docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube ghcr.io/kinvolk/headlamp:latest /headlamp/headlamp-server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
 ```
 
 If you want to make a new container image called `kinvolk/headlamp:development`
@@ -106,7 +106,7 @@ $ DOCKER_IMAGE_VERSION=development make image
 ...
 Successfully tagged kinvolk/headlamp:development
 
-$ docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube kinvolk/headlamp:development /headlamp/server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
+$ docker run --network="host" -p 127.0.0.1:4466:4466/tcp --mount type=bind,source="/home/rene/.minikube",target=$HOME/.minikube --mount type=bind,source="$HOME/.kube",target=/root/.kube kinvolk/headlamp:development /headlamp/headlamp-server -html-static-dir /headlamp/frontend -plugins-dir=/headlamp/plugins
 ```
 
 Then go to https://localhost:4466 in your browser.
@@ -136,7 +136,7 @@ $ DOCKER_IMAGE_VERSION=development make image
 #### Create a deployment yaml.
 
 ```bash
-$ kubectl create deployment headlamp -n kube-system --image=kinvolk/headlamp:development -o yaml --dry-run -- /headlamp/server -html-static-dir /headlamp/frontend -in-cluster -plugins-dir=/headlamp/plugins > minikube-headlamp.yaml
+$ kubectl create deployment headlamp -n kube-system --image=kinvolk/headlamp:development -o yaml --dry-run -- /headlamp/headlamp-server -html-static-dir /headlamp/frontend -in-cluster -plugins-dir=/headlamp/plugins > minikube-headlamp.yaml
 ```
 
 To use the local container image we change the `imagePullPolicy` to Never.
@@ -166,7 +166,7 @@ spec:
     spec:
       containers:
       - command:
-        - /headlamp/server
+        - /headlamp/headlamp-server
         - -html-static-dir
         - /headlamp/frontend
         - -in-cluster

--- a/docs/development/plugins/building.md
+++ b/docs/development/plugins/building.md
@@ -122,7 +122,7 @@ For in-cluster Headlamp deployments, when running Headlamp's server,
 the `-plugin-dir` option should point to the directory:
 
 ```bash
-./server -plugins-dir=.plugins
+./headlamp-server -plugins-dir=.plugins
 ```
 
 ### Using plugins on the desktop version

--- a/docs/installation/base-url.md
+++ b/docs/installation/base-url.md
@@ -23,7 +23,7 @@ If in doubt, host Headlamp on a separate origin (domain or port, don't use the `
 ### Dev mode
 
 ```bash
-./backend/server -dev -base-url /headlamp
+./backend/headlamp-server -dev -base-url /headlamp
 PUBLIC_URL="/headlamp" make run-frontend
 ```
 
@@ -34,7 +34,7 @@ Then go to http://localhost:3000/headlamp/ in your browser.
 
 ```bash
 cd frontend && npm install && npm run build && cd ..
-./backend/server -dev -base-url /headlamp -html-static-dir frontend/build
+./backend/headlamp-server -dev -base-url /headlamp -html-static-dir frontend/build
 ```
 
 Then go to http://localhost:4466/headlamp/ in your browser.


### PR DESCRIPTION
The former name was too generic, which made it difficult to spot, and
could clash on Windows as well.

This patch renames it as headlamp-server but keeps as /headlamp/server
symlink in the container image, for backward compatibility.

fixes #487 