### PR TITLE
frontend: truncate long cronjob names

### DIFF
--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -32,14 +32,18 @@ const uniqueString = () => {
   return `${timestamp}-${randomNum}`;
 };
 
+const maxNameLength = 63;
+
 function SpawnJobDialog(props: { cronJob: CronJob; onClose: () => void }) {
   const { cronJob, onClose } = props;
   const { namespace } = useParams<{ namespace: string }>();
   const { t } = useTranslation(['translation']);
   const dispatch: AppDispatch = useDispatch();
 
+  const suffix = `-manual-spawn-${uniqueString()}`;
+
   const [jobName, setJobName] = useState(
-    () => `${cronJob?.metadata?.name}-manual-spawn-${uniqueString()}`
+    () => `${cronJob?.metadata?.name.substring(0, maxNameLength - suffix.length)}${suffix}`
   );
 
   function handleSpawn() {


### PR DESCRIPTION
Truncates the generated cronjob name to a maximum of 63 characters to comply with kubernetes naming rules

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3133