### PR TITLE
frontend: Add e2e-tests for react-hotkeys dependency

### DIFF
--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -51,6 +51,28 @@ test('main page should have Network tab', async () => {
   await headlampPage.hasNetworkTab();
 });
 
+test('main page should have global search along with react-hotkey hint text', async () => {
+  const globalSearch = await headlampPage.hasGlobalSearch();
+
+  const searchHintContainer = globalSearch.locator('xpath=following-sibling::div');
+  const pressTextExists = await searchHintContainer.getByText(/^Press/).isVisible();
+  const slashHotKeyExists = await searchHintContainer
+    .locator('div')
+    .filter({ hasText: /^\/$/ })
+    .isVisible();
+  const toSearchTextExists = await searchHintContainer.getByText(/to search$/).isVisible();
+
+  expect(pressTextExists && slashHotKeyExists && toSearchTextExists).toBeTruthy();
+});
+
+test('react-hotkey for global search', async ({ page }) => {
+  await page.keyboard.press('/');
+
+  const focusedSearch = page.getByPlaceholder(/^Search resources, pages, clusters by name$/);
+  await expect(focusedSearch).toBeVisible();
+  await expect(focusedSearch).toBeFocused();
+});
+
 test('service page should have headlamp service', async () => {
   await servicesPage.navigateToServices();
   await servicesPage.clickOnServicesSection();

--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -76,6 +76,16 @@ export class HeadlampPage {
     expect(await securityTab.textContent()).toBe('Security');
   }
 
+  async hasGlobalSearch() {
+    const globalSearch = this.page.getByPlaceholder(/^Search$/);
+
+    await expect(globalSearch).toBeVisible();
+    await expect(globalSearch).toHaveValue(/^$/);
+    await expect(globalSearch).not.toBeFocused();
+
+    return globalSearch;
+  }
+
   async checkPageContent(text: string) {
     await this.page.waitForSelector(`:has-text("${text}")`);
     const pageContent = await this.page.content();

--- a/e2e-tests/tests/multiCluster.spec.ts
+++ b/e2e-tests/tests/multiCluster.spec.ts
@@ -111,4 +111,34 @@ test.describe('multi-cluster setup', () => {
     await page.waitForLoadState('load');
     await headlampPage.hasTitleContaining(/Choose a cluster/);
   });
+
+  // This is commented out because the CI e2e test job loads the plugins
+  // Which interferes with the test. It replaces the cluster chooser,
+  // so this test does not work.
+
+  // test('react-hotkey to open cluster chooser', async ({ page }) => {
+  //   const testClusterAnchor = page.locator('table tbody tr td a', {
+  //     hasText: /^test$/,
+  //   });
+  //   await expect(testClusterAnchor).toBeVisible();
+  //   await expect(testClusterAnchor).toHaveAttribute('href', '/c/test/');
+
+  //   await Promise.all([page.waitForNavigation(), testClusterAnchor.click()]);
+
+  //   await headlampPage.authenticate(testToken);
+  //   await headlampPage.pageLocatorContent(
+  //     'button:has-text("Our Cluster Chooser button. Cluster: test")',
+  //     'Our Cluster Chooser button. Cluster: test'
+  //   );
+
+  //   await page.keyboard.press('Control+Shift+L');
+
+  //   const chooseClusterLabel = page.getByLabel(/^Choose cluster$/);
+  //   await expect(chooseClusterLabel).toBeVisible();
+
+  //   const clusterNameInput = page.getByPlaceholder(/^Name$/);
+  //   await expect(clusterNameInput).toBeVisible();
+  //   await expect(clusterNameInput).toHaveValue(/^$/);
+  //   await expect(clusterNameInput).toBeFocused();
+  // });
 });


### PR DESCRIPTION
Fixes #2380 
- #2380 

This will help us update the react-hotkeys dependency with an automated check helping us catch issues.
