### PR TITLE
backend: add support for skip context

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -376,7 +376,7 @@ func TestInvalidKubeConfig(t *testing.T) {
 		kubeConfigStore:       kubeConfigStore,
 	}
 
-	err = kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, absPath, kubeconfig.KubeConfig)
+	err = kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, absPath, kubeconfig.KubeConfig, nil)
 	assert.Error(t, err)
 
 	clusters := c.getClusters()

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -39,6 +39,7 @@ func main() {
 	StartHeadlampServer(&HeadlampConfig{
 		useInCluster:          conf.InCluster,
 		kubeConfigPath:        conf.KubeConfigPath,
+		skippedKubeContexts:   conf.SkippedKubeContexts,
 		listenAddr:            conf.ListenAddr,
 		port:                  conf.Port,
 		devMode:               conf.DevMode,

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ListenAddr            string `koanf:"listen-addr"`
 	Port                  uint   `koanf:"port"`
 	KubeConfigPath        string `koanf:"kubeconfig"`
+	SkippedKubeContexts   string `koanf:"skipped-kube-contexts"`
 	StaticDir             string `koanf:"html-static-dir"`
 	PluginsDir            string `koanf:"plugins-dir"`
 	BaseURL               string `koanf:"base-url"`
@@ -156,6 +157,7 @@ func flagset() *flag.FlagSet {
 	f.Bool("enable-dynamic-clusters", false, "Enable dynamic clusters, which stores stateless clusters in the frontend.")
 
 	f.String("kubeconfig", "", "Absolute path to the kubeconfig file")
+	f.String("skipped-kube-contexts", "", "Context name which should be ignored in kubeconfig file")
 	f.String("html-static-dir", "", "Static HTML directory to serve")
 	f.String("plugins-dir", defaultPluginDir(), "Specify the plugins directory to build the backend with")
 	f.String("base-url", "", "Base URL path. eg. /headlamp")

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -910,26 +910,27 @@ func GetInClusterContext(oidcIssuerURL string,
 	}, nil
 }
 
-// func type for context filter
-// if the func return true, the context will be skipped
-// otherwise the context will be used
+// Func type for context filter, if the func return true,
+// the context will be skipped otherwise the context will be used.
 type shouldBeSkippedFunc = func(kubeContext Context) bool
 
-// AllowAllKubeContext will keep all contexts
+// AllowAllKubeContext will keep all contexts.
 func AllowAllKubeContext(_ Context) bool {
 	return false
 }
 
-// SkipKubeContextInCommaSeperatedString will skip the contexts
+// SkipKubeContextInCommaSeparatedString will skip the contexts
 // whose names are in the given comma-separated string.
 // For example, if pass the "a,b" for blackKubeContextNameStr,
-// the contexts named "a" and "b" will be skipped
-func SkipKubeContextInCommaSeperatedString(blackKubeContextNameStr string) shouldBeSkippedFunc {
+// the contexts named "a" and "b" will be skipped.
+func SkipKubeContextInCommaSeparatedString(blackKubeContextNameStr string) shouldBeSkippedFunc {
 	blackKubeContextNameList := strings.Split(blackKubeContextNameStr, ",")
 	blackKubeContextNameMap := map[string]bool{}
+
 	for _, blackKubeContextName := range blackKubeContextNameList {
 		blackKubeContextNameMap[blackKubeContextName] = true
 	}
+
 	return func(kubeContext Context) bool {
 		return blackKubeContextNameMap[kubeContext.Name]
 	}
@@ -940,7 +941,9 @@ func SkipKubeContextInCommaSeperatedString(blackKubeContextNameStr string) shoul
 // It stores the valid contexts and returns the errors if any.
 // Note: No need to remove contexts from the store, since
 // adding a context with the same name will overwrite the old one.
-func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, source int, ignoreFunc shouldBeSkippedFunc) error {
+func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, source int,
+	ignoreFunc shouldBeSkippedFunc,
+) error {
 	var errs []error //nolint:prealloc
 
 	kubeConfigContexts, contextErrors, err := LoadContextsFromMultipleFiles(kubeConfigs, source)
@@ -953,10 +956,12 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 	if _ignoreFunc == nil {
 		_ignoreFunc = AllowAllKubeContext
 	}
+
 	for _, kubeConfigContext := range kubeConfigContexts {
 		if _ignoreFunc(kubeConfigContext) {
 			continue
 		}
+
 		kubeConfigContext := kubeConfigContext
 
 		err := kubeConfigStore.AddContext(&kubeConfigContext)

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -910,12 +910,37 @@ func GetInClusterContext(oidcIssuerURL string,
 	}, nil
 }
 
+// func type for context filter
+// if the func return true, the context will be skipped
+// otherwise the context will be used
+type shouldBeSkippedFunc = func(kubeContext Context) bool
+
+// AllowAllKubeContext will keep all contexts
+func AllowAllKubeContext(_ Context) bool {
+	return false
+}
+
+// SkipKubeContextInCommaSeperatedString will skip the contexts
+// whose names are in the given comma-separated string.
+// For example, if pass the "a,b" for blackKubeContextNameStr,
+// the contexts named "a" and "b" will be skipped
+func SkipKubeContextInCommaSeperatedString(blackKubeContextNameStr string) shouldBeSkippedFunc {
+	blackKubeContextNameList := strings.Split(blackKubeContextNameStr, ",")
+	blackKubeContextNameMap := map[string]bool{}
+	for _, blackKubeContextName := range blackKubeContextNameList {
+		blackKubeContextNameMap[blackKubeContextName] = true
+	}
+	return func(kubeContext Context) bool {
+		return blackKubeContextNameMap[kubeContext.Name]
+	}
+}
+
 // LoadAndStoreKubeConfigs loads contexts from the given kubeconfig files and
 // stores them in the given context store.
 // It stores the valid contexts and returns the errors if any.
 // Note: No need to remove contexts from the store, since
 // adding a context with the same name will overwrite the old one.
-func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, source int) error {
+func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, source int, ignoreFunc shouldBeSkippedFunc) error {
 	var errs []error //nolint:prealloc
 
 	kubeConfigContexts, contextErrors, err := LoadContextsFromMultipleFiles(kubeConfigs, source)
@@ -923,7 +948,15 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 		return fmt.Errorf("error loading kubeconfig files: %v", err)
 	}
 
+	// if pass the shouldBeSkippedFunc=nil, it works like before
+	_ignoreFunc := ignoreFunc
+	if _ignoreFunc == nil {
+		_ignoreFunc = AllowAllKubeContext
+	}
 	for _, kubeConfigContext := range kubeConfigContexts {
+		if _ignoreFunc(kubeConfigContext) {
+			continue
+		}
 		kubeConfigContext := kubeConfigContext
 
 		err := kubeConfigStore.AddContext(&kubeConfigContext)

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -24,7 +24,7 @@ func TestLoadAndStoreKubeConfigs(t *testing.T) {
 	t.Run("valid_file", func(t *testing.T) {
 		kubeConfigFile := kubeConfigFilePath
 
-		err := kubeconfig.LoadAndStoreKubeConfigs(contextStore, kubeConfigFile, kubeconfig.KubeConfig)
+		err := kubeconfig.LoadAndStoreKubeConfigs(contextStore, kubeConfigFile, kubeconfig.KubeConfig, nil)
 		require.NoError(t, err)
 
 		contexts, err := contextStore.GetContexts()
@@ -41,7 +41,7 @@ func TestLoadAndStoreKubeConfigs(t *testing.T) {
 	t.Run("invalid_file", func(t *testing.T) {
 		kubeConfigFile := "invalid_kubeconfig"
 
-		err := kubeconfig.LoadAndStoreKubeConfigs(contextStore, kubeConfigFile, kubeconfig.KubeConfig)
+		err := kubeconfig.LoadAndStoreKubeConfigs(contextStore, kubeConfigFile, kubeconfig.KubeConfig, nil)
 		require.Error(t, err)
 	})
 }
@@ -91,7 +91,7 @@ func TestContext(t *testing.T) {
 
 	configStore := kubeconfig.NewContextStore()
 
-	err := kubeconfig.LoadAndStoreKubeConfigs(configStore, kubeConfigFile, kubeconfig.KubeConfig)
+	err := kubeconfig.LoadAndStoreKubeConfigs(configStore, kubeConfigFile, kubeconfig.KubeConfig, nil)
 	require.NoError(t, err)
 
 	testContext, err := configStore.GetContext("minikube")

--- a/backend/pkg/kubeconfig/watcher_test.go
+++ b/backend/pkg/kubeconfig/watcher_test.go
@@ -25,7 +25,7 @@ func TestWatchAndLoadFiles(t *testing.T) {
 
 	kubeConfigStore := kubeconfig.NewContextStore()
 
-	go kubeconfig.LoadAndWatchFiles(kubeConfigStore, path, kubeconfig.KubeConfig)
+	go kubeconfig.LoadAndWatchFiles(kubeConfigStore, path, kubeconfig.KubeConfig, nil)
 
 	// Test adding a context
 	t.Run("Add context", func(t *testing.T) {


### PR DESCRIPTION
for the default use-case, headlamp will load kubeconfig with `kubeconfig` options, and all context in the `kubeconfig` files will be automatically loaded, but sometimes there are some needs to hide some context across the kubeconfig file. So I want to add the feature to skip the contexts according to `skipped-kube-contexts`, it will be used like 
```
headlamp -kubeconfig=${kubeconfig1}:${kubeconfig2}
-html-static-dir=${path/to/static/bundles}
-plugins-dir=${path/to/plugins}
-dev
-enable-dynamic-clusters
-skipped-kube-contexts=ctx1,ctx2,ctx3
```