### PR TITLE
frontend: Settings: Replace theme dropdown menu with grid-based selector

### DIFF
--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -15,9 +15,8 @@
  */
 
 import Box from '@mui/material/Box';
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
 import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
 import { capitalize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -29,6 +28,7 @@ import { useTypedSelector } from '../../../redux/reducers/reducers';
 import { uiSlice } from '../../../redux/uiSlice';
 import { ActionButton, NameValueTable, SectionBox } from '../../common';
 import TimezoneSelect from '../../common/TimezoneSelect';
+import { theme } from '../../TestHelpers/theme';
 import { setTheme, useAppThemes } from '../themeSlice';
 import DrawerModeSettings from './DrawerModeSettings';
 import { useSettings } from './hook';
@@ -99,29 +99,6 @@ export default function Settings() {
             value: <LocaleSelect showFullNames formControlProps={{ className: '' }} />,
           },
           {
-            name: t('translation|Theme'),
-            value: (
-              <Select
-                variant="outlined"
-                size="small"
-                defaultValue={themeName}
-                onChange={e => {
-                  dispatch(setTheme(e.target.value as string));
-                  console.log(e, e.target.value);
-                }}
-              >
-                {appThemes.map(it => (
-                  <MenuItem key={it.name} value={it.name}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <ThemePreview theme={it} />
-                      {capitalize(it.name)}
-                    </Box>
-                  </MenuItem>
-                ))}
-              </Select>
-            ),
-          },
-          {
             name: t('translation|Resource details view'),
             value: <DrawerModeSettings />,
           },
@@ -166,6 +143,87 @@ export default function Settings() {
           },
         ]}
       />
+      <Box
+        sx={{
+          mt: '2',
+          borderTop: '1px solid',
+          borderTopColor: 'divider',
+          pt: '2',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'baseline',
+            px: 1.5,
+            py: 1,
+          }}
+        >
+          <Typography
+            variant="body1"
+            sx={theme => ({
+              textAlign: 'left',
+              color: theme.palette.text.secondary,
+              fontSize: '1rem',
+              [theme.breakpoints.down('sm')]: {
+                fontSize: '1.5rem',
+                color: theme.palette.text.primary,
+              },
+            })}
+          >
+            {t('translation|Theme')}
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            width: '100%',
+            margin: 'auto',
+            pb: 5,
+          }}
+        >
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+              gap: 2,
+              justifyContent: 'center',
+              [theme.breakpoints.down('sm')]: {
+                gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))',
+                gap: 2,
+              },
+            }}
+          >
+            {appThemes.map(it => (
+              <Box
+                key={it.name}
+                role="button"
+                tabIndex={0}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') dispatch(setTheme(it.name));
+                }}
+                sx={{
+                  cursor: 'pointer',
+                  border: themeName === it.name ? '2px solid' : '1px solid',
+                  borderColor: themeName === it.name ? 'primary' : 'divider',
+                  borderRadius: 2,
+                  p: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  transition: '0.2 ease',
+                  '&:hover': {
+                    backgroundColor: 'divider',
+                  },
+                }}
+                onClick={() => dispatch(setTheme(it.name))}
+              >
+                <ThemePreview theme={it} size={110} />
+                <Box sx={{ mt: 1 }}>{capitalize(it.name)}</Box>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      </Box>
     </SectionBox>
   );
 }

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -134,87 +134,6 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
           >
