### PR TITLE
eslint: documentaton: fix dead link to headlamp eslint-config

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/kubernetes-sigs/headlamp/issues"
   },
-  "homepage": "https://github.com/kubernetes-sigs/headlamp/eslint-config/README.md",
+  "homepage": "https://github.com/kubernetes-sigs/headlamp/blob/main/eslint-config/README.md",
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "eslint": "^8.57.0",


### PR DESCRIPTION
Due to restructuring the current present link is resulting in a 404.

No changes apart from correcting link pointing to correct README file