### PR TITLE
frontend: Include pod status in column text value to avoid stale status label state

### DIFF
--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -14,11 +14,9 @@ import { LightTooltip, Link, SimpleTableProps } from '../common';
 import { StatusLabel, StatusLabelProps } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
 
-export function makePodStatusLabel(pod: Pod, showContainerStatus: boolean = true) {
+function getPodStatus(pod: Pod) {
   const phase = pod.status.phase;
   let status: StatusLabelProps['status'] = '';
-
-  const { reason, message: tooltip } = pod.getDetailedStatus();
 
   if (phase === 'Failed') {
     status = 'error';
@@ -30,6 +28,13 @@ export function makePodStatusLabel(pod: Pod, showContainerStatus: boolean = true
       status = 'warning';
     }
   }
+
+  return status;
+}
+
+export function makePodStatusLabel(pod: Pod, showContainerStatus: boolean = true) {
+  const status = getPodStatus(pod);
+  const { reason, message: tooltip } = pod.getDetailedStatus();
 
   const containerStatuses = pod.status?.containerStatuses || [];
   const containerIndicators = containerStatuses.map((cs, index) => {
@@ -205,7 +210,7 @@ export function PodListRenderer(props: PodListProps) {
           id: 'status',
           gridTemplate: 'min-content',
           label: t('translation|Status'),
-          getValue: pod => pod.getDetailedStatus().reason,
+          getValue: pod => getPodStatus(pod) + '' + pod.getDetailedStatus().reason,
           render: makePodStatusLabel,
         },
         ...(metrics?.length


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/headlamp/issues/3108

Table cell wasn't re-rendering because the "reason" label stayed the same but status (which impacts color and the icon) changed but wasn't taken into account in the getValue function

How to test (steps from reported issue):

Go to pod list
Delete a pod
Wait for recreation
Check status color