### PR TITLE
frontend: pod: Add quick status for containers

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -472,7 +472,7 @@ export default function PodDetails(props: PodDetailsProps) {
         item && [
           {
             name: t('State'),
-            value: makePodStatusLabel(item),
+            value: makePodStatusLabel(item, false),
           },
           {
             name: t('Node'),

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -3,6 +3,7 @@ import { Box } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ApiError } from '../../lib/k8s/apiProxy';
+import { KubeContainerStatus } from '../../lib/k8s/cluster';
 import Pod from '../../lib/k8s/pod';
 import { METRIC_REFETCH_INTERVAL_MS, PodMetrics } from '../../lib/k8s/PodMetrics';
 import { parseCpu, parseRam, unparseCpu, unparseRam } from '../../lib/units';
@@ -13,7 +14,7 @@ import { LightTooltip, Link, SimpleTableProps } from '../common';
 import { StatusLabel, StatusLabelProps } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
 
-export function makePodStatusLabel(pod: Pod) {
+export function makePodStatusLabel(pod: Pod, showContainerStatus: boolean = true) {
   const phase = pod.status.phase;
   let status: StatusLabelProps['status'] = '';
 
@@ -30,17 +31,34 @@ export function makePodStatusLabel(pod: Pod) {
     }
   }
 
+  const containerStatuses = pod.status?.containerStatuses || [];
+  const containerIndicators = containerStatuses.map((cs, index) => {
+    const { color, tooltip } = getContainerDisplayStatus(cs);
+    return (
+      <LightTooltip title={tooltip} key={index}>
+        <Icon icon="mdi:circle" style={{ color }} width="1rem" height="1rem" />
+      </LightTooltip>
+    );
+  });
+
   return (
-    <LightTooltip title={tooltip} interactive>
-      <Box display="inline">
-        <StatusLabel status={status}>
-          {(status === 'warning' || status === 'error') && (
-            <Icon aria-label="hidden" icon="mdi:alert-outline" width="1.2rem" height="1.2rem" />
-          )}
-          {reason}
-        </StatusLabel>
-      </Box>
-    </LightTooltip>
+    <Box display="flex" alignItems="center" gap={1}>
+      <LightTooltip title={tooltip} interactive>
+        <Box display="inline">
+          <StatusLabel status={status}>
+            {(status === 'warning' || status === 'error') && (
+              <Icon aria-label="hidden" icon="mdi:alert-outline" width="1.2rem" height="1.2rem" />
+            )}
+            {reason}
+          </StatusLabel>
+        </Box>
+      </LightTooltip>
+      {showContainerStatus && containerIndicators.length > 0 && (
+        <Box display="flex" gap={0.5}>
+          {containerIndicators}
+        </Box>
+      )}
+    </Box>
   );
 }
 
@@ -58,6 +76,56 @@ function getReadinessGatesStatus(pods: Pod) {
   });
 
   return readinessGatesMap;
+}
+
+function getContainerDisplayStatus(container: KubeContainerStatus) {
+  const state = container.state || {};
+  let color = 'grey';
+  let label = '';
+  const tooltipLines: string[] = [`Name: ${container.name}`];
+
+  if (state.waiting) {
+    color = 'orange';
+    label = 'Waiting';
+    if (state.waiting.reason) {
+      tooltipLines.push(`Reason: ${state.waiting.reason}`);
+    }
+  } else if (state.terminated) {
+    color = 'green';
+    label = 'Terminated';
+    if (state.terminated.reason) {
+      tooltipLines.push(`Reason: ${state.terminated.reason}`);
+    }
+    if (state.terminated.exitCode !== undefined) {
+      tooltipLines.push(`Exit Code: ${state.terminated.exitCode}`);
+    }
+    if (state.terminated.startedAt) {
+      tooltipLines.push(`Started: ${new Date(state.terminated.startedAt).toLocaleString()}`);
+    }
+    if (state.terminated.finishedAt) {
+      tooltipLines.push(`Finished: ${new Date(state.terminated.finishedAt).toLocaleString()}`);
+    }
+    if (container.restartCount > 0) {
+      tooltipLines.push(`Restarts: ${container.restartCount}`);
+    }
+  } else if (state.running) {
+    color = 'green';
+    label = 'Running';
+    if (state.running.startedAt) {
+      tooltipLines.push(`Started: ${new Date(state.running.startedAt).toLocaleString()}`);
+    }
+    if (container.restartCount > 0) {
+      tooltipLines.push(`Restarts: ${container.restartCount}`);
+    }
+  }
+
+  tooltipLines.splice(1, 0, `Status: ${label}`);
+
+  return {
+    color,
+    label,
+    tooltip: <span style={{ whiteSpace: 'pre-line' }}>{tooltipLines.join('\n')}</span>,
+  };
 }
 
 export interface PodListProps {

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Error.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Error.stories.storyshot
@@ -219,15 +219,19 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1y9cgfq-MuiTypography-root"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Error
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1y9cgfq-MuiTypography-root"
+                        >
+                          Error
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
@@ -219,15 +219,19 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Init:0/2
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                        >
+                          Init:0/2
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
@@ -219,15 +219,19 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-op46cf-MuiTypography-root"
+                      <div
+                        aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        CrashLoopBackOff
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-op46cf-MuiTypography-root"
+                        >
+                          CrashLoopBackOff
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
@@ -219,15 +219,19 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label="Back-off pulling image "doesnotexist:nover""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                      <div
+                        aria-label="Back-off pulling image "doesnotexist:nover""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        ImagePullBackOff
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                        >
+                          ImagePullBackOff
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Running.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Running.stories.storyshot
@@ -219,15 +219,19 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Running
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                        >
+                          Running
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Successful.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Successful.stories.storyshot
@@ -219,15 +219,19 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <div
-                      aria-label=""
-                      class="MuiBox-root css-6n7j50"
-                      data-mui-internal-clone-element="true"
+                      class="MuiBox-root css-axw7ok"
                     >
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                      <div
+                        aria-label=""
+                        class="MuiBox-root css-6n7j50"
+                        data-mui-internal-clone-element="true"
                       >
-                        Completed
-                      </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                        >
+                          Completed
+                        </span>
+                      </div>
                     </div>
                   </dd>
                   <dt

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -944,15 +944,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label="Back-off pulling image "doesnotexist:nover""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                  <div
+                    aria-label="Back-off pulling image "doesnotexist:nover""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    ImagePullBackOff
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                    >
+                      ImagePullBackOff
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1084,15 +1091,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Completed
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                    >
+                      Completed
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1226,15 +1240,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Init:0/2
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-nm2nmp-MuiTypography-root"
+                    >
+                      Init:0/2
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1366,15 +1387,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-op46cf-MuiTypography-root"
+                  <div
+                    aria-label="back-off 5m0s restarting failed container=liveness pod=liveness-http_default(4f8b71a3-f99c-41c2-9523-83edc1de02ce)"
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    CrashLoopBackOff
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-op46cf-MuiTypography-root"
+                    >
+                      CrashLoopBackOff
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1506,15 +1534,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1y9cgfq-MuiTypography-root"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Error
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1y9cgfq-MuiTypography-root"
+                    >
+                      Error
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1646,15 +1681,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Running
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                    >
+                      Running
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1786,15 +1828,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Running
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                    >
+                      Running
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td
@@ -1926,15 +1975,22 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-c9i7d5-MuiTableCell-root"
               >
                 <div
-                  aria-label=""
-                  class="MuiBox-root css-6n7j50"
-                  data-mui-internal-clone-element="true"
+                  class="MuiBox-root css-axw7ok"
                 >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                  <div
+                    aria-label=""
+                    class="MuiBox-root css-6n7j50"
+                    data-mui-internal-clone-element="true"
                   >
-                    Running
-                  </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1ybpqju-MuiTypography-root"
+                    >
+                      Running
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-1utx3w7"
+                  />
                 </div>
               </td>
               <td


### PR DESCRIPTION
This change adds a new icon displaying the status of each container in the pods list. Hovering over the icon gives important info about the container at a glance: name, status, reason, exit code, and start/finish times.

Fixes: #2689, follow-up from #3008 

### Testing
- [X] Navigate to the Pods page in Headlamp
- [X] Note the container status icon, and hover over to see additional info about the container

------
![image](https://github.com/user-attachments/assets/c40e684f-2552-45b5-a3f4-c855bb8b8a99)
------
![image](https://github.com/user-attachments/assets/95f1cb5c-bfad-401c-ad00-4f5603af1cb0)