### PR TITLE
docs: Update links to APIs in the plugin functionality page

### DIFF
--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -40,7 +40,7 @@ These are:
 Thus, plugins only need to install dependencies that are not yet provided by Headlamp.
 If any dependencies already covered by Headlamp are installed by the plugins, ensure
 that they are the same version that Headlamp supports. These will not be bundled when
-[building the plugin](./building.md).
+[building the plugin](../building.md).
 Particularly, the mentioned modules will be replaced by their version that's included
 in a global object called `pluginLib`.
 
@@ -57,118 +57,118 @@ what we have so far:
 ### App Bar Action
 
 Show a component in the app bar (in the top right) with
-[registerAppBarAction](../api/plugin/registry/functions/registerappbaraction).
+[registerAppBarAction](../../api/plugin/registry/functions/registerappbaraction).
 
 ![screenshot of the header showing two actions](../images/podcounter_screenshot.png)
 
 - Example plugin shows [How To Register an App Bar Action](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/pod-counter)
-- API reference for [registerAppBarAction](../api/plugin/registry/functions/registerappbaraction)
+- API reference for [registerAppBarAction](../../api/plugin/registry/functions/registerappbaraction)
 
 ### App Logo
 
 Change the logo (at the top left) with
-[registerAppLogo](../api/plugin/registry/functions/registerapplogo).
+[registerAppLogo](../../api/plugin/registry/functions/registerapplogo).
 
 ![screenshot of the logo being changed](../images/change-logo.png)
 
 - Example plugin shows [How To Change The Logo](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/change-logo)
-- API reference for [registerAppLogo](../api/plugin/registry/functions/registerapplogo)
+- API reference for [registerAppLogo](../../api/plugin/registry/functions/registerapplogo)
 
 ### App Menus
 
 Add menus when Headlamp is running as an app.
