### PR TITLE
auto-hide menubar (can still be recalled by holding Alt key)

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1040,6 +1040,7 @@ function startElecron() {
         contextIsolation: true,
         preload: `${__dirname}/preload.js`,
       },
+      autoHideMenuBar: true,
     });
 
     setMenu(mainWindow, currentMenu);


### PR DESCRIPTION
The default Electron menu bar is visible even when there is nothing custom, eg. settings or so on.
This PR effectively hides it, with the option to recall it again using Alt key.