### PR TITLE
frontend: Improve nav in map view

### DIFF
--- a/frontend/src/components/common/Resource/DeleteButton.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.tsx
@@ -39,6 +39,7 @@ export default function DeleteButton(props: DeleteButtonProps) {
       const callback = item!.delete;
 
       const itemName = item!.metadata.name;
+      const redirectUrl = location.pathname.includes('/map') ? undefined : item!.getListLink();
 
       callback &&
         dispatch(
@@ -48,8 +49,8 @@ export default function DeleteButton(props: DeleteButtonProps) {
             successMessage: t('Deleted item {{ itemName }}.', { itemName }),
             errorMessage: t('Error deleting item {{ itemName }}.', { itemName }),
             cancelUrl: location.pathname,
-            startUrl: item!.getListLink(),
-            errorUrl: item!.getListLink(),
+            startUrl: redirectUrl,
+            errorUrl: redirectUrl,
             ...options,
           })
         );

--- a/frontend/src/components/common/Resource/RestartButton.tsx
+++ b/frontend/src/components/common/Resource/RestartButton.tsx
@@ -59,6 +59,7 @@ export function RestartButton(props: RestartButtonProps) {
 
   function handleSave() {
     const itemName = item.metadata.name;
+    const redirectUrl = location.pathname.includes('/map') ? undefined : item.getListLink();
 
     dispatch(
       clusterAction(() => restartResource(), {
@@ -67,8 +68,8 @@ export function RestartButton(props: RestartButtonProps) {
         successMessage: t('Restarted {{ itemName }}.', { itemName }),
         errorMessage: t('Failed to restart {{ itemName }}.', { itemName }),
         cancelUrl: location.pathname,
-        startUrl: item.getListLink(),
-        errorUrl: item.getListLink(),
+        startUrl: redirectUrl,
+        errorUrl: redirectUrl,
       })
     );
   }


### PR DESCRIPTION
These changes add improvements to navigation within the map feature of Headlamp. These focus around keeping the map in-view when restarting/deleting resources, or when clicking on links within the resources' details pages.

Fixes: #2928 