### PR TITLE
github/workflows/push-release-assets: Fix pushing assets

### DIFF
--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -65,6 +65,10 @@ jobs:
         run: |
           mkdir -p ./flattened-artifacts
           find ./artifacts -type f -not -path "*/\.*" -exec cp {} ./flattened-artifacts/ \;
+
+          # Remove blockmap files if they exist
+          find ./flattened-artifacts -type f -name "*.blockmap" -exec rm {} \;
+
           echo "Files prepared for upload:"
           ls -la ./flattened-artifacts/
 

--- a/app/scripts/push-release-assets/push-release-assets.js
+++ b/app/scripts/push-release-assets/push-release-assets.js
@@ -189,7 +189,7 @@ async function pushFiles(release, files) {
         repo,
         release_id: release.id,
         name: baseFileName,
-        data: `@${filePath}`,
+        data,
         headers,
       });
     } catch (e) {
@@ -282,7 +282,8 @@ async function main() {
     process.exit(1);
   }
 
-  pushFiles(release, [args.asset1].concat(args.asset2));
+  await pushFiles(release, [args.asset1].concat(args.asset2));
+  console.log('Files pushed successfully.');
 }
 
 main();


### PR DESCRIPTION
- app push-release-assets.js: Fix uploading actual file. Waits for app assets to be uploaded and actually uploads
the file data.
- github push-release-assets: Remove blockmap files before uploading