### PR TITLE
Headlamp Plugins CLI: Bulk installations support

### DIFF
--- a/plugins/headlamp-plugin/README.md
+++ b/plugins/headlamp-plugin/README.md
@@ -52,10 +52,33 @@ headlamp-plugin --help
                                             working directory. Can also be a
                                             folder of packages.
   headlamp-plugin.js list                   List installed plugins.
-  headlamp-plugin.js install [URL]          Install a plugin from the specified
-                                            Artifact Hub URL.
+  headlamp-plugin.js install [URL]          Install plugin(s) from a configuration
+                                            file or a plugin Artifact Hub URL.
+                                            Options:
+                                            -c, --config: Path to config file
+                                            --folderName: Install folder name
+                                            --headlampVersion: Target version
+                                            -q, --quiet: Suppress logs
   headlamp-plugin.js update [pluginName]    Update the plugin to the latest version.
   headlamp-plugin.js uninstall [pluginName] Uninstall the plugin.
+```
+
+## Template for installing plugins from a configuration file
+
+plugins.yaml:
+
+```yaml
+plugins:
+  - name: my-plugin
+    source: https://artifacthub.io/packages/headlamp/test-123/my-plugin
+    version: 1.0.0
+  - name: another-plugin
+    source: https://artifacthub.io/packages/headlamp/test-123/another-plugin
+    dependencies:
+      - my-plugin
+installOptions:
+  parallel: true
+  maxConcurrent: 3
 ```
 
 ## Development notes
@@ -113,7 +136,6 @@ Run `npm run check-dependencies` to see if frontend/package.json and
 headlamp-plugin/package.json are synced. This is run in CI to make sure when dependencies
 are changed, they are synced appropriately.
 
-
 ### Upgrading to an alpha release
 
 You can try an alpha release for testing with the following command.
@@ -125,6 +147,7 @@ npx @kinvolk/headlamp-plugin@alpha upgrade --headlamp-plugin-version=alpha your-
 ### Making an alpha release of headlamp-plugin
 
 You can bump the version to do a new alpha release like so:
+
 ```bash
 cd plugins/headlamp-plugin
 npm version preminor --preid=alpha

--- a/plugins/headlamp-plugin/dependencies-sync.js
+++ b/plugins/headlamp-plugin/dependencies-sync.js
@@ -32,6 +32,7 @@
 // Some packages are used by headlamp-plugin that are not used by the frontend.
 // These won't be removed from headlamp-plugin/package.json
 const dependenciesFrontDoesNotHave = new Set([
+  'ajv',
   'env-paths',
   'shx',
   'fs-extra',

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -59,6 +59,7 @@
         "@xterm/addon-search": "^0.15.0",
         "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "^12.2.0",
+        "ajv": "^8.12.0",
         "base64-arraybuffer": "^1.0.2",
         "buffer": "^6.0.3",
         "console-browserify": "^1.2.0",
@@ -1726,15 +1727,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@jest/console/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/console/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -1832,15 +1824,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/core/node_modules/slash": {
@@ -2043,15 +2026,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@jest/reporters/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
@@ -2224,15 +2198,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@jest/transform/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/transform/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2300,15 +2265,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/types/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/types/node_modules/supports-color": {
@@ -3028,12 +2984,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@rollup/plugin-inject/node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "license": "MIT"
     },
     "node_modules/@rollup/plugin-inject/node_modules/estree-walker": {
       "version": "2.0.2",
@@ -3807,12 +3757,6 @@
         }
       }
     },
-    "node_modules/@storybook/react-vite/node_modules/@rollup/pluginutils/node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "license": "MIT"
-    },
     "node_modules/@storybook/react-vite/node_modules/@storybook/react": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.6.0.tgz",
@@ -4122,14 +4066,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@testing-library/dom/node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -4219,14 +4155,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
       "version": "7.2.0",
@@ -4421,9 +4349,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
       "version": "1.0.5",
@@ -5228,10 +5157,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "peer": true,
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5662,15 +5591,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/babel-jest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/babel-jest/node_modules/slash": {
@@ -6675,15 +6595,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/create-jest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/create-jest/node_modules/supports-color": {
@@ -8618,14 +8529,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8678,17 +8581,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/esprima": {
@@ -8750,12 +8642,6 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
-    },
-    "node_modules/estree-walker/node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -9394,6 +9280,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -9498,11 +9393,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/hast-util-to-jsx-runtime/node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
@@ -10559,14 +10449,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-report/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/istanbul-lib-report/node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -10778,15 +10660,6 @@
         }
       }
     },
