### PR TITLE
multiplexer: Fix token refresh for ws reconnection

### DIFF
--- a/frontend/src/lib/k8s/api/v2/webSocket.test.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.test.ts
@@ -448,6 +448,7 @@ describe('WebSocket Tests', () => {
         query,
         userId,
         type: 'REQUEST',
+        token: 'test-token', // Token is now included in resubscription messages
       });
 
       // Verify reconnection state is reset

--- a/frontend/src/lib/k8s/api/v2/webSocket.ts
+++ b/frontend/src/lib/k8s/api/v2/webSocket.ts
@@ -175,6 +175,7 @@ export const WebSocketManager = {
         query,
         userId: userId || '',
         type: 'REQUEST',
+        token: getToken(clusterId), // Include the current token to ensure it's fresh
       };
       socket.send(JSON.stringify(requestMsg));
     });


### PR DESCRIPTION
Updates the websocket implementation to refresh authentication tokens during reconnection. This fixes the mismatch between token lifetime and websocket lifetime by ensuring the backend always has the latest token from the frontend, even after reconnection.


### Testing

It is difficult to simulate a network disruption even when closing connection so the tests that I wrote help with that.

`TestGetOrCreateConnection_TokenRefresh`: When a new token is provided in a message, the connection's token is updated correctly.
`TestReconnect_WithToken`: During reconnection, the most recent token is used.

These tests provide good confidence that this change will correctly handle token refreshes during websocket reconnections.

- Run tests `cd backend && go test -v ./cmd -run "TestGetOrCreateConnection_TokenRefresh|TestReconnect_WithToken"`

