### PR TITLE
frontend: Hide row actions with hidden columns

### DIFF
--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -306,6 +306,7 @@ function HomeComponent(props: HomeComponentProps) {
                 getValue: ({ name }) => versions[name]?.gitVersion || '⋯',
               },
               {
+                id: 'actions',
                 label: '',
                 getValue: () => '',
                 cellProps: {

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -320,6 +320,21 @@ export default function Table<RowItem extends Record<string, any>>({
     },
   });
 
+  // Hide actions column when others are hidden
+  useEffect(() => {
+    const visibility = table.getState().columnVisibility || {};
+
+    const shouldHideActions = tableColumns
+      .filter(col => (col.id ?? '') !== 'actions')
+      .every(col => visibility[col.id ?? ''] === false);
+
+    if (shouldHideActions && visibility['actions'] !== false) {
+      table.setColumnVisibility(prev => ({ ...prev, actions: false }));
+    } else if (!shouldHideActions && visibility['actions'] === false) {
+      table.setColumnVisibility(prev => ({ ...prev, actions: true }));
+    }
+  }, [table.getState().columnVisibility, tableColumns, table]);
+
   const gridTemplateColumns = useMemo(() => {
     let preGridTemplateColumns = tableProps.columns
       .filter((it, i) => {


### PR DESCRIPTION
This change ensures that when all of the non-action columns are hidden, the action column is also hidden.

Fixes: #2932 

### Testing
- [X] Navigate to the Headlamp home page
- [X] Manually hide all the cluster fields in the table
- [X] Ensure that the row actions are also hidden
- [X] Manually unhide one field and ensure that the row actions appear again