### PR TITLE
frontend: Table: Add horizontal scrollbar on overflow

### DIFF
--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -151,7 +151,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1rr7dye-MuiTable-root"
+          class="MuiTable-root css-1p2wpqe-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -151,7 +151,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1rr7dye-MuiTable-root"
+          class="MuiTable-root css-1p2wpqe-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -151,7 +151,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1rr7dye-MuiTable-root"
+          class="MuiTable-root css-1p2wpqe-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -151,7 +151,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1rr7dye-MuiTable-root"
+          class="MuiTable-root css-1p2wpqe-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -151,7 +151,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1rr7dye-MuiTable-root"
+          class="MuiTable-root css-1p2wpqe-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -151,7 +151,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-jg49s4-MuiTable-root"
+          class="MuiTable-root css-1ca5o47-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -125,7 +125,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-4ih6jr-MuiTable-root"
+      class="MuiTable-root css-ygfd7h-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -125,7 +125,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-4ih6jr-MuiTable-root"
+      class="MuiTable-root css-ygfd7h-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -125,7 +125,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-5t7rfc-MuiTable-root"
+      class="MuiTable-root css-1jnbgrs-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -381,7 +381,8 @@ export default function Table<RowItem extends Record<string, any>>({
           borderColor: theme.palette.tables.head.borderColor,
           borderRadius: 1,
           borderBottom: 'none',
-          overflow: 'hidden',
+          overflowX: 'auto',
+          width: '100%',
           gridTemplateColumns,
         }}
       >

--- a/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
@@ -125,7 +125,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
@@ -125,7 +125,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-35vhoj-MuiTable-root"
+      class="MuiTable-root css-j5wd0t-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
@@ -234,7 +234,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
@@ -234,7 +234,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
@@ -234,7 +234,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
@@ -268,7 +268,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
@@ -234,7 +234,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
@@ -234,7 +234,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-yhdpo9-MuiTable-root"
+      class="MuiTable-root css-dq3jrr-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
@@ -142,7 +142,7 @@
         </div>
       </div>
       <table
-        class="MuiTable-root css-yhdpo9-MuiTable-root"
+        class="MuiTable-root css-dq3jrr-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
@@ -142,7 +142,7 @@
         </div>
       </div>
       <table
-        class="MuiTable-root css-yhdpo9-MuiTable-root"
+        class="MuiTable-root css-dq3jrr-MuiTable-root"
       >
         <thead
           class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
@@ -234,7 +234,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
@@ -125,7 +125,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1ww7pa8-MuiTable-root"
+      class="MuiTable-root css-1q0rggb-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -190,7 +190,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
@@ -125,7 +125,7 @@
       </div>
     </div>
     <table
-      class="MuiTable-root css-1rr7dye-MuiTable-root"
+      class="MuiTable-root css-1p2wpqe-MuiTable-root"
     >
       <thead
         class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-geqyri-MuiTable-root"
+          class="MuiTable-root css-xsr5nr-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -600,7 +600,7 @@
                 </div>
               </div>
               <table
-                class="MuiTable-root css-vqz2ad-MuiTable-root"
+                class="MuiTable-root css-aypfj2-MuiTable-root"
               >
                 <thead
                   class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -240,7 +240,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1yzichq-MuiTable-root"
+          class="MuiTable-root css-o2jlm0-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -235,7 +235,7 @@
                 </div>
               </div>
               <table
-                class="MuiTable-root css-vqz2ad-MuiTable-root"
+                class="MuiTable-root css-aypfj2-MuiTable-root"
               >
                 <thead
                   class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-iughmm-MuiTable-root"
+          class="MuiTable-root css-10si4eq-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -255,7 +255,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-au31rb-MuiTable-root"
+            class="MuiTable-root css-7biw9r-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -255,7 +255,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-1l0hp7f-MuiTable-root"
+            class="MuiTable-root css-heugea-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1frccgy-MuiTable-root"
+          class="MuiTable-root css-1pn9zsq-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -163,7 +163,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-ezzezi-MuiTable-root"
+          class="MuiTable-root css-1ah2k8q-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-jg49s4-MuiTable-root"
+          class="MuiTable-root css-1ca5o47-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-14ed351-MuiTable-root"
+          class="MuiTable-root css-13kw56n-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-j39jtj-MuiTable-root"
+          class="MuiTable-root css-1cl9dip-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-6j6zyh-MuiTable-root"
+          class="MuiTable-root css-1qlqnwc-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -163,7 +163,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-10c70tg-MuiTable-root"
+          class="MuiTable-root css-1b3kskg-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-14ed351-MuiTable-root"
+          class="MuiTable-root css-13kw56n-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -240,7 +240,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1rba7vu-MuiTable-root"
+          class="MuiTable-root css-ylfzox-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-azn9u7-MuiTable-root"
+          class="MuiTable-root css-1rgvv0h-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -240,7 +240,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-jg49s4-MuiTable-root"
+          class="MuiTable-root css-1ca5o47-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -163,7 +163,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-jg49s4-MuiTable-root"
+          class="MuiTable-root css-1ca5o47-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -166,7 +166,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-1d6yn00-MuiTable-root"
+            class="MuiTable-root css-1drzxj3-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -240,7 +240,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1qms20a-MuiTable-root"
+          class="MuiTable-root css-yo0ry-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-ln76w2-MuiTable-root"
+          class="MuiTable-root css-pp14pd-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -163,7 +163,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1jj4fq4-MuiTable-root"
+          class="MuiTable-root css-14pvwot-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -255,7 +255,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-t25swp-MuiTable-root"
+            class="MuiTable-root css-155ms3a-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -240,7 +240,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-j39jtj-MuiTable-root"
+          class="MuiTable-root css-1cl9dip-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -163,7 +163,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1xvvytd-MuiTable-root"
+          class="MuiTable-root css-1fjavuh-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-anbprb-MuiTable-root"
+          class="MuiTable-root css-1tyiahi-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1s4tfn4-MuiTable-root"
+          class="MuiTable-root css-kmiwto-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -163,7 +163,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1jtzi6r-MuiTable-root"
+          class="MuiTable-root css-1lubqn6-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -163,7 +163,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-1jtzi6r-MuiTable-root"
+          class="MuiTable-root css-1lubqn6-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -252,7 +252,7 @@
           </div>
         </div>
         <table
-          class="MuiTable-root css-14ed351-MuiTable-root"
+          class="MuiTable-root css-13kw56n-MuiTable-root"
         >
           <thead
             class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -166,7 +166,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-mm1xvq-MuiTable-root"
+            class="MuiTable-root css-mh2h9q-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -166,7 +166,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-mm1xvq-MuiTable-root"
+            class="MuiTable-root css-mh2h9q-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"


### PR DESCRIPTION
This change adds a horizontal scrollbar to the Table component on overflow, allowing the resource list tables to be usable on zoom levels above 200%.

Fixes: #3056 

### Testing
- [X] Open Headlamp and navigate to a resource list
- [X] Increase the zoom until some of the columns are cut off the page and ensure a horizontal scrollbar is visible