### PR TITLE
frontend: Map: Persist query params on refresh

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -16,8 +16,10 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import Namespace from '../../lib/k8s/namespace';
 import K8sNode from '../../lib/k8s/node';
+import { setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/reducers/reducers';
 import { NamespacesAutocomplete } from '../common';
 import { GraphNodeDetails } from './details/GraphNodeDetails';
@@ -101,9 +103,17 @@ function GraphViewContent({
   defaultFilters = defaultFiltersValue,
 }: GraphViewContentProps) {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
 
   // List of selected namespaces
   const namespaces = useTypedSelector(state => state.filter).namespaces;
+
+  // Sync namespace and URL
+  const [namespacesParam] = useQueryParamsState<string>('namespace', '');
+  useEffect(() => {
+    const list = namespacesParam?.split(' ') ?? [];
+    dispatch(setNamespaceFilter(list));
+  }, [namespacesParam, dispatch]);
 
   // Filters
   const [hasErrorsFilter, setHasErrorsFilter] = useState(false);


### PR DESCRIPTION
This change adds a queryParamsState for the namespace filter, allowing the query parameters to persist on refresh when they previously did not.

Fixes: #3110 

### Testing
- [X] Open the map in Headlamp
- [X] Filter by 2+ namespaces
- [X] Refresh and ensure that the query params persist