### PR TITLE
frontend: Details: Make multi cluster aware

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -17,7 +17,7 @@ import React, { PropsWithChildren, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, NavLinkProps, useLocation } from 'react-router-dom';
 import YAML from 'yaml';
-import { labelSelectorToQuery, ResourceClasses } from '../../../lib/k8s';
+import { labelSelectorToQuery, ResourceClasses, useClusterFromURLVar } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/apiProxy';
 import { KubeCondition, KubeContainer, KubeContainerStatus } from '../../../lib/k8s/cluster';
 import { KubeEvent } from '../../../lib/k8s/event';
@@ -113,7 +113,6 @@ export function DetailsGrid<T extends KubeObjectClass>(props: DetailsGridProps<T
     resourceType,
     name,
     namespace,
-    cluster,
     children,
     withEvents,
     extraSections,
@@ -128,6 +127,8 @@ export function DetailsGrid<T extends KubeObjectClass>(props: DetailsGridProps<T
     state => state.detailsViewSection.detailsViewSectionsProcessors
   );
   const dispatchHeadlampEvent = useEventCallback();
+  const clusterFromURLVar = useClusterFromURLVar();
+  const cluster = props.cluster || clusterFromURLVar;
 
   // This component used to have a MainInfoSection with all these props passed to it, so we're
   // using them to accomplish the same behavior.

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -89,6 +89,8 @@ export interface DetailsGridProps<T extends KubeObjectClass>
   name: string;
   /** Namespace of the resource. If not provided, it's assumed the resource is not namespaced. */
   namespace?: string;
+  /** Cluster of the resource. If not provided, it's assumed single cluster mode. */
+  cluster?: string;
   /** Sections to show in the details grid (besides the default ones). */
   extraSections?:
     | ((item: InstanceType<T>) => boolean | DetailsViewSection[] | ReactNode[])
@@ -111,6 +113,7 @@ export function DetailsGrid<T extends KubeObjectClass>(props: DetailsGridProps<T
     resourceType,
     name,
     namespace,
+    cluster,
     children,
     withEvents,
     extraSections,
@@ -131,7 +134,7 @@ export function DetailsGrid<T extends KubeObjectClass>(props: DetailsGridProps<T
   const { extraInfo, actions, noDefaultActions, headerStyle, backLink, title, headerSection } =
     otherMainInfoSectionProps;
 
-  const [item, error] = resourceType.useGet(name, namespace) as [
+  const [item, error] = resourceType.useGet(name, namespace, { cluster }) as [
     InstanceType<T> | null,
     ApiError | null
   ];

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -126,7 +126,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
       namespace: this.getNamespace(),
       name: this.getName(),
     };
-    const link = createRouteURL(this.detailsRoute, params);
+    const link = createRouteURL(this.detailsRoute, params, { cluster: this.cluster });
     return link;
   }
 

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -140,6 +140,17 @@ export function useClusterGroup(): string[] {
   return clusterGroup;
 }
 
+/**
+ * Use the cluster name from the URL query parameters if it's there.
+ *
+ * @returns the cluster name from the URL. If no cluster is defined in the URL, undefined is returned.
+ */
+export function useDetailsSingleCluster(): string | undefined {
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  return searchParams.get('cluster') || undefined;
+}
+
 export function getVersion(clusterName: string = ''): Promise<StringDict> {
   return clusterRequest('/version', { cluster: clusterName || getCluster() });
 }

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -864,7 +864,19 @@ export interface RouteURLProps {
   [prop: string]: any;
 }
 
-export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
+/**
+ * Creates a URL for the given route, params and query parameters.
+ *
+ * @param routeName - The name of the route
+ * @param params - The optional parameters to use in the route.
+ * @param queryParams - The optional query parameters to use in the route.
+ * @returns the URL for the route as a string.
+ */
+export function createRouteURL(
+  routeName: string,
+  params: RouteURLProps = {},
+  queryParams: {} = {}
+): string {
   const storeRoutes = store.getState().routes.routes;
   const route = (storeRoutes && storeRoutes[routeName]) || getRoute(routeName);
 
@@ -894,7 +906,10 @@ export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
   }
 
   const url = getRoutePath(route);
-  return generatePath(url, fullParams);
+  const fullURL = generatePath(url, fullParams);
+
+  const searchParams = new URLSearchParams(queryParams).toString();
+  return searchParams ? `${fullURL}?${searchParams}` : fullURL;
 }
 
 export function getDefaultRoutes() {

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -366,6 +366,7 @@
       "default": [Function],
     },
     "useCluster": [Function],
+    "useClusterFromURLVar": [Function],
     "useClusterGroup": [Function],
     "useClustersConf": [Function],
     "useClustersVersion": [Function],


### PR DESCRIPTION
This makes Details views work with multiple cluster. 

The ?cluster is passed via a URL query parameter. Because in the normal cluster part of the URL is the group of clusters, and the details view needs to know which of the clusters the resource is in.


Here you can see details views being clicked on and the work (even though multiple clusters are active).

https://github.com/user-attachments/assets/3a840c4d-7e73-4dd4-8ef9-4b81d171cb2f



- **frontend: DetailsGrid: Fix for using a specific cluster**
- **frontend: router: Fix createRouteURL to take query params**
- **frontend: KubeObject: Add cluster query param to getDetailsLink**
- **frontend: k8s: Add useClusterFromURLVar to get cluster**
- **frontend: Details: Add support for cluster via URL var**
