### PR TITLE
app: backend: Add flag for watching plugins changes

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -90,6 +90,10 @@ const args = yargs(hideBin(process.argv))
       describe: 'Disable use of GPU. For people who may have buggy graphics drivers',
       type: 'boolean',
     },
+    'watch-plugins-changes': {
+      describe: 'Reloads plugins when there are changes to them or their directory',
+      type: 'boolean',
+    },
   })
   .positional('kubeconfig', {
     describe:
@@ -561,6 +565,9 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   const proxyUrls = !!buildManifest && buildManifest['proxy-urls'];
   if (!!proxyUrls && proxyUrls.length > 0) {
     serverArgs = serverArgs.concat(['--proxy-urls', proxyUrls.join(',')]);
+  }
+  if (args.watchPluginsChanges !== undefined) {
+    serverArgs.push(`--watch-plugins-changes=${args.watchPluginsChanges}`);
   }
 
   const bundledPlugins = path.join(process.resourcesPath, '.plugins');

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -47,6 +47,7 @@ type HeadlampConfig struct {
 	insecure              bool
 	enableHelm            bool
 	enableDynamicClusters bool
+	watchPluginsChanges   bool
 	port                  uint
 	kubeConfigPath        string
 	skippedKubeContexts   string
@@ -358,7 +359,7 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 
 	skipFunc := kubeconfig.SkipKubeContextInCommaSeparatedString(config.skippedKubeContexts)
 
-	if !config.useInCluster {
+	if !config.useInCluster || config.watchPluginsChanges {
 		// in-cluster mode is unlikely to want reloading plugins.
 		pluginEventChan := make(chan string)
 		go plugins.Watch(config.pluginDir, pluginEventChan)

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -54,6 +54,7 @@ func main() {
 		proxyURLs:             strings.Split(conf.ProxyURLs, ","),
 		enableHelm:            conf.EnableHelm,
 		enableDynamicClusters: conf.EnableDynamicClusters,
+		watchPluginsChanges:   conf.WatchPluginsChanges,
 		cache:                 cache,
 		kubeConfigStore:       kubeConfigStore,
 		multiplexer:           multiplexer,

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	EnableHelm            bool   `koanf:"enable-helm"`
 	EnableDynamicClusters bool   `koanf:"enable-dynamic-clusters"`
 	ListenAddr            string `koanf:"listen-addr"`
+	WatchPluginsChanges   bool   `koanf:"watch-plugins-changes"`
 	Port                  uint   `koanf:"port"`
 	KubeConfigPath        string `koanf:"kubeconfig"`
 	SkippedKubeContexts   string `koanf:"skipped-kube-contexts"`
@@ -88,6 +89,13 @@ func Parse(args []string) (*Config, error) {
 		return nil, fmt.Errorf("error parsing flags: %w", err)
 	}
 
+	explicitFlags := make(map[string]bool)
+
+	// Record which flags were explicitly set by the user
+	f.Visit(func(f *flag.Flag) {
+		explicitFlags[f.Name] = true
+	})
+
 	// Load config from env
 	if err := k.Load(env.Provider("HEADLAMP_CONFIG_", ".", func(s string) string {
 		return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(s, "HEADLAMP_CONFIG_")), "_", "-")
@@ -119,6 +127,12 @@ func Parse(args []string) (*Config, error) {
 		logger.Log(logger.LevelError, nil, err, "unmarshalling config")
 
 		return nil, fmt.Errorf("error unmarshal config: %w", err)
+	}
+
+	// If running in-cluster and the user did not explicitly set the watch flag,
+	// then force WatchPluginsChanges to false.
+	if config.InCluster && !explicitFlags["watch-plugins-changes"] {
+		config.WatchPluginsChanges = false
 	}
 
 	// Validate parsed config
@@ -155,6 +169,8 @@ func flagset() *flag.FlagSet {
 	f.Bool("dev", false, "Allow connections from other origins")
 	f.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	f.Bool("enable-dynamic-clusters", false, "Enable dynamic clusters, which stores stateless clusters in the frontend.")
+	// Note: When running in-cluster and if not explicitly set, this flag defaults to false.
+	f.Bool("watch-plugins-changes", true, "Reloads plugins when there are changes to them or their directory")
 
 	f.String("kubeconfig", "", "Absolute path to the kubeconfig file")
 	f.String("skipped-kube-contexts", "", "Context name which should be ignored in kubeconfig file")

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -198,7 +198,7 @@ DOCKER_IMAGE_VERSION=development make image
 #### Create a deployment yaml
 
 ```bash
-kubectl create deployment headlamp -n kube-system --image=headlamp-k8s/headlamp:development -o yaml --dry-run -- /headlamp/headlamp-server -html-static-dir /headlamp/frontend -in-cluster -plugins-dir=/headlamp/plugins > minikube-headlamp.yaml
+kubectl create deployment headlamp -n kube-system --image=headlamp-k8s/headlamp:development -o yaml --dry-run -- /headlamp/headlamp-server -html-static-dir /headlamp/frontend -in-cluster -watch-plugins-changes false -plugins-dir=/headlamp/plugins > minikube-headlamp.yaml
 ```
 
 To use the local container image we change the `imagePullPolicy` to Never.


### PR DESCRIPTION
This change creates a CLI flag in the backend + desktop for watching changes to the plugins or their directory.

Fixes: #2894, follow-up from #2939

### Testing
#### Backend
- [X] Run `make backend`
- [X] Run `cd backend && ./headlamp-server -watch-plugins-changes false`

#### Desktop
- [X] Run `cd app && npm run build`
- [X] Run `cd dist/linux-unpacked && ./headlamp -watch-plugins-changes  false` and ensure that the flag is passed in