### PR TITLE
frontend: i18n: Table: Add missing locale mappings

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -23,6 +23,8 @@ import { MRT_Localization_IT } from 'material-react-table/locales/it';
 import { MRT_Localization_JA } from 'material-react-table/locales/ja';
 import { MRT_Localization_KO } from 'material-react-table/locales/ko';
 import { MRT_Localization_PT } from 'material-react-table/locales/pt';
+import { MRT_Localization_ZH_HANS } from 'material-react-table/locales/zh-Hans';
+import { MRT_Localization_ZH_HANT } from 'material-react-table/locales/zh-Hant';
 import { memo, ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTablesRowsPerPage } from '../../../helpers/tablesRowsPerPage';
@@ -136,6 +138,8 @@ const tableLocalizationMap: Record<string, MRT_Localization> = {
   ja: MRT_Localization_JA,
   pt: MRT_Localization_PT,
   ko: MRT_Localization_KO,
+  zh: MRT_Localization_ZH_HANS,
+  'zh-TW': MRT_Localization_ZH_HANT,
 };
 
 const StyledHeadRow = styled('tr')(({ theme }) => ({

--- a/frontend/src/i18n/ThemeProviderNexti18n.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.tsx
@@ -1,4 +1,16 @@
-import { deDE, enUS, esES, frFR, hiIN, itIT, jaJP, koKR, ptPT, zhTW } from '@mui/material/locale';
+import {
+  deDE,
+  enUS,
+  esES,
+  frFR,
+  hiIN,
+  itIT,
+  jaJP,
+  koKR,
+  ptPT,
+  zhCN,
+  zhTW,
+} from '@mui/material/locale';
 import { createTheme, StyledEngineProvider, Theme, ThemeProvider } from '@mui/material/styles';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,8 +29,21 @@ function getLocale(locale: string): typeof enUS {
     ko: koKR,
     'zh-tw': zhTW,
     ja: jaJP,
+    zh: zhCN,
   };
-  type LocalesType = 'en' | 'pt' | 'es' | 'ta' | 'de' | 'hi' | 'fr' | 'it' | 'zh-tw' | 'ja' | 'ko';
+  type LocalesType =
+    | 'en'
+    | 'pt'
+    | 'es'
+    | 'ta'
+    | 'de'
+    | 'hi'
+    | 'fr'
+    | 'it'
+    | 'zh-tw'
+    | 'ja'
+    | 'ko'
+    | 'zh';
   return locale in LOCALES ? LOCALES[locale as LocalesType] : LOCALES['en'];
 }
 


### PR DESCRIPTION
This is so Material React Table, and Material UI use their internal locales when we switch to our locales.

So various UI elements in Table/Mui are rendered with the correct locales.

Before:
![image](https://github.com/user-attachments/assets/2e72251b-ce96-442f-b6d6-1b030ce87502)

After:
![image](https://github.com/user-attachments/assets/7e2fce47-ed91-4555-bcfe-7c57599eab6d)

![image](https://github.com/user-attachments/assets/157b4876-06ce-4c18-8fdb-e2f477709c09)