-            Theme
-          </dt>
-          <dd
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
-          >
-            <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall  css-uwmwwo-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-            >
-              <div
-                aria-controls=":mock-test-id:"
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-oswssk-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                role="combobox"
-                tabindex="0"
-              >
-                <div
-                  class="MuiBox-root css-axw7ok"
-                >
-                  <div
-                    class="MuiBox-root css-1ii52co"
-                  >
-                    <div
-                      class="MuiBox-root css-1f1uc6a"
-                    />
-                    <div
-                      class="MuiBox-root css-1z0uf79"
-                    />
-                    <div
-                      class="MuiBox-root css-5zxu0k"
-                    />
-                    <div
-                      class="MuiBox-root css-1oxk0si"
-                    />
-                    <div
-                      class="MuiBox-root css-jkymop"
-                    />
-                    <div
-                      class="MuiBox-root css-n01h7b"
-                    />
-                  </div>
-                  Light
-                </div>
-              </div>
-              <input
-                aria-hidden="true"
-                aria-invalid="false"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                tabindex="-1"
-                value="light"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
-                data-testid="ArrowDropDownIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7 10l5 5 5-5z"
-                />
-              </svg>
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-              >
-                <legend
-                  class="css-ihdtdm"
-                >
-                  <span
-                    class="notranslate"
-                  >
-                    ​
-                  </span>
-                </legend>
-              </fieldset>
-            </div>
-          </dd>
-          <dt
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
-          >
             Resource details view
           </dt>
           <dd
@@ -462,6 +381,126 @@
             </span>
           </dd>
         </dl>
+        <div
+          class="MuiBox-root css-1k57ox4"
+        >
+          <div
+            class="MuiBox-root css-xonqoi"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-k2ogvs-MuiTypography-root"
+            >
+              Theme
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-exrnj3"
+          >
+            <div
+              class="MuiBox-root css-1a2ne5x"
+            >
+              <div
+                class="MuiBox-root css-1yhz2ch"
+                role="button"
+                tabindex="0"
+              >
+                <div
+                  class="MuiBox-root css-h3uu27"
+                >
+                  <div
+                    class="MuiBox-root css-1f1uc6a"
+                  />
+                  <div
+                    class="MuiBox-root css-1z0uf79"
+                  />
+                  <div
+                    class="MuiBox-root css-5zxu0k"
+                  />
+                  <div
+                    class="MuiBox-root css-1oxk0si"
+                  />
+                  <div
+                    class="MuiBox-root css-jkymop"
+                  />
+                  <div
+                    class="MuiBox-root css-n01h7b"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root css-164r41r"
+                >
+                  Light
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-ba9uxd"
+                role="button"
+                tabindex="0"
+              >
+                <div
+                  class="MuiBox-root css-1giqewv"
+                >
+                  <div
+                    class="MuiBox-root css-ni9bm1"
+                  />
+                  <div
+                    class="MuiBox-root css-1z0uf79"
+                  />
+                  <div
+                    class="MuiBox-root css-3dcp9m"
+                  />
+                  <div
+                    class="MuiBox-root css-1coq5wc"
+                  />
+                  <div
+                    class="MuiBox-root css-ew82rx"
+                  />
+                  <div
+                    class="MuiBox-root css-1ep3rs4"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root css-164r41r"
+                >
+                  Dark
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-ba9uxd"
+                role="button"
+                tabindex="0"
+              >
+                <div
+                  class="MuiBox-root css-h3uu27"
+                >
+                  <div
+                    class="MuiBox-root css-1aoxae"
+                  />
+                  <div
+                    class="MuiBox-root css-1xqumfe"
+                  />
+                  <div
+                    class="MuiBox-root css-19czym2"
+                  />
+                  <div
+                    class="MuiBox-root css-1swhc7p"
+                  />
+                  <div
+                    class="MuiBox-root css-c8sfqn"
+                  />
+                  <div
+                    class="MuiBox-root css-8jmga1"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root css-164r41r"
+                >
+                  Headlamp classic
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR replaces the theme <Select> dropdown with a grid-based selector.

The grid uses appThemes to render all themes visually, allowing users to click and apply them.

I noticed the base themes are defined in themeSlice.ts, but I couldn’t clearly identify how to distinguish them from plugin-registered themes. If there’s a recommended way to separate base and plugin themes visually, I’d love some guidance to follow up with a second PR or improvement.

![headlamp](https://github.com/user-attachments/assets/07cd771a-e259-4676-b074-c84aa9c91857)

#3155
