### PR TITLE
charts: Improve Helm chart template testing

### DIFF
--- a/.github/workflows/helm-chart-template-test.yml
+++ b/.github/workflows/helm-chart-template-test.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - charts/**
       - '!charts/**/README.md'
+      - Makefile
+      - .github/workflows/helm-chart-template-test.yml
+      - charts/headlamp/tests/**
   push:
     branches:
       - main

--- a/Makefile
+++ b/Makefile
@@ -191,3 +191,7 @@ i18n:
 .PHONY: helm-template-test
 helm-template-test:
 	charts/headlamp/tests/test.sh
+
+.PHONY: helm-update-template-version
+helm-update-template-version:
+	charts/headlamp/tests/update-version.sh

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -229,6 +229,33 @@ env:
     value: "6443"
 ```
 
+## Contributing
+
+We welcome contributions to the Headlamp Helm chart! To contribute:
+
+1. Fork the repository and create your branch from `main`.
+2. Make your changes and test them thoroughly.
+3. Run Helm chart template tests to ensure your changes don't break existing functionality:
+
+   ```console
+   $ make helm-template-test
+   ```
+   This command executes the script at `charts/headlamp/tests/test.sh` to validate Helm chart templates against expected templates.
+
+4. If you've made changes that intentionally affect the rendered templates (like version updates or new features):
+
+   ```console
+   $ make helm-update-template-version
+   ```
+   This updates the expected templates with the current versions from Chart.yaml and only shows files where versions changed.
+
+5. Review the updated templates carefully to ensure they contain only your intended changes.
+
+6. Submit a pull request with a clear description of your changes.
+
+
+For more details, refer to our [contributing guidelines](https://github.com/kubernetes-sigs/headlamp/blob/main/CONTRIBUTING.md).
+
 ## Links
 
 - [GitHub Repository](https://github.com/kubernetes-sigs/headlamp)

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -25,10 +25,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,13 +45,14 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
+  
   ports:
     - port: 80
       targetPort: http
@@ -62,15 +63,18 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -94,13 +98,14 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.23.1"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           env:
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
+            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -25,10 +25,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,10 +45,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -71,10 +71,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -98,7 +98,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.28.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -42,10 +42,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -62,10 +62,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -88,10 +88,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -115,7 +115,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.28.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -29,10 +29,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49,10 +49,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -102,7 +102,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.28.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -25,10 +25,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,10 +45,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -71,10 +71,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -98,7 +98,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.28.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -17,10 +17,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37,10 +37,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -63,10 +63,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -90,7 +90,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.28.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -17,10 +17,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37,10 +37,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -63,10 +63,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -90,7 +90,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.28.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           # Check if externalSecret is enabled

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -25,10 +25,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,10 +45,10 @@ kind: Service
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -71,10 +71,10 @@ kind: Deployment
 metadata:
   name: headlamp
   labels:
-    helm.sh/chart: headlamp-0.28.0
+    helm.sh/chart: headlamp-0.30.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.28.0"
+    app.kubernetes.io/version: "0.30.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -98,7 +98,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.28.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.30.0"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/readme.md
+++ b/charts/headlamp/tests/readme.md
@@ -54,3 +54,43 @@ To run the Helm template testing for the Headlamp chart, follow these steps:
     ```
 
 This will execute the `charts/headlamp/tests/test.sh` script, which dynamically renders and compares Helm templates for different test cases against their expected templates.
+
+## Updating Template Versions
+
+When changes are made to the Helm chart that intentionally modify the rendered templates (such as version updates, new features, or bug fixes), you'll need to update the expected templates to match the new output. The `helm-update-template-version` command simplifies this process.
+
+### How Template Version Updates Work
+
+The template version update process:
+
+1. Reads the current chart version and app version from `Chart.yaml`
+2. Checks each expected template file for version references
+3. Only updates files where versions are outdated
+4. Provides concise output showing only which files required updates
+
+### When to Use Template Version Updates
+
+You should run the template version update when:
+
+- You've updated the Helm chart version in `Chart.yaml`
+- You've updated the app version in `Chart.yaml`
+- You've made intentional changes to templates that affect their rendered output
+- The `helm-template-test` command fails with template differences that are expected
+
+### Running Template Version Updates
+
+To update the expected templates with the current versions:
+
+```bash
+make helm-update-template-version
+```
+
+This executes the `charts/headlamp/tests/update-version.sh` script, which renders templates with current versions and updates the expected templates accordingly.
+
+### After Updating Template Versions
+
+After running the template version update:
+
+1. Review the changes to ensure they're as expected
+2. Run `helm-template-test` again to verify that tests now pass
+3. Commit the updated expected templates along with your chart changes

--- a/charts/headlamp/tests/test.sh
+++ b/charts/headlamp/tests/test.sh
@@ -3,15 +3,16 @@
 # Enable strict mode
 set -euo pipefail
 
+# This script only tests templates - it does not update them
+# To update templates, use update-version.sh
+
 # Set up variables
 CHART_DIR="./charts/headlamp"
 TEST_CASES_DIR="${CHART_DIR}/tests/test_cases"
 EXPECTED_TEMPLATES_DIR="${CHART_DIR}/tests/expected_templates"
 
-# Get the current chart, app and image version
-CURRENT_CHART_VERSION=$(grep '^version:' ${CHART_DIR}/Chart.yaml | awk '{print $2}')
-CURRENT_APP_VERSION=$(grep '^appVersion:' ${CHART_DIR}/Chart.yaml | awk '{print $2}')
-CURRENT_IMAGE_VERSION=$(grep '^appVersion:' ${CHART_DIR}/Chart.yaml | awk '{print $2}')
+# Print header information
+echo "Testing Helm chart templates against expected output..."
 
 # Function to render templates for a specific values file
 render_templates() {
@@ -19,41 +20,79 @@ render_templates() {
     output_dir="$2"
     # Render templates
     helm template headlamp ${CHART_DIR} --values ${values_file} > "${output_dir}/rendered_templates.yaml"
+    # Verify the file was created successfully
+    if [ ! -s "${output_dir}/rendered_templates.yaml" ]; then
+        echo "ERROR: Failed to render templates for ${values_file}"
+        exit 1
+    fi
 }
 
-# Function to update expected templates with the current versions
-update_versions_in_expected_templates() {
-    expected_file="$1"
-    # Replace the old chart version with the current chart version
-    sed -i.bak "s/helm.sh\/chart: headlamp-[0-9]\+\.[0-9]\+\.[0-9]\+/helm.sh\/chart: headlamp-${CURRENT_CHART_VERSION}/g" "${expected_file}"
-    # Replace the old app version with the current app version
-    sed -i.bak "s/app.kubernetes.io\/version: \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/app.kubernetes.io\/version: \"${CURRENT_APP_VERSION}\"/g" "${expected_file}"
-    # Replace the old image version with the current image version
-    sed -i.bak "s/ghcr.io\/headlamp-k8s\/headlamp:v[0-9]\+\.[0-9]\+\.[0-9]\+/ghcr.io\/headlamp-k8s\/headlamp:v${CURRENT_IMAGE_VERSION}/g" "${expected_file}"
-    rm -f "${expected_file}.bak"
+# Clean up function to handle errors and cleanup
+cleanup() {
+    # Get exit code
+    exit_code=$?
+
+    # Clean up any temporary files/directories
+    if [ -d "${CHART_DIR}/tests/defaultvaluetest" ]; then
+        rm -rf "${CHART_DIR}/tests/defaultvaluetest"
+    fi
+
+    # Clean up test case output directories
+    if [ "$(ls -A ${TEST_CASES_DIR} 2>/dev/null)" ]; then
+        for values_file in ${TEST_CASES_DIR}/*; do
+            case_name=$(basename "${values_file}")
+            if [ -d "${CHART_DIR}/tests/${case_name}_output" ]; then
+                rm -rf "${CHART_DIR}/tests/${case_name}_output"
+            fi
+        done
+    fi
+
+    # If exiting with error, help user understand what to do
+    if [ $exit_code -ne 0 ]; then
+        echo ""
+        echo "============================================="
+        echo "Test failed! To update expected templates to match current output:"
+        echo "  1. Review the differences above carefully"
+        echo "  2. If the changes are related to version, run:"
+        echo "     make helm-update-template-version"
+        echo "     This will update ALL expected templates with current Helm version"
+        echo "  3. Verify the changes and commit them"
+        echo "============================================="
+    fi
+
+    exit $exit_code
 }
+
+# Register cleanup function
+trap cleanup EXIT
 
 # Function to compare rendered templates with expected templates
 compare_templates() {
     values_file="$1"
     output_dir="$2"
     expected_file="$3"
+
     # Compare rendered template with expected template
     if ! diff_output=$(diff -u "${output_dir}/rendered_templates.yaml" "${expected_file}" 2>&1); then
-        echo "Template test failed for ${values_file} against ${expected_file}:"
+        echo "Template test FAILED for ${values_file} against ${expected_file}:"
         echo "${diff_output}"
+        echo "============================================="
+        echo "The rendered template does not match the expected template!"
+        echo "This could be due to changes in the chart or an outdated expected template."
+        echo "If this is an intentional change, update the expected template."
+        echo "============================================="
         exit 1
     else
-        echo "Template test passed for ${values_file} against ${expected_file}"
+        echo "Template test PASSED for ${values_file} against ${expected_file}"
     fi
 }
+
 
 # Check for default values.yaml test case
 mkdir -p "${CHART_DIR}/tests/defaultvaluetest"
 render_templates "${CHART_DIR}/values.yaml" ${CHART_DIR}/tests/defaultvaluetest
-update_versions_in_expected_templates ${CHART_DIR}/tests/defaultvaluetest/rendered_templates.yaml
-compare_templates "${CHART_DIR}/values.yaml" ${CHART_DIR}/tests/defaultvaluetest ${CHART_DIR}/tests/defaultvaluetest/rendered_templates.yaml
-rm -rf ${CHART_DIR}/tests/defaultvaluetest
+compare_templates "${CHART_DIR}/values.yaml" ${CHART_DIR}/tests/defaultvaluetest "${EXPECTED_TEMPLATES_DIR}/default.yaml"
+# Cleanup is handled by the cleanup function
 
 # Check if TEST_CASES_DIR is not empty
 if [ "$(ls -A ${TEST_CASES_DIR})" ]; then
@@ -69,12 +108,9 @@ if [ "$(ls -A ${TEST_CASES_DIR})" ]; then
             mkdir -p "${output_dir}"
             # Render templates for the current test case
             render_templates "${values_file}" "${output_dir}"
-            # Update expected template versions
-            update_versions_in_expected_templates "${expected_file}"
             # Compare rendered templates with expected templates for the current test case
             compare_templates "${values_file}" "${output_dir}" "${expected_file}"
-            # Clean up temporary files
-            rm -rf "${output_dir}"
+            # Cleanup is handled by the cleanup function
         else
             echo "No expected template found for ${values_file}. Skipping template testing."
         fi

--- a/charts/headlamp/tests/update-version.sh
+++ b/charts/headlamp/tests/update-version.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Enable strict mode
+set -euo pipefail
+
+# Set up variables
+CHART_DIR="./charts/headlamp"
+TEST_CASES_DIR="${CHART_DIR}/tests/test_cases"
+EXPECTED_TEMPLATES_DIR="${CHART_DIR}/tests/expected_templates"
+
+# Get the current chart, app and image version
+CURRENT_CHART_VERSION=$(grep '^version:' ${CHART_DIR}/Chart.yaml | awk '{print $2}')
+CURRENT_APP_VERSION=$(grep '^appVersion:' ${CHART_DIR}/Chart.yaml | awk '{print $2}')
+CURRENT_IMAGE_VERSION=$(grep '^appVersion:' ${CHART_DIR}/Chart.yaml | awk '{print $2}')
+
+echo "Checking and updating template versions..."
+echo "Using chart version: ${CURRENT_CHART_VERSION}, app version: ${CURRENT_APP_VERSION}, image version: ${CURRENT_IMAGE_VERSION}"
+
+# Function to render templates for a specific values file
+render_templates() {
+    values_file="$1"
+    output_dir="$2"
+    # Render templates
+    helm template headlamp ${CHART_DIR} --values ${values_file} > "${output_dir}/rendered_templates.yaml"
+    if [ ! -s "${output_dir}/rendered_templates.yaml" ]; then
+        echo "ERROR: Failed to render templates for ${values_file}"
+        exit 1
+    fi
+}
+
+# Check if versions need updating and update the expected template if needed
+check_and_update_template() {
+    case_name="$1"
+    values_file="$2"
+    
+    expected_file="${EXPECTED_TEMPLATES_DIR}/${case_name}"
+    needs_update=false
+    
+    # Check if versions need updating
+    if [ -f "${expected_file}" ]; then
+        # Check chart version
+        if ! grep -q "helm.sh/chart: headlamp-${CURRENT_CHART_VERSION}" "${expected_file}"; then
+            needs_update=true
+        fi
+        
+        # Check app version
+        if ! grep -q "app.kubernetes.io/version: \"${CURRENT_APP_VERSION}\"" "${expected_file}"; then
+            needs_update=true
+        fi
+        
+        # Check image version
+        if ! grep -q "ghcr.io/headlamp-k8s/headlamp:v${CURRENT_IMAGE_VERSION}" "${expected_file}"; then
+            needs_update=true
+        fi
+    else
+        # File doesn't exist, so it needs to be created
+        needs_update=true
+    fi
+    
+    if [ "$needs_update" = true ]; then
+        echo "${case_name}: Updating to version ${CURRENT_CHART_VERSION}..."
+        
+        # Create temporary output directory
+        output_dir="${CHART_DIR}/tests/update_${case_name}"
+        mkdir -p "${output_dir}"
+        
+        # Render the template
+        render_templates "${values_file}" "${output_dir}"
+        
+        # Update the expected template
+        cp "${output_dir}/rendered_templates.yaml" "${expected_file}"
+        
+        # Clean up
+        rm -rf "${output_dir}"
+    else
+        echo "${case_name}: Version ${CURRENT_CHART_VERSION} already up to date"  
+    fi
+}
+
+# Check and update default template
+check_and_update_template "default.yaml" "${CHART_DIR}/values.yaml"
+
+# Check and update templates for each test case
+if [ "$(ls -A ${TEST_CASES_DIR})" ]; then
+    for values_file in ${TEST_CASES_DIR}/*; do
+        case_name=$(basename "${values_file}")
+        check_and_update_template "${case_name}" "${values_file}"
+    done
+else
+    echo "No test cases found in ${TEST_CASES_DIR}."
+fi
+
+echo "Version check complete. Please review any changes before committing."


### PR DESCRIPTION
- Separates template testing from version updating.
- Fixes default test case comparison in test.sh
- Creates update-version.sh for version updates only
- Updates Makefile with helm-update-template-version target
- Adds documentation in README.md and tests/readme.md
- Improves GitHub workflow to catch all relevant changes

This change creates a cleaner workflow for testing and updating Helm chart templates, making it easier for contributors to validate their changes and update templates when needed.