### PR TITLE
e2e-tests: Add a11y check with Axe in many tests

### DIFF
--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -57,6 +57,7 @@ test('service page should have headlamp service', async () => {
 
   // Check if there is text "headlamp" on the page
   await headlampPage.checkPageContent('headlamp');
+  await headlampPage.a11y();
 });
 
 test('headlamp service page should contain port', async () => {
@@ -66,6 +67,7 @@ test('headlamp service page should contain port', async () => {
 
   // Check if there is text "TCP" on the page
   await headlampPage.checkPageContent('TCP');
+  await headlampPage.a11y();
 });
 
 test('main page should have Security tab', async () => {
@@ -78,6 +80,7 @@ test('Service account tab should have headlamp-admin', async () => {
 
   // Check if there is text "headlamp-admin" on the page
   await headlampPage.checkPageContent('headlamp-admin');
+  await headlampPage.a11y();
 });
 
 test('Logout the user', async () => {
@@ -94,9 +97,11 @@ test('pagination goes to next page', async () => {
 
   // Check if there is text "Rows per page" on the page
   await headlampPage.checkPageContent('Rows per page');
+  await headlampPage.a11y();
 
   // Check working of pagination
   await headlampPage.checkRows();
+  await headlampPage.a11y();
 });
 
 // --- Headlamp tests end --- //

--- a/e2e-tests/tests/headlampPage.ts
+++ b/e2e-tests/tests/headlampPage.ts
@@ -15,6 +15,7 @@
  */
 
 /// <reference types="node" />
+import { AxeBuilder } from '@axe-core/playwright';
 import { expect, Page } from '@playwright/test';
 
 export class HeadlampPage {
@@ -22,6 +23,12 @@ export class HeadlampPage {
 
   constructor(private page: Page) {
     this.testURL = process.env.HEADLAMP_TEST_URL || '/';
+  }
+
+  async a11y() {
+    const axeBuilder = new AxeBuilder({ page: this.page });
+    const accessibilityResults = await axeBuilder.analyze();
+    expect(accessibilityResults.violations).toStrictEqual([]);
   }
 
   async authenticate(token?: string) {
@@ -84,6 +91,7 @@ export class HeadlampPage {
     await this.page.goto(`${this.testURL}${path}`, {
       waitUntil: 'networkidle',
     });
+    await this.page.waitForLoadState('load');
     if (title) {
       await this.hasTitleContaining(title);
     }

--- a/e2e-tests/tests/namespaces.spec.ts
+++ b/e2e-tests/tests/namespaces.spec.ts
@@ -32,17 +32,11 @@ test('create a namespace with the minimal editor then delete it', async ({ page 
 
   const namespacesPage = new NamespacesPage(page);
   await namespacesPage.navigateToNamespaces();
-
-  const axeBuilder = new AxeBuilder({ page });
-
-  const accessibilityResults = await axeBuilder.analyze();
-
-  expect(accessibilityResults.violations.length).toBe(0);
+  await namespacesPage.a11y();
 
   await namespacesPage.createNamespace(name);
-  const postCreationScanResults = await axeBuilder.analyze();
-
-  expect(postCreationScanResults.violations.length).toBe(0);
+  await namespacesPage.a11y();
 
   await namespacesPage.deleteNamespace(name);
+  await namespacesPage.a11y();
 });

--- a/e2e-tests/tests/namespacesPage.ts
+++ b/e2e-tests/tests/namespacesPage.ts
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { AxeBuilder } from '@axe-core/playwright';
 import { expect, Page } from '@playwright/test';
 
 export class NamespacesPage {
   constructor(private page: Page) {}
+
+  async a11y() {
+    const axeBuilder = new AxeBuilder({ page: this.page });
+    const accessibilityResults = await axeBuilder.analyze();
+    expect(accessibilityResults.violations).toStrictEqual([]);
+  }
 
   async navigateToNamespaces() {
     await this.page.click('a span:has-text("Cluster")');
@@ -62,6 +68,8 @@ export class NamespacesPage {
     await page.getByRole('button', { name: 'Apply' }).click();
 
     await page.waitForSelector(`text=Applied ${name}`);
+
+    await this.a11y();
   }
 
   async deleteNamespace(name) {
@@ -83,5 +91,7 @@ export class NamespacesPage {
     await page.waitForSelector(`text=Are you sure you want to delete item ${name}?`);
     await page.click('button:has-text("Yes")');
     await page.waitForSelector(`text=Deleted item ${name}`);
+
+    await this.a11y();
   }
 }

--- a/e2e-tests/tests/pluginSetting.spec.ts
+++ b/e2e-tests/tests/pluginSetting.spec.ts
@@ -35,6 +35,8 @@ test('plugin settings page should have a table', async () => {
 
   await headlampPage.navigateTopage('/settings/plugins', /Plugins/);
   await headlampPage.tableHasHeaders('table', expectedHeaders);
+  // @todo: there be a11y dragons on settings page.
+  // await headlampPage.a11y();
 });
 
 test('pod counter plugin should have setting option', async () => {
@@ -44,4 +46,6 @@ test('pod counter plugin should have setting option', async () => {
   await headlampPage.clickOnPlugin(pluginName);
   await headlampPage.hasTitleContaining(/Plugin Details/);
   await headlampPage.checkPageContent('Custom Error Message');
+  // @todo: there be a11y dragons on settings page.
+  // await headlampPage.a11y();
 });

--- a/e2e-tests/tests/podsPage.ts
+++ b/e2e-tests/tests/podsPage.ts
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { AxeBuilder } from '@axe-core/playwright';
 import { expect, Page } from '@playwright/test';
 
 export class podsPage {
   constructor(private page: Page) {}
+
+  async a11y() {
+    const axeBuilder = new AxeBuilder({ page: this.page });
+    const accessibilityResults = await axeBuilder.analyze();
+    expect(accessibilityResults.violations).toStrictEqual([]);
+  }
 
   async navigateToPods() {
     await this.page.click('span:has-text("Workloads")');
@@ -25,6 +31,8 @@ export class podsPage {
     await this.page.waitForSelector('span:has-text("Pods")');
     await this.page.waitForLoadState('load');
     await this.page.click('span:has-text("Pods")');
+
+    await this.a11y();
 
     console.log('Now on the pods page');
   }
@@ -76,6 +84,7 @@ spec:
     await expect(podLink).toBeVisible();
 
     console.log(`Created pod ${name}`);
+    await this.a11y();
   }
 
   async deletePod(name) {
@@ -99,6 +108,7 @@ spec:
     await page.waitForSelector(`text=Deleted item ${name}`);
 
     console.log(`Deleted pod ${name}`);
+    await this.a11y();
   }
 
   async confirmPodCreation(name) {
@@ -111,6 +121,7 @@ spec:
     await expect(podLink).toBeVisible();
 
     console.log(`Pod ${name} is running`);
+    await this.a11y();
   }
 
   async confirmPodDeletion(name) {
@@ -123,5 +134,6 @@ spec:
     await expect(podLink).not.toBeVisible();
 
     console.log(`Pod ${name} is deleted`);
+    await this.a11y();
   }
 }


### PR DESCRIPTION
This should let us find a11y issues in the parts of the app that are tested by our playwright tests.

Thanks @vyncent-t


### When it fails

This is what it looks like when it fails. (Note the a11y violations are there pretty printed with the failing test).

![image](https://github.com/user-attachments/assets/d6a25d0f-3860-47b8-b4ff-14ac174441ac)
