### PR TITLE
backend/cmd/headlamp: Fix issue in cluster looking for kube config

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -365,21 +365,33 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 	fmt.Println("*** Headlamp Server ***")
 	fmt.Println("  API Routers:")
 
-	if !config.useInCluster {
-		// load kubeConfig clusters
-		err := kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig)
-		if err != nil {
+	// load kubeConfig clusters
+	err := kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig)
+	if err != nil {
+		if config.useInCluster {
+			logger.Log(logger.LevelInfo, nil, err, "loading kubeconfig")
+		} else {
 			logger.Log(logger.LevelError, nil, err, "loading kubeconfig")
 		}
+	}
 
-		// load dynamic clusters
-		kubeConfigPersistenceFile, err := defaultKubeConfigPersistenceFile()
-		if err != nil {
+	// load dynamic clusters
+	// @todo: is this needed in-cluster at all?
+	kubeConfigPersistenceFile, err := defaultKubeConfigPersistenceFile()
+	if err != nil {
+		if config.useInCluster {
+			logger.Log(logger.LevelInfo, nil, err, "getting default kubeconfig persistence file")
+		} else {
 			logger.Log(logger.LevelError, nil, err, "getting default kubeconfig persistence file")
 		}
+	}
 
-		err = kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPersistenceFile, kubeconfig.DynamicCluster)
-		if err != nil {
+	// @todo: is this needed in-cluster at all?
+	err = kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPersistenceFile, kubeconfig.DynamicCluster)
+	if err != nil {
+		if config.useInCluster {
+			logger.Log(logger.LevelInfo, nil, err, "loading dynamic kubeconfig")
+		} else {
 			logger.Log(logger.LevelError, nil, err, "loading dynamic kubeconfig")
 		}
 	}

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -365,21 +365,23 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 	fmt.Println("*** Headlamp Server ***")
 	fmt.Println("  API Routers:")
 
-	// load kubeConfig clusters
-	err := kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "loading kubeconfig")
-	}
+	if !config.useInCluster {
+		// load kubeConfig clusters
+		err := kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "loading kubeconfig")
+		}
 
-	// load dynamic clusters
-	kubeConfigPersistenceFile, err := defaultKubeConfigPersistenceFile()
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "getting default kubeconfig persistence file")
-	}
+		// load dynamic clusters
+		kubeConfigPersistenceFile, err := defaultKubeConfigPersistenceFile()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "getting default kubeconfig persistence file")
+		}
 
-	err = kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPersistenceFile, kubeconfig.DynamicCluster)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "loading dynamic kubeconfig")
+		err = kubeconfig.LoadAndStoreKubeConfigs(config.kubeConfigStore, kubeConfigPersistenceFile, kubeconfig.DynamicCluster)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "loading dynamic kubeconfig")
+		}
 	}
 
 	addPluginRoutes(config, r)


### PR DESCRIPTION
Fixes #1826

I'm not sure what's best? The first commit disables it.

There is a use case of using kube config in cluster here: https://github.com/headlamp-k8s/headlamp/issues/1826#issuecomment-2343595252

But are the other statements needed in-cluster too?

I guess if we do support kube config loading in cluster then they should be warnings and not error logs?