### PR TITLE
frontend: Fix container status color

### DIFF
--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -98,6 +98,9 @@ function getContainerDisplayStatus(container: KubeContainerStatus) {
   } else if (state.terminated) {
     color = 'green';
     label = 'Terminated';
+    if (state.terminated.reason === 'Error') {
+      color = 'red';
+    }
     if (state.terminated.reason) {
       tooltipLines.push(`Reason: ${state.terminated.reason}`);
     }


### PR DESCRIPTION
Fixes #3171 
* Add condition and different color when container state was terminated by an error

how to test:

apply the following 2 pod manifests to create a faulty and a working pod
start app and see both are showed properly
* the one with an error is red
* the one which was completed is green

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: error-pod
spec:
  restartPolicy: Never
  containers:
  - name: error-container
    image: busybox
    command: ["sh", "-c", "exit 1"]
```

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: good-pod
spec:
  restartPolicy: Never
  containers:
  - name: working-container
    image: busybox
    command: ["sh", "-c", "exit 0"]
```