### PR TITLE
Revert "Fix e2e auth logic + add namespace a11y playwright tests"

### DIFF
--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -9,24 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@axe-core/playwright": "^4.10.1",
         "yaml": "^2.3.4"
       },
       "devDependencies": {
         "@playwright/test": "^1.42.1",
         "@types/node": "^20.12.2"
-      }
-    },
-    "node_modules/@axe-core/playwright": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
-      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "axe-core": "~4.10.2"
-      },
-      "peerDependencies": {
-        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -51,15 +38,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/axe-core": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fsevents": {
@@ -98,6 +76,7 @@
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
       "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -121,14 +100,6 @@
     }
   },
   "dependencies": {
-    "@axe-core/playwright": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
-      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
-      "requires": {
-        "axe-core": "~4.10.2"
-      }
-    },
     "@playwright/test": {
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
@@ -146,11 +117,6 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
-    },
-    "axe-core": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -172,7 +138,8 @@
     "playwright-core": {
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA=="
+      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "dev": true
     },
     "undici-types": {
       "version": "5.26.5",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -12,7 +12,6 @@
     "@types/node": "^20.12.2"
   },
   "dependencies": {
-    "@axe-core/playwright": "^4.10.1",
     "yaml": "^2.3.4"
   }
 }

--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -9,6 +9,8 @@ export class HeadlampPage {
   }
 
   async authenticate(token?: string) {
+    await this.page.waitForSelector('h1:has-text("Authentication")');
+
     // Check to see if already authenticated
     if (await this.page.isVisible('button:has-text("Authenticate")')) {
       this.hasToken(token || '');
@@ -22,16 +24,10 @@ export class HeadlampPage {
         this.page.click('button:has-text("Authenticate")'),
       ]);
     }
-
-    await this.page.waitForLoadState('load');
   }
 
   async navigateToCluster(name: string, token?: string) {
-    // Since we are using multi cluster structure we need to have a full reset navigation
-    await this.page.goto(`${this.testURL}`);
-    await this.page.waitForLoadState('load');
-    await this.page.getByRole('link', { name: name, exact: true }).click();
-    await this.page.waitForLoadState('load');
+    await this.navigateTopage(`/c/${name}`);
     await this.authenticate(token);
   }
 
@@ -79,16 +75,11 @@ export class HeadlampPage {
 
   async logout() {
     // Click on the account button to open the user menu
-    const userButton = await this.page.waitForSelector('[data-testid="user-account-button"]', {
-      state: 'visible',
-    });
-
-    await userButton.click();
+    await this.page.click('button[aria-label="Account of current user"]');
 
     // Wait for the logout option to be visible and click on it
-    await this.page.waitForSelector('[data-testid="logout-menu-item"]');
-    await this.page.click('[data-testid="logout-menu-item"]');
-
+    await this.page.waitForSelector('a.MuiMenuItem-root:has-text("Log out")');
+    await this.page.click('a.MuiMenuItem-root:has-text("Log out")');
     await this.page.waitForLoadState('load');
 
     // Expects the URL to contain c/test/token

--- a/e2e-tests/tests/namespaces.spec.ts
+++ b/e2e-tests/tests/namespaces.spec.ts
@@ -1,5 +1,4 @@
-import { AxeBuilder } from '@axe-core/playwright';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { NamespacesPage } from './namespacesPage';
 
@@ -16,17 +15,6 @@ test('create a namespace with the minimal editor then delete it', async ({ page 
 
   const namespacesPage = new NamespacesPage(page);
   await namespacesPage.navigateToNamespaces();
-
-  const axeBuilder = new AxeBuilder({ page });
-
-  const accessibilityResults = await axeBuilder.analyze();
-
-  expect(accessibilityResults.violations.length).toBe(0);
-
   await namespacesPage.createNamespace(name);
-  const postCreationScanResults = await axeBuilder.analyze();
-
-  expect(postCreationScanResults.violations.length).toBe(0);
-
   await namespacesPage.deleteNamespace(name);
 });

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -269,7 +269,6 @@ export const PureTopBar = memo(
             <Icon icon="mdi:logout" />
           </ListItemIcon>
           <ListItemText
-            data-testid="logout-menu-item"
             primary={t('Log out')}
             secondary={hasToken ? null : t('(No token set up)')}
           />
@@ -329,7 +328,6 @@ export const PureTopBar = memo(
         action: !!isClusterContext && (
           <MenuItem>
             <IconButton
-              data-testid="user-account-button"
               aria-label={t('Account of current user')}
               aria-controls={userMenuId}
               aria-haspopup="true"
@@ -388,7 +386,6 @@ export const PureTopBar = memo(
         id: DefaultAppBarAction.USER,
         action: !!isClusterContext && (
           <IconButton
-            data-testid="user-account-button"
             aria-label={t('Account of current user')}
             aria-controls={userMenuId}
             aria-haspopup="true"

--- a/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
@@ -124,7 +124,6 @@
           aria-haspopup="true"
           aria-label="Account of current user"
           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
-          data-testid="user-account-button"
           tabindex="0"
           type="button"
         >

--- a/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
@@ -143,7 +143,6 @@
           aria-haspopup="true"
           aria-label="Account of current user"
           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
-          data-testid="user-account-button"
           tabindex="0"
           type="button"
         >

--- a/frontend/src/components/common/CreateResourceButton.tsx
+++ b/frontend/src/components/common/CreateResourceButton.tsx
@@ -36,7 +36,6 @@ export function CreateResourceButton(props: CreateResourceButtonProps) {
         errorMessage={errorMessage}
         onEditorChanged={() => setErrorMessage('')}
         title={t('translation|Create {{ name }}', { name })}
-        aria-label={t('translation|Create {{ name }}', { name })}
       />
     </AuthVisible>
   );


### PR DESCRIPTION
Reverts kubernetes-sigs/headlamp#3144

Seems like e2e tests started failing after this PR was merged 

Examples
https://github.com/kubernetes-sigs/headlamp/actions/runs/14639858867/job/41079478461?pr=3168
https://github.com/kubernetes-sigs/headlamp/actions/runs/14638805739/job/41076090849?pr=3167
https://github.com/kubernetes-sigs/headlamp/actions/runs/14639718092/job/41079030065?pr=3166
https://github.com/kubernetes-sigs/headlamp/actions/runs/14635662403/job/41066121159