### PR TITLE
backend: fix helm repo test

### DIFF
--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -136,7 +136,7 @@ func TestUpdateRepo(t *testing.T) {
 		// update repository request
 		updateRepo := helm.AddUpdateRepoRequest{
 			Name: "headlamp_test_repo",
-			URL:  "https://headlamp-k8s-update-url.github.io/headlamp/",
+			URL:  "https://kubernetes-sigs-update-url.github.io/headlamp/",
 		}
 
 		updateRepoRequestJSON, err := json.Marshal(updateRepo)


### PR DESCRIPTION
## Description

Fixes the failing `repository_test.go` file, causing due to repo. migration.

Related to https://github.com/kubernetes-sigs/headlamp/actions/runs/14382933450/job/40331061953?pr=2976

PR: https://github.com/kubernetes-sigs/headlamp/pull/2976 