### PR TITLE
backend(oidc): Add support for custom CA and skipping TLS verification

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -54,6 +55,8 @@ type HeadlampConfig struct {
 	oidcClientID          string
 	oidcClientSecret      string
 	oidcIdpIssuerURL      string
+	oidcSkipTLSVerify     bool
+	oidcCACert            string
 	baseURL               string
 	oidcScopes            []string
 	proxyURLs             []string
@@ -366,7 +369,7 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 	if config.useInCluster {
 		context, err := kubeconfig.GetInClusterContext(config.oidcIdpIssuerURL,
 			config.oidcClientID, config.oidcClientSecret,
-			strings.Join(config.oidcScopes, ","))
+			strings.Join(config.oidcScopes, ","), config.oidcSkipTLSVerify, config.oidcCACert)
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "Failed to get in-cluster context")
 		}
@@ -545,6 +548,32 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		if oidcAuthConfig.SkipTLSVerify {
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			}
+			insecureClient := &http.Client{Transport: tr}
+			ctx = oidc.ClientContext(ctx, insecureClient)
+		}
+
+		if oidcAuthConfig.CACert != "" {
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM([]byte(oidcAuthConfig.CACert)) {
+				logger.Log(logger.LevelError, map[string]string{"oidc-ca-file": oidcAuthConfig.CACert},
+					errors.New("failed to append oidc-ca-file to cert pool"), "failed to append oidc-ca-file to cert pool")
+				http.Error(w, "invalid oidc-ca-file", http.StatusBadRequest)
+				return
+			}
+
+			secureTLSClient := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{RootCAs: caCertPool}, //nolint:gosec
+				},
+			}
+			ctx = oidc.ClientContext(ctx, secureTLSClient)
+		}
+
 		provider, err := oidc.NewProvider(ctx, oidcAuthConfig.IdpIssuerURL)
 		if err != nil {
 			logger.Log(logger.LevelError, map[string]string{"idpIssuerURL": oidcAuthConfig.IdpIssuerURL},

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/x509"
 	"errors"
 	"flag"
 	"fmt"
@@ -35,6 +36,8 @@ type Config struct {
 	OidcClientSecret      string `koanf:"oidc-client-secret"`
 	OidcIdpIssuerURL      string `koanf:"oidc-idp-issuer-url"`
 	OidcScopes            string `koanf:"oidc-scopes"`
+	OidcSkipTLSVerify     bool   `koanf:"oidc-skip-tls-verify"`
+	OidcCAFile            string `koanf:"oidc-ca-file"`
 }
 
 func (c *Config) Validate() error {
@@ -141,6 +144,22 @@ func Parse(args []string) (*Config, error) {
 		}
 	}
 
+	if config.OidcSkipTLSVerify {
+		logger.Log(logger.LevelWarn, nil, nil, "oidc-skip-tls-verify is set, this is not safe for production")
+	}
+
+	if config.OidcCAFile != "" {
+		caFile, err := os.ReadFile(config.OidcCAFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading oidc-ca-file: %w", err)
+		}
+		// check if the file is a valid PEM file
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caFile) {
+			return nil, errors.New("invalid oidc-ca-file")
+		}
+	}
+
 	config.KubeConfigPath = kubeConfigPath
 
 	return &config, nil
@@ -166,6 +185,8 @@ func flagset() *flag.FlagSet {
 	f.String("oidc-idp-issuer-url", "", "Identity provider issuer URL for OIDC")
 	f.String("oidc-scopes", "profile,email",
 		"A comma separated list of scopes needed from the OIDC provider")
+	f.Bool("oidc-skip-tls-verify", false, "Skip TLS verification for OIDC")
+	f.String("oidc-ca-file", "", "CA file for OIDC")
 
 	return f
 }


### PR DESCRIPTION
this patch adds support for custom CA and skipping TLS verification for OIDC provider verification. This improves flexibility for users working with self-signed OIDC providers.