### PR TITLE
e2e: Add a11y test for namespace and add aria label to create resourc…

### DIFF
--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -9,11 +9,24 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@axe-core/playwright": "^4.10.1",
         "yaml": "^2.3.4"
       },
       "devDependencies": {
         "@playwright/test": "^1.42.1",
         "@types/node": "^20.12.2"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
+      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.2"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -38,6 +51,15 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {
@@ -76,7 +98,6 @@
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
       "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -100,6 +121,14 @@
     }
   },
   "dependencies": {
+    "@axe-core/playwright": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.1.tgz",
+      "integrity": "sha512-EV5t39VV68kuAfMKqb/RL+YjYKhfuGim9rgIaQ6Vntb2HgaCaau0h98Y3WEUqW1+PbdzxDtDNjFAipbtZuBmEA==",
+      "requires": {
+        "axe-core": "~4.10.2"
+      }
+    },
     "@playwright/test": {
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
@@ -117,6 +146,11 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
+    },
+    "axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -138,8 +172,7 @@
     "playwright-core": {
       "version": "1.42.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true
+      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^20.12.2"
   },
   "dependencies": {
+    "@axe-core/playwright": "^4.10.1",
     "yaml": "^2.3.4"
   }
 }

--- a/e2e-tests/tests/namespaces.spec.ts
+++ b/e2e-tests/tests/namespaces.spec.ts
@@ -1,4 +1,5 @@
-import { test } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 import { NamespacesPage } from './namespacesPage';
 
@@ -15,6 +16,17 @@ test('create a namespace with the minimal editor then delete it', async ({ page 
 
   const namespacesPage = new NamespacesPage(page);
   await namespacesPage.navigateToNamespaces();
+
+  const axeBuilder = new AxeBuilder({ page });
+
+  const accessibilityResults = await axeBuilder.analyze();
+
+  expect(accessibilityResults.violations.length).toBe(0);
+
   await namespacesPage.createNamespace(name);
+  const postCreationScanResults = await axeBuilder.analyze();
+
+  expect(postCreationScanResults.violations.length).toBe(0);
+
   await namespacesPage.deleteNamespace(name);
 });

--- a/frontend/src/components/common/CreateResourceButton.tsx
+++ b/frontend/src/components/common/CreateResourceButton.tsx
@@ -36,6 +36,7 @@ export function CreateResourceButton(props: CreateResourceButtonProps) {
         errorMessage={errorMessage}
         onEditorChanged={() => setErrorMessage('')}
         title={t('translation|Create {{ name }}', { name })}
+        aria-label={t('translation|Create {{ name }}', { name })}
       />
     </AuthVisible>
   );


### PR DESCRIPTION
### Description

reworking reverted namespace PR since it was tied with another change

This PR improves accessibility testing coverage and reliability of Playwright E2E tests in the project.

#### Accessibility Enhancements

- Adds `@axe-core/playwright` integration to the Namespaces Playwright test to perform automated **A11Y checks**.
- Introduces accessibility assertions to verify that no critical violations occur before and after creating a namespace.
- Fixes an issue detected by these tests: the **"Create" button lacked an accessible label**. This was resolved by adding an `aria-label` to ensure compliance with screen reader standards.

### Notes

- No issue was filed for this work — these improvements were identified during test development.
- More accessibility and stability improvements are planned in follow-up PRs to expand coverage across additional areas of the UI.
