### PR TITLE
Fix e2e auth logic + add namespace a11y playwright tests

### DIFF
--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -9,11 +9,24 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@axe-core/playwright": "^4.10.1",
         "yaml": "^2.3.4"
       },
       "devDependencies": {
         "@playwright/test": "^1.42.1",
         "@types/node": "^20.12.2"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
+      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.2"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -38,6 +51,15 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {
@@ -76,7 +98,6 @@
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
       "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -100,6 +121,14 @@
     }
   },
   "dependencies": {
+    "@axe-core/playwright": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
+      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
+      "requires": {
+        "axe-core": "~4.10.2"
+      }
+    },
     "@playwright/test": {
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
@@ -117,6 +146,11 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
+    },
+    "axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -138,8 +172,7 @@
     "playwright-core": {
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true
+      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^20.12.2"
   },
   "dependencies": {
+    "@axe-core/playwright": "^4.10.1",
     "yaml": "^2.3.4"
   }
 }

--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -9,8 +9,6 @@ export class HeadlampPage {
   }
 
   async authenticate(token?: string) {
-    await this.page.waitForSelector('h1:has-text("Authentication")');
-
     // Check to see if already authenticated
     if (await this.page.isVisible('button:has-text("Authenticate")')) {
       this.hasToken(token || '');
@@ -24,10 +22,16 @@ export class HeadlampPage {
         this.page.click('button:has-text("Authenticate")'),
       ]);
     }
+
+    await this.page.waitForLoadState('load');
   }
 
   async navigateToCluster(name: string, token?: string) {
-    await this.navigateTopage(`/c/${name}`);
+    // Since we are using multi cluster structure we need to have a full reset navigation
+    await this.page.goto(`${this.testURL}`);
+    await this.page.waitForLoadState('load');
+    await this.page.getByRole('link', { name: name, exact: true }).click();
+    await this.page.waitForLoadState('load');
     await this.authenticate(token);
   }
 
@@ -75,11 +79,16 @@ export class HeadlampPage {
 
   async logout() {
     // Click on the account button to open the user menu
-    await this.page.click('button[aria-label="Account of current user"]');
+    const userButton = await this.page.waitForSelector('[data-testid="user-account-button"]', {
+      state: 'visible',
+    });
+
+    await userButton.click();
 
     // Wait for the logout option to be visible and click on it
-    await this.page.waitForSelector('a.MuiMenuItem-root:has-text("Log out")');
-    await this.page.click('a.MuiMenuItem-root:has-text("Log out")');
+    await this.page.waitForSelector('[data-testid="logout-menu-item"]');
+    await this.page.click('[data-testid="logout-menu-item"]');
+
     await this.page.waitForLoadState('load');
 
     // Expects the URL to contain c/test/token

--- a/e2e-tests/tests/namespaces.spec.ts
+++ b/e2e-tests/tests/namespaces.spec.ts
@@ -1,4 +1,5 @@
-import { test } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { NamespacesPage } from './namespacesPage';
 
@@ -15,6 +16,17 @@ test('create a namespace with the minimal editor then delete it', async ({ page 
 
   const namespacesPage = new NamespacesPage(page);
   await namespacesPage.navigateToNamespaces();
+
+  const axeBuilder = new AxeBuilder({ page });
+
+  const accessibilityResults = await axeBuilder.analyze();
+
+  expect(accessibilityResults.violations.length).toBe(0);
+
   await namespacesPage.createNamespace(name);
+  const postCreationScanResults = await axeBuilder.analyze();
+
+  expect(postCreationScanResults.violations.length).toBe(0);
+
   await namespacesPage.deleteNamespace(name);
 });

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -269,6 +269,7 @@ export const PureTopBar = memo(
             <Icon icon="mdi:logout" />
           </ListItemIcon>
           <ListItemText
+            data-testid="logout-menu-item"
             primary={t('Log out')}
             secondary={hasToken ? null : t('(No token set up)')}
           />
@@ -328,6 +329,7 @@ export const PureTopBar = memo(
         action: !!isClusterContext && (
           <MenuItem>
             <IconButton
+              data-testid="user-account-button"
               aria-label={t('Account of current user')}
               aria-controls={userMenuId}
               aria-haspopup="true"
@@ -386,6 +388,7 @@ export const PureTopBar = memo(
         id: DefaultAppBarAction.USER,
         action: !!isClusterContext && (
           <IconButton
+            data-testid="user-account-button"
             aria-label={t('Account of current user')}
             aria-controls={userMenuId}
             aria-haspopup="true"

--- a/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
@@ -124,6 +124,7 @@
           aria-haspopup="true"
           aria-label="Account of current user"
           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-testid="user-account-button"
           tabindex="0"
           type="button"
         >

--- a/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
@@ -143,6 +143,7 @@
           aria-haspopup="true"
           aria-label="Account of current user"
           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-testid="user-account-button"
           tabindex="0"
           type="button"
         >

--- a/frontend/src/components/common/CreateResourceButton.tsx
+++ b/frontend/src/components/common/CreateResourceButton.tsx
@@ -36,6 +36,7 @@ export function CreateResourceButton(props: CreateResourceButtonProps) {
         errorMessage={errorMessage}
         onEditorChanged={() => setErrorMessage('')}
         title={t('translation|Create {{ name }}', { name })}
+        aria-label={t('translation|Create {{ name }}', { name })}
       />
     </AuthVisible>
   );


### PR DESCRIPTION
### Description

This PR improves accessibility testing coverage and reliability of Playwright E2E tests in the project.

Note: this also fixes some e2e test failures for my other branches, once this is merged in I will drop the duplicates in the other branches.

- https://github.com/kubernetes-sigs/headlamp/pull/3124
- https://github.com/kubernetes-sigs/headlamp/pull/3123

#### Accessibility Enhancements

- Adds `@axe-core/playwright` integration to the Namespaces Playwright test to perform automated **A11Y checks**.
- Introduces accessibility assertions to verify that no critical violations occur before and after creating a namespace.
- Fixes an issue detected by these tests: the **"Create" button lacked an accessible label**. This was resolved by adding an `aria-label` to ensure compliance with screen reader standards.

#### Navigation & Auth Logic Improvements

- Updates the **navigation and authentication logic** used in our Playwright E2E test setup.
(Previously, navigation during multi-cluster testing was **unreliable and prone to hanging or timing out** due to race conditions and cluster token loading delays.)
- The logic has been refactored to **work consistently in both CI and local testing environments**, with better handling of cluster contexts and token usage.

### Notes

- No issue was filed for this work — these improvements were identified during test development.
- More accessibility and stability improvements are planned in follow-up PRs to expand coverage across additional areas of the UI.
