### PR TITLE
frontend: Add 2 more default themes

### DIFF
--- a/frontend/src/components/App/themeSlice.ts
+++ b/frontend/src/components/App/themeSlice.ts
@@ -104,7 +104,75 @@ export const lightTheme: AppTheme = {
   radius: 6,
 };
 
-const defaultAppThemes = [lightTheme, darkTheme, headlampClassicLightTheme];
+export const lightsOutTheme: AppTheme = {
+  name: 'Lights Out',
+  base: 'dark',
+  primary: '#1f6feb',
+  secondary: '#212830',
+  text: {
+    primary: '#f0f6fc',
+  },
+  link: {
+    color: '#4493f8',
+  },
+  background: {
+    default: '#010409',
+    surface: '#0d1117',
+    muted: '#151b23',
+  },
+  sidebar: {
+    background: '#010409',
+    color: '#f0f6fc',
+    selectedBackground: '#484f57',
+    selectedColor: '#fff',
+    actionBackground: '#1f6feb',
+  },
+  navbar: {
+    background: '#010409',
+    color: '#bdc3c9',
+  },
+  radius: 6,
+  buttonTextTransform: 'none',
+};
+
+export const monochromeLightTheme: AppTheme = {
+  name: 'Monochrome Light',
+  base: 'light',
+  primary: '#25292e',
+  secondary: '#f6f8fa',
+  text: {
+    primary: '#1f2328',
+  },
+  link: {
+    color: '#0969da',
+  },
+  background: {
+    default: '#ffffff',
+    surface: '#ffffff',
+    muted: '#f6f8fa',
+  },
+  sidebar: {
+    background: '#fff',
+    color: '#59636e',
+    selectedBackground: '#333',
+    selectedColor: '#1f2328',
+    actionBackground: '#333436',
+  },
+  navbar: {
+    background: '#ffffff',
+    color: '#1f2328',
+  },
+  radius: 6,
+  buttonTextTransform: 'none',
+};
+
+const defaultAppThemes = [
+  lightTheme,
+  darkTheme,
+  headlampClassicLightTheme,
+  lightsOutTheme,
+  monochromeLightTheme,
+];
 
 export const initialState: ThemeState = {
   logo: null,


### PR DESCRIPTION
Adds 2 more themes. 

Monochrome Light

![localhost_3000_c_olek-test-cluster_statefulsets](https://github.com/user-attachments/assets/b7d435ff-e649-42b0-8811-29123de53fba)

Lights Out

![localhost_3000_c_olek-test-cluster_statefulsets (2)](https://github.com/user-attachments/assets/ae185d7a-0e95-4955-bde3-624804f4bcb8)

## Testing done

- Checked with "Accessibility Insights for Web" 
- Manually tested text contrast to verify accessible contrast level
- No a11y issues found
