### PR TITLE
[OLD] frontend: PluginSettings: Refactor local storage and plugin data

### DIFF
--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -9,8 +9,6 @@ export class HeadlampPage {
   }
 
   async authenticate(token?: string) {
-    await this.page.waitForSelector('h1:has-text("Authentication")');
-
     // Check to see if already authenticated
     if (await this.page.isVisible('button:has-text("Authenticate")')) {
       this.hasToken(token || '');
@@ -27,7 +25,11 @@ export class HeadlampPage {
   }
 
   async navigateToCluster(name: string, token?: string) {
-    await this.navigateTopage(`/c/${name}`);
+    // Since we are using multi cluster structure we need to have a full reset navigation
+    await this.page.goto(`${this.testURL}`);
+    await this.page.waitForLoadState('load');
+    await this.page.getByRole('link', { name: name, exact: true }).click();
+    await this.page.waitForLoadState('load');
     await this.authenticate(token);
   }
 

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import helpers from '../../../helpers';
+import { usePlugins } from '../../../lib/k8s/api/v2/plugins';
 import { useFilterFunc } from '../../../lib/util';
 import { PluginInfo, reloadPage, setPluginSettings } from '../../../plugin/pluginsSlice';
 import { useTypedSelector } from '../../../redux/reducers/reducers';
@@ -285,9 +286,15 @@ export default function PluginSettings() {
 
   const pluginSettings = useTypedSelector(state => state.plugins.pluginSettings);
 
+  const { data: plugins } = usePlugins(pluginSettings);
+
+  if (!plugins?.length) {
+    return null;
+  }
+
   return (
     <PluginSettingsPure
-      plugins={pluginSettings}
+      plugins={plugins}
       onSave={plugins => {
         dispatch(setPluginSettings(plugins));
         dispatch(reloadPage());

--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import helpers from '../../../helpers';
 import { getCluster } from '../../../lib/cluster';
+import { usePlugins } from '../../../lib/k8s/api/v2/plugins';
 import { deletePlugin } from '../../../lib/k8s/apiProxy';
 import { ConfigStore } from '../../../plugin/configStore';
 import { PluginInfo, reloadPage } from '../../../plugin/pluginsSlice';
@@ -66,13 +67,14 @@ const PluginSettingsDetailsInitializer = (props: { plugin: PluginInfo }) => {
 };
 
 export default function PluginSettingsDetails() {
-  const pluginSettings = useTypedSelector(state => state.plugins.pluginSettings);
   const { name } = useParams<{ name: string }>();
+  const pluginSettings = useTypedSelector(state => state.plugins.pluginSettings);
+  const { data: plugins } = usePlugins(pluginSettings);
 
   const plugin = useMemo(() => {
     const decodedName = decodeURIComponent(name);
-    return pluginSettings.find(plugin => plugin.name === decodedName);
-  }, [pluginSettings, name]);
+    return plugins?.find((plugin: PluginInfo) => plugin.name === decodedName);
+  }, [plugins, name]);
 
   if (!plugin) {
     return <NotFoundComponent />;

--- a/frontend/src/lib/k8s/api/v2/fetch.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.ts
@@ -17,7 +17,7 @@ export const BASE_HTTP_URL = helpers.getAppUrl();
  *
  * @returns fetch Response
  */
-async function backendFetch(url: string | URL, init: RequestInit) {
+export async function backendFetch(url: string | URL, init?: RequestInit) {
   const response = await fetch(makeUrl([BASE_HTTP_URL, url]), init);
 
   // The backend signals through this header that it wants a reload.

--- a/frontend/src/lib/k8s/api/v2/plugins.ts
+++ b/frontend/src/lib/k8s/api/v2/plugins.ts
@@ -1,0 +1,101 @@
+import '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import semver from 'semver';
+import helpers from '../../../../helpers';
+import { PluginInfo, PluginSettings } from '../../../../plugin/pluginsSlice';
+import { backendFetch } from './fetch';
+
+/*
+ * this function is used to check the compatibility of the plugin version with the headlamp version
+ *
+ * @param compatibleVersion headlamp-plugin version this build is compatible with.
+ *     If the plugin engine version is not compatible, the plugin will not be loaded.
+ *     Can be set to a semver range, e.g. '>= 0.6.0' or '0.6.0 - 0.7.0'.
+ *     If set to an empty string, all plugin versions will be loaded.
+ */
+export function checkCompatibleVersion(packageInfo: PluginInfo, checkAllVersions: boolean = false) {
+  /*
+   * this is the compatible version of the plugin with the headlamp version
+   */
+  const compatibleVersion = !checkAllVersions ? '>=0.8.0-alpha.3' : '';
+
+  // Can set this to a semver version range like '>=0.8.0-alpha.3'.
+  // '' means all versions.
+  const isCompatible = semver.satisfies(
+    semver.coerce(packageInfo.devDependencies?.['@kinvolk/headlamp-plugin']) || '',
+    compatibleVersion
+  );
+
+  return isCompatible;
+}
+
+export async function getPluginPaths() {
+  const pluginPaths = (await fetch(`${helpers.getAppUrl()}plugins`).then(resp =>
+    resp.json()
+  )) as string[];
+
+  return pluginPaths;
+}
+
+/*
+ * this function is used for the plugin settings and is extended from the original `fetchAndExecutePlugins` function in the Plugins.tsx file
+ * - the function is used to fetch the plugins from the backend and return the plugins with their settings
+ * - it will also do a compatibility check for the plugins and return the plugins with their compatibility status,
+ * - the compatibility check is needed to render the plugin switches
+ */
+export async function getPlugins(pluginSettings: PluginSettings[]) {
+  const pluginPaths = await getPluginPaths();
+
+  const packageInfosPromise = await Promise.all<PluginInfo>(
+    pluginPaths.map(path =>
+      backendFetch(`${path}/package.json`).then(resp => {
+        if (!resp.ok) {
+          if (resp.status !== 404) {
+            return Promise.reject(resp);
+          }
+
+          console.warn(
+            'Missing package.json. ' +
+              `Please upgrade the plugin ${path}` +
+              ' by running "headlamp-plugin extract" again.' +
+              ' Please use headlamp-plugin >= 0.8.0'
+          );
+
+          return {
+            name: path.split('/').slice(-1)[0],
+            version: '0.0.0',
+            author: 'unknown',
+            description: '',
+          };
+        }
+        return resp.json();
+      })
+    )
+  );
+
+  const packageInfos = await packageInfosPromise;
+
+  const pluginsWithIsEnabled = packageInfos.map(plugin => {
+    const matchedSetting = pluginSettings.find(p => plugin.name === p.name);
+    if (matchedSetting) {
+      const isCompatible = checkCompatibleVersion(plugin);
+
+      return {
+        ...plugin,
+        settingsComponent: matchedSetting.settingsComponent,
+        displaySettingsComponentWithSaveButton:
+          matchedSetting.displaySettingsComponentWithSaveButton,
+        isEnabled: matchedSetting.isEnabled,
+        isCompatible: isCompatible,
+      };
+    }
+    return plugin;
+  });
+
+  return pluginsWithIsEnabled;
+}
+
+export function usePlugins(pluginSettings: { name: string; isEnabled: boolean }[]) {
+  // takes two params, the key and the function that will be called to get the data
+  return useQuery({ queryKey: ['plugins'], queryFn: () => getPlugins(pluginSettings) });
+}

--- a/frontend/src/plugin/filterSources.test.ts
+++ b/frontend/src/plugin/filterSources.test.ts
@@ -8,13 +8,7 @@ describe('filterSources', () => {
     const settingsPackages = undefined;
     const appMode = false;
 
-    const { sourcesToExecute } = filterSources(
-      sources,
-      packageInfos,
-      appMode,
-      '>=0.8.0-alpha.3',
-      settingsPackages
-    );
+    const { sourcesToExecute } = filterSources(sources, packageInfos, appMode, settingsPackages);
     expect(sourcesToExecute.length).toBe(0);
   });
 
@@ -39,7 +33,6 @@ describe('filterSources', () => {
       sources,
       packageInfos,
       appMode,
-      '>=0.8.0-alpha.3',
       settingsPackages
     );
     expect(Object.keys(incompatiblePlugins).length).toBe(0);
@@ -68,13 +61,7 @@ describe('filterSources', () => {
       },
     ];
     const appMode = true;
-    const { sourcesToExecute } = filterSources(
-      sources,
-      packageInfos,
-      appMode,
-      '>=0.8.0-alpha.3',
-      settingsPackages
-    );
+    const { sourcesToExecute } = filterSources(sources, packageInfos, appMode, settingsPackages);
 
     expect(sourcesToExecute.length).toBe(0);
   });
@@ -122,13 +109,7 @@ describe('filterSources', () => {
       },
     ];
     const appMode = true;
-    const { sourcesToExecute } = filterSources(
-      sources,
-      packageInfos,
-      appMode,
-      '>=0.8.0-alpha.3',
-      settingsPackages
-    );
+    const { sourcesToExecute } = filterSources(sources, packageInfos, appMode, settingsPackages);
 
     expect(sourcesToExecute.length).toBe(1);
     expect(sourcesToExecute[0]).toBe('source1');
@@ -181,7 +162,6 @@ describe('filterSources', () => {
       sources,
       packageInfos,
       appMode,
-      '>=0.8.0-alpha.3',
       settingsPackages
     );
 
@@ -194,8 +174,8 @@ describe('filterSources', () => {
       sources,
       packageInfos,
       appMode,
-      '', // empty string disables compatibility check
-      settingsPackages
+      settingsPackages,
+      true
     );
 
     expect(disabledCompatCheck.sourcesToExecute.length).toBe(2);

--- a/frontend/src/plugin/pluginSlice.test.tsx
+++ b/frontend/src/plugin/pluginSlice.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { describe, expect, test } from 'vitest';
 import {
   PluginInfo,
   PluginSettingsComponentType,
@@ -6,30 +7,21 @@ import {
   PluginsState,
 } from './pluginsSlice';
 
-// initial state for the plugins slice
-const initialState: PluginsState = {
-  /** Once the plugins have been fetched and executed. */
-  loaded: false,
-  /** If plugin settings are saved use those. */
-  pluginSettings: JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]'),
-};
-
 // Mock React component for testing
 const MockComponent: React.FC = () => <div>New Component</div>;
 
 describe('pluginsSlice reducers', () => {
   const { setPluginSettingsComponent } = pluginsSlice.actions;
 
-  test('should handle setting a new plugin settings component when plugin name matches', () => {
+  test('should handle setting a new plugin settings component when plugin name matches', async () => {
     const existingPluginName = 'test-plugin';
     const initialStateWithPlugin: PluginsState = {
-      ...initialState,
+      loaded: true,
       pluginSettings: [
         {
           name: existingPluginName,
-          settingsComponent: undefined,
-          displaySettingsComponentWithSaveButton: false,
-        } as PluginInfo,
+          isEnabled: true,
+        },
       ],
     };
 
@@ -39,27 +31,28 @@ describe('pluginsSlice reducers', () => {
       displaySaveButton: true,
     });
 
-    const newState = pluginsSlice.reducer(initialStateWithPlugin, action);
+    const newState = await pluginsSlice.reducer(initialStateWithPlugin, action);
 
-    expect(newState.pluginSettings[0].settingsComponent).toBeDefined();
-    expect(newState.pluginSettings[0].displaySettingsComponentWithSaveButton).toBe(true);
+    expect((newState.pluginSettings[0] as PluginInfo)?.settingsComponent).toBeDefined();
+    expect((newState.pluginSettings[0] as PluginInfo)?.displaySettingsComponentWithSaveButton).toBe(
+      true
+    );
   });
 
   test('should not modify state when plugin name does not match any existing plugin', () => {
     const nonExistingPluginName = 'non-existing-plugin';
     const initialStateWithPlugin: PluginsState = {
-      ...initialState,
+      loaded: true,
       pluginSettings: [
         {
-          name: 'existing-plugin',
-          settingsComponent: undefined,
-          displaySettingsComponentWithSaveButton: false,
-        } as PluginInfo,
+          name: nonExistingPluginName,
+          isEnabled: true,
+        },
       ],
     };
 
     const action = setPluginSettingsComponent({
-      name: nonExistingPluginName,
+      name: 'existing-plugin',
       component: MockComponent as PluginSettingsComponentType,
       displaySaveButton: true,
     });

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -87,11 +87,18 @@ export type PluginInfo = {
   displaySettingsComponentWithSaveButton?: boolean;
 };
 
+export interface PluginSettings {
+  name: string;
+  isEnabled: boolean;
+  settingsComponent?: PluginSettingsComponentType;
+  displaySettingsComponentWithSaveButton?: boolean;
+}
+
 export interface PluginsState {
   /** Have plugins finished executing? */
   loaded: boolean;
   /** Information stored by settings about plugins. */
-  pluginSettings: PluginInfo[];
+  pluginSettings: PluginSettings[];
 }
 const initialState: PluginsState = {
   /** Once the plugins have been fetched and executed. */
@@ -110,9 +117,13 @@ export const pluginsSlice = createSlice({
     /**
      * Save the plugin settings. To both the store, and localStorage.
      */
-    setPluginSettings(state, action: PayloadAction<PluginInfo[]>) {
-      state.pluginSettings = action.payload;
-      localStorage.setItem('headlampPluginSettings', JSON.stringify(action.payload));
+    setPluginSettings(state, action: PayloadAction<any[]>) {
+      const pluginInfo = action.payload.map(p => ({
+        name: p.name,
+        isEnabled: p.isEnabled,
+      }));
+      state.pluginSettings = pluginInfo;
+      localStorage.setItem('headlampPluginSettings', JSON.stringify(pluginInfo));
     },
     /** Reloads the browser page */
     reloadPage() {

--- a/frontend/src/plugin/updateSettingsPackages.test.ts
+++ b/frontend/src/plugin/updateSettingsPackages.test.ts
@@ -17,7 +17,7 @@ describe('updateSettingsPackages tests', () => {
         author: 'author1',
       },
     ];
-    const settingsPlugins: PluginInfo[] = [];
+    const settingsPlugins: { name: string; isEnabled: boolean }[] = [];
     const updatedSettingsPlugins = updateSettingsPackages(backendPlugins, settingsPlugins);
     expect(updatedSettingsPlugins.length).toBe(1);
     expect(updatedSettingsPlugins[0].isEnabled).toBe(true);
@@ -33,21 +33,13 @@ describe('updateSettingsPackages tests', () => {
         author: 'author1',
       },
     ];
-    const settingsPlugins: PluginInfo[] = [
+    const settingsPlugins: { name: string; isEnabled: boolean }[] = [
       {
         name: 'ourplugin1',
-        description: 'package description1',
-        homepage: 'https://example.com/1',
-        version: '1.0.0',
-        author: 'author1',
         isEnabled: true,
       },
       {
         name: 'ourplugin2',
-        description: 'package description2',
-        homepage: 'https://example.com/1',
-        version: '1.0.0',
-        author: 'author2',
         isEnabled: true,
       },
     ];
@@ -59,13 +51,9 @@ describe('updateSettingsPackages tests', () => {
 
   test('when a setting exists, but then is removed from the backend', () => {
     const backendPlugins: PluginInfo[] = [];
-    const settingsPlugins: PluginInfo[] = [
+    const settingsPlugins: { name: string; isEnabled: boolean }[] = [
       {
         name: 'ourplugin1',
-        description: 'package description1',
-        homepage: 'https://example.com/1',
-        version: '1.0.0',
-        author: 'author1',
         isEnabled: true,
       },
     ];


### PR DESCRIPTION
Fixes Issue #2595


## Description

- This PR shrinks the saved JSON data from the plugins information and saves only the `name` and `isEnabled` status in local storage. This ensures plugin settings persist when closing and reopening the app.
- This PR introduces the `usePlugins` hook into `lib/k8s/api/v2`
- It also handles backward compatibility, allowing previously saved settings to be used in this new format.
- Additionally, it no longer takes old information from the JSON in local storage. Instead, it retrieves the necessary plugin data from the backend when the main Plugin component is called.

## Changes

1. **Introduces usePlugins hook**: Hook used to fetch the plugins from the backend and return the plugins with their settings
2. **Reduced Storage Data**: Only stores essential plugin info (`name` and `isEnabled`) in local storage.
3. **Backward Compatibility**: Converts old-format data into the new structure on first run.
4. **Data Source Shift**: Eliminates use of outdated local storage JSON data, and instead fetches plugin details from the backend when the Plugin component mounts.

## How to Test

1. **Setup**:
   - Pull this branch and run the application.
2. **Verify Plugin Settings**:
   - Open headlamp in app mode
   - Navigate to the settings page then to plugins settings tab
   - Check local storage item `headlampPluginSettings`
3. **Check Backward Compatibility**:
   - Start with an older version of the app or start from main.
   - Navigate to the settings page then to plugins settings tab
   - Check local storage item `headlampPluginSettings`
   - Switch to this branch and run the app.
   - Confirm that previously stored plugin settings are recognized and converted correctly.
5. **Backend Data**:
   - Verify that after loading, the plugin details (other than `name` and `isEnabled`) are fetched from the backend and displayed correctly in the UI.
   - Switch plugins off and on and observe the changes in local storage and in app

## Notes

- If you have preexisting local storage data, this PR will convert it automatically. You can reset the local storage if you return to main and go to the same plugin settings paage.
- Double-check the logs to ensure no errors appear during the migration from old data to new data.
