### PR TITLE
frontend: Sidebar: Use theme color for Add Cluster Button

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -63,6 +63,7 @@ function AddClusterButton() {
         <Button
           onClick={() => history.push(createRouteURL('addCluster'))}
           startIcon={<InlineIcon icon="mdi:plus-box-outline" />}
+          sx={{ color: theme => theme.palette.sidebar.color }}
         >
           {t('translation|Add Cluster')}
         </Button>


### PR DESCRIPTION
This change updates the color of the Add Cluster button based on the currently used theme.

### Testing
- [X] Open the General Settings in Headlamp and change the theme
- [X] Notice that the 'Add Cluster' button in the side is visible and the color matches the other items