### PR TITLE
frontend: Allow direct editing of resource fields

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -11,7 +11,6 @@ import { BaseTextFieldProps } from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/system';
 import { Location } from 'history';
-import { Base64 } from 'js-base64';
 import _, { has } from 'lodash';
 import React, { PropsWithChildren, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -506,12 +505,12 @@ export function SecretField(props: InputProps) {
       </Grid>
       <Grid item xs>
         <Input
-          readOnly
+          readOnly={!showPassword}
           type="password"
           fullWidth
           multiline={showPassword}
           maxRows="20"
-          value={showPassword ? Base64.decode(value as string) : '******'}
+          value={showPassword ? (value as string) : '******'}
           {...other}
         />
       </Grid>

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@iconify/react';
 import Editor from '@monaco-editor/react';
-import { InputLabel } from '@mui/material';
+import { Button, InputLabel } from '@mui/material';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Grid, { GridProps, GridSize } from '@mui/material/Grid';
@@ -400,13 +400,24 @@ export function SectionGrid(props: SectionGridProps) {
 
 export interface DataFieldProps extends BaseTextFieldProps {
   disableLabel?: boolean;
+  onSave?: (newValue: string) => void;
+  onChange?: (newValue: string) => void;
 }
 
 export function DataField(props: DataFieldProps) {
-  const { disableLabel, label, value } = props;
+  const { disableLabel, label, value, onSave, onChange } = props;
   // Make sure we reload after a theme change
   useTheme();
   const themeName = getThemeName();
+
+  const [data, setData] = React.useState(value as string);
+
+  const handleChange = (newValue: string | undefined) => {
+    if (newValue !== undefined) {
+      setData(newValue);
+      onChange?.(newValue);
+    }
+  };
 
   function handleEditorDidMount(editor: any) {
     const editorElement: HTMLElement | null = editor.getDomNode();
@@ -428,22 +439,21 @@ export function DataField(props: DataFieldProps) {
   if (language !== 'json') {
     language = 'yaml';
   }
-  if (disableLabel === true) {
-    return (
-      <Box borderTop={0} border={1}>
-        <Editor
-          value={value as string}
-          language={language}
-          onMount={handleEditorDidMount}
-          options={{ readOnly: true, lineNumbers: 'off', automaticLayout: true }}
-          theme={themeName === 'dark' ? 'vs-dark' : 'light'}
-        />
-      </Box>
-    );
-  }
-  return (
-    <>
-      <Box borderTop={0} border={1}>
+
+  const editorComponent = (
+    <Editor
+      value={data}
+      language={language}
+      onChange={handleChange}
+      onMount={handleEditorDidMount}
+      options={{ lineNumbers: 'off', automaticLayout: true }}
+      theme={themeName === 'dark' ? 'vs-dark' : 'light'}
+    />
+  );
+
+  const content = (
+    <Box borderTop={0} border={1}>
+      {!disableLabel && (
         <Box display="flex">
           <Box width="10%" borderTop={1} height={'1px'}></Box>
           <Box pb={1} mt={-1} px={0.5}>
@@ -451,17 +461,24 @@ export function DataField(props: DataFieldProps) {
           </Box>
           <Box width="100%" borderTop={1} height={'1px'}></Box>
         </Box>
-        <Box mt={1} px={1} pb={1}>
-          <Editor
-            value={value as string}
-            language={language}
-            onMount={handleEditorDidMount}
-            options={{ readOnly: true, lineNumbers: 'off', automaticLayout: true }}
-            theme={themeName === 'dark' ? 'vs-dark' : 'light'}
-          />
-        </Box>
+      )}
+      <Box mt={1} px={1} pb={1}>
+        {editorComponent}
       </Box>
-    </>
+    </Box>
+  );
+
+  return (
+    <Box>
+      {content}
+      {onSave && (
+        <Box mt={1} display="flex" justifyContent="flex-end">
+          <Button variant="contained" color="primary" onClick={() => onSave && onSave(data)}>
+            Save
+          </Button>
+        </Box>
+      )}
+    </Box>
   );
 }
 

--- a/frontend/src/components/configmap/Details.tsx
+++ b/frontend/src/components/configmap/Details.tsx
@@ -1,6 +1,12 @@
+import { Box, Button } from '@mui/material';
+import _ from 'lodash';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import ConfigMap from '../../lib/k8s/configMap';
+import { clusterAction } from '../../redux/clusterActionSlice';
+import { AppDispatch } from '../../redux/stores/store';
 import EmptyContent from '../common/EmptyContent';
 import { DataField, DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
@@ -14,6 +20,7 @@ export default function ConfigDetails(props: {
   const params = useParams<{ namespace: string; name: string }>();
   const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation(['translation']);
+  const dispatch: AppDispatch = useDispatch();
 
   return (
     <DetailsGrid
@@ -27,19 +34,70 @@ export default function ConfigDetails(props: {
           {
             id: 'headlamp.configmap-data',
             section: () => {
-              const itemData = item?.data || [];
-              const mainRows: NameValueTableRow[] = Object.entries(itemData).map(
-                (item: unknown[]) => ({
-                  name: item[0] as string,
-                  value: <DataField label={item[0] as string} disableLabel value={item[1]} />,
-                })
-              );
+              const [data, setData] = React.useState(() => _.cloneDeep(item.data));
+              const [isDirty, setIsDirty] = React.useState(false);
+              const lastDataRef = React.useRef(_.cloneDeep(item.data));
+
+              const handleFieldChange = (key: string, newValue: string) => {
+                setData(prev => ({ ...prev, [key]: newValue }));
+                setIsDirty(true);
+              };
+
+              React.useEffect(() => {
+                const newData = _.cloneDeep(item.data);
+                if (!isDirty && !_.isEqual(newData, lastDataRef.current)) {
+                  setData(newData);
+                  lastDataRef.current = newData;
+                }
+              }, [item.data, isDirty]);
+
+              const handleSave = () => {
+                const updatedConfigMap = { ...item.jsonData, data };
+                dispatch(
+                  clusterAction(() => item.update(updatedConfigMap), {
+                    startMessage: t('translation|Applying changes to {{ itemName }}…', {
+                      itemName: item.metadata.name,
+                    }),
+                    cancelledMessage: t('translation|Cancelled changes to {{ itemName }}.', {
+                      itemName: item.metadata.name,
+                    }),
+                    successMessage: t('translation|Applied changes to {{ itemName }}.', {
+                      itemName: item.metadata.name,
+                    }),
+                    errorMessage: t('translation|Failed to apply changes to {{ itemName }}.', {
+                      itemName: item.metadata.name,
+                    }),
+                  })
+                );
+                lastDataRef.current = _.cloneDeep(data);
+                setIsDirty(false);
+              };
+
+              const mainRows: NameValueTableRow[] = Object.entries(data).map((item: unknown[]) => ({
+                name: item[0] as string,
+                value: (
+                  <DataField
+                    label={item[0] as string}
+                    disableLabel
+                    value={item[1]}
+                    onChange={(newValue: string) => handleFieldChange(item[0] as string, newValue)}
+                  />
+                ),
+              }));
+
               return (
                 <SectionBox title={t('translation|Data')}>
                   {mainRows.length === 0 ? (
                     <EmptyContent>{t('No data in this config map')}</EmptyContent>
                   ) : (
-                    <NameValueTable rows={mainRows} />
+                    <>
+                      <NameValueTable rows={mainRows} />
+                      <Box mt={2} display="flex" justifyContent="flex-end">
+                        <Button variant="contained" color="primary" onClick={handleSave}>
+                          {t('translation|Save')}
+                        </Button>
+                      </Box>
+                    </>
                   )}
                 </SectionBox>
               );

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
@@ -215,11 +215,19 @@
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                 >
                   <div
-                    class="MuiBox-root css-1rsqta2"
+                    class="MuiBox-root css-0"
                   >
                     <div
-                      class="mock-monaco-editor"
-                    />
+                      class="MuiBox-root css-1rsqta2"
+                    >
+                      <div
+                        class="MuiBox-root css-1y5kcuw"
+                      >
+                        <div
+                          class="mock-monaco-editor"
+                        />
+                      </div>
+                    </div>
                   </div>
                 </dd>
                 <dt
@@ -231,11 +239,19 @@
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                 >
                   <div
-                    class="MuiBox-root css-1rsqta2"
+                    class="MuiBox-root css-0"
                   >
                     <div
-                      class="mock-monaco-editor"
-                    />
+                      class="MuiBox-root css-1rsqta2"
+                    >
+                      <div
+                        class="MuiBox-root css-1y5kcuw"
+                      >
+                        <div
+                          class="mock-monaco-editor"
+                        />
+                      </div>
+                    </div>
                   </div>
                 </dd>
                 <dt
@@ -247,14 +263,36 @@
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-1xrovmc-MuiGrid-root"
                 >
                   <div
-                    class="MuiBox-root css-1rsqta2"
+                    class="MuiBox-root css-0"
                   >
                     <div
-                      class="mock-monaco-editor"
-                    />
+                      class="MuiBox-root css-1rsqta2"
+                    >
+                      <div
+                        class="MuiBox-root css-1y5kcuw"
+                      >
+                        <div
+                          class="mock-monaco-editor"
+                        />
+                      </div>
+                    </div>
                   </div>
                 </dd>
               </dl>
+              <div
+                class="MuiBox-root css-10igwnb"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Save
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/secret/Details.tsx
+++ b/frontend/src/components/secret/Details.tsx
@@ -1,6 +1,13 @@
+import { Box, Button } from '@mui/material';
+import { Base64 } from 'js-base64';
+import _ from 'lodash';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import Secret from '../../lib/k8s/secret';
+import { clusterAction } from '../../redux/clusterActionSlice';
+import { AppDispatch } from '../../redux/stores/store';
 import { EmptyContent } from '../common';
 import { DetailsGrid, SecretField } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
@@ -14,6 +21,7 @@ export default function SecretDetails(props: {
   const params = useParams<{ namespace: string; name: string }>();
   const { name = params.name, namespace = params.namespace, cluster } = props;
   const { t } = useTranslation();
+  const dispatch: AppDispatch = useDispatch();
 
   return (
     <DetailsGrid
@@ -35,19 +43,68 @@ export default function SecretDetails(props: {
           {
             id: 'headlamp.secrets-data',
             section: () => {
-              const itemData = item?.data || {};
-              const mainRows: NameValueTableRow[] = Object.entries(itemData).map(
-                (item: unknown[]) => ({
-                  name: item[0] as string,
-                  value: <SecretField value={item[1]} />,
-                })
-              );
+              const initialData = _.mapValues(item.data, (v: string) => Base64.decode(v));
+              const [data, setData] = React.useState(initialData);
+              const lastDataRef = React.useRef(initialData);
+
+              React.useEffect(() => {
+                const newData = _.mapValues(item.data, (v: string) => Base64.decode(v));
+                if (!_.isEqual(newData, lastDataRef.current)) {
+                  if (_.isEqual(data, lastDataRef.current)) {
+                    setData(newData);
+                    lastDataRef.current = newData;
+                  }
+                }
+              }, [item.data]);
+
+              const handleFieldChange = (key: string, newValue: string) => {
+                setData(prev => ({ ...prev, [key]: newValue }));
+              };
+
+              const handleSave = () => {
+                const encodedData = _.mapValues(data, (v: string) => Base64.encode(v));
+                const updatedSecret = { ...item.jsonData, data: encodedData };
+                dispatch(
+                  clusterAction(() => item.update(updatedSecret), {
+                    startMessage: t('translation|Applying changes to {{ itemName }}…', {
+                      itemName: item.metadata.name,
+                    }),
+                    cancelledMessage: t('translation|Cancelled changes to {{ itemName }}.', {
+                      itemName: item.metadata.name,
+                    }),
+                    successMessage: t('translation|Applied changes to {{ itemName }}.', {
+                      itemName: item.metadata.name,
+                    }),
+                    errorMessage: t('translation|Failed to apply changes to {{ itemName }}.', {
+                      itemName: item.metadata.name,
+                    }),
+                  })
+                );
+                lastDataRef.current = _.cloneDeep(data);
+              };
+
+              const mainRows: NameValueTableRow[] = Object.entries(data).map((item: unknown[]) => ({
+                name: item[0] as string,
+                value: (
+                  <SecretField
+                    value={item[1]}
+                    onChange={e => handleFieldChange(item[0] as string, e.target.value)}
+                  />
+                ),
+              }));
               return (
                 <SectionBox title={t('translation|Data')}>
                   {mainRows.length === 0 ? (
                     <EmptyContent>{t('No data in this secret')}</EmptyContent>
                   ) : (
-                    <NameValueTable rows={mainRows} />
+                    <>
+                      <NameValueTable rows={mainRows} />
+                      <Box mt={2} display="flex" justifyContent="flex-end">
+                        <Button variant="contained" color="primary" onClick={handleSave}>
+                          {t('translation|Save')}
+                        </Button>
+                      </Box>
+                    </>
                   )}
                 </SectionBox>
               );

--- a/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
@@ -344,6 +344,20 @@
                   </div>
                 </dd>
               </dl>
+              <div
+                class="MuiBox-root css-10igwnb"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Save
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
These changes allow the user to directly make changes to fields for configmaps and secrets without having to open the entire resource YAML in the editor dialog.

Fixes: #2412, follow-up from #2994
- #2412

### Testing

- [X] Navigate to the details page for any configmap or secret
- [X] Edit the field and hit the save button
- [X] Ensure that the resource gets updated with the new value