### PR TITLE
github/workflows/push-release-assets: Limit token permissions

### DIFF
--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish Assets


### PR DESCRIPTION
This change limits the permissions of the GITHUB_TOKEN as desired.