### PR TITLE
app: Allow commands to be run as elevated

### DIFF
--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -1,7 +1,8 @@
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { ChildProcessWithoutNullStreams,spawn } from 'child_process';
 import { app, BrowserWindow, dialog } from 'electron';
 import { IpcMainEvent } from 'electron/main';
 import fs from 'node:fs';
+import { platform } from 'os';
 import path from 'path';
 import i18n from './i18next.config';
 
@@ -20,6 +21,10 @@ interface CommandData {
    * See https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
    */
   options: {};
+  /**
+   * Whether the command needs elevated privileges (sudo/admin).
+   */
+  elevated?: boolean;
 }
 
 /**
@@ -99,6 +104,136 @@ function checkCommandConsent(command: string, mainWindow: BrowserWindow): boolea
 }
 
 /**
+ * Runs a command with elevated privileges using platform-specific methods.
+ *
+ * @param event - The IPC event used to communicate back with the renderer.
+ * @param eventData - The command data including ID, command, and arguments.
+ * @returns A promise that resolves when the command completes.
+ */
+function runElevatedCommand(event: IpcMainEvent, eventData: CommandData): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const cmd = eventData.command;
+    const args = eventData.args;
+    const cmdString = `${cmd} ${args.join(' ')}`;
+    let elevatedProcess: ChildProcessWithoutNullStreams | undefined;
+    const currentPlatform = platform();
+
+    try {
+      if (currentPlatform === 'win32') {
+        // On Windows, use PowerShell's Start-Process with -Verb RunAs to elevate
+        elevatedProcess = spawn(
+          'powershell.exe',
+          [
+            '-NoProfile',
+            '-Command',
+            `Start-Process -FilePath "${cmd}" -ArgumentList '${args.join(
+              ' '
+            )}' -Verb RunAs -Wait -WindowStyle Hidden`,
+          ],
+          { windowsHide: true }
+        );
+      } else if (currentPlatform === 'darwin') {
+        // On macOS, use osascript to show a GUI prompt for sudo
+        const escapedCmd = cmdString.replace(/"/g, '\\"');
+        elevatedProcess = spawn('osascript', [
+          '-e',
+          `do shell script "${escapedCmd}" with administrator privileges`,
+        ]);
+      } else {
+        // On Linux, use pkexec, gksudo, or sudo depending on what's available
+        const graphicalSudoCommands = [
+          { cmd: 'pkexec', args: [cmdString] },
+          { cmd: 'gksudo', args: ['--description', 'Headlamp', '--', cmdString] },
+          {
+            cmd: 'kdesudo',
+            args: ['--comment', 'Headlamp needs elevated privileges', '--', cmdString],
+          },
+          { cmd: 'sudo', args: ['-E', cmd, ...args] },
+        ];
+
+        // Find the first available sudo command
+        let foundSudo = false;
+        for (const sudoCommand of graphicalSudoCommands) {
+          try {
+            // Check if the command exists by trying to spawn it with --version
+            const checkResult = spawn(sudoCommand.cmd, ['--version']);
+            checkResult.on('error', (e) => {
+              // Command doesn't exist, will try the next one
+              console.log(`Command ${sudoCommand.cmd}: ${e}`);
+            });
+
+            checkResult.on('exit', code => {
+              if (code === 0 && !foundSudo) {
+                foundSudo = true;
+                console.log(`CommandFOUND ${sudoCommand.cmd}: ${foundSudo}`);
+                elevatedProcess = spawn(sudoCommand.cmd, sudoCommand.args);
+                setupProcessEvents(elevatedProcess);
+              }
+            });
+
+            // Don't wait for the check to complete, we'll try all commands and use the first one that works
+          } catch (error) {
+            // Just try the next command if this one doesn't exist
+            continue;
+          }
+        }
+
+        if (!foundSudo) {
+          // If no sudo command was found, fall back to basic sudo
+          // This will likely fail in a GUI app, but it's our last resort
+          elevatedProcess = spawn('sudo', [cmd, ...args]);
+          setupProcessEvents(elevatedProcess);
+        }
+      }
+
+      function setupProcessEvents(process: ChildProcessWithoutNullStreams) {
+        process.stdout.on('data', (data: Buffer) => {
+          event.sender.send('command-stdout', eventData.id, data.toString());
+        });
+
+        process.stderr.on('data', (data: Buffer) => {
+          event.sender.send('command-stderr', eventData.id, data.toString());
+        });
+
+        process.on('exit', (code: number | null) => {
+          event.sender.send('command-exit', eventData.id, code);
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`Process exited with code ${code}`));
+          }
+        });
+
+        process.on('error', error => {
+          console.error(`Failed to start elevated process: ${error.message}`);
+          event.sender.send(
+            'command-stderr',
+            eventData.id,
+            `Failed to start elevated process: ${error.message}`
+          );
+          event.sender.send('command-exit', eventData.id, 1);
+          reject(error);
+        });
+      }
+
+      if (!!elevatedProcess && currentPlatform !== 'linux') {
+        // For Windows and macOS, set up the process events
+        setupProcessEvents(elevatedProcess);
+      }
+    } catch (error) {
+      console.error(`Error executing elevated command: ${error.message}`);
+      event.sender.send(
+        'command-stderr',
+        eventData.id,
+        `Error executing elevated command: ${error.message}`
+      );
+      event.sender.send('command-exit', eventData.id, 1);
+      reject(error);
+    }
+  });
+}
+
+/**
  * Handles 'run-command' events from the renderer process.
  *
  * Spawns the requested command and sends 'command-stdout',
@@ -131,6 +266,29 @@ export function handleRunCommand(
   }
   if (!checkCommandConsent(eventData.command, mainWindow)) {
     return;
+  }
+console.log('>>>>>>>>>>>>>>>>>>>>', eventData.command, eventData.args, eventData.options);
+  // Handle elevated command requests with a dedicated confirmation dialog
+  if (eventData.elevated) {
+    const resp = dialog.showMessageBoxSync(mainWindow, {
+      title: i18n.t('Elevated Privileges Required'),
+      message: i18n.t('This command requires administrator privileges to run.'),
+      detail: `${eventData.command} ${eventData.args.join(' ')}`,
+      type: 'question',
+      buttons: [i18n.t('Run with privileges'), i18n.t('Cancel')],
+    });
+
+    if (resp === 0) {
+      runElevatedCommand(event, eventData).catch(err =>
+        console.error('Error in elevated command execution:', err)
+      );
+      return;
+    } else {
+      // User cancelled the elevation request
+      event.sender.send('command-stderr', eventData.id, 'Elevation request cancelled by user');
+      event.sender.send('command-exit', eventData.id, 1);
+      return;
+    }
   }
 
   const child: ChildProcessWithoutNullStreams = spawn(eventData.command, eventData.args, {

--- a/frontend/src/components/App/runCommand.ts
+++ b/frontend/src/components/App/runCommand.ts
@@ -27,7 +27,10 @@
 export function runCommand(
   command: 'minikube' | 'az',
   args: string[],
-  options: {}
+  options: {
+    elevated?: boolean;
+    [key: string]: any;
+  }
 ): {
   stdout: { on: (event: string, listener: (chunk: any) => void) => void };
   stderr: { on: (event: string, listener: (chunk: any) => void) => void };
@@ -45,7 +48,8 @@ export function runCommand(
   const stderr = new EventTarget();
   const exit = new EventTarget();
 
-  window.desktopApi.send('run-command', { id, command, args, options });
+  const {elevated, ...restOptions} = options;
+  window.desktopApi.send('run-command', { id, command, args, options: restOptions, elevated });
 
   window.desktopApi.receive('command-stdout', (cmdId: string, data: string) => {
     if (cmdId === id) {


### PR DESCRIPTION
Certain commands may need to be run as admin, e.g. creating VMs.
This patch adds a new option `elevated` to the run-command IPC call.

Tests in platforms:
- [ ] Linux (it's failing on WSL)
- [ ] Mac
- [ ] Windows

I added a temp way to test by adding a button to run an elevated command to the change-logo settings.

cc/ @sniok 