### PR TITLE
frontend: Add simplified Theme preview to Settings and Search

### DIFF
--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -14,6 +14,7 @@ import { setTheme, useAppThemes } from '../themeSlice';
 import DrawerModeSettings from './DrawerModeSettings';
 import { useSettings } from './hook';
 import NumRowsInput from './NumRowsInput';
+import { ThemePreview } from './ThemePreview';
 
 export default function Settings() {
   const { t } = useTranslation(['translation']);
@@ -72,7 +73,10 @@ export default function Settings() {
               >
                 {appThemes.map(it => (
                   <MenuItem key={it.name} value={it.name}>
-                    {capitalize(it.name)}
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <ThemePreview theme={it} />
+                      {capitalize(it.name)}
+                    </Box>
                   </MenuItem>
                 ))}
               </Select>

--- a/frontend/src/components/App/Settings/ThemePreview.tsx
+++ b/frontend/src/components/App/Settings/ThemePreview.tsx
@@ -1,0 +1,108 @@
+import { Box } from '@mui/system';
+import { useMemo } from 'react';
+import { AppTheme } from '../../../lib/AppTheme';
+import { createMuiTheme } from '../../../lib/themes';
+
+export function ThemePreview({ theme, size = 50 }: { theme: AppTheme; size?: number }) {
+  const muiTheme = useMemo(() => createMuiTheme(theme), [theme]);
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: size + 'px',
+        height: size + 'px',
+        background: muiTheme.palette.background.default,
+        border: '1px solid',
+        borderColor: muiTheme.palette.divider,
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        // Sidebar
+        sx={{
+          height: '100%',
+          width: '40%',
+          background: muiTheme.palette.sidebar.background,
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          borderRight: '1px solid',
+          borderColor: muiTheme.palette.divider,
+        }}
+      />
+
+      <Box
+        // Sidebar Selected Item
+        sx={{
+          position: 'absolute',
+          top: '30%',
+          left: '2%',
+          width: '36%',
+          background: muiTheme.palette.sidebar.selectedBackground,
+          zIndex: 1,
+          height: '5px',
+          borderRadius: muiTheme.shape.borderRadius / 4 + 'px',
+        }}
+      />
+
+      <Box
+        // Card 1
+        sx={{
+          position: 'absolute',
+          top: '25%',
+          left: '45%',
+          width: '22%',
+          height: '22%',
+          background: muiTheme.palette.background.muted,
+          zIndex: 2,
+          borderRadius: muiTheme.shape.borderRadius / 4 + 'px',
+          border: '1px solid',
+          borderColor: muiTheme.palette.divider,
+        }}
+      />
+
+      <Box
+        // Card 2
+        sx={{
+          position: 'absolute',
+          top: '25%',
+          left: '71%',
+          width: '22%',
+          height: '22%',
+          background: muiTheme.palette.background.muted,
+          zIndex: 2,
+          borderRadius: muiTheme.shape.borderRadius / 4 + 'px',
+          border: '1px solid',
+          borderColor: muiTheme.palette.divider,
+        }}
+      />
+
+      <Box
+        // Sidebar Action Button
+        sx={{
+          position: 'absolute',
+          bottom: '5%',
+          left: '10%',
+          width: '20%',
+          height: '5%',
+          background: muiTheme.palette.sidebar.actionBackground,
+          zIndex: 1,
+        }}
+      />
+
+      <Box
+        // Navbar
+        sx={{
+          position: 'absolute',
+          width: '100%',
+          borderBottom: '1px solid',
+          borderColor: muiTheme.palette.divider,
+          background: muiTheme.palette.navbar.background,
+          height: '20%',
+        }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -150,7 +150,33 @@
                 role="combobox"
                 tabindex="0"
               >
-                Light
+                <div
+                  class="MuiBox-root css-axw7ok"
+                >
+                  <div
+                    class="MuiBox-root css-1ii52co"
+                  >
+                    <div
+                      class="MuiBox-root css-1f1uc6a"
+                    />
+                    <div
+                      class="MuiBox-root css-1z0uf79"
+                    />
+                    <div
+                      class="MuiBox-root css-5zxu0k"
+                    />
+                    <div
+                      class="MuiBox-root css-1oxk0si"
+                    />
+                    <div
+                      class="MuiBox-root css-jkymop"
+                    />
+                    <div
+                      class="MuiBox-root css-n01h7b"
+                    />
+                  </div>
+                  Light
+                </div>
               </div>
               <input
                 aria-hidden="true"

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -10,6 +10,7 @@ import {
   UseAutocompleteReturnValue,
 } from '@mui/material';
 import Fuse from 'fuse.js';
+import { capitalize } from 'lodash';
 import { lazy, Suspense, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -34,6 +35,7 @@ import StatefulSet from '../../lib/k8s/statefulSet';
 import { createRouteURL, getDefaultRoutes } from '../../lib/router';
 import { getClusterPrefixedPath } from '../../lib/util';
 import { useTypedSelector } from '../../redux/reducers/reducers';
+import { ThemePreview } from '../App/Settings/ThemePreview';
 import { setTheme, useAppThemes } from '../App/themeSlice';
 import { Delayed } from './Delayed';
 import { useRecent } from './useRecent';
@@ -225,7 +227,8 @@ export function GlobalSearchContent({
     return appThemes.map(theme => ({
       id: 'switch-theme-' + theme.name,
       subLabel: 'Theme',
-      label: theme.name,
+      icon: <ThemePreview theme={theme} size={32} />,
+      label: capitalize(theme.name),
       onClick: () => dispatch(setTheme(theme.name)),
     }));
   }, [appThemes]);


### PR DESCRIPTION
Add a little minimal preview of the theme 

![image](https://github.com/user-attachments/assets/2a356e68-261b-4732-bc08-fac14e827a52)
![image](https://github.com/user-attachments/assets/669a05cb-29c8-4da5-bd1a-932e559c3142)
![image](https://github.com/user-attachments/assets/a8d698f2-07bf-4389-8d3d-93e53b3d7e8a)
