### PR TITLE
frontend: Add multicluster support for details pages

### DIFF
--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -6,7 +6,8 @@ import { styled } from '@mui/material/styles';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { getCluster, getClusterGroup } from '../../lib/cluster';
+import { getCluster } from '../../lib/cluster';
+import { getSelectedClusters } from '../../lib/cluster';
 import { useClustersConf } from '../../lib/k8s';
 import { request } from '../../lib/k8s/apiProxy';
 import { Cluster } from '../../lib/k8s/cluster';
@@ -186,7 +187,7 @@ export default function Layout({}: LayoutProps) {
       });
   };
 
-  const urlClusters = getClusterGroup();
+  const urlClusters = getSelectedClusters();
   const clustersNotInURL =
     allClusters && urlClusters.length !== 0
       ? urlClusters.filter(clusterName => !Object.keys(allClusters).includes(clusterName))

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Redirect, Route, RouteProps, Switch, useHistory } from 'react-router-dom';
 import { getToken } from '../../lib/auth';
-import { getCluster, getClusterGroup } from '../../lib/cluster';
+import { getCluster, getSelectedClusters } from '../../lib/cluster';
 import { useClustersConf } from '../../lib/k8s';
 import {
   createRouteURL,
@@ -149,7 +149,7 @@ function AuthRoute(props: AuthRouteProps) {
     }
 
     if (requiresCluster) {
-      if (getClusterGroup().length > 1) {
+      if (getSelectedClusters().length > 1) {
         // In multi-cluster mode, we do not know if one of them requires a token.
         return children;
       }

--- a/frontend/src/components/Sidebar/ListItemLink.tsx
+++ b/frontend/src/components/Sidebar/ListItemLink.tsx
@@ -210,7 +210,13 @@ export default function ListItemLink(props: ListItemLinkProps) {
         })}
       >
         {listItemLinkContainer}
-        {!iconOnly && <ListItemText primary={primary} secondary={subtitle} />}
+        {!iconOnly && (
+          <ListItemText
+            primary={primary}
+            secondary={subtitle}
+            secondaryTypographyProps={{ sx: { whiteSpace: 'pre' } }}
+          />
+        )}
       </ListItemButton>
     </StyledLi>
   );

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -4,7 +4,7 @@ import ListItem, { ListItemProps } from '@mui/material/ListItem';
 import React, { memo } from 'react';
 import { generatePath } from 'react-router';
 import { getClusterPrefixedPath } from '../../lib/cluster';
-import { useCluster } from '../../lib/k8s';
+import { useSelectedClusters } from '../../lib/k8s';
 import { createRouteURL, getRoute } from '../../lib/router';
 import ListItemLink from './ListItemLink';
 import { SidebarEntry } from './sidebarSlice';
@@ -43,11 +43,12 @@ const SidebarItem = memo((props: SidebarItemProps) => {
     hide,
     ...other
   } = props;
-  const cluster = useCluster();
-
+  const clusters = useSelectedClusters();
   let fullURL = url;
-  if (fullURL && useClusterURL && cluster) {
-    fullURL = generatePath(getClusterPrefixedPath(url), { cluster });
+  if (fullURL && useClusterURL && clusters.length) {
+    fullURL = generatePath(getClusterPrefixedPath(url), {
+      cluster: clusters.length ? clusters.join('+') : '',
+    });
   }
 
   if (!fullURL) {

--- a/frontend/src/components/Sidebar/useSidebarItems.ts
+++ b/frontend/src/components/Sidebar/useSidebarItems.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isElectron } from '../../helpers/isElectron';
-import { useCluster } from '../../lib/k8s';
+import { useSelectedClusters } from '../../lib/k8s';
 import { createRouteURL } from '../../lib/router';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 import { DefaultSidebars, SidebarItemProps } from '.';
@@ -34,11 +34,11 @@ const sortSidebarItems = (items: SidebarItemProps[]): SidebarItemProps[] => {
 
 export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER) => {
   const clusters = useTypedSelector(state => state.config.clusters) ?? {};
+  const settings = useTypedSelector(state => state.config.settings);
   const customSidebarEntries = useTypedSelector(state => state.sidebar.entries);
   const customSidebarFilters = useTypedSelector(state => state.sidebar.filters);
-  const settings = useTypedSelector(state => state.config.settings);
   const shouldShowHomeItem = isElectron() || Object.keys(clusters).length !== 1;
-  const cluster = useCluster();
+  const selectedClusters = useSelectedClusters();
   const { t } = useTranslation();
 
   const sidebars = useMemo(() => {
@@ -93,8 +93,8 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
       },
       {
         name: 'cluster',
-        label: t('glossary|Cluster'),
-        subtitle: cluster || undefined,
+        label: selectedClusters.length ? t('Clusters') : t('glossary|Cluster'),
+        subtitle: selectedClusters.join('\n') || undefined,
         icon: 'mdi:hexagon-multiple-outline',
         subList: [
           {
@@ -369,7 +369,13 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
     }
 
     return sidebars;
-  }, [customSidebarEntries, shouldShowHomeItem, Object.keys(clusters).join(','), cluster, t]);
+  }, [
+    customSidebarEntries,
+    shouldShowHomeItem,
+    Object.keys(clusters).join(','),
+    selectedClusters.join(','),
+    t,
+  ]);
 
   const unsortedItems =
     sidebars[sidebarName === '' ? DefaultSidebars.IN_CLUSTER : sidebarName] ?? [];

--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -19,7 +19,7 @@ import { generatePath } from 'react-router';
 import { useHistory } from 'react-router-dom';
 import { isElectron } from '../../helpers/isElectron';
 import { getRecentClusters, setRecentCluster } from '../../helpers/recentClusters';
-import { useCluster, useClustersConf } from '../../lib/k8s';
+import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import { Cluster } from '../../lib/k8s/cluster';
 import { createRouteURL } from '../../lib/router';
 import { getCluster, getClusterPrefixedPath } from '../../lib/util';
@@ -76,7 +76,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
       node.focus();
     }
   }, []);