-[Headlamp.setAppMenu](../api/plugin/lib/classes/Headlamp#setappmenu)
+[Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp#setappmenu)
 
 ![screenshot of the logo being changed](../images/app-menus.png)
 
 - Example plugin shows [How To Add App Menus](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/app-menus)
-- API reference for [Headlamp.setAppMenu](../api/plugin/lib/classes/Headlamp#setappmenu)
+- API reference for [Headlamp.setAppMenu](../../api/plugin/lib/classes/Headlamp#setappmenu)
 
 ### Cluster Chooser
 
 Change the Cluster Chooser button (in the middle top of the Headlamp app bar) with
-[registerClusterChooser](../api/plugin/registry/functions/registerclusterchooser).
+[registerClusterChooser](../../api/plugin/registry/functions/registerclusterchooser).
 
 ![screenshot of the cluster chooser button](../images/cluster-chooser.png)
 
 - Example plugin shows [How To Register Cluster Chooser button](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/clusterchooser)
-- API reference for [registerClusterChooser](../api/plugin/registry/functions/registerclusterchooser)
+- API reference for [registerClusterChooser](../../api/plugin/registry/functions/registerclusterchooser)
 
 ### Details View Header Action
 
 Show a component to the top right area of a detail view
 (in the area of the screenshot below that's highlighted as yellow)
-[registerDetailsViewHeaderAction](../api/plugin/registry/functions/registerdetailsviewheaderaction).
+[registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerdetailsviewheaderaction).
 
 ![screenshot of the header showing two actions](../images/header_actions_screenshot.png)
 
 - Example plugin shows [How To set a Details View Header Action](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/details-view)
-- API reference for [registerDetailsViewHeaderAction](../api/plugin/registry/functions/registerdetailsviewheaderaction)
+- API reference for [registerDetailsViewHeaderAction](../../api/plugin/registry/functions/registerdetailsviewheaderaction)
 
 ### Details View Section
 
-Change sections in cluster resources' details views with [registerDetailsViewSectionsProcessor](../api/plugin/registry/functions/registerdetailsviewsectionsprocessor). This allows you to remove, add, update, or shuffle sections within details views, including the back link.
+Change sections in cluster resources' details views with [registerDetailsViewSectionsProcessor](../../api/plugin/registry/functions/registerdetailsviewsectionsprocessor). This allows you to remove, add, update, or shuffle sections within details views, including the back link.
 
 Or simply append a component at the bottom of different details views with
-[registerDetailsViewSection](../api/plugin/registry/functions/registerdetailsviewsection).
+[registerDetailsViewSection](../../api/plugin/registry/functions/registerdetailsviewsection).
 
 ![screenshot of the appended Details View Section](../images/details-view.jpeg)
 
 - Example plugin shows [How To set a Details View Section](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/details-view)
-- API reference for [registerDetailsViewSection](../api/plugin/registry/functions/registerdetailsviewsection)
+- API reference for [registerDetailsViewSection](../../api/plugin/registry/functions/registerdetailsviewsection)
 
 ### Dynamic Clusters
 
 Set a cluster dynamically, rather than have the backend read it from configuration files.
-[Headlamp.setCluster](../api/plugin/lib/classes/Headlamp.md#setcluster).
+[Headlamp.setCluster](../../api/plugin/lib/classes/Headlamp.md#setcluster).
 
 - Example plugin shows [How To Dynamically Set a Cluster](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/dynamic-clusters)
-- API reference for [Headlamp.setCluster](../api/plugin/lib/classes/Headlamp.md#setcluster)
+- API reference for [Headlamp.setCluster](../../api/plugin/lib/classes/Headlamp.md#setcluster)
 
 ### Route
 
 Show a component (in Headlamps main area) at a given URL with
-[registerRoute](../api/plugin/registry/functions/registerroute).
+[registerRoute](../../api/plugin/registry/functions/registerroute).
 
 - Example plugin shows [How To Register a Route](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/sidebar), and how to remove a route.
-- API reference for [registerRoute](../api/plugin/registry/functions/registerroute)
-- API reference for [registerRouteFilter](../api/plugin/registry/functions/registerroutefilter)
+- API reference for [registerRoute](../../api/plugin/registry/functions/registerroute)
+- API reference for [registerRouteFilter](../../api/plugin/registry/functions/registerroutefilter)
 
 ### Sidebar Item
 
 Add sidebar items (menu on the left) with
-[registerSidebarEntry](../api/plugin/registry/functions/registersidebarentry).
-Remove sidebar items with [registerSidebarEntryFilter](../api/plugin/registry/functions/registersidebarentryfilter).
+[registerSidebarEntry](../../api/plugin/registry/functions/registersidebarentry).
+Remove sidebar items with [registerSidebarEntryFilter](../../api/plugin/registry/functions/registersidebarentryfilter).
 
 ![screenshot of the sidebar being changed](../images/sidebar.png)
 
 - Example plugin shows [How To add items to the sidebar](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/sidebar), and also how to remove sidebar items.
-- API reference for [registerSidebarEntry](../api/plugin/registry/functions/registersidebarentry)
-- API reference for [registerSidebarEntryFilter](../api/plugin/registry/functions/registersidebarentryfilter)
+- API reference for [registerSidebarEntry](../../api/plugin/registry/functions/registersidebarentry)
+- API reference for [registerSidebarEntryFilter](../../api/plugin/registry/functions/registersidebarentryfilter)
 
 ### Tables
 
-Change what tables across Headlamp show with [registerResourceTableColumnsProcessor](../api/plugin/registry/functions/registersidebarentry). This allows you to remove, add, update, or shuffle table columns.
+Change what tables across Headlamp show with [registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registersidebarentry). This allows you to remove, add, update, or shuffle table columns.
 
 ![screenshot of the pods list with a context menu added by a plugin](../images/table-context-menu.png)
 
 - Example plugin shows [How to add a context menu to each row in the pods list table](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/tables).
-- API reference for [registerResourceTableColumnsProcessor](../api/plugin/registry/functions/registerresourcetablecolumnsprocessor)
+- API reference for [registerResourceTableColumnsProcessor](../../api/plugin/registry/functions/registerresourcetablecolumnsprocessor)
 
 ### Headlamp Events
 
 Headlamp has the concept of "Headlamp events". Those are fired when something relevant happens in Headlamp.
 
-React to Headlamp events with [registerHeadlampEventCallback](../api/plugin/registry/functions/registerheadlampeventcallback).
+React to Headlamp events with [registerHeadlampEventCallback](../../api/plugin/registry/functions/registerheadlampeventcallback).
 
 ![screenshot of a snackbar notification when an event occurred](../images/event-snackbar.png)
 
 - Example plugin shows [How to show snackbars for Headlamp events](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/headlamp-events).
-- API reference for [registerHeadlampEventCallback](../api/plugin/registry/functions/registerheadlampeventcallback)
+- API reference for [registerHeadlampEventCallback](../../api/plugin/registry/functions/registerheadlampeventcallback)
 
 ### Plugin Settings
 
-The plugins can have user-configurable settings that can be used to change the behavior of the plugin. The plugin settings can be created using [registerPluginSettings](../api/plugin/registry/functions/registerpluginsettings).
+The plugins can have user-configurable settings that can be used to change the behavior of the plugin. The plugin settings can be created using [registerPluginSettings](../../api/plugin/registry/functions/registerpluginsettings).
 
 - Example plugin shows [How to create plugin settings and use them](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/change-logo)
 


### PR DESCRIPTION
Fixes links on this page https://headlamp.dev/docs/latest/development/plugins/functionality/

how to test:
in frontend run `npm run build-typedoc`
in headlamp-website repo run `npm run start`, make sure you've linked the docs 