### PR TITLE
Improve WebSocket compatibility

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1136,6 +1136,7 @@ func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
 
 		r.Host = clusterURL.Host
 		r.Header.Set("X-Forwarded-Host", r.Host)
+		r.Header.Del("User-Agent")
 		r.URL.Host = clusterURL.Host
 		r.URL.Path = mux.Vars(r)["api"]
 		r.URL.Scheme = clusterURL.Scheme

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1141,6 +1141,9 @@ func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
 		r.URL.Path = mux.Vars(r)["api"]
 		r.URL.Scheme = clusterURL.Scheme
 
+		// Process WebSocket protocol headers if present
+		processWebSocketProtocolHeader(r)
+
 		plugins.HandlePluginReload(c.cache, w)
 
 		err = kContext.ProxyRequest(w, r)
@@ -1152,6 +1155,64 @@ func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
 			return
 		}
 	})
+}
+
+// Handle WebSocket connections that include token in Sec-WebSocket-Protocol
+// Some cluster setups don't support tokens via Sec-Websocket-Protocol value
+// Authorization header is more commonly supported and it also used by kubectl.
+func processWebSocketProtocolHeader(r *http.Request) {
+	secWebSocketProtocol := r.Header.Get("Sec-Websocket-Protocol")
+	if secWebSocketProtocol == "" {
+		return
+	}
+
+	// Split by comma and trim spaces to get all protocols
+	protocols := strings.Split(secWebSocketProtocol, ",")
+
+	var validProtocols []string
+
+	// This prefix is used to identify bearer tokens in the WebSocket protocol
+	const bearerTokenPrefix = "base64url.bearer.authorization.k8s.io." // #nosec G101
+
+	for _, protocol := range protocols {
+		protocol = strings.TrimSpace(protocol)
+
+		// Process protocols that contain tokens
+		if strings.HasPrefix(protocol, bearerTokenPrefix) {
+			processTokenProtocol(r, protocol, bearerTokenPrefix)
+		} else {
+			// Keep non-token protocols
+			validProtocols = append(validProtocols, protocol)
+		}
+	}
+
+	// Update the header with remaining valid protocols or remove it entirely
+	if len(validProtocols) > 0 {
+		r.Header.Set("Sec-WebSocket-Protocol", strings.Join(validProtocols, ", "))
+	} else {
+		r.Header.Del("Sec-WebSocket-Protocol")
+	}
+}
+
+// processTokenProtocol extracts a bearer token from a WebSocket protocol string
+// and sets it as an Authorization header if one doesn't already exist.
+func processTokenProtocol(r *http.Request, protocol, tokenPrefix string) {
+	// Only process if Authorization header is empty
+	if r.Header.Get("Authorization") != "" {
+		return
+	}
+
+	token := strings.TrimPrefix(protocol, tokenPrefix)
+	if token == "" {
+		return
+	}
+
+	// Try to decode token from base64
+	if decodedBytes, err := base64.URLEncoding.DecodeString(token); err == nil {
+		token = string(decodedBytes)
+	}
+
+	r.Header.Set("Authorization", "Bearer "+token)
 }
 
 func (c *HeadlampConfig) handleClusterRequests(router *mux.Router) {

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -343,18 +343,17 @@ func (m *Multiplexer) dialWebSocket(
 		HandshakeTimeout: HandshakeTimeout,
 	}
 
+	headers := http.Header{
+		"Origin": {host},
+	}
+
 	if token != nil {
-		dialer.Subprotocols = []string{
-			"base64.binary.k8s.io",
-			"base64url.bearer.authorization.k8s.io." + base64.RawStdEncoding.EncodeToString([]byte(*token)),
-		}
+		headers.Set("Authorization", "Bearer"+*token)
 	}
 
 	conn, resp, err := dialer.Dial(
 		wsURL,
-		http.Header{
-			"Origin": {host},
-		},
+		headers,
 	)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "dialing WebSocket")


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/headlamp/issues/2970

Certain k8s vendors don't support tokens via Sec-Websocket-Protocol value, so we need to use the Authorization header instead.
Certain k8s vendors will perform additional cors check when browser-like User-Agent is present, which we currently pass but now will just remove.

How to test:

Create rancher cluster
Open headlamp and check for websocket connections (live updates to lists, logs and attach features)