-  const currentCluster = useCluster();
+  const selectedClusters = useSelectedClusters();
 
   function handleClose() {
     setFilter('');
@@ -99,7 +99,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
 
     allClusters.forEach(c => {
       const cluster = { ...c };
-      if (c.name === currentCluster) {
+      if (selectedClusters.includes(c.name)) {
         cluster.isCurrent = true;
       }
 
@@ -131,7 +131,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
     });
 
     return [recentClusters, clustersToShow];
-  }, [clusters, currentCluster, filter]);
+  }, [clusters, selectedClusters.join(','), filter]);
 
   React.useEffect(() => {
     setActiveDescendantIndex(-1);

--- a/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
+++ b/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
@@ -1,7 +1,7 @@
 import { Alert, AlertTitle, Box, Button } from '@mui/material';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useClusterGroup } from '../../lib/k8s';
+import { useSelectedClusters } from '../../lib/k8s';
 import { ApiError } from '../../lib/k8s/api/v2/ApiError';
 
 export interface ClusterGroupErrorMessageProps {
@@ -21,7 +21,7 @@ export function ClusterGroupErrorMessage({ errors }: ClusterGroupErrorMessagePro
 
 function ErrorMessage({ error }: { error: ApiError }) {
   const { t } = useTranslation();
-  const showClusterName = useClusterGroup().length > 1;
+  const showClusterName = useSelectedClusters().length > 1;
   const [showMessage, setShowMessage] = useState(false);
 
   const defaultTitle = t('Failed to load resources');

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Link as RouterLink } from 'react-router-dom';
+import { getCluster } from '../../lib/cluster';
 import { kubeObjectQueryKey, useEndpoints } from '../../lib/k8s/api/v2/hooks';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import { createRouteURL, RouteURLProps } from '../../lib/router';
@@ -123,6 +124,10 @@ export default function Link(props: React.PropsWithChildren<LinkProps | LinkObje
   const { tooltip, ...propsRest } = props as LinkObjectProps;
 
   const kind = 'kubeObject' in props ? props.kubeObject?._class().kind : props?.routeName;
+  const cluster =
+    'kubeObject' in props && props.kubeObject?.cluster
+      ? props.kubeObject?.cluster
+      : getCluster() ?? '';
 
   const openDrawer =
     drawerEnabled && canRenderDetails(kind)
@@ -142,9 +147,10 @@ export default function Link(props: React.PropsWithChildren<LinkProps | LinkObje
                     name: props.params?.crName,
                     namespace,
                   },
+                  cluster,
                   customResourceDefinition: props.params?.crd,
                 }
-              : { kind, metadata: { name, namespace } };
+              : { kind, metadata: { name, namespace }, cluster };
 
           dispatch(setSelectedResource(selectedResource));
         }

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -61,7 +61,11 @@ export default function AuthVisible(props: AuthVisibleProps) {
     ],
     queryFn: async () => {
       try {
-        const res = await item!.getAuthorization(authVerb, { subresource, namespace });
+        const res = await item!.getAuthorization(
+          authVerb,
+          { subresource, namespace },
+          (item as any).cluster
+        );
         return res;
       } catch (e: any) {
         onError?.(e);

--- a/frontend/src/components/common/Resource/CreateButton.tsx
+++ b/frontend/src/components/common/Resource/CreateButton.tsx
@@ -7,7 +7,7 @@ import Select from '@mui/material/Select';
 import { alpha } from '@mui/system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useClusterGroup } from '../../../lib/k8s';
+import { useSelectedClusters } from '../../../lib/k8s';
 import ActionButton from '../ActionButton';
 import EditorDialog from './EditorDialog';
 
@@ -21,7 +21,7 @@ export default function CreateButton(props: CreateButtonProps) {
   const [openDialog, setOpenDialog] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
   const { t } = useTranslation(['translation']);
-  const clusters = useClusterGroup();
+  const clusters = useSelectedClusters();
   const [targetCluster, setTargetCluster] = React.useState(clusters[0] || '');
 
   // We want to avoid resetting the dialog state on close.

--- a/frontend/src/components/common/Resource/DetailsDrawer.tsx
+++ b/frontend/src/components/common/Resource/DetailsDrawer.tsx
@@ -65,7 +65,11 @@ export default function DetailsDrawer() {
         <Box>
           {selectedResource && (
             <KubeObjectDetails
-              resource={{ kind: selectedResource.kind, metadata: selectedResource.metadata }}
+              resource={{
+                kind: selectedResource.kind,
+                metadata: selectedResource.metadata,
+                cluster: selectedResource.cluster,
+              }}
               customResourceDefinition={selectedResource.customResourceDefinition}
             />
           )}

--- a/frontend/src/components/common/Resource/MetadataDisplay.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.tsx
@@ -4,7 +4,7 @@ import IconButton from '@mui/material/IconButton';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ResourceClasses } from '../../../lib/k8s';
+import { ResourceClasses, useSelectedClusters } from '../../../lib/k8s';
 import { KubeOwnerReference } from '../../../lib/k8s/cluster';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { localeDate } from '../../../lib/util';
@@ -36,6 +36,8 @@ export interface MetadataDisplayProps<T extends KubeObject = KubeObject> {
 export function MetadataDisplay<T extends KubeObject>(props: MetadataDisplayProps<T>) {
   const { resource, extraRows } = props;
   const { t } = useTranslation();
+  const shouldShowCluster = useSelectedClusters().length > 1;
+
   let makeExtraRows: ExtraRowsFunc<T>;
 
   function makeOwnerReferences(ownerReferences: KubeOwnerReference[]) {
@@ -103,6 +105,10 @@ export function MetadataDisplay<T extends KubeObject>(props: MetadataDisplayProp
         ),
         hide: !resource.metadata.namespace,
       },
+      shouldShowCluster && {
+        name: t('glossary|Cluster'),
+        value: resource.cluster,
+      },
       {
         name: t('Creation'),
         value: localeDate(resource.metadata.creationTimestamp),
@@ -127,7 +133,7 @@ export function MetadataDisplay<T extends KubeObject>(props: MetadataDisplayProp
         value: makeOwnerReferences(resource.metadata.ownerReferences || []),
         hide: !resource.metadata.ownerReferences || resource.metadata.ownerReferences.length === 0,
       },
-    ] as NameValueTableRow[]
+    ].filter(Boolean) as NameValueTableRow[]
   ).concat(makeExtraRows(resource) || []);
 
   return (

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -956,7 +956,7 @@ export function ContainerInfo(props: ContainerInfoProps) {
 }
 
 export interface OwnedPodsSectionProps {
-  resource: KubeObjectInterface;
+  resource: KubeObject;
   hideColumns?: PodListProps['hideColumns'];
   /**
    * Hides the namespace selector
@@ -975,8 +975,11 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   }
   const queryData = {
     namespace,
-    labelSelector: resource?.spec?.selector ? labelSelectorToQuery(resource?.spec?.selector) : '',
+    labelSelector: resource?.jsonData?.spec?.selector
+      ? labelSelectorToQuery(resource?.jsonData?.spec?.selector)
+      : '',
     fieldSelector: resource.kind === 'Node' ? `spec.nodeName=${resource.metadata.name}` : undefined,
+    cluster: resource.cluster,
   };
 
   const { items: pods, errors } = Pod.useList(queryData);

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -1,9 +1,9 @@
-import { MenuItem, TableCellProps } from '@mui/material';
+import { Box, MenuItem, TableCellProps } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { MRT_FilterFns, MRT_Row, MRT_SortingFn, MRT_TableInstance } from 'material-react-table';
 import { ComponentProps, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useClusterGroup } from '../../../lib/k8s';
+import { useSelectedClusters } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/apiProxy';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { KubeObjectClass } from '../../../lib/k8s/KubeObject';
@@ -291,7 +291,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
   const { t } = useTranslation(['glossary', 'translation']);
   const theme = useTheme();
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
-  const clusters = useClusterGroup();
+  const clusters = useSelectedClusters();
   const tableProcessors = useTypedSelector(state => state.resourceTable.tableColumnsProcessors);
   const defaultFilterFunc = useFilterFunc();
   const [columnVisibility, setColumnVisibility] = useState(() =>
@@ -409,6 +409,10 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
             return {
               id: 'cluster',
               header: t('glossary|Cluster'),
+              gridTemplate: 'min-content',
+              Cell: ({ row }: { row: MRT_Row<RowItem> }) => (
+                <Box sx={{ whiteSpace: 'nowrap' }}>{row.original.cluster}</Box>
+              ),
               accessorFn: (resource: KubeObject) => resource.cluster,
             };
           case 'type':

--- a/frontend/src/components/configmap/Details.tsx
+++ b/frontend/src/components/configmap/Details.tsx
@@ -6,9 +6,13 @@ import { DataField, DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import { NameValueTable, NameValueTableRow } from '../common/SimpleTable';
 
-export default function ConfigDetails(props: { name?: string; namespace?: string }) {
+export default function ConfigDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['translation']);
 
   return (
@@ -16,6 +20,7 @@ export default function ConfigDetails(props: { name?: string; namespace?: string
       resourceType={ConfigMap}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraSections={item =>
         item && [

--- a/frontend/src/components/crd/CustomResourceDetails.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.tsx
@@ -20,15 +20,17 @@ export interface CustomResourceDetailsProps {
   crd: string;
   crName: string;
   namespace: string;
+  cluster?: string;
 }
 
 export function CustomResourceDetails({
   crd: crdName,
   crName,
   namespace: ns,
+  cluster,
 }: CustomResourceDetailsProps) {
   const { t } = useTranslation('glossary');
-  const [crd, error] = CustomResourceDefinition.useGet(crdName);
+  const [crd, error] = CustomResourceDefinition.useGet(crdName, undefined, { cluster });
 
   const namespace = ns === '-' ? undefined : ns;
 
@@ -47,7 +49,12 @@ export function CustomResourceDetails({
       <Loader title={t('translation|Loading custom resource details')} />
     )
   ) : (
-    <CustomResourceDetailsRenderer crd={crd} crName={crName} namespace={namespace} />
+    <CustomResourceDetailsRenderer
+      crd={crd}
+      crName={crName}
+      namespace={namespace}
+      cluster={cluster}
+    />
   );
 }
 
@@ -101,15 +108,16 @@ export interface CustomResourceDetailsRendererProps {
   crd: CustomResourceDefinition;
   crName: string;
   namespace?: string;
+  cluster?: string;
 }
 
 function CustomResourceDetailsRenderer(props: CustomResourceDetailsRendererProps) {
-  const { crd, crName, namespace } = props;
+  const { crd, crName, namespace, cluster } = props;
 
   const { t } = useTranslation('glossary');
 
   const CRClass = React.useMemo(() => crd.makeCRClass(), [crd]);
-  const [item, error] = CRClass.useGet(crName, namespace);
+  const [item, error] = CRClass.useGet(crName, namespace, { cluster });
 
   const apiVersion = item?.jsonData.apiVersion?.split('/')[1] || '';
   const extraColumns: AdditionalPrinterColumns = getExtraColumns(crd, apiVersion) || [];

--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -121,9 +121,13 @@ function SpawnJobDialog(props: { cronJob: CronJob; onClose: () => void }) {
   );
 }
 
-export default function CronJobDetails(props: { name?: string; namespace?: string }) {
+export default function CronJobDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
 
   const { t, i18n } = useTranslation('glossary');
   const dispatch: AppDispatch = useDispatch();
@@ -210,6 +214,7 @@ export default function CronJobDetails(props: { name?: string; namespace?: strin
       resourceType={CronJob}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       actions={actions}
       extraInfo={item =>

--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -132,8 +132,8 @@ export default function CronJobDetails(props: {
   const { t, i18n } = useTranslation('glossary');
   const dispatch: AppDispatch = useDispatch();
 
-  const { items: jobs, errors } = Job.useList({ namespace });
   const [cronJob] = CronJob.useGet(name, namespace);
+  const { items: jobs, errors } = Job.useList({ namespace, cluster: cronJob?.cluster });
   const [isSpawnDialogOpen, setIsSpawnDialogOpen] = useState(false);
   const [isPendingSuspend, setIsPendingSuspend] = useState(false);
   const isCronSuspended = cronJob?.spec.suspend;

--- a/frontend/src/components/daemonset/Details.tsx
+++ b/frontend/src/components/daemonset/Details.tsx
@@ -65,9 +65,13 @@ function TolerationsSection(props: TolerationsSection) {
   );
 }
 
-export default function DaemonSetDetails(props: { name?: string; namespace?: string }) {
+export default function DaemonSetDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   return (
@@ -75,6 +79,7 @@ export default function DaemonSetDetails(props: { name?: string; namespace?: str
       resourceType={DaemonSet}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/daemonset/Details.tsx
+++ b/frontend/src/components/daemonset/Details.tsx
@@ -100,7 +100,7 @@ export default function DaemonSetDetails(props: {
       extraSections={item => [
         {
           id: 'headlamp.daemonset-owned-pods',
-          section: <OwnedPodsSection resource={item?.jsonData} />,
+          section: <OwnedPodsSection resource={item} />,
         },
         {
           id: 'headlamp.daemonset-tolerations',

--- a/frontend/src/components/endpoints/Details.tsx
+++ b/frontend/src/components/endpoints/Details.tsx
@@ -8,9 +8,13 @@ import { DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
-export default function EndpointDetails(props: { name?: string; namespace?: string }) {
+export default function EndpointDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const location = useLocation();
   const { t } = useTranslation(['glossary', 'translation']);
 
@@ -19,6 +23,7 @@ export default function EndpointDetails(props: { name?: string; namespace?: stri
       resourceType={Endpoints}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       title={t('Endpoint')}
       withEvents
       extraSections={(item: KubeEndpoint) =>

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { generatePath, useHistory, useLocation, useRouteMatch } from 'react-router';
 import { FixedSizeList } from 'react-window';
-import { useClusterGroup, useClustersConf } from '../../lib/k8s';
+import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import ConfigMap from '../../lib/k8s/configMap';
 import CronJob from '../../lib/k8s/cronJob';
 import Deployment from '../../lib/k8s/deployment';
@@ -81,7 +81,7 @@ const classes: KubeObjectClass[] = [
  * Loads lists of Kubernetes objects for searching
  */
 function useSearchResources() {
-  const inACluster = useClusterGroup().length > 0;
+  const inACluster = useSelectedClusters().length > 0;
   const results = classes.map(cls => cls.useList({ clusters: inACluster ? undefined : [] }));
 
   return useMemo(() => {
@@ -141,7 +141,7 @@ export function GlobalSearchContent({
   const history = useHistory();
   const [query, setQuery] = useState(defaultValue ?? '');
   const clusters = useClustersConf() ?? {};
-  const selectedClusters = useClusterGroup();
+  const selectedClusters = useSelectedClusters();
 
   const [recent, bump] = useRecent('search-recent-items');
 

--- a/frontend/src/components/horizontalPodAutoscaler/Details.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/Details.tsx
@@ -3,9 +3,9 @@ import { useParams } from 'react-router-dom';
 import HPA from '../../lib/k8s/hpa';
 import { ConditionsSection, DetailsGrid, Link, SimpleTable } from '../common';
 
-export default function HpaDetails(props: { name?: string; namespace?: string }) {
+export default function HpaDetails(props: { name?: string; namespace?: string; cluster?: string }) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation();
 
   return (
@@ -13,6 +13,7 @@ export default function HpaDetails(props: { name?: string; namespace?: string })
       resourceType={HPA}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/ingress/ClassDetails.tsx
+++ b/frontend/src/components/ingress/ClassDetails.tsx
@@ -3,15 +3,16 @@ import { useParams } from 'react-router-dom';
 import IngressClass from '../../lib/k8s/ingressClass';
 import { DetailsGrid } from '../common/Resource';
 
-export default function IngressClassDetails(props: { name?: string }) {
+export default function IngressClassDetails(props: { name?: string; cluster?: string }) {
   const params = useParams<{ name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
   const { t } = useTranslation('glossary');
 
   return (
     <DetailsGrid
       resourceType={IngressClass}
       name={name}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -152,9 +152,13 @@ export function BackendFormat({ backend }: BackendFormatProps) {
   );
 }
 
-export default function IngressDetails(props: { name?: string; namespace?: string }) {
+export default function IngressDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
 
@@ -193,6 +197,7 @@ export default function IngressDetails(props: { name?: string; namespace?: strin
       resourceType={Ingress}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={ingress =>
         ingress && [

--- a/frontend/src/components/lease/Details.tsx
+++ b/frontend/src/components/lease/Details.tsx
@@ -3,9 +3,9 @@ import { useParams } from 'react-router';
 import { Lease } from '../../lib/k8s/lease';
 import { DateLabel, DetailsGrid } from '../common';
 
-export function LeaseDetails(props: { name?: string; namespace?: string }) {
+export function LeaseDetails(props: { name?: string; namespace?: string; cluster?: string }) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation();
 
   return (
@@ -13,6 +13,7 @@ export function LeaseDetails(props: { name?: string; namespace?: string }) {
       resourceType={Lease}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/limitRange/Details.tsx
+++ b/frontend/src/components/limitRange/Details.tsx
@@ -4,15 +4,16 @@ import { useParams } from 'react-router';
 import { LimitRange } from '../../lib/k8s/limitRange';
 import { DetailsGrid, MetadataDictGrid } from '../common';
 
-export function LimitRangeDetails(props: { name?: string; namespace?: string }) {
+export function LimitRangeDetails(props: { name?: string; namespace?: string; cluster?: string }) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['translation']);
   return (
     <DetailsGrid
       resourceType={LimitRange}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/namespace/Details.tsx
+++ b/frontend/src/components/namespace/Details.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { LimitRange } from '../../lib/k8s/limitRange';
-import Namespace, { KubeNamespace } from '../../lib/k8s/namespace';
+import Namespace from '../../lib/k8s/namespace';
 import ResourceQuota from '../../lib/k8s/resourceQuota';
 import { StatusLabel } from '../common/Label';
 import { ConditionsSection, DetailsGrid, OwnedPodsSection } from '../common/Resource';
@@ -41,11 +41,11 @@ export default function NamespaceDetails(props: { name?: string; cluster?: strin
           },
           {
             id: 'headlamp.namespace-owned-resourcequotas',
-            section: <NamespacedResourceQuotasSection resource={item?.jsonData} />,
+            section: <NamespacedResourceQuotasSection resource={item} />,
           },
           {
             id: 'headlamp.namespace-owned-limitranges',
-            section: <NamespacedLimitRangesSection resource={item?.jsonData} />,
+            section: <NamespacedLimitRangesSection resource={item} />,
           },
           {
             id: 'headlamp.namespace-owned-pods',
@@ -62,7 +62,7 @@ export default function NamespaceDetails(props: { name?: string; cluster?: strin
 }
 
 export interface NamespacedLimitRangesSectionProps {
-  resource: KubeNamespace;
+  resource: Namespace;
 }
 
 export function NamespacedLimitRangesSection(props: NamespacedLimitRangesSectionProps) {
@@ -70,6 +70,7 @@ export function NamespacedLimitRangesSection(props: NamespacedLimitRangesSection
 
   const { items: limitRanges, errors } = LimitRange.useList({
     namespace: resource.metadata.name,
+    cluster: resource.cluster,
   });
 
   return (
@@ -83,7 +84,7 @@ export function NamespacedLimitRangesSection(props: NamespacedLimitRangesSection
 }
 
 export interface NamespacedResourceQuotasSectionProps {
-  resource: KubeNamespace;
+  resource: Namespace;
 }
 
 export function NamespacedResourceQuotasSection(props: NamespacedResourceQuotasSectionProps) {
@@ -91,6 +92,7 @@ export function NamespacedResourceQuotasSection(props: NamespacedResourceQuotasS
 
   const { items: resourceQuotas, errors } = ResourceQuota.useList({
     namespace: resource.metadata.name,
+    cluster: resource.cluster,
   });
 
   return (

--- a/frontend/src/components/namespace/Details.tsx
+++ b/frontend/src/components/namespace/Details.tsx
@@ -49,9 +49,7 @@ export default function NamespaceDetails(props: { name?: string; cluster?: strin
           },
           {
             id: 'headlamp.namespace-owned-pods',
-            section: (
-              <OwnedPodsSection hideColumns={['namespace']} resource={item?.jsonData} noSearch />
-            ),
+            section: <OwnedPodsSection hideColumns={['namespace']} resource={item} noSearch />,
           },
           {
             id: 'headlamp.namespace-details-view',

--- a/frontend/src/components/namespace/Details.tsx
+++ b/frontend/src/components/namespace/Details.tsx
@@ -9,9 +9,9 @@ import DetailsViewSection from '../DetailsViewSection';
 import { LimitRangeRenderer } from '../limitRange/List';
 import { ResourceQuotaRenderer } from '../resourceQuota/List';
 
-export default function NamespaceDetails(props: { name?: string }) {
+export default function NamespaceDetails(props: { name?: string; cluster?: string }) {
   const params = useParams<{ name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   function makeStatusLabel(namespace: Namespace | null) {
@@ -23,6 +23,7 @@ export default function NamespaceDetails(props: { name?: string }) {
     <DetailsGrid
       resourceType={Namespace}
       name={name}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/networkpolicy/Details.tsx
+++ b/frontend/src/components/networkpolicy/Details.tsx
@@ -10,9 +10,13 @@ import NetworkPolicy, {
 } from '../../lib/k8s/networkpolicy';
 import { DetailsGrid, metadataStyles, NameValueTable, SectionBox } from '../common';
 
-export function NetworkPolicyDetails(props: { name?: string; namespace?: string }) {
+export function NetworkPolicyDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   function prepareMatchLabelsAndExpressions(
@@ -169,6 +173,7 @@ export function NetworkPolicyDetails(props: { name?: string; namespace?: string 
       resourceType={NetworkPolicy}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/networkpolicy/List.tsx
+++ b/frontend/src/components/networkpolicy/List.tsx
@@ -18,7 +18,6 @@ export function NetworkPolicyList() {
           gridTemplate: 'auto',
           label: t('translation|Type'),
           getValue: networkpolicy => {
-            console.log(networkpolicy);
             const isIngressAvailable =
               networkpolicy.jsonData.spec.ingress && networkpolicy.jsonData.spec.ingress.length > 0;
             const isEgressAvailable =

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -35,9 +35,9 @@ function NodeConditionsLabel(props: { node: Node }) {
   );
 }
 
-export default function NodeDetails(props: { name?: string }) {
+export default function NodeDetails(props: { name?: string; cluster?: string }) {
   const params = useParams<{ name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
   const { t } = useTranslation(['glossary']);
   const dispatch: AppDispatch = useDispatch();
 
@@ -186,6 +186,7 @@ export default function NodeDetails(props: { name?: string }) {
       <DetailsGrid
         resourceType={Node}
         name={name}
+        cluster={cluster}
         error={nodeError}
         headerSection={item => (
           <ChartsSection node={item} metrics={nodeMetrics} noMetrics={noMetrics} />

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -262,7 +262,7 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
             },
             {
               id: 'headlamp.node-owned-pods',
-              section: <OwnedPodsSection resource={item?.jsonData} />,
+              section: <OwnedPodsSection resource={item} />,
             },
           ]
         }

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -381,12 +381,13 @@ export interface PodDetailsProps {
   showLogsDefault?: boolean;
   name?: string;
   namespace?: string;
+  cluster?: string;
 }
 
 export default function PodDetails(props: PodDetailsProps) {
   const { showLogsDefault } = props;
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const [showLogs, setShowLogs] = React.useState(!!showLogsDefault);
   const [showTerminal, setShowTerminal] = React.useState(false);
   const { t } = useTranslation('glossary');
@@ -398,6 +399,7 @@ export default function PodDetails(props: PodDetailsProps) {
       resourceType={Pod}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       actions={item =>
         item && [

--- a/frontend/src/components/podDisruptionBudget/Details.tsx
+++ b/frontend/src/components/podDisruptionBudget/Details.tsx
@@ -4,9 +4,9 @@ import { useParams } from 'react-router-dom';
 import PDB from '../../lib/k8s/podDisruptionBudget';
 import { DetailsGrid, StatusLabel } from '../common';
 
-export default function PDBDetails(props: { name?: string; namespace?: string }) {
+export default function PDBDetails(props: { name?: string; namespace?: string; cluster?: string }) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
 
   function selectorsToJSX(selectors: string[]) {
     const values: ReactNode[] = [];
@@ -28,6 +28,7 @@ export default function PDBDetails(props: { name?: string; namespace?: string })
       resourceType={PDB}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/priorityClass/Details.tsx
+++ b/frontend/src/components/priorityClass/Details.tsx
@@ -3,15 +3,16 @@ import { useParams } from 'react-router-dom';
 import PriorityClass from '../../lib/k8s/priorityClass';
 import { DetailsGrid } from '../common';
 
-export default function PriorityClassDetails(props: { name?: string }) {
+export default function PriorityClassDetails(props: { name?: string; cluster?: string }) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
   const { t } = useTranslation(['translation']);
 
   return (
     <DetailsGrid
       resourceType={PriorityClass}
       name={name}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
@@ -38,7 +38,7 @@ import WorkloadDetails from '../../workload/Details';
 
 const kindComponentMap: Record<
   string,
-  (props: { name?: string; namespace?: string }) => ReactElement
+  (props: { name?: string; namespace?: string; cluster?: string }) => ReactElement
 > = {
   Pod: PodDetails,
   Deployment: props => <WorkloadDetails {...props} workloadKind={Deployment} />,
@@ -97,11 +97,12 @@ export const KubeObjectDetails = memo(
   }: {
     resource: {
       kind: string;
+      cluster?: string;
       metadata: { name: string; namespace?: string };
     };
     customResourceDefinition?: string;
   }) => {
-    const kind = resource.kind;
+    const { cluster, kind } = resource;
     const { name, namespace } = resource.metadata;
 
     const Component =
@@ -110,9 +111,14 @@ export const KubeObjectDetails = memo(
       )?.[1] ?? DetailsNotFound;
 
     const content = customResourceDefinition ? (
-      <CustomResourceDetails crName={name} crd={customResourceDefinition} namespace={namespace!} />
+      <CustomResourceDetails
+        crName={name}
+        crd={customResourceDefinition}
+        namespace={namespace!}
+        cluster={cluster}
+      />
     ) : (
-      <Component name={name} namespace={namespace} />
+      <Component name={name} namespace={namespace} cluster={cluster} />
     );
 
     useEffect(() => {

--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -40,7 +40,8 @@ const makeRelation = <From extends KubeObjectClass, To extends KubeObjectClass>(
   predicate(fromNode, toNode) {
     const fromObject = fromNode.kubeObject as InstanceType<From>;
     const toObject = toNode.kubeObject as InstanceType<To>;
-    return Boolean(selector(fromObject, toObject));
+
+    return fromObject.cluster === toObject.cluster && Boolean(selector(fromObject, toObject));
   },
 });
 

--- a/frontend/src/components/resourceQuota/Details.tsx
+++ b/frontend/src/components/resourceQuota/Details.tsx
@@ -4,9 +4,13 @@ import ResourceQuota from '../../lib/k8s/resourceQuota';
 import { compareUnits, normalizeUnit } from '../../lib/util';
 import { DetailsGrid, SimpleTable } from '../common';
 
-export default function ResourceQuotaDetails(props: { name?: string; namespace?: string }) {
+export default function ResourceQuotaDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['translation', 'glossary']);
 
   return (
@@ -14,6 +18,7 @@ export default function ResourceQuotaDetails(props: { name?: string; namespace?:
       resourceType={ResourceQuota}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/role/BindingDetails.tsx
+++ b/frontend/src/components/role/BindingDetails.tsx
@@ -7,16 +7,21 @@ import { DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
-export default function RoleBindingDetails(props: { name?: string; namespace?: string }) {
+export default function RoleBindingDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation('glossary');
 
   return (
     <DetailsGrid
       resourceType={!!namespace ? RoleBinding : ClusterRoleBinding}
-      namespace={namespace}
       name={name}
+      namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/role/Details.tsx
+++ b/frontend/src/components/role/Details.tsx
@@ -6,9 +6,13 @@ import { DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
-export default function RoleDetails(props: { name?: string; namespace?: string }) {
+export default function RoleDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace?: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation('glossary');
 
   return (
@@ -16,6 +20,7 @@ export default function RoleDetails(props: { name?: string; namespace?: string }
       resourceType={!namespace ? ClusterRole : Role}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraSections={item =>
         item && [

--- a/frontend/src/components/role/List.tsx
+++ b/frontend/src/components/role/List.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useClusterGroup } from '../../lib/k8s';
+import { useSelectedClusters } from '../../lib/k8s';
 import ClusterRole from '../../lib/k8s/clusterRole';
 import Role from '../../lib/k8s/role';
 import { useNamespaces } from '../../redux/filterSlice';
@@ -13,7 +13,7 @@ export default function RoleList() {
   const { items: roles, errors: rolesErrors } = Role.useList({ namespace: useNamespaces() });
   const { items: clusterRoles, errors: clusterRolesErrors } = ClusterRole.useList();
 
-  const clusters = useClusterGroup();
+  const clusters = useSelectedClusters();
   const isMultiCluster = clusters.length > 1;
 
   const allRoles = React.useMemo(() => {

--- a/frontend/src/components/runtimeClass/Details.tsx
+++ b/frontend/src/components/runtimeClass/Details.tsx
@@ -3,9 +3,13 @@ import { useParams } from 'react-router';
 import { RuntimeClass } from '../../lib/k8s/runtime';
 import { DetailsGrid } from '../common';
 
-export function RuntimeClassDetails(props: { name?: string; namespace?: string }) {
+export function RuntimeClassDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['translation']);
 
   return (
@@ -13,6 +17,7 @@ export function RuntimeClassDetails(props: { name?: string; namespace?: string }
       resourceType={RuntimeClass}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/secret/Details.tsx
+++ b/frontend/src/components/secret/Details.tsx
@@ -6,9 +6,13 @@ import { DetailsGrid, SecretField } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import { NameValueTable, NameValueTableRow } from '../common/SimpleTable';
 
-export default function SecretDetails(props: { name?: string; namespace?: string }) {
+export default function SecretDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation();
 
   return (
@@ -16,6 +20,7 @@ export default function SecretDetails(props: { name?: string; namespace?: string
       resourceType={Secret}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/service/Details.tsx
+++ b/frontend/src/components/service/Details.tsx
@@ -14,9 +14,13 @@ import PortForward from '../common/Resource/PortForward';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
 
-export default function ServiceDetails(props: { name?: string; namespace?: string }) {
+export default function ServiceDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   const [endpoints, endpointsError] = Endpoint.useList({ namespace });
@@ -30,6 +34,7 @@ export default function ServiceDetails(props: { name?: string; namespace?: strin
       resourceType={Service}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/serviceaccount/Details.tsx
+++ b/frontend/src/components/serviceaccount/Details.tsx
@@ -5,9 +5,13 @@ import ServiceAccount from '../../lib/k8s/serviceAccount';
 import { Link } from '../common';
 import { DetailsGrid } from '../common/Resource';
 
-export default function ServiceAccountDetails(props: { name?: string; namespace?: string }) {
+export default function ServiceAccountDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation('glossary');
 
   return (
@@ -15,6 +19,7 @@ export default function ServiceAccountDetails(props: { name?: string; namespace?
       resourceType={ServiceAccount}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/statefulset/Details.tsx
+++ b/frontend/src/components/statefulset/Details.tsx
@@ -41,7 +41,7 @@ export default function StatefulSetDetails(props: {
         item && [
           {
             id: 'headlamp.statefulset-owned-pods',
-            section: <OwnedPodsSection resource={item?.jsonData} />,
+            section: <OwnedPodsSection resource={item} />,
           },
           {
             id: 'headlamp.statefulset-containers',

--- a/frontend/src/components/statefulset/Details.tsx
+++ b/frontend/src/components/statefulset/Details.tsx
@@ -9,9 +9,13 @@ import {
   OwnedPodsSection,
 } from '../common/Resource';
 
-export default function StatefulSetDetails(props: { name?: string; namespace?: string }) {
+export default function StatefulSetDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation('glossary');
 
   return (
@@ -19,6 +23,7 @@ export default function StatefulSetDetails(props: { name?: string; namespace?: s
       resourceType={StatefulSet}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/storage/ClaimDetails.tsx
+++ b/frontend/src/components/storage/ClaimDetails.tsx
@@ -10,9 +10,13 @@ export function makePVCStatusLabel(item: PersistentVolumeClaim) {
   return StatusLabelByPhase(status!);
 }
 
-export default function VolumeClaimDetails(props: { name?: string; namespace?: string }) {
+export default function VolumeClaimDetails(props: {
+  name?: string;
+  namespace?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   return (
@@ -20,6 +24,7 @@ export default function VolumeClaimDetails(props: { name?: string; namespace?: s
       resourceType={PersistentVolumeClaim}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/storage/ClassDetails.tsx
+++ b/frontend/src/components/storage/ClassDetails.tsx
@@ -4,15 +4,16 @@ import { useParams } from 'react-router-dom';
 import StorageClass from '../../lib/k8s/storageClass';
 import { DetailsGrid } from '../common/Resource';
 
-export default function StorageClassDetails(props: { name?: string }) {
+export default function StorageClassDetails(props: { name?: string; cluster?: string }) {
   const params = useParams<{ name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
   const { t } = useTranslation('glossary');
 
   return (
     <DetailsGrid
       resourceType={StorageClass}
       name={name}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/storage/VolumeDetails.tsx
+++ b/frontend/src/components/storage/VolumeDetails.tsx
@@ -10,15 +10,16 @@ export function makePVStatusLabel(item: PersistentVolume) {
   return StatusLabelByPhase(status);
 }
 
-export default function VolumeDetails(props: { name?: string }) {
+export default function VolumeDetails(props: { name?: string; cluster?: string }) {
   const params = useParams<{ name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   return (
     <DetailsGrid
       resourceType={PersistentVolume}
       name={name}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/verticalPodAutoscaler/Details.tsx
+++ b/frontend/src/components/verticalPodAutoscaler/Details.tsx
@@ -3,9 +3,9 @@ import { useParams } from 'react-router-dom';
 import VPA from '../../lib/k8s/vpa';
 import { DateLabel, DetailsGrid, Link, SectionBox, SimpleTable } from '../common';
 
-export default function VpaDetails(props: { name?: string; namespace?: string }) {
+export default function VpaDetails(props: { name?: string; namespace?: string; cluster?: string }) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['translation', 'glossary']);
   const formatRecommendation = (data: Record<string, string>): string => {
     let result = '';
@@ -23,6 +23,7 @@ export default function VpaDetails(props: { name?: string; namespace?: string })
       resourceType={VPA}
       name={name}
       namespace={namespace}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/webhookconfiguration/Details.tsx
+++ b/frontend/src/components/webhookconfiguration/Details.tsx
@@ -8,16 +8,18 @@ import { MatchExpressions } from '../common/Resource/MatchExpressions';
 export interface WebhookConfigurationDetailsProps {
   resourceClass: typeof ValidatingWebhookConfiguration | typeof MutatingWebhookConfiguration;
   name: string;
+  cluster?: string;
 }
 
 export default function WebhookConfigurationDetails(props: WebhookConfigurationDetailsProps) {
-  const { resourceClass, name } = props;
+  const { resourceClass, name, cluster } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   return (
     <DetailsGrid
       resourceType={resourceClass}
       name={name}
+      cluster={cluster}
       withEvents
       extraInfo={item =>
         item && [

--- a/frontend/src/components/webhookconfiguration/MutatingWebhookConfigDetails.tsx
+++ b/frontend/src/components/webhookconfiguration/MutatingWebhookConfigDetails.tsx
@@ -2,9 +2,15 @@ import { useParams } from 'react-router-dom';
 import MutatingWebhookConfiguration from '../../lib/k8s/mutatingWebhookConfiguration';
 import WebhookConfigurationDetails from './Details';
 
-export default function MutatingWebhookConfigList(props: { name?: string }) {
+export default function MutatingWebhookConfigList(props: { name?: string; cluster?: string }) {
   const params = useParams<{ name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
 
-  return <WebhookConfigurationDetails resourceClass={MutatingWebhookConfiguration} name={name} />;
+  return (
+    <WebhookConfigurationDetails
+      resourceClass={MutatingWebhookConfiguration}
+      name={name}
+      cluster={cluster}
+    />
+  );
 }

--- a/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigDetails.tsx
+++ b/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigDetails.tsx
@@ -2,9 +2,18 @@ import { useParams } from 'react-router-dom';
 import ValidatingWebhookConfiguration from '../../lib/k8s/validatingWebhookConfiguration';
 import WebhookConfigurationDetails from './Details';
 
-export default function ValidatingWebhookConfigurationDetails(props: { name?: string }) {
+export default function ValidatingWebhookConfigurationDetails(props: {
+  name?: string;
+  cluster?: string;
+}) {
   const params = useParams<{ name: string }>();
-  const { name = params.name } = props;
+  const { name = params.name, cluster } = props;
 
-  return <WebhookConfigurationDetails resourceClass={ValidatingWebhookConfiguration} name={name} />;
+  return (
+    <WebhookConfigurationDetails
+      resourceClass={ValidatingWebhookConfiguration}
+      name={name}
+      cluster={cluster}
+    />
+  );
 }

--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -15,11 +15,12 @@ interface WorkloadDetailsProps<T extends WorkloadClass> {
   workloadKind: T;
   name?: string;
   namespace?: string;
+  cluster?: string;
 }
 
 export default function WorkloadDetails<T extends WorkloadClass>(props: WorkloadDetailsProps<T>) {
   const params = useParams<{ namespace: string; name: string }>();
-  const { name = params.name, namespace = params.namespace } = props;
+  const { name = params.name, namespace = params.namespace, cluster } = props;
   const { workloadKind } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
@@ -84,8 +85,9 @@ export default function WorkloadDetails<T extends WorkloadClass>(props: Workload
     <DetailsGrid
       resourceType={workloadKind}
       name={name}
-      withEvents
       namespace={namespace}
+      cluster={cluster}
+      withEvents
       actions={item => {
         if (!item) return [];
         const isLoggable = ['Deployment', 'ReplicaSet', 'DaemonSet'].includes(workloadKind.kind);

--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -130,7 +130,7 @@ export default function WorkloadDetails<T extends WorkloadClass>(props: Workload
           },
           {
             id: 'headlamp.workload-owned-pods',
-            section: <OwnedPodsSection resource={item?.jsonData} />,
+            section: <OwnedPodsSection resource={item} />,
           },
           {
             id: 'headlamp.workload-containers',

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -448,6 +448,7 @@
   "Collapse Sidebar": "Seitenleiste einklappen",
   "Navigation": "Navigation",
   "General": "",
+  "Clusters": "",
   "Instances": "",
   "Cluster version upgraded to {{ gitVersion }}": "Cluster-Version auf {{ gitVersion }} aktualisiert",
   "Cluster version downgraded to {{ gitVersion }}": "Cluster-Version auf {{ gitVersion }} heruntergestuft",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -448,6 +448,7 @@
   "Collapse Sidebar": "Collapse Sidebar",
   "Navigation": "Navigation",
   "General": "General",
+  "Clusters": "Clusters",
   "Instances": "Instances",
   "Cluster version upgraded to {{ gitVersion }}": "Cluster version upgraded to {{ gitVersion }}",
   "Cluster version downgraded to {{ gitVersion }}": "Cluster version downgraded to {{ gitVersion }}",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -449,6 +449,7 @@
   "Collapse Sidebar": "Contraer barra lateral",
   "Navigation": "Navegación",
   "General": "General",
+  "Clusters": "",
   "Instances": "Instancias",
   "Cluster version upgraded to {{ gitVersion }}": "Versión del cluster actualizada a {{ gitVersion }}",
   "Cluster version downgraded to {{ gitVersion }}": "Versión del cluster cambiada a {{ gitVersion }}",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -449,6 +449,7 @@
   "Collapse Sidebar": "Réduire la barre latérale",
   "Navigation": "Navigation",
   "General": "",
+  "Clusters": "",
   "Instances": "",
   "Cluster version upgraded to {{ gitVersion }}": "Version du cluster mise à jour vers {{ gitVersion }}",
   "Cluster version downgraded to {{ gitVersion }}": "Version du cluster déclassée vers {{ gitVersion }}",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -449,6 +449,7 @@
   "Collapse Sidebar": "Comprimi Barra Laterale",
   "Navigation": "Navigazione",
   "General": "Generale",
+  "Clusters": "",
   "Instances": "Istanze",
   "Cluster version upgraded to {{ gitVersion }}": "Versione del cluster aggiornata a {{ gitVersion }}",
   "Cluster version downgraded to {{ gitVersion }}": "Versione del cluster retrocessa a {{ gitVersion }}",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -449,6 +449,7 @@
   "Collapse Sidebar": "Encolher Barra Lateral",
   "Navigation": "Navegação",
   "General": "Geral",
+  "Clusters": "",
   "Instances": "Instâncias",
   "Cluster version upgraded to {{ gitVersion }}": "Versão do cluster actualizada para {{ gitVersion }}",
   "Cluster version downgraded to {{ gitVersion }}": "Versão do cluster mudada para {{ gitVersion }}",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -447,6 +447,7 @@
   "Collapse Sidebar": "折疊側邊欄",
   "Navigation": "導航",
   "General": "一般",
+  "Clusters": "",
   "Instances": "實例",
   "Cluster version upgraded to {{ gitVersion }}": "叢集版本升級到 {{ gitVersion }}",
   "Cluster version downgraded to {{ gitVersion }}": "叢集版本降級到 {{ gitVersion }}",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -447,6 +447,7 @@
   "Collapse Sidebar": "折叠侧边栏",
   "Navigation": "导航",
   "General": "一般",
+  "Clusters": "",
   "Instances": "实例",
   "Cluster version upgraded to {{ gitVersion }}": "集群版本升级到 {{ gitVersion }}",
   "Cluster version downgraded to {{ gitVersion }}": "集群版本降级到 {{ gitVersion }}",

--- a/frontend/src/lib/cluster.ts
+++ b/frontend/src/lib/cluster.ts
@@ -16,10 +16,18 @@ export function getClusterPrefixedPath(path?: string | null) {
 }
 
 /**
+ * Get the currently selected cluster name.
+ *
+ * If more than one cluster is selected it will return:
+ *  - On details pages: the cluster of the currently viewed resource
+ *  - On any other page: one of the selected clusters
+ *
+ * To get all currently selected clusters please use {@link getSelectedClusters}
+ *
  * @returns The current cluster name, or null if not in a cluster context.
  */
-export function getCluster(): string | null {
-  const clusterString = getClusterPathParam();
+export function getCluster(urlPath?: string): string | null {
+  const clusterString = getClusterPathParam(urlPath);
   if (!clusterString) return null;
 
   if (clusterString.includes('+')) {
@@ -29,11 +37,13 @@ export function getCluster(): string | null {
 }
 
 /** Returns cluster URL parameter from the current path or the given path */
-export function getClusterPathParam(): string | undefined {
+export function getClusterPathParam(maybeUrlPath?: string): string | undefined {
   const prefix = getBaseUrl();
-  const urlPath = isElectron()
-    ? window.location.hash.substring(1)
-    : window.location.pathname.slice(prefix.length);
+  const urlPath =
+    maybeUrlPath ??
+    (isElectron()
+      ? window.location.hash.substring(1)
+      : window.location.pathname.slice(prefix.length));
 
   const clusterURLMatch = matchPath<{ cluster?: string }>(urlPath, {
     path: getClusterPrefixedPath(),
@@ -50,5 +60,20 @@ export function getClusterPathParam(): string | undefined {
  */
 export function getClusterGroup(returnWhenNoClusters: string[] = []): string[] {
   const clusterFromURL = getCluster();
+  return clusterFromURL?.split('+') || returnWhenNoClusters;
+}
+
+/**
+ * Get list of selected clusters.
+ *
+ * @param returnWhenNoClusters return this value when no clusters are found.
+ * @param urlPath optional, path string containing cluster parameters.
+ * @returns the cluster group from the URL.
+ */
+export function getSelectedClusters(
+  returnWhenNoClusters: string[] = [],
+  urlPath?: string
+): string[] {
+  const clusterFromURL = getClusterPathParam(urlPath);
   return clusterFromURL?.split('+') || returnWhenNoClusters;
 }

--- a/frontend/src/lib/cluster.ts
+++ b/frontend/src/lib/cluster.ts
@@ -19,6 +19,17 @@ export function getClusterPrefixedPath(path?: string | null) {
  * @returns The current cluster name, or null if not in a cluster context.
  */
 export function getCluster(): string | null {
+  const clusterString = getClusterPathParam();
+  if (!clusterString) return null;
+
+  if (clusterString.includes('+')) {
+    return clusterString.split('+')[0];
+  }
+  return clusterString;
+}
+
+/** Returns cluster URL parameter from the current path or the given path */
+export function getClusterPathParam(): string | undefined {
   const prefix = getBaseUrl();
   const urlPath = isElectron()
     ? window.location.hash.substring(1)
@@ -27,7 +38,8 @@ export function getCluster(): string | null {
   const clusterURLMatch = matchPath<{ cluster?: string }>(urlPath, {
     path: getClusterPrefixedPath(),
   });
-  return (!!clusterURLMatch && clusterURLMatch.params.cluster) || null;
+
+  return clusterURLMatch?.params?.cluster;
 }
 
 /**

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -2,10 +2,10 @@ import { JSONPath } from 'jsonpath-plus';
 import { cloneDeep, unset } from 'lodash';
 import React, { useMemo } from 'react';
 import { loadClusterSettings } from '../../helpers/clusterSettings';
-import { getCluster } from '../cluster';
+import { getCluster, getSelectedClusters } from '../cluster';
 import { createRouteURL } from '../router';
-import { timeAgo } from '../util';
-import { useClusterGroup, useConnectApi } from '.';
+import { getSelectedClusters, timeAgo } from '../util';
+import { useConnectApi } from '.';
 import { RecursivePartial } from './api/v1/factories';
 import { useKubeObject } from './api/v2/hooks';
 import { makeListRequests, useKubeObjectList } from './api/v2/useKubeObjectList';
@@ -122,9 +122,19 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
   }
 
   getDetailsLink() {
+    const selectedClusters = getSelectedClusters();
+
+    let cluster = this.cluster;
+    if (selectedClusters.length > 1) {
+      const sortedClusters = selectedClusters.filter(it => it !== this.cluster);
+      sortedClusters.unshift(this.cluster);
+      cluster = sortedClusters.join('+');
+    }
+
     const params = {
       namespace: this.getNamespace(),
       name: this.getName(),
+      cluster: cluster,
     };
     const link = createRouteURL(this.detailsRoute, params);
     return link;

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -4,8 +4,8 @@ import React, { useMemo } from 'react';
 import { loadClusterSettings } from '../../helpers/clusterSettings';
 import { getCluster, getSelectedClusters } from '../cluster';
 import { createRouteURL } from '../router';
-import { getSelectedClusters, timeAgo } from '../util';
-import { useConnectApi } from '.';
+import { timeAgo } from '../util';
+import { useConnectApi, useSelectedClusters } from '.';
 import { RecursivePartial } from './api/v1/factories';
 import { useKubeObject } from './api/v2/hooks';
 import { makeListRequests, useKubeObjectList } from './api/v2/useKubeObjectList';
@@ -320,7 +320,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
       refetchInterval?: number;
     } & QueryParameters = {}
   ) {
-    const fallbackClusters = useClusterGroup();
+    const fallbackClusters = useSelectedClusters();
 
     // Create requests for each cluster and namespace
     const requests = useMemo(() => {
@@ -488,7 +488,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
    * @param reResourceAttrs The attributes describing this access request. See https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/#SelfSubjectAccessReviewSpec .
    * @returns The result of the access request.
    */
-  static async fetchAuthorization(reqResourseAttrs?: AuthRequestResourceAttrs) {
+  static async fetchAuthorization(reqResourseAttrs?: AuthRequestResourceAttrs, cluster?: string) {
     // @todo: We should get the API info from the API endpoint.
     const authApiVersions = ['v1', 'v1beta1'];
     for (let j = 0; j < authApiVersions.length; j++) {
@@ -504,7 +504,8 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
               resourceAttributes: reqResourseAttrs,
             },
           },
-          false
+          false,
+          { cluster }
         );
       } catch (err) {
         // If this is the last attempt or the error is not 404, let it throw.
@@ -515,7 +516,11 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     }
   }
 
-  static async getAuthorization(verb: string, reqResourseAttrs?: AuthRequestResourceAttrs) {
+  static async getAuthorization(
+    verb: string,
+    reqResourseAttrs?: AuthRequestResourceAttrs,
+    cluster?: string
+  ) {
     const resourceAttrs: AuthRequestResourceAttrs = {
       verb,
       ...reqResourseAttrs,
@@ -530,7 +535,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     // If we already have the group and version, then we can make the request without
     // trying the API info, which may have several versions and thus be less optimal.
     if (!!resourceAttrs.group && !!resourceAttrs.version && !!resourceAttrs.resource) {
-      return this.fetchAuthorization(resourceAttrs);
+      return this.fetchAuthorization(resourceAttrs, cluster);
     }
 
     // If we don't have the group or version, then we have to try all of the
@@ -544,7 +549,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
       let authResult;
 
       try {
-        authResult = await this.fetchAuthorization(attrs);
+        authResult = await this.fetchAuthorization(attrs, cluster);
       } catch (err) {
         // If this is the last attempt or the error is not 404, let it throw.
         if ((err as ApiError).status !== 404 || i === apiInfo.length - 1) {
@@ -584,7 +589,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
       resourceAttrs['version'] = version;
     }
 
-    return this._class().getAuthorization(verb, resourceAttrs);
+    return this._class().getAuthorization(verb, resourceAttrs, this.cluster);
   }
 
   static getErrorMessage(err: ApiError | null) {

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -7,7 +7,7 @@ import {
   findKubeconfigByClusterName,
   storeStatelessClusterKubeconfig,
 } from '../../../../stateless';
-import { getCluster, getClusterGroup } from '../../../cluster';
+import { getCluster, getSelectedClusters } from '../../../cluster';
 import { ClusterRequest, clusterRequest, post, request } from './clusterRequests';
 import { JSON_HEADERS } from './constants';
 
@@ -30,7 +30,7 @@ export async function testAuth(cluster = '', namespace = 'default') {
  * Will throw an error if the cluster is not healthy.
  */
 export async function testClusterHealth(cluster?: string) {
-  const clusterNames = cluster ? [cluster] : getClusterGroup();
+  const clusterNames = cluster ? [cluster] : getSelectedClusters();
 
   const healthChecks = clusterNames.map(clusterName => {
     return clusterRequest('/healthz', { isJSON: false, cluster: clusterName }).catch(error => {

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -83,7 +83,7 @@ export function useKubeObject<K extends KubeObject>({
   kubeObjectClass,
   namespace,
   name,
-  cluster = getCluster() ?? undefined,
+  cluster = getCluster() ?? '',
   queryParams,
 }: {
   /** Class to instantiate the object with */
@@ -96,9 +96,6 @@ export function useKubeObject<K extends KubeObject>({
   cluster?: string;
   queryParams?: QueryParameters;
 }): [K | null, ApiError | null] & QueryResponse<K, ApiError> {
-  if (!cluster) {
-    throw new Error('No cluster provided');
-  }
   type Instance = K;
   const { endpoint, error: endpointError } = useEndpoints(
     kubeObjectClass.apiEndpoint.apiInfo,

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -83,7 +83,7 @@ export function useKubeObject<K extends KubeObject>({
   kubeObjectClass,
   namespace,
   name,
-  cluster: maybeCluster,
+  cluster = getCluster() ?? undefined,
   queryParams,
 }: {
   /** Class to instantiate the object with */
@@ -96,8 +96,10 @@ export function useKubeObject<K extends KubeObject>({
   cluster?: string;
   queryParams?: QueryParameters;
 }): [K | null, ApiError | null] & QueryResponse<K, ApiError> {
+  if (!cluster) {
+    throw new Error('No cluster provided');
+  }
   type Instance = K;
-  const cluster = maybeCluster ?? getCluster() ?? '';
   const { endpoint, error: endpointError } = useEndpoints(
     kubeObjectClass.apiEndpoint.apiInfo,
     cluster
@@ -127,7 +129,7 @@ export function useKubeObject<K extends KubeObject>({
       const obj: KubeObjectInterface = await clusterFetch(url, {
         cluster,
       }).then(it => it.json());
-      return new kubeObjectClass(obj) as Instance;
+      return new kubeObjectClass(obj, cluster) as Instance;
     },
   });
 

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -125,6 +125,7 @@ class Event extends KubeObject<KubeEvent> {
     const namespace = object.metadata.namespace;
     const name = object.metadata.name;
     const objectKind = object.kind;
+    const cluster = object.cluster;
 
     let path = '/api/v1/events';
     const fieldSelector: { [key: string]: string } = {
@@ -146,7 +147,7 @@ class Event extends KubeObject<KubeEvent> {
       limit: this.maxLimit,
     };
 
-    const response = await request(path, {}, true, true, queryParams);
+    const response = await request(path, { cluster }, true, true, queryParams);
 
     return response.items;
   }

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -124,7 +124,7 @@ export function useCluster() {
   React.useEffect(() => {
     // Listen to route changes
     return history.listen(() => {
-      const newCluster = getCluster();
+      const newCluster = getCluster(history.location.pathname);
       // Update the state only when the cluster changes
       setCluster(currentCluster => (newCluster !== currentCluster ? newCluster : currentCluster));
     });
@@ -140,9 +140,10 @@ export function useCluster() {
  */
 export function useSelectedClusters(): string[] {
   const clusterInURL = useCluster();
+  const history = useHistory();
 
   const clusterGroup = React.useMemo(() => {
-    return getSelectedClusters();
+    return getSelectedClusters([], history.location.pathname);
   }, [clusterInURL]);
 
   return clusterGroup;

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -92,8 +92,8 @@ class Pod extends KubeObject<KubePod> {
 
   protected detailedStatusCache: Partial<{ resourceVersion: string; details: PodDetailedStatus }>;
 
-  constructor(jsonData: KubePod) {
-    super(jsonData);
+  constructor(jsonData: KubePod, cluster?: string) {
+    super(jsonData, cluster);
     this.detailedStatusCache = {};
   }
 

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -94,13 +94,14 @@ import WorkloadOverview from '../components/workload/Overview';
 import { isElectron } from '../helpers/isElectron';
 import LocaleSelect from '../i18n/LocaleSelect/LocaleSelect';
 import store from '../redux/stores/store';
-import { getCluster, getClusterPrefixedPath } from './cluster';
+import { getClusterPathParam } from './cluster';
 import { useCluster } from './k8s';
 import DaemonSet from './k8s/daemonSet';
 import Deployment from './k8s/deployment';
 import Job from './k8s/job';
 import ReplicaSet from './k8s/replicaSet';
 import StatefulSet from './k8s/statefulSet';
+import { getClusterPrefixedPath } from './util';
 
 export interface Route {
   /** Any valid URL path or array of paths that path-to-regexp@^1.7.0 understands. */
@@ -971,14 +972,15 @@ export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
     return '';
   }
 
-  let cluster: string | null = params.cluster || null;
+  let cluster = params.cluster;
   if (!cluster && getRouteUseClusterURL(route)) {
-    cluster = getCluster();
+    cluster = getClusterPathParam();
     if (!cluster) {
       return '/';
     }
   }
   const fullParams = {
+    selected: undefined,
     ...params,
   };
 

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -172,17 +172,6 @@ export function useFilterFunc<
   };
 }
 
-/**
- * Get list of selected clusters.
- *
- * @param returnWhenNoClusters return this value when no clusters are found.
- * @returns the cluster group from the URL.
- */
-export function getSelectedClusters(returnWhenNoClusters: string[] = []): string[] {
-  const clusterFromURL = getClusterPathParam();
-  return clusterFromURL?.split('+') || returnWhenNoClusters;
-}
-
 export function useErrorState(dependentSetter?: (...args: any) => void) {
   const [error, setError] = React.useState<ApiError | null>(null);
 

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -172,6 +172,17 @@ export function useFilterFunc<
   };
 }
 
+/**
+ * Get list of selected clusters.
+ *
+ * @param returnWhenNoClusters return this value when no clusters are found.
+ * @returns the cluster group from the URL.
+ */
+export function getSelectedClusters(returnWhenNoClusters: string[] = []): string[] {
+  const clusterFromURL = getClusterPathParam();
+  return clusterFromURL?.split('+') || returnWhenNoClusters;
+}
+
 export function useErrorState(dependentSetter?: (...args: any) => void) {
   const [error, setError] = React.useState<ApiError | null>(null);
 

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -379,10 +379,10 @@
       "default": [Function],
     },
     "useCluster": [Function],
-    "useClusterGroup": [Function],
     "useClustersConf": [Function],
     "useClustersVersion": [Function],
     "useConnectApi": [Function],
+    "useSelectedClusters": [Function],
   },
   "Lodash": Function {
     "default": [Function],

--- a/frontend/src/redux/drawerModeSlice.ts
+++ b/frontend/src/redux/drawerModeSlice.ts
@@ -10,6 +10,7 @@ export interface DrawerModeState {
      * the name of the custom resource definition
      */
     customResourceDefinition?: string;
+    cluster: string;
   };
 }
 


### PR DESCRIPTION
Displays details page for resources in multi cluster setup.

Uses first cluster from the cluster list for the useCluster value (eg `http://localhost:3000/c/meow+meow2/deployments/kube-system/coredns` uses the "meow" cluster not the "meow2" cluster).

Formats links so that details path have the cluster of the resource as the first cluster in the list.


Things that don't work yet, todo in future PRs:

 - Selecting resources from event on cluster overview page
 - useCluster returns wrong one in overlay panel in certain cases (breaks prometheus for example only in overlay mode)
 - Cluster selector in top right only displays one cluster


![image](https://github.com/user-attachments/assets/f529383d-7075-4e8c-b4c5-50dbf444e01c)

- Storage classes page doesn't list cluster column (so didn't try details page)
- Not related to this PR, but it looks like there is an issue with the Endpoints list page, where there are two "k8s.io-minikube-hostpath" ones but both are in the same cluster? One should be for each cluster.
