### PR TITLE
charts: Add headlamp-plugin sidecar for automated plugin management

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -177,6 +177,9 @@ spec:
             {{- if .Values.config.inCluster }}
             - "-in-cluster"
             {{- end }}
+            {{- if .Values.config.watchPlugins }}
+            - "-watch-plugins-changes"
+            {{- end }}
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
             {{- end }}
@@ -238,10 +241,39 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.pluginsManager.enabled .Values.volumeMounts }}
           volumeMounts:
+            {{- if .Values.pluginsManager.enabled }}
+            - name: plugins-dir
+              mountPath: {{ .Values.config.pluginsDir }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
+        {{- if .Values.pluginsManager.enabled }}
+        - name: headlamp-plugin
+
+          image: {{ .Values.pluginsManager.baseImage }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Installing headlamp-plugin globally..."
+              npm install -g @kinvolk/headlamp-plugin@{{ .Values.pluginsManager.version }}
+              echo "Installed headlamp-plugin successfully."
+              if [ -f "/config/plugin.yml" ]; then
+                echo "Installing plugins from config..."
+                cat /config/plugin.yml
+                headlamp-plugin install --config /config/plugin.yml --folderName {{ .Values.config.pluginsDir }} --watch
+              fi
+          volumeMounts:
+            - name: plugins-dir
+              mountPath: {{ .Values.config.pluginsDir }}
+            - name: plugin-config
+              mountPath: /config
+          resources:
+            {{- toYaml .Values.pluginsManager.resources | nindent 12 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -254,7 +286,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.volumes}}
+      {{- if or .Values.pluginsManager.enabled .Values.volumes }}
       volumes:
+        {{- if .Values.pluginsManager.enabled }}
+        - name: plugins-dir
+          emptyDir: {}
+        - name: plugin-config
+          configMap:
+            name: {{ include "headlamp.fullname" . }}-plugin-config
+        {{- end }}
+        {{- with .Values.volumes}}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}

--- a/charts/headlamp/templates/plugin-configmap.yaml
+++ b/charts/headlamp/templates/plugin-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.pluginsManager.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "headlamp.fullname" . }}-plugin-config
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+data:
+  plugin.yml: |
+    {{ .Values.pluginsManager.configContent | nindent 4 }}
+{{- end }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -91,6 +91,7 @@ config:
       name: ""
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
+  watchPlugins: false
   # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.
   extraArgs: []
 
@@ -229,6 +230,27 @@ tolerations: []
 
 # -- Affinity settings for pod assignment
 affinity: {}
+
+# Plugin Manager Sidecar Container Configuration
+pluginsManager:
+  # -- Enable plugin manager
+  enabled: false
+  # -- Plugin configuration file name
+  configFile: "plugin.yml"
+  # -- Plugin configuration content in YAML format. This is required if plugins.enabled is true.
+  configContent: ""
+  # -- Base node image to use
+  baseImage: node:lts-alpine
+  # -- Headlamp plugin package version to install
+  version: latest
+  # -- Specify resrouces
+  # resources:
+  #   requests:
+  #     cpu: "500m"
+  #     memory: "2048Mi"
+  #   limits:
+  #     cpu: "1000m"
+  #     memory: "4096Mi"
 
 # -- Additional Kubernetes manifests to be deployed. Include the manifest as nested YAML.
 extraManifests: []

--- a/plugins/headlamp-plugin/README.md
+++ b/plugins/headlamp-plugin/README.md
@@ -55,10 +55,13 @@ headlamp-plugin --help
   headlamp-plugin.js install [URL]          Install plugin(s) from a configuration
                                             file or a plugin Artifact Hub URL.
                                             Options:
-                                            -c, --config: Path to config file
-                                            --folderName: Install folder name
-                                            --headlampVersion: Target version
-                                            -q, --quiet: Suppress logs
+                                                  --version          Show version number
+                                              -c, --config           Path to plugin configuration file
+                                                  --folderName       Name of the folder to install the plugin 
+                                                  --headlampVersion  Version of headlamp to install the plugin 
+                                              -q, --quiet            Do not print logs
+                                              -w, --watch            Watch config file for changes and automatically
+                                                                    reinstall plugins
   headlamp-plugin.js update [pluginName]    Update the plugin to the latest version.
   headlamp-plugin.js uninstall [pluginName] Uninstall the plugin.
 ```


### PR DESCRIPTION
Implemented headlamp-plugin sidecar container for plugin management.

- charts: Added `--watch-plugins-changes` option to charts for the main headlamp container
- headlamp-plugin: Added watch option for config file changes in bulk install
- headlamp-plugin: Added cleanup for removal of plugins (in case the user removes a plugin from the config file)
- charts: Mount plugin.yml using a configMap-based volume
- charts: do a global `@kinvolk/headlamp-plugin` install and watch the config file

## Testing

 For docs, see https://github.com/kubernetes-sigs/headlamp/pull/2983/files#diff-6ba75da13a137e0dc291f25e5514187d41c825abf7cc74cee9e238cffbf7d539

I've tested by using my published npm package from my account https://www.npmjs.com/package/@faakhir/headlamp-plugin
and building the headlamp server image locally, and overriding it by `minikube image load ghcr.io/headlamp-k8s/headlamp:v0.30.0`.

sample `plugin.yml` to try:

```
plugins:
  - name: test-app-catalog
    source: https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin
    version: 0.0.3
  - name: ai-plugin
    source: https://artifacthub.io/packages/headlamp/test-123/ai_plugin
    version: 0.0.2
  - name: prometheus
    source: https://artifacthub.io/packages/headlamp/test-123/prometheus_headlamp_plugin
    version: 0.0.3
    dependencies:
      - test-app-catalog

installOptions:
  parallel: true
  maxConcurrent: 2
```

**NOTES:**
- The latest `v0.30.0` version of  ghcr.io/headlamp-k8s/headlamp image does not include the `--watch-plugins-changes` flag. So would require a release for that image.
- Also, the headlamp-plugin package would require a release, though I could not see an NPM package release workflow. Does the headlamp do this manually from the terminal with `npm publish`?
- The sidecar container watch was having some delay sometimes on my minikube cluster during testing, not sure though if it was due to resource contention on my end only, because it is working fine when updating multiple times locally using `bin/headlamp-plugin.js install -c plugin.yml -w --folderName /home/f/w/oss/headlamp/plugins/headlamp-plugin/out`