### PR TITLE
backend: Resolve issues with websocket token encoding

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1209,8 +1209,15 @@ func processTokenProtocol(r *http.Request, protocol, tokenPrefix string) {
 	}
 
 	// Try to decode token from base64
-	if decodedBytes, err := base64.URLEncoding.DecodeString(token); err == nil {
+	decodedBytes, err := base64.URLEncoding.DecodeString(token)
+	if err == nil {
 		token = string(decodedBytes)
+	} else {
+		// Account for the possibility of tokens without base64 padding
+		decodedBytes, err := base64.RawStdEncoding.DecodeString(token)
+		if err == nil {
+			token = string(decodedBytes)
+		}
 	}
 
 	r.Header.Set("Authorization", "Bearer "+token)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1064,6 +1064,7 @@ func TestHandleClusterHelm(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestProcessWebSocketProtocolHeader(t *testing.T) {
 	tests := []struct {
 		name                   string
@@ -1089,6 +1090,14 @@ func TestProcessWebSocketProtocolHeader(t *testing.T) {
 			name: "Header with single token protocol",
 			initialHeader: http.Header{
 				"Sec-Websocket-Protocol": []string{"base64url.bearer.authorization.k8s.io.dGVzdC10b2tlbg=="}, // "test-token"
+			},
+			expectedAuthHeader:     "Bearer test-token",
+			expectedProtocolHeader: "",
+		},
+		{
+			name: "Header with single token protocol and raw base64 encoding",
+			initialHeader: http.Header{
+				"Sec-Websocket-Protocol": []string{"base64url.bearer.authorization.k8s.io.dGVzdC10b2tlbg"}, // "test-token"
 			},
 			expectedAuthHeader:     "Bearer test-token",
 			expectedProtocolHeader: "",


### PR DESCRIPTION
This resolves an issue introduced in #3142 when decoding the bearer token from the websocket Sec-Websocket-Protoccol it assumes the token is padded.

When testing with tokens generated for Azure AKS and GKE, I noticed headlamp started to fail all websocket connections and upon further investigation, the tokens that did not have padding (==) were not decoded properly and the authorization header was malformed when sent to K8s.

This attempts to decode the token additionally with RawStdEncoding to catch these edge cases.

How to test:
- Included test case for tokens without base64 padding
- Test using Azure AKS or GKE using token obtained via OIDC integration or `kubelogin` (depends on the token whether or not padding is necessary, results were intermittent prior to this patch).