### PR TITLE
frontend: pod: Add quick status for containers

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -472,7 +472,7 @@ export default function PodDetails(props: PodDetailsProps) {
         item && [
           {
             name: t('State'),
-            value: makePodStatusLabel(item),
+            value: makePodStatusLabel(item, false),
           },
           {
             name: t('Node'),

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Error.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Error.stories.storyshot
@@ -219,16 +219,20 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                        style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Error
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                          style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
+                        >
+                          Error
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
@@ -219,16 +219,20 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                        style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Init:0/2
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                          style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                        >
+                          Init:0/2
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
@@ -219,16 +219,20 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                        style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                      <div
+                        aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        CrashLoopBackOff
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                          style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                        >
+                          CrashLoopBackOff
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
@@ -219,16 +219,20 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label="Back-off pulling image "doesnotexist:nover""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                        style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                      <div
+                        aria-label="Back-off pulling image "doesnotexist:nover""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        ImagePullBackOff
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                          style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                        >
+                          ImagePullBackOff
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Running.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Running.stories.storyshot
@@ -219,16 +219,20 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                        style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Running
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                          style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                        >
+                          Running
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Successful.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Successful.stories.storyshot
@@ -219,16 +219,20 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                        style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Completed
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                          style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                        >
+                          Completed
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -944,16 +944,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label="Back-off pulling image "doesnotexist:nover""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                  <div
+                    aria-label="Back-off pulling image "doesnotexist:nover""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    ImagePullBackOff
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                    >
+                      ImagePullBackOff
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1085,16 +1092,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Completed
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                    >
+                      Completed
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1228,16 +1242,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Init:0/2
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(240, 240, 240); color: rgba(0, 0, 0, 0.87);"
+                    >
+                      Init:0/2
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1369,16 +1390,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                  <div
+                    aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    CrashLoopBackOff
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(255, 243, 224); color: rgb(196, 69, 0);"
+                    >
+                      CrashLoopBackOff
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1510,16 +1538,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Error
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(255, 235, 238); color: rgb(198, 40, 40);"
+                    >
+                      Error
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1651,16 +1686,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Running
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                    >
+                      Running
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1792,16 +1834,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Running
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                    >
+                      Running
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1933,16 +1982,23 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wvh8pc-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
-                    style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Running
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1q14vbw-MuiTypography-root"
+                      style="background-color: rgb(248, 255, 240); color: rgb(46, 125, 50);"
+                    >
+                      Running
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td


### PR DESCRIPTION
This change adds a new icon displaying the status of each container in the pods list. Hovering over the icon gives important info about the container at a glance: name, status, reason, exit code, and start/finish times.

Fixes: #2689 

### Testing
- [X] Navigate to the Pods page in Headlamp
- [X] Note the container status icon, and hover over to see additional info about the container

-----
![image](https://github.com/user-attachments/assets/c40e684f-2552-45b5-a3f4-c855bb8b8a99)
------
![image](https://github.com/user-attachments/assets/95f1cb5c-bfad-401c-ad00-4f5603af1cb0)