### PR TITLE
plugins/examples/dynamic-clusters: Use theme color for buttons

### DIFF
--- a/plugins/examples/dynamic-clusters/src/index.tsx
+++ b/plugins/examples/dynamic-clusters/src/index.tsx
@@ -97,7 +97,9 @@ function ClusterCreationButton() {
 
   return (
     <>
-      <Button onClick={handleOpen}>New cluster</Button>
+      <Button color="inherit" onClick={handleOpen}>
+        New cluster
+      </Button>
       <Modal open={open} onClose={handleClose} style={modalStyle}>
         <Paper style={{ padding: '16px', width: '400px' }}>
           <Stack spacing={2}>
@@ -132,7 +134,9 @@ function ClusterCreationButton() {
                 />
               </>
             )}
-            <Button onClick={handleSubmit}>Submit</Button>
+            <Button color="inherit" onClick={handleSubmit}>
+              Submit
+            </Button>
 
             {/* Display error message to the user if an error occurred */}
             {error && (


### PR DESCRIPTION
This change applies the color of the button text for the dynamic-clusters plugin from the currently used theme.

### Testing
- [X] Run the dynamic-clusters plugin:

```
cd plugins/examples/dynamic-clusters && npm install
npm run build
npm run start
```
- [X] Change the theme and ensure that the text for the "New cluster" button and the "Submit" button in the dialog is visible

