### PR TITLE
Improve WebSocket compatibility

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1132,6 +1132,7 @@ func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
 
 		r.Host = clusterURL.Host
 		r.Header.Set("X-Forwarded-Host", r.Host)
+		r.Header.Del("User-Agent")
 		r.URL.Host = clusterURL.Host
 		r.URL.Path = mux.Vars(r)["api"]
 		r.URL.Scheme = clusterURL.Scheme

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -343,18 +343,17 @@ func (m *Multiplexer) dialWebSocket(
 		HandshakeTimeout: HandshakeTimeout,
 	}
 
+	headers := http.Header{
+		"Origin": {host},
+	}
+
 	if token != nil {
-		dialer.Subprotocols = []string{
-			"base64.binary.k8s.io",
-			"base64url.bearer.authorization.k8s.io." + base64.RawStdEncoding.EncodeToString([]byte(*token)),
-		}
+		headers.Set("Authorization", "Bearer"+*token)
 	}
 
 	conn, resp, err := dialer.Dial(
 		wsURL,
-		http.Header{
-			"Origin": {host},
-		},
+		headers,
 	)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "dialing WebSocket")


### PR DESCRIPTION
Fixes #2970 

Certain k8s vendors don't support tokens via Sec-Websocket-Protocol value, so we need to use the Authorization header instead.
Certain k8s vendors will perform additional cors check when browser-like User-Agent is present, which we currently pass but now will just remove.


How to test:
 - Create rancher cluster
 - Open headlamp and check for websocket connections (live updates to lists, logs and attach features)