### PR TITLE
backend: fix some typo errors

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -69,7 +69,7 @@ const isWindows = runtime.GOOS == "windows"
 
 const ContextCacheTTL = 5 * time.Minute // minutes
 
-const ContextUpdateChacheTTL = 20 * time.Second // seconds
+const ContextUpdateCacheTTL = 20 * time.Second // seconds
 
 const JWTExpirationTTL = 10 * time.Second // seconds
 
@@ -82,7 +82,7 @@ const (
 
 type clientConfig struct {
 	Clusters                []Cluster `json:"clusters"`
-	IsDyanmicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
+	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
 }
 
 type spaHandler struct {

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -53,7 +53,7 @@ func (c *HeadlampConfig) setKeyInCache(key string, context kubeconfig.Context) e
 			return err
 		}
 	} else {
-		if err = c.kubeConfigStore.UpdateTTL(key, ContextUpdateChacheTTL); err != nil {
+		if err = c.kubeConfigStore.UpdateTTL(key, ContextUpdateCacheTTL); err != nil {
 			logger.Log(logger.LevelError, map[string]string{"key": key},
 				err, "updating context ttl")
 

--- a/backend/pkg/kubeconfig/contextStore.go
+++ b/backend/pkg/kubeconfig/contextStore.go
@@ -91,7 +91,7 @@ func (c *contextStore) RemoveContext(name string) error {
 	return c.cache.Delete(context.Background(), name)
 }
 
-// AddContextWithTTL adds a context to the store with a ttl.
+// AddContextWithKeyAndTTL adds a context to the store with a ttl.
 func (c *contextStore) AddContextWithKeyAndTTL(headlampContext *Context, key string, ttl time.Duration) error {
 	return c.cache.SetWithTTL(context.Background(), key, headlampContext, ttl)
 }


### PR DESCRIPTION
just like the title, fix some typo errors in method comment and struct field