### PR TITLE
WIP: Improve pod matcher

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -15,8 +15,6 @@ import * as monaco from 'monaco-editor';
 import React, { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, Link as RouterLink, NavLinkProps, useLocation } from 'react-router-dom';
-import { useMetadataDisplayStyles } from '.';
-import { LightTooltip } from '..';
 import DetailsViewPluginRenderer from '../../../helpers/renderHelpers';
 import { ApiError } from '../../../lib/k8s/apiProxy';
 import {
@@ -24,7 +22,7 @@ import {
   KubeContainer,
   KubeContainerStatus,
   KubeObject,
-  KubeObjectInterface
+  KubeObjectInterface,
 } from '../../../lib/k8s/cluster';
 import Pod, { KubePod } from '../../../lib/k8s/pod';
 import { createRouteURL, RouteURLProps } from '../../../lib/router';
@@ -35,9 +33,11 @@ import { SectionBox } from '../../common/SectionBox';
 import SectionHeader, { HeaderStyleProps } from '../../common/SectionHeader';
 import SimpleTable, { NameValueTable, NameValueTableRow } from '../../common/SimpleTable';
 import { PodListProps, PodListRenderer } from '../../pod/List';
+import { LightTooltip } from '..';
 import Empty from '../EmptyContent';
 import { DateLabel, HoverInfoLabel, StatusLabel, StatusLabelProps } from '../Label';
 import Link, { LinkProps } from '../Link';
+import { useMetadataDisplayStyles } from '.';
 import DeleteButton from './DeleteButton';
 import EditButton from './EditButton';
 import { MetadataDictGrid, MetadataDisplay } from './MetadataDisplay';

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -15,6 +15,8 @@ import * as monaco from 'monaco-editor';
 import React, { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, Link as RouterLink, NavLinkProps, useLocation } from 'react-router-dom';
+import { useMetadataDisplayStyles } from '.';
+import { LightTooltip } from '..';
 import DetailsViewPluginRenderer from '../../../helpers/renderHelpers';
 import { ApiError } from '../../../lib/k8s/apiProxy';
 import {
@@ -22,7 +24,7 @@ import {
   KubeContainer,
   KubeContainerStatus,
   KubeObject,
-  KubeObjectInterface,
+  KubeObjectInterface
 } from '../../../lib/k8s/cluster';
 import Pod, { KubePod } from '../../../lib/k8s/pod';
 import { createRouteURL, RouteURLProps } from '../../../lib/router';
@@ -33,11 +35,9 @@ import { SectionBox } from '../../common/SectionBox';
 import SectionHeader, { HeaderStyleProps } from '../../common/SectionHeader';
 import SimpleTable, { NameValueTable, NameValueTableRow } from '../../common/SimpleTable';
 import { PodListProps, PodListRenderer } from '../../pod/List';
-import { LightTooltip } from '..';
 import Empty from '../EmptyContent';
 import { DateLabel, HoverInfoLabel, StatusLabel, StatusLabelProps } from '../Label';
 import Link, { LinkProps } from '../Link';
-import { useMetadataDisplayStyles } from '.';
 import DeleteButton from './DeleteButton';
 import EditButton from './EditButton';
 import { MetadataDictGrid, MetadataDisplay } from './MetadataDisplay';
@@ -634,32 +634,87 @@ export interface OwnedPodsSectionProps {
 export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   const { resource, hideColumns } = props;
 
-  const [pods, error] = Pod.useList();
+  const queryData = {
+    namespace: resource.kind === 'Namespace' ? resource.metadata.name : undefined,
+    labelSelector: getLabelSelector(resource),
+    fieldSelector: resource.kind === 'Node' ? `spec.nodeName=${resource.metadata.name}` : undefined,
+  };
 
-  function getOwnedPods() {
-    if (!pods) {
-      return null;
-    }
+  const [pods, error] = Pod.useList(queryData);
 
-    if (resource.kind === 'Node') {
-      return pods.filter(item => item.spec.nodeName === resource.metadata.name);
-    }
+  return <PodListRenderer hideColumns={hideColumns} pods={pods} error={error} />;
+}
 
-    if (resource.kind === 'Namespace') {
-      return pods.filter(item => item.metadata.namespace === resource.metadata.name);
-    }
+// Label selector examples: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering
+// deployment selector example: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering
+// Possible operators: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/selection/operator.go#L24
+// Format rule for expressions: https://github.com/kubernetes/apimachinery/blob/be3a79b26814a8d7637d70f4d434a4626ee1c1e7/pkg/labels/selector.go#L305
+function getLabelSelector(item: KubeObjectInterface): string | undefined {
+  const segments: string[] = [];
 
-    const resourceTemplateLabel = Object.values(resource?.spec?.template?.metadata?.labels || []);
-    if (!resourceTemplateLabel) {
-      return [];
-    }
-    return pods.filter(item =>
-      resourceTemplateLabel.every(elem => Object.values(item.metadata.labels || {}).includes(elem))
-    );
+  const matchLabels = item?.spec?.selector?.matchLabels ?? {};
+  for (const k in matchLabels) {
+    segments.push(`${k}=${matchLabels[k]}`);
   }
 
-  const filteredPods = getOwnedPods();
-  return <PodListRenderer hideColumns={hideColumns} pods={filteredPods} error={error} />;
+  const matchExpressions = item?.spec?.selector?.matchExpressions ?? [];
+  for (const expr of matchExpressions) {
+    let segment = '';
+    if (expr.operator === 'DoesNotExist') {
+      segment += '!';
+    }
+
+    segment += expr.key;
+    switch (expr.operator) {
+      case 'Equals':
+        segment += '=';
+        break;
+      case 'DoubleEquals':
+        segment += '==';
+        break;
+      case 'NotEquals':
+        segment += '!=';
+        break;
+      case 'In':
+        segment += ' in ';
+        break;
+      case 'NotIn':
+        segment += ' notin ';
+        break;
+      case 'GreaterThan':
+        segment += '>';
+        break;
+      case 'LessThan':
+        segment += '<';
+        break;
+      case 'Exists':
+      case 'DoesNotExist':
+        segments.push(segment);
+        continue;
+    }
+
+    switch (expr.operator) {
+      case 'In':
+      case 'NotIn':
+        segment += '(';
+    }
+
+    const sorted = [...(expr.values ?? [])].sort();
+    segment += sorted.join(',');
+    switch (expr.operator) {
+      case 'In':
+      case 'NotIn':
+        segment += ')';
+    }
+
+    segments.push(segment);
+  }
+
+  if (segments.length === 0) {
+    return undefined;
+  }
+
+  return segments.join(',');
 }
 
 export function ContainersSection(props: { resource: KubeObjectInterface | null }) {

--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -217,13 +217,22 @@ function singleApiFactory(group: string, version: string, resource: string) {
   const apiRoot = getApiRoot(group, version);
   const url = `${apiRoot}/${resource}`;
   return {
-    list: (cb: StreamResultsCb, errCb: StreamErrCb) => streamResults(url, cb, errCb),
-    get: (name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResult(url, name, cb, errCb),
-    post: (body: KubeObjectInterface) => post(url, body),
-    put: (body: KubeObjectInterface) => put(`${url}/${body.metadata.name}`, body),
-    patch: (body: OpPatch[], name: string) => patch(`${url}/${name}?pretty=true`, body),
-    delete: (name: string) => remove(`${url}/${name}`),
+    list: (cb: StreamResultsCb, errCb: StreamErrCb, queryParams?: { [k: string]: string }) =>
+      streamResults(url, queryParams, cb, errCb),
+    get: (
+      name: string,
+      cb: StreamResultsCb,
+      errCb: StreamErrCb,
+      queryParams?: { [k: string]: string }
+    ) => streamResult(url, name, queryParams, cb, errCb),
+    post: (body: KubeObjectInterface, queryParams?: { [k: string]: string }) =>
+      post(url + asQuery(queryParams), body),
+    put: (body: KubeObjectInterface, queryParams?: { [k: string]: string }) =>
+      put(`${url}/${body.metadata.name}` + asQuery(queryParams), body),
+    patch: (body: OpPatch[], name: string, queryParams?: { [k: string]: string }) =>
+      patch(url + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body),
+    delete: (name: string, queryParams?: { [k: string]: string }) =>
+      remove(`${url}/${name}` + asQuery(queryParams)),
     isNamespaced: false,
   };
 }
@@ -274,16 +283,35 @@ function simpleApiFactoryWithNamespace(
   const results: {
     [other: string]: any;
   } = {
-    list: (namespace: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResults(url(namespace), cb, errCb),
-    get: (namespace: string, name: string, cb: StreamResultsCb, errCb: StreamErrCb) =>
-      streamResult(url(namespace), name, cb, errCb),
-    post: (body: KubeObjectInterface) => post(url(body.metadata.namespace as string), body),
-    patch: (body: OpPatch[], namespace: string, name: string) =>
-      patch(`${url(namespace)}/${name}?pretty=true`, body),
-    put: (body: KubeObjectInterface) =>
-      put(`${url(body.metadata.namespace as string)}/${body.metadata.name}`, body),
-    delete: (namespace: string, name: string) => remove(`${url(namespace)}/${name}`),
+    list: (
+      namespace: string,
+      cb: StreamResultsCb,
+      errCb: StreamErrCb,
+      queryParams?: { [k: string]: string }
+    ) => streamResults(url(namespace), queryParams, cb, errCb),
+    get: (
+      namespace: string,
+      name: string,
+      cb: StreamResultsCb,
+      errCb: StreamErrCb,
+      queryParams?: { [k: string]: string }
+    ) => streamResult(url(namespace), name, queryParams, cb, errCb),
+    post: (body: KubeObjectInterface, queryParams?: { [k: string]: string }) =>
+      post(url(body.metadata.namespace as string) + asQuery(queryParams), body),
+    patch: (
+      body: OpPatch[],
+      namespace: string,
+      name: string,
+      queryParams?: { [k: string]: string }
+    ) =>
+      patch(`${url(namespace)}/${name}` + asQuery({ ...queryParams, ...{ pretty: 'true' } }), body),
+    put: (body: KubeObjectInterface, queryParams?: { [k: string]: string }) =>
+      put(
+        `${url(body.metadata.namespace as string)}/${body.metadata.name}` + asQuery(queryParams),
+        body
+      ),
+    delete: (namespace: string, name: string, queryParams?: { [k: string]: string }) =>
+      remove(`${url(namespace)}/${name}` + asQuery(queryParams)),
     isNamespaced: true,
   };
 
@@ -296,6 +324,10 @@ function simpleApiFactoryWithNamespace(
   function url(namespace: string) {
     return namespace ? `${apiRoot}/namespaces/${namespace}/${resource}` : `${apiRoot}/${resource}`;
   }
+}
+
+function asQuery(queryParams?: { [k: string]: string }): string {
+  return '?' + new URLSearchParams(queryParams).toString();
 }
 
 function resourceDefToApiFactory(resourceDef: KubeObjectInterface): ApiFactoryReturn {
@@ -389,6 +421,7 @@ export function remove(url: string, requestOptions = {}) {
 export async function streamResult(
   url: string,
   name: string,
+  queryParams: { [k: string]: string } | undefined,
   cb: StreamResultsCb,
   errCb: StreamErrCb
 ) {
@@ -400,13 +433,14 @@ export async function streamResult(
 
   async function run() {
     try {
-      const item = await request(`${url}/${name}`);
+      const item = await request(`${url}/${name}` + asQuery(queryParams));
 
       if (isCancelled) return;
       cb(item);
 
-      const fieldSelector = encodeURIComponent(`metadata.name=${name}`);
-      const watchUrl = `${url}?watch=1&fieldSelector=${fieldSelector}`;
+      const watchUrl =
+        url +
+        asQuery({ ...queryParams, ...{ watch: '1', fieldSelector: `metadata.name=${name}` } });
 
       socket = stream(watchUrl, x => cb(x.object), { isJson: true });
     } catch (err) {
@@ -423,7 +457,12 @@ export async function streamResult(
   }
 }
 
-export async function streamResults(url: string, cb: StreamResultsCb, errCb: StreamErrCb) {
+export async function streamResults(
+  url: string,
+  queryParams: { [k: string]: string } | undefined,
+  cb: StreamResultsCb,
+  errCb: StreamErrCb
+) {
   const results: {
     [uid: string]: KubeObjectInterface;
   } = {};
@@ -435,13 +474,15 @@ export async function streamResults(url: string, cb: StreamResultsCb, errCb: Str
 
   async function run() {
     try {
-      const { kind, items, metadata } = await request(url);
+      const { kind, items, metadata } = await request(url + asQuery(queryParams));
 
       if (isCancelled) return;
 
       add(items, kind);
 
-      const watchUrl = `${url}?watch=1&resourceVersion=${metadata.resourceVersion}`;
+      const watchUrl =
+        url +
+        asQuery({ ...queryParams, ...{ watch: '1', resourceVersion: metadata.resourceVersion } });
       socket = stream(watchUrl, update, { isJson: true });
     } catch (err) {
       console.error('Error in api request', { err, url });


### PR DESCRIPTION
This is based on a PR by @fondoger . As originally written:

Pod list of a deployment is determined by its selector.
Example Deployment selector:
```
selector:
  matchLabels:
    component: redis
  matchExpressions:
    - {key: tier, operator: In, values: [cache]}
    - {key: environment, operator: NotIn, values: [dev]}
```

We can't simply fetch all pods and filter by labels only.

## Update to this PR

This PR has a commit to fix an issue in the original one (it was not passing all the query options when using `useList`).
We do not want to merge this right away since it's a bit complex and so we should make sure we have tests in place for verifying the conversion of selectors to queries, or replace it with a lib that does this for us.