### PR TITLE
frontend: filter list views by default namespace

### DIFF
--- a/frontend/src/lib/k8s/apiProxy.ts
+++ b/frontend/src/lib/k8s/apiProxy.ts
@@ -767,7 +767,11 @@ function simpleApiFactoryWithNamespace(
         console.debug('k8s/apiProxy@simpleApiFactoryWithNamespace list', { cluster, queryParams });
       }
 
-      return streamResultsForCluster(url(namespace), { cb, errCb, cluster }, queryParams);
+      return streamResultsForCluster(
+        url(namespace, cluster, true),
+        { cb, errCb, cluster },
+        queryParams
+      );
     },
     get: (
       namespace: string,
@@ -811,8 +815,15 @@ function simpleApiFactoryWithNamespace(
 
   return results;
 
-  function url(namespace: string) {
-    return namespace ? `${apiRoot}/namespaces/${namespace}/${resource}` : `${apiRoot}/${resource}`;
+  function url(namespace: string, cluster?: string, checkDefaultNamespace?: boolean) {
+    let ns = namespace;
+
+    if (checkDefaultNamespace) {
+      const clusterName = cluster || getCluster() || '';
+      ns = getClusterDefaultNamespace(clusterName, true);
+    }
+
+    return ns ? `${apiRoot}/namespaces/${ns}/${resource}` : `${apiRoot}/${resource}`;
   }
 }
 


### PR DESCRIPTION
This issue fixes [#750](https://github.com/headlamp-k8s/headlamp/issues/750) by allowing to filter cluster resources on the backend by using a globally defined default namespace.

It currently works with one namespace at a time, as that's what the Kubernetes API allows. If we want to support multiple namespaces, extra requests would be needed for each one.

Thanks to that we can limit results from API and reduce response size.

How to test:
- Define default namespace in settings.
- Check e.g. workloads -> pods whether results are filtered to a given namespace.