-    "node_modules/jest-circus/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-circus/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10870,15 +10743,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-cli/node_modules/supports-color": {
@@ -11002,15 +10866,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jest-config/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-config/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11091,15 +10946,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-diff/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-diff/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11169,15 +11015,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-each/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-each/node_modules/supports-color": {
@@ -11302,15 +11139,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-matcher-utils/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-matcher-utils/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11372,15 +11200,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-message-util/node_modules/slash": {
@@ -11508,15 +11327,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-resolve/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-resolve/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11599,15 +11409,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-runner/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-runner/node_modules/supports-color": {
@@ -11719,15 +11520,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jest-runtime/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-runtime/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11824,15 +11616,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-snapshot/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11893,15 +11676,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-util/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11960,15 +11734,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-validate/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-validate/node_modules/supports-color": {
@@ -12033,15 +11798,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-watcher/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-watcher/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12067,30 +11823,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/js-base64": {
@@ -12466,14 +12198,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lint-staged/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lint-staged/node_modules/human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -12590,14 +12314,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/log-symbols/node_modules/supports-color": {
@@ -13674,14 +13390,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/msw/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/msw/node_modules/path-to-regexp": {
@@ -16351,6 +16059,22 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -16485,19 +16209,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -17075,18 +16786,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/unplugin/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/unplugin/node_modules/webpack-virtual-modules": {
@@ -17716,12 +17415,6 @@
       "peerDependencies": {
         "@svgr/core": "*"
       }
-    },
-    "node_modules/vite-plugin-svgr/node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "license": "MIT"
     },
     "node_modules/vite-plugin-svgr/node_modules/cosmiconfig": {
       "version": "8.3.6",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -63,6 +63,7 @@
     "@xterm/addon-search": "^0.15.0",
     "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.2.0",
+    "ajv": "^8.12.0",
     "base64-arraybuffer": "^1.0.2",
     "buffer": "^6.0.3",
     "console-browserify": "^1.2.0",
@@ -153,7 +154,8 @@
     "lib",
     "types",
     ".storybook",
-    "plugin-management/plugin-management.js"
+    "plugin-management/plugin-management.js",
+    "plugin-management/multi-plugin-management.js"
   ],
   "keywords": [
     "headlamp",

--- a/plugins/headlamp-plugin/plugin-management/multi-plugin-management.js
+++ b/plugins/headlamp-plugin/plugin-management/multi-plugin-management.js
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const PluginManagement = require('./plugin-management');
+const PluginManager = PluginManagement.PluginManager;
+const Ajv = require('ajv');
+const yaml = require('js-yaml');
+
+// Plugin configuration schema
+const pluginConfigSchema = {
+  type: 'object',
+  required: ['plugins'],
+  properties: {
+    plugins: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'source'],
+        properties: {
+          name: {
+            type: 'string',
+            pattern: '^[a-z0-9][a-z0-9-_]*[a-z0-9-]$', // Only allow lowercase, numbers, hyphens, and underscores (not at start/end)
+            minLength: 1,
+          },
+          source: {
+            type: 'string',
+            pattern: '^https://artifacthub\\.io/packages/[^\\s]+$',
+          },
+          version: {
+            type: 'string',
+            pattern: '^\\d+\\.\\d+\\.\\d+', // Semver format
+          },
+          dependencies: {
+            type: 'array',
+            items: { type: 'string', pattern: '^[a-z0-9][a-z0-9-_]*[a-z0-9-]$' },
+            uniqueItems: true,
+          },
+        },
+      },
+    },
+    installOptions: {
+      type: 'object',
+      properties: {
+        parallel: { type: 'boolean' },
+        maxConcurrent: { type: 'integer', minimum: 1 },
+      },
+    },
+  },
+};
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(pluginConfigSchema);
+
+/**
+ * Manages multiple plugins from a configuration file.
+ */
+class MultiPluginManager {
+  /**
+   * @param {string} [pluginsDir=''] - The directory to install plugins to.
+   * @param {string} [headlampVersion=''] - The version of Headlamp for compatibility checking.
+   * @param {function} [progressCallback=null] - Optional callback for progress updates.
+   * @param {AbortSignal} [signal=null] - Optional signal for cancellation.
+   */
+  constructor(pluginsDir = '', headlampVersion = '', progressCallback = null, signal = null) {
+    this.pluginsDir = pluginsDir;
+    this.headlampVersion = headlampVersion;
+    this.progressCallback = progressCallback;
+    this.signal = signal;
+  }
+
+  /**
+   * Wraps the progress callback to add context about the current plugin installation
+   * @private
+   */
+  _wrapProgressCallback(pluginName, index, total) {
+    return progress => {
+      if (this.progressCallback) {
+        this.progressCallback({
+          ...progress,
+          plugin: pluginName,
+          current: index + 1,
+          total,
+          percentage: Math.round(((index + 1) / total) * 100),
+        });
+      }
+    };
+  }
+
+  /**
+   * Installs plugins from a configuration file.
+   * @param {string} configPath - Path to yaml configuration file.
+   * @returns {Promise<{ failed: number, successful: number, total: number }>}
+   */
+  async installFromConfig(configPath) {
+    if (!fs.existsSync(configPath)) {
+      throw new Error('Configuration file not found');
+    }
+    if (this.progressCallback) {
+      this.progressCallback({ message: `Installing plugins from config: ${configPath}` });
+    }
+    const config = await this.validateConfig(configPath);
+    const { parallel = false, maxConcurrent = 1 } = config.installOptions || {};
+
+    if (this.signal?.aborted) {
+      throw new Error('Installation cancelled');
+    }
+    // Create dependency graph and determine installation order
+    const graph = this._createDependencyGraph(config.plugins);
+    const pluginsNames = config.plugins.map(p => p.name);
+    const failedPlugins = new Set();
+    const skippedPlugins = new Set();
+
+    if (parallel) {
+      // Create optimal chunks that respect dependencies
+      const chunks = this._createOptimalChunks(graph, maxConcurrent);
+
+      // Process each chunk
+      for (const chunk of chunks) {
+        if (this.signal?.aborted) {
+          throw new Error('Installation cancelled');
+        }
+
+        const chunkPromises = chunk.map(pluginName => {
+          const plugin = config.plugins.find(p => p.name === pluginName);
+          const deps = graph.get(pluginName) || [];
+          const index = pluginsNames.indexOf(pluginName);
+          const progressCallback = this._wrapProgressCallback(
+            pluginName,
+            index,
+            pluginsNames.length
+          );
+
+          // Check if any dependencies failed or were skipped
+          const hasFailedDeps = deps.some(dep => failedPlugins.has(dep));
+          const hasSkippedDeps = deps.some(dep => skippedPlugins.has(dep));
+
+          if (hasFailedDeps || hasSkippedDeps) {
+            skippedPlugins.add(pluginName);
+            return Promise.resolve(
+              progressCallback({
+                type: 'error',
+                message: `Skipped installation since dependencies were ${
+                  hasFailedDeps ? 'failed' : 'skipped'
+                }: ${deps
+                  .filter(d => (hasFailedDeps ? failedPlugins.has(d) : skippedPlugins.has(d)))
+                  .join(', ')}`,
+                raise: false,
+              })
+            );
+          }
+
+          return this.installPlugin(plugin, progressCallback).then(
+            () =>
+              progressCallback({
+                name: pluginName,
+                type: 'success',
+                message: 'Plugin installed successfully',
+              }),
+            error => {
+              failedPlugins.add(pluginName);
+              progressCallback({
+                name: pluginName,
+                type: 'error',
+                message: error.message,
+                raise: false,
+              });
+            }
+          );
+        });
+
+        await Promise.all(chunkPromises);
+      }
+    } else {
+      // Sequential installation
+      for (const [index, pluginName] of pluginsNames.entries()) {
+        if (this.signal?.aborted) {
+          throw new Error('Installation cancelled');
+        }
+
+        const plugin = config.plugins.find(p => p.name === pluginName);
+        const deps = graph.get(pluginName) || [];
+        const hasFailedDeps = deps.some(dep => failedPlugins.has(dep));
+        const hasSkippedDeps = deps.some(dep => skippedPlugins.has(dep));
+
+        const progressCallback = this._wrapProgressCallback(pluginName, index, pluginsNames.length);
+
+        if (hasFailedDeps || hasSkippedDeps) {
+          skippedPlugins.add(pluginName);
+          progressCallback({
+            name: pluginName,
+            status: 'skipped',
+            message: `Skipped installation since dependencies were ${
+              hasFailedDeps ? 'failed' : 'skipped'
+            }: ${deps
+              .filter(d => (hasFailedDeps ? failedPlugins.has(d) : skippedPlugins.has(d)))
+              .join(', ')}`,
+            raise: false,
+          });
+          continue;
+        }
+
+        try {
+          await this.installPlugin(plugin, progressCallback);
+          progressCallback({
+            name: pluginName,
+            status: 'success',
+            message: 'Plugin installed successfully',
+          });
+        } catch (error) {
+          failedPlugins.add(pluginName);
+          progressCallback({
+            name: pluginName,
+            status: 'error',
+            message: error.message,
+            raise: false,
+          });
+        }
+      }
+    }
+
+    const result = {
+      total: pluginsNames.length,
+      failed: failedPlugins.size,
+      skipped: skippedPlugins.size,
+      successful: pluginsNames.length - failedPlugins.size - skippedPlugins.size,
+    };
+    if (this.progressCallback) {
+      // Log final status
+      this.progressCallback({
+        message: `Bulk installation completed: ${JSON.stringify(result)}`,
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Creates a dependency graph from plugin configurations
+   * @private
+   */
+  _createDependencyGraph(plugins) {
+    const graph = new Map();
+
+    for (const plugin of plugins) {
+      graph.set(plugin.name, plugin.dependencies || []);
+    }
+
+    return graph;
+  }
+
+  async validateConfig(configPath) {
+    try {
+      if (!fs.statSync(configPath).isFile()) {
+        throw new Error(`Configuration file not found: ${configPath}`);
+      }
+      const configContent = fs.readFileSync(configPath, 'utf8');
+      const config = yaml.load(configContent);
+      const valid = validate(config);
+      if (!valid) {
+        const errors = validate.errors.map(err => `${err.instancePath} ${err.message}`).join('\n');
+        throw new Error(`Configuration validation failed:\n${errors}`);
+      }
+      // Check for duplicate plugin names
+      const pluginNames = config.plugins.map(p => p.name);
+      const duplicatesNames = pluginNames.filter(
+        (name, index) => pluginNames.indexOf(name) !== index
+      );
+      if (duplicatesNames.length > 0) {
+        throw new Error(`Duplicate plugin names found: ${duplicatesNames.join(', ')}`);
+      }
+      // duplicate sources
+      const sources = config.plugins.map(p => p.source);
+      const duplicateSources = sources.filter((source, index) => sources.indexOf(source) !== index);
+      if (duplicateSources.length > 0) {
+        throw new Error(`Duplicate plugin sources found: ${duplicateSources.join(', ')}`);
+      }
+      this._checkCircularDependencies(config.plugins);
+      return config;
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        throw new Error(`Configuration file not found: ${configPath}`);
+      }
+      throw error;
+    }
+  }
+
+  _checkCircularDependencies(plugins) {
+    const visited = new Set();
+    const recStack = new Set(); // Keeps track of nodes in the recursion stack
+    const graph = this._createDependencyGraph(plugins);
+    function dfs(node) {
+      if (recStack.has(node)) {
+        throw new Error(`Circular dependencies found for plugin ${node}`);
+      }
+      if (visited.has(node)) return; // Already processed, skip
+
+      visited.add(node);
+      recStack.add(node);
+
+      for (const neighbor of graph.get(node) || []) {
+        dfs(neighbor);
+      }
+
+      recStack.delete(node); // Remove from recursion stack after processing
+    }
+
+    for (const plugin of plugins) {
+      if (!visited.has(plugin.name) && dfs(plugin.name)) {
+        throw new Error(`Circular dependencies found for plugin ${plugin.name}`);
+      }
+    }
+  }
+
+  /**
+   * Install a single plugin
+   * @param {Object} plugin - Plugin configuration
+   * @param {function} [progressCallback] - Progress callback for this specific plugin
+   * @returns {Promise<void>}
+   */
+  async installPlugin(plugin, progressCallback) {
+    progressCallback({ message: `Installing plugin ${plugin.name}` });
+
+    const params = [
+      plugin.source,
+      this.pluginsDir || undefined,
+      this.headlampVersion || undefined,
+      progressCallback,
+      this.signal,
+      plugin.version || undefined,
+    ];
+
+    await PluginManager.install(...params);
+  }
+
+  /**
+   * Creates optimal chunks for parallel installation that respect dependencies
+   * Plugins in the same chunk must not depend on each other
+   * @private
+   */
+  _createOptimalChunks(graph, maxConcurrent) {
+    const chunks = [];
+    const remaining = new Set(graph.keys());
+
+    while (remaining.size > 0) {
+      const chunk = [];
+      const chunkDeps = new Set(); // Track all deps of plugins in current chunk
+
+      // Try to add plugins to current chunk
+      for (const plugin of remaining) {
+        const deps = graph.get(plugin) || [];
+
+        // Plugin can be added if:
+        // 1. Chunk size < maxConcurrent
+        // 2. None of its deps are in current chunk
+        // 3. None of its deps are in remaining plugins to be processed
+        if (
+          chunk.length < maxConcurrent &&
+          !deps.some(dep => chunk.includes(dep) || chunkDeps.has(dep))
+        ) {
+          chunk.push(plugin);
+          // Add this plugin's deps to track for next plugins in chunk
+          deps.forEach(dep => chunkDeps.add(dep));
+        }
+      }
+
+      // Remove processed plugins from remaining
+      chunk.forEach(plugin => remaining.delete(plugin));
+      chunks.push(chunk);
+    }
+
+    return chunks;
+  }
+}
+
+module.exports = MultiPluginManager;

--- a/plugins/headlamp-plugin/plugin-management/multi-plugin-management.test.js
+++ b/plugins/headlamp-plugin/plugin-management/multi-plugin-management.test.js
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const fsp = require('fs').promises;
+const os = require('os');
+const MultiPluginManager = require('./multi-plugin-management');
+
+describe('MultiPluginManagement', () => {
+  let tempDir;
+  let configPath;
+  let installer;
+  const PLUGIN_DATA = [
+    {
+      name: 'appcatalog_headlamp_plugin',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin',
+      version: '0.0.3',
+    },
+    {
+      name: 'ai_plugin',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/ai_plugin',
+      version: '0.0.2',
+    },
+    {
+      name: 'prometheus_headlamp_plugin',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/prometheus_headlamp_plugin',
+      version: '0.0.3',
+    },
+  ];
+  beforeEach(async () => {
+    // Create temporary directory for tests
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'headlamp-test-'));
+    configPath = path.join(tempDir, 'plugins.yaml');
+
+    const mockProgressCallback = data => {
+      const { type = 'info', message, raise = true } = data;
+      if (type === 'error' && raise) {
+        throw new Error(message);
+      }
+    };
+    installer = new MultiPluginManager(tempDir, '', mockProgressCallback);
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('validateConfig', () => {
+    it('should validate a valid configuration', async () => {
+      const config = `
+plugins:
+  - name: ${PLUGIN_DATA[1].name}
+    source: ${PLUGIN_DATA[1].source}
+    version: ${PLUGIN_DATA[1].version}
+`;
+      await fsp.writeFile(configPath, config);
+
+      const result = await installer.validateConfig(configPath);
+      expect(result).toBeDefined();
+      expect(result.plugins).toHaveLength(1);
+      expect(result.plugins[0].name).toBe(PLUGIN_DATA[1].name);
+    });
+
+    it('should reject invalid configuration', async () => {
+      const config = `
+plugins:
+  - source: https://example.com/plugin.tar.gz
+`;
+      await fsp.writeFile(configPath, config);
+
+      await expect(installer.validateConfig(configPath)).rejects.toThrow(
+        'Configuration validation failed'
+      );
+    });
+
+    it('should reject duplicate plugin names', async () => {
+      const config = `
+plugins:
+  - name: ${PLUGIN_DATA[1].name}
+    source: ${PLUGIN_DATA[1].source}
+  - name: ${PLUGIN_DATA[1].name}
+    source: ${PLUGIN_DATA[1].source}
+`;
+      await fsp.writeFile(configPath, config);
+
+      await expect(installer.validateConfig(configPath)).rejects.toThrow(
+        `Duplicate plugin names found: ${PLUGIN_DATA[1].name}`
+      );
+    });
+
+    it('should reject duplicate plugin sources', async () => {
+      const config = `
+plugins:
+  - name: ${PLUGIN_DATA[1].name}
+    source: ${PLUGIN_DATA[1].source}
+  - name: ${PLUGIN_DATA[2].name}
+    source: ${PLUGIN_DATA[1].source}
+`;
+      await fsp.writeFile(configPath, config);
+
+      await expect(installer.validateConfig(configPath)).rejects.toThrow(
+        `Duplicate plugin sources found: ${PLUGIN_DATA[1].source}`
+      );
+    });
+  });
+
+  describe('dependency handling', () => {
+    it('should detect circular dependencies', async () => {
+      const config = `
+plugins:
+  - name: ${PLUGIN_DATA[1].name}
+    source: ${PLUGIN_DATA[1].source}
+    dependencies:
+      - ${PLUGIN_DATA[2].name}
+  - name: ${PLUGIN_DATA[2].name}
+    source: ${PLUGIN_DATA[2].source}
+    dependencies:
+      - ${PLUGIN_DATA[1].name}
+`;
+      await fsp.writeFile(configPath, config);
+
+      await expect(installer.installFromConfig(configPath)).rejects.toThrow(
+        `Circular dependencies found for plugin ${PLUGIN_DATA[1].name}`
+      );
+    });
+
+    it('should skip plugins with failed dependencies', async () => {
+      const config = `
+plugins:
+  - name: invalid-plugin
+    source: https://artifacthub.io/packages/headlamp/test-123/invalid-plugin
+  - name: ${PLUGIN_DATA[0].name}
+    source: ${PLUGIN_DATA[0].source}
+    dependencies:
+      - invalid-plugin
+installOptions:
+  parallel: false
+`;
+      await fsp.writeFile(configPath, config);
+
+      const result = await installer.installFromConfig(configPath);
+      console.log('Result:', result);
+      expect(result.failed).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.successful).toBe(0);
+    }, 10000);
+  });
+
+  describe('parallel installation', () => {
+    it('should respect maxConcurrent setting', async () => {
+      const config = `
+plugins:
+  - name: ${PLUGIN_DATA[0].name}
+    source: ${PLUGIN_DATA[0].source}
+  - name: ${PLUGIN_DATA[1].name}
+    source: ${PLUGIN_DATA[1].source}
+  - name: ${PLUGIN_DATA[2].name}
+    source: ${PLUGIN_DATA[2].source}
+installOptions:
+  parallel: true
+  maxConcurrent: 2
+`;
+      await fsp.writeFile(configPath, config);
+
+      // Mock installer._createOptimalChunks to verify chunk sizes
+      const createOptimalChunksSpy = jest.spyOn(installer, '_createOptimalChunks');
+      await installer.installFromConfig(configPath);
+
+      const chunks = createOptimalChunksSpy.mock.results[0].value;
+      expect(chunks.every(chunk => chunk.length <= 2)).toBe(true);
+    }, 10000);
+    it('should not install dependent plugins in parallel', async () => {
+      const config = `
+plugins:
+  - name: ${PLUGIN_DATA[0].name}
+    source: ${PLUGIN_DATA[0].source}
+  - name: ${PLUGIN_DATA[1].name}
+    source: ${PLUGIN_DATA[1].source}
+    dependencies:
+      - ${PLUGIN_DATA[0].name}
+  - name: ${PLUGIN_DATA[2].name}
+    source: ${PLUGIN_DATA[2].source}
+installOptions:
+  parallel: true
+  maxConcurrent: 3
+`;
+      await fsp.writeFile(configPath, config);
+
+      const createOptimalChunksSpy = jest.spyOn(installer, '_createOptimalChunks');
+      await installer.installFromConfig(configPath);
+
+      const chunks = createOptimalChunksSpy.mock.results[0].value;
+
+      // Verify that base-plugin and dependent-plugin are not in the same chunk
+      const hasInvalidChunk = chunks.some(
+        chunk => chunk.includes(PLUGIN_DATA[0].name) && chunk.includes(PLUGIN_DATA[1].name)
+      );
+      expect(hasInvalidChunk).toBe(false);
+
+      // Verify that independent-plugin can be installed in parallel with base-plugin
+      const hasValidParallelChunk = chunks.some(
+        chunk => chunk.length > 1 && chunk.includes(PLUGIN_DATA[2].name)
+      );
+      expect(hasValidParallelChunk).toBe(true);
+    }, 10000); // Increase timeout to 10 seconds
+  });
+
+  describe('installFromConfig', () => {
+    it('should installs plugins from a configuration file', async () => {
+      const config = `
+plugins:
+  - name: ${PLUGIN_DATA[0].name}
+    source: ${PLUGIN_DATA[0].source}
+    version: ${PLUGIN_DATA[0].version}
+`;
+      await fsp.writeFile(configPath, config);
+
+      const result = await installer.installFromConfig(configPath);
+      await new Promise(resolve => setTimeout(resolve, 1000)); // Add delay to ensure all logs are processed
+
+      expect(result.successful).toEqual(1);
+      expect(result.failed).toEqual(0);
+      expect(fs.existsSync(path.join(tempDir, PLUGIN_DATA[0].name))).toBe(true);
+    }, 10000);
+
+    it('should handle missing configuration file', async () => {
+      await expect(installer.installFromConfig('/nonexistent/config.yaml')).rejects.toThrow(
+        'Configuration file not found'
+      );
+    });
+
+    it('should handle invalid source URLs', async () => {
+      const config = `
+plugins:
+  - name: test-plugin
+    source: invalid-url
+`;
+      await fsp.writeFile(configPath, config);
+      await expect(installer.installFromConfig(configPath)).rejects.toThrow(
+        'Configuration validation failed'
+      );
+    });
+  });
+
+  describe('installPlugin', () => {
+    it('should handle plugin installation errors', async () => {
+      const plugin = {
+        name: 'test-plugin',
+        source: 'https://example.com/nonexistent.tar.gz',
+      };
+
+      await expect(installer.installPlugin(plugin)).rejects.toThrow();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle YAML parsing errors', async () => {
+      const invalidYaml = `
+plugins:
+  - name: test-plugin
+    source: [invalid yaml
+`;
+      await fsp.writeFile(configPath, invalidYaml);
+
+      await expect(installer.installFromConfig(configPath)).rejects.toThrow();
+    });
+
+    it('should handle file system errors', async () => {
+      const plugin = {
+        name: 'test-plugin',
+        source: 'https://example.com/plugin.tar.gz',
+      };
+
+      // Make plugins directory read-only
+      await fsp.chmod(tempDir, 0o444);
+
+      await expect(installer.installPlugin(plugin)).rejects.toThrow();
+    });
+  });
+});

--- a/plugins/headlamp-plugin/plugin-management/plugin-management.js
+++ b/plugins/headlamp-plugin/plugin-management/plugin-management.js
@@ -65,6 +65,7 @@ class PluginManager {
    * @param {string} [headlampVersion=""] - The version of Headlamp for compatibility checking.
    * @param {function} [progressCallback=null] - Optional callback for progress updates.
    * @param {AbortSignal} [signal=null] - Optional AbortSignal for cancellation.
+   * @param {string} [pluginVersion=""] - The version of the plugin to install.
    * @returns {Promise<void>} A promise that resolves when the installation is complete.
    */
   static async install(
@@ -72,14 +73,16 @@ class PluginManager {
     destinationFolder = defaultPluginsDir(),
     headlampVersion = '',
     progressCallback = null,
-    signal = null
+    signal = null,
+    pluginVersion = ''
   ) {
     try {
       const [name, tempFolder] = await downloadExtractPlugin(
         URL,
         headlampVersion,
         progressCallback,
-        signal
+        signal,
+        pluginVersion
       );
 
       // sleep(2000);  // comment out for testing
@@ -313,14 +316,21 @@ function validateArchiveURL(archiveURL) {
  * @param {string} headlampVersion - The version of Headlamp for compatibility checking.
  * @param {function} progressCallback - A callback function for reporting progress.
  * @param {AbortSignal} signal - An optional AbortSignal for cancellation.
+ * @param {string} [pluginVersion=""] - The version of the plugin to install.
  * @returns {Promise<[string, string]>} A promise that resolves to an array containing the plugin name and temporary folder path.
  */
-async function downloadExtractPlugin(URL, headlampVersion, progressCallback, signal) {
+async function downloadExtractPlugin(
+  URL,
+  headlampVersion,
+  progressCallback,
+  signal,
+  pluginVersion
+) {
   // fetch plugin metadata
   if (signal && signal.aborted) {
     throw new Error('Download cancelled');
   }
-  const pluginInfo = await fetchPluginInfo(URL, progressCallback, signal);
+  const pluginInfo = await fetchPluginInfo(URL, progressCallback, signal, pluginVersion);
   // await sleep(4000);  // comment out for testing
 
   if (signal && signal.aborted) {
@@ -328,6 +338,9 @@ async function downloadExtractPlugin(URL, headlampVersion, progressCallback, sig
   }
   if (progressCallback) {
     progressCallback({ type: 'info', message: 'Plugin Metadata Fetched' });
+  }
+  if (!pluginInfo || pluginInfo.message === '') {
+    throw new Error('Unable to fetch plugin metadata. Please check the plugin details.');
   }
   const pluginName = pluginInfo.name;
   if (!validatePluginName(pluginName)) {
@@ -460,9 +473,10 @@ async function downloadExtractPlugin(URL, headlampVersion, progressCallback, sig
  * @param {string} URL - The URL to fetch plugin metadata from.
  * @param {function} progressCallback - A callback function for reporting progress.
  * @param {AbortSignal} signal - An optional AbortSignal for cancellation.
+ * @param {string} [pluginVersion=""] - The version of the plugin to install.
  * @returns {Promise<object>} A promise that resolves to the fetched plugin metadata.
  */
-async function fetchPluginInfo(URL, progressCallback, signal) {
+async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
   try {
     if (!URL.startsWith('https://artifacthub.io/packages/headlamp/')) {
       throw new Error('Invalid URL. Please provide a valid URL from ArtifactHub.');
@@ -476,11 +490,30 @@ async function fetchPluginInfo(URL, progressCallback, signal) {
     if (progressCallback) {
       progressCallback({ type: 'info', message: 'Fetching Plugin Metadata' });
     }
-    const response = await fetch(apiURL, { redirect: 'follow', follow: 10 }, { signal });
+    let response = await fetch(apiURL, { redirect: 'follow', follow: 10 }, { signal });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    return await response.json();
+    let pluginInfo = await response.json();
+    if (pluginVersion && pluginVersion !== pluginInfo.version) {
+      if (!pluginInfo.available_versions.map(v => v.version).includes(pluginVersion)) {
+        throw new Error(
+          `Plugin version ${pluginVersion} not found. Please check the plugin details.`
+        );
+      }
+      // Remove trailing slash if present to avoid double slashes
+      const baseURL = apiURL.endsWith('/') ? apiURL.slice(0, -1) : apiURL;
+      response = await fetch(
+        `${baseURL}/${pluginVersion}`,
+        { redirect: 'follow', follow: 10 },
+        { signal }
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      pluginInfo = await response.json();
+    }
+    return pluginInfo;
   } catch (e) {
     if (progressCallback) {
       progressCallback({ type: 'error', message: e.message });


### PR DESCRIPTION
Refs #2787, first PR towards original propossed solution.

**Scope and Tasks of this PR:**
- [x] Add parsing and validation of yaml config(Used [ajv](https://www.npmjs.com/package/ajv) for now, would update if maintainers suggests so.)
- [x] Add batch installation module (reuses `PluginManager` for installation, URL and version validations ...)
- [x] Install specific versions pinned, else latest
- [x] Add tests for batch installation module
- [x] Update CLI arguments to support both yaml config file files and direct artifact hub source URLs
- [x] Update Docs (document the plugin yml config)
- [x] Add concurrency control for parallel installations
- [x] add the ability to define DAG using dependencies relations in plugins

The plugin-level config option was removed for now, as it might cause unnecessary confusion, though saved the TODO-based implementation that I removed in git stash, can be redone if required.


---
## Testing:
**individual Plugin with URL:**
  `bin/headlamp-plugin.js install https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin --folderName tmp`
**Bulk installations:**
- Create a file plugin-config.yml:
``` yml
plugins:
  - name: test-app-catalog
    source: https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin
    version: 0.0.3
  - name: ai-plugin
    source: https://artifacthub.io/packages/headlamp/test-123/ai_plugin
    version: 0.0.2
  - name: prometheus
    source: https://artifacthub.io/packages/headlamp/test-123/prometheus_headlamp_plugin
    version: 0.0.3
    dependencies:
      - test-app-catalog

installOptions:
  parallel: true
  maxConcurrent: 2
```
- Then try out: `bin/headlamp-plugin.js install --config tmp/plugin-config.yml --folderName tmp` Make sure `tmp` directory is present.

**Unit Tests:**
For `jest` based tests:
  `f@f:~/w/oss/headlamp/plugins/headlamp-plugin$ npx jest plugin-management/*`
 