### PR TITLE
frontend: Add option to alphabetize sidebar items

### DIFF
--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { Box, MenuItem, Select } from '@mui/material';
+import { Box, MenuItem, Select, Switch } from '@mui/material';
 import { capitalize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,9 +20,11 @@ export default function Settings() {
   const settingsObj = useSettings();
   const storedTimezone = settingsObj.timezone;
   const storedRowsPerPageOptions = settingsObj.tableRowsPerPageOptions;
+  const storedSortSidebar = settingsObj.sidebarSortAlphabetically;
   const [selectedTimezone, setSelectedTimezone] = useState<string>(
     storedTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone
   );
+  const [sortSidebar, setSortSidebar] = useState<boolean>(storedSortSidebar);
   const dispatch = useDispatch();
   const themeName = useTypedSelector(state => state.theme.name);
   const appThemes = useAppThemes();
@@ -34,6 +36,14 @@ export default function Settings() {
       })
     );
   }, [selectedTimezone]);
+
+  useEffect(() => {
+    dispatch(
+      setAppSettings({
+        sidebarSortAlphabetically: sortSidebar,
+      })
+    );
+  }, [sortSidebar]);
 
   return (
     <SectionBox
@@ -99,6 +109,16 @@ export default function Settings() {
                   onChange={name => setSelectedTimezone(name)}
                 />
               </Box>
+            ),
+          },
+          {
+            name: t('translation|Sort sidebar items alphabetically'),
+            value: (
+              <Switch
+                color="primary"
+                checked={sortSidebar}
+                onChange={e => setSortSidebar(e.target.checked)}
+              />
             ),
           },
         ]}

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -290,12 +290,12 @@
             </div>
           </dd>
           <dt
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-iqixpy-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
           >
             Timezone to display for dates
           </dt>
           <dd
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-1xrovmc-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
           >
             <div
               class="MuiBox-root css-10rqxfs"
@@ -373,6 +373,36 @@
                 </div>
               </div>
             </div>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-iqixpy-MuiGrid-root"
+          >
+            Sort sidebar items alphabetically
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-1xrovmc-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1emuodk-MuiButtonBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
           </dd>
         </dl>
       </div>

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -73,6 +73,7 @@
   "Resource details view": "",
   "Number of rows for tables": "Zeilen pro Tabelle",
   "Timezone to display for dates": "Zeitzone",
+  "Sort sidebar items alphabetically": "",
   "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "Namespaces dürfen nur alphanumerische Kleinbuchstaben oder \"-\" enthalten und müssen mit einem alphanumerischen Zeichen beginnen und enden.",
   "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "",
   "Cluster Settings": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -73,6 +73,7 @@
   "Resource details view": "Resource details view",
   "Number of rows for tables": "Number of rows for tables",
   "Timezone to display for dates": "Timezone to display for dates",
+  "Sort sidebar items alphabetically": "Sort sidebar items alphabetically",
   "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.",
   "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.",
   "Cluster Settings": "Cluster Settings",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -73,6 +73,7 @@
   "Resource details view": "Vista de detalles del recurso",
   "Number of rows for tables": "Núm. de líneas para las tablas",
   "Timezone to display for dates": "Huso horario para mostrar en fechas",
+  "Sort sidebar items alphabetically": "",
   "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "Los espacios de nombre deben contener solo caracteres alfanuméricos en minúsculas o '-', y deben comenzar y terminar con un carácter alfanumérico.",
   "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "El nombre del cluster debe contener solo caracteres alfanuméricos en minúsculas o '-', y debe comenzar y terminar con un carácter alfanumérico.",
   "Cluster Settings": "Configuración del cluster",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -73,6 +73,7 @@
   "Resource details view": "",
   "Number of rows for tables": "Nombre de lignes pour les tableaux",
   "Timezone to display for dates": "Fuseau horaire à afficher pour les dates",
+  "Sort sidebar items alphabetically": "",
   "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "Les espaces de noms ne doivent contenir que des caractères alphanumériques minuscules ou '-', et doivent commencer et se terminer par un caractère alphanumérique.",
   "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "",
   "Cluster Settings": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -73,6 +73,7 @@
   "Resource details view": "Visualizzazione dettagli risorsa",
   "Number of rows for tables": "Numero di righe per le tabelle",
   "Timezone to display for dates": "Fuso orario per la visualizzazione delle date",
+  "Sort sidebar items alphabetically": "",
   "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "I namespace possono contenere solo caratteri alfanumerici minuscoli o '-', e devono iniziare e terminare con un carattere alfanumerico.",
   "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "Il nome del cluster può contenere solo caratteri alfanumerici minuscoli o '-', e deve iniziare e terminare con un carattere alfanumerico.",
   "Cluster Settings": "Impostazioni Cluster",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -73,6 +73,7 @@
   "Resource details view": "Vista de detalhes do recurso",
   "Number of rows for tables": "Núm. de linhas para as tabelas",
   "Timezone to display for dates": "Fuso horário para mostrar em datas",
+  "Sort sidebar items alphabetically": "",
   "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "Os namespaces devem conter apenas caracteres alfanuméricos minúsculos ou '-', e devem começar e terminar com um carácter alfanumérico.",
   "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "O nome do cluster deve conter apenas caracteres alfanuméricos minúsculos ou '-', e deve começar e terminar com um carácter alfanumérico.",
   "Cluster Settings": "Definições do Cluster",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -73,6 +73,7 @@
   "Resource details view": "資源詳細資訊檢視",
   "Number of rows for tables": "表格的行數",
   "Timezone to display for dates": "顯示日期的時區",
+  "Sort sidebar items alphabetically": "",
   "Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "命名空間只能包含小寫字母數字字元或 '-'，且必須以字母數字字元開頭和結尾。",
   "Cluster name must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character.": "叢集名稱只能包含小寫字母數字字元或 '-'，且必須以字母數字字元開頭和結尾。",
   "Cluster Settings": "叢集設定",

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -57,6 +57,7 @@ export const initialState: ConfigState = {
     tableRowsPerPageOptions:
       storedSettings.tableRowsPerPageOptions || defaultTableRowsPerPageOptions,
     timezone: storedSettings.timezone || defaultTimezone(),
+    sidebarSortAlphabetically: storedSettings.sidebarSortAlphabetically || false,
   },
 };
 


### PR DESCRIPTION
This change adds an option in the settings to sort the sidebar items alphabetically.

Fixes: #3061 

### Testing
- [X] Open the General Settings in Headlamp
- [X] Toggle the sidebar item sorting option

![image](https://github.com/user-attachments/assets/f474edbe-fb73-4dbb-b1e0-65cf1a3ae92e)
