### PR TITLE
frontend: Various multicluster fixes

### DIFF
--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -20,6 +20,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router-dom';
+import { formatClusterPathParam } from '../../../lib/cluster';
 import { useClustersConf, useClustersVersion } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/apiProxy';
 import { Cluster } from '../../../lib/k8s/cluster';
@@ -189,10 +190,9 @@ export default function ClusterTable({
           onClick={() => {
             history.push({
               pathname: generatePath(getClusterPrefixedPath(), {
-                cluster: table
-                  .getSelectedRowModel()
-                  .rows.map(it => it.original.name)
-                  .join('+'),
+                cluster: formatClusterPathParam(
+                  table.getSelectedRowModel().rows.map(it => it.original.name)
+                ),
               }),
             });
           }}

--- a/frontend/src/components/App/Home/RecentClusters.tsx
+++ b/frontend/src/components/App/Home/RecentClusters.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router-dom';
 import { isElectron } from '../../../helpers/isElectron';
 import { getRecentClusters, setRecentCluster } from '../../../helpers/recentClusters';
-import { getClusterPrefixedPath } from '../../../lib/cluster';
+import { formatClusterPathParam, getClusterPrefixedPath } from '../../../lib/cluster';
 import { Cluster } from '../../../lib/k8s/cluster';
 import { createRouteURL } from '../../../lib/router';
 import { MULTI_HOME_ENABLED } from './config';
@@ -119,7 +119,7 @@ export default function RecentClusters(props: RecentClustersProps) {
 
     history.push({
       pathname: generatePath(getClusterPrefixedPath(), {
-        cluster: selectedClusters.map(cluster => cluster.name).join('+'),
+        cluster: formatClusterPathParam(selectedClusters.map(cluster => cluster.name)),
       }),
     });
   }

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -19,7 +19,7 @@ import List from '@mui/material/List';
 import ListItem, { ListItemProps } from '@mui/material/ListItem';
 import React, { memo } from 'react';
 import { generatePath } from 'react-router';
-import { getClusterPrefixedPath } from '../../lib/cluster';
+import { formatClusterPathParam, getClusterPrefixedPath } from '../../lib/cluster';
 import { useSelectedClusters } from '../../lib/k8s';
 import { createRouteURL, getRoute } from '../../lib/router';
 import ListItemLink from './ListItemLink';
@@ -63,7 +63,7 @@ const SidebarItem = memo((props: SidebarItemProps) => {
   let fullURL = url;
   if (fullURL && useClusterURL && clusters.length) {
     fullURL = generatePath(getClusterPrefixedPath(url), {
-      cluster: clusters.length ? clusters.join('+') : '',
+      cluster: clusters.length ? formatClusterPathParam(clusters) : '',
     });
   }
 

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -19,7 +19,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Link as RouterLink } from 'react-router-dom';
-import { getCluster } from '../../lib/cluster';
+import { formatClusterPathParam, getCluster, getSelectedClusters } from '../../lib/cluster';
 import { kubeObjectQueryKey, useEndpoints } from '../../lib/k8s/api/v2/hooks';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import { createRouteURL, RouteURLProps } from '../../lib/router';
@@ -40,6 +40,8 @@ export interface LinkProps extends LinkBaseProps {
   params?: RouteURLProps;
   /** A string representation of query parameters. */
   search?: string;
+  /** Cluster name of the resource. Set this parameter to not override selected clusters param */
+  activeCluster?: string;
   /** State to persist to the location. */
   state?: {
     [prop: string]: any;
@@ -109,8 +111,13 @@ function PureLink(
     state,
     // eslint-disable-next-line no-unused-vars -- make sure not to pass it to the link
     kubeObject,
+    activeCluster,
     ...otherProps
   } = props as LinkObjectProps;
+
+  if (activeCluster) {
+    params.cluster = formatClusterPathParam(getSelectedClusters(), activeCluster);
+  }
 
   return (
     <MuiLink
@@ -143,7 +150,7 @@ export default function Link(props: React.PropsWithChildren<LinkProps | LinkObje
   const cluster =
     'kubeObject' in props && props.kubeObject?.cluster
       ? props.kubeObject?.cluster
-      : getCluster() ?? '';
+      : props.activeCluster ?? getCluster() ?? '';
 
   const openDrawer =
     drawerEnabled && canRenderDetails(kind)

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -414,7 +414,13 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
               filterVariant: 'multi-select',
               Cell: ({ row }: { row: MRT_Row<RowItem> }) =>
                 row.original?.getNamespace() ? (
-                  <Link routeName="namespace" params={{ name: row.original.getNamespace() }}>
+                  <Link
+                    routeName="namespace"
+                    params={{
+                      name: row.original.getNamespace(),
+                    }}
+                    activeCluster={row.original.cluster}
+                  >
                     {row.original.getNamespace()}
                   </Link>
                 ) : (

--- a/frontend/src/components/crd/CustomResourceDetails.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.tsx
@@ -162,6 +162,7 @@ function CustomResourceDetailsRenderer(props: CustomResourceDetailsRendererProps
                 params={{
                   name: crd.metadata.name,
                 }}
+                activeCluster={crd.cluster}
               >
                 {crd.metadata.name}
               </Link>

--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -111,6 +111,7 @@ function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
                     crd: getCRDForCR(cr).metadata.name,
                     namespace: cr.metadata.namespace ?? '-',
                   }}
+                  activeCluster={cr.cluster}
                 >
                   {cr.metadata.name}
                 </Link>
@@ -129,6 +130,7 @@ function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
                   params={{
                     name: getCRDForCR(cr).metadata.name,
                   }}
+                  activeCluster={cr.cluster}
                 >
                   {cr.kind}
                 </Link>

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -70,6 +70,7 @@ function CustomResourceLink(props: {
         crd: crd.metadata.name,
         namespace: resource.metadata.namespace || '-',
       }}
+      activeCluster={resource.cluster}
       {...otherProps}
     >
       {resource.metadata.name}
@@ -97,7 +98,7 @@ function CustomResourceListRenderer(props: CustomResourceListProps) {
         ]}
         actions={[
           <Box mr={2}>
-            <Link routeName="crd" params={{ name: crd.metadata.name }}>
+            <Link routeName="crd" params={{ name: crd.metadata.name }} activeCluster={crd.cluster}>
               {t('glossary|CRD: {{ crdName }}', { crdName: crd.metadata.name })}
             </Link>
           </Box>,

--- a/frontend/src/components/crd/Details.tsx
+++ b/frontend/src/components/crd/Details.tsx
@@ -66,6 +66,7 @@ export default function CustomResourceDefinitionDetails(props: { name?: string }
                   params={{
                     crd: item.metadata.name,
                   }}
+                  activeCluster={item.cluster}
                 >
                   {item.spec.names.kind}
                 </Link>

--- a/frontend/src/components/crd/List.tsx
+++ b/frontend/src/components/crd/List.tsx
@@ -58,6 +58,7 @@ export default function CustomResourceDefinitionList() {
               params={{
                 crd: crd.metadata.name,
               }}
+              activeCluster={crd.cluster}
             >
               {crd.spec.names.kind}
             </Link>
@@ -72,6 +73,7 @@ export default function CustomResourceDefinitionList() {
               params={{
                 name: crd.metadata.name,
               }}
+              activeCluster={crd.cluster}
             >
               {crd.metadata.name}
             </Link>

--- a/frontend/src/components/gateway/GatewayDetails.tsx
+++ b/frontend/src/components/gateway/GatewayDetails.tsx
@@ -89,7 +89,11 @@ export default function GatewayDetails(props: { name?: string; namespace?: strin
           {
             name: t('Class Name'),
             value: gateway.spec?.gatewayClassName ? (
-              <Link routeName="gatewayclass" params={{ name: gateway.spec?.gatewayClassName }}>
+              <Link
+                routeName="gatewayclass"
+                params={{ name: gateway.spec?.gatewayClassName }}
+                activeCluster={gateway.cluster}
+              >
                 {gateway.spec?.gatewayClassName}
               </Link>
             ) : null,

--- a/frontend/src/components/gateway/GatewayList.tsx
+++ b/frontend/src/components/gateway/GatewayList.tsx
@@ -37,7 +37,11 @@ export default function GatewayList() {
           getValue: gateway => gateway.spec?.gatewayClassName,
           render: gateway =>
             gateway.spec?.gatewayClassName ? (
-              <Link routeName="gatewayclass" params={{ name: gateway.spec?.gatewayClassName }}>
+              <Link
+                routeName="gatewayclass"
+                params={{ name: gateway.spec?.gatewayClassName }}
+                activeCluster={gateway.cluster}
+              >
                 {gateway.spec?.gatewayClassName}
               </Link>
             ) : null,

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -239,7 +239,11 @@ export default function IngressDetails(props: {
           {
             name: t('Class Name'),
             value: ingress.spec?.ingressClassName ? (
-              <Link routeName="ingressclass" params={{ name: ingress.spec?.ingressClassName }}>
+              <Link
+                routeName="ingressclass"
+                params={{ name: ingress.spec?.ingressClassName }}
+                activeCluster={ingress.cluster}
+              >
                 {ingress.spec?.ingressClassName}
               </Link>
             ) : null,

--- a/frontend/src/components/ingress/List.tsx
+++ b/frontend/src/components/ingress/List.tsx
@@ -67,7 +67,11 @@ export default function IngressList() {
           getValue: ingress => ingress.spec?.ingressClassName,
           render: ingress =>
             ingress.spec?.ingressClassName ? (
-              <Link routeName="ingressclass" params={{ name: ingress.spec?.ingressClassName }}>
+              <Link
+                routeName="ingressclass"
+                params={{ name: ingress.spec?.ingressClassName }}
+                activeCluster={ingress.cluster}
+              >
                 {ingress.spec?.ingressClassName}
               </Link>
             ) : null,

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -495,7 +495,11 @@ export default function PodDetails(props: PodDetailsProps) {
           {
             name: t('Node'),
             value: item.spec.nodeName ? (
-              <Link routeName="node" params={{ name: item.spec.nodeName }}>
+              <Link
+                routeName="node"
+                params={{ name: item.spec.nodeName }}
+                activeCluster={item.cluster}
+              >
                 {item.spec.nodeName}
               </Link>
             ) : (
@@ -512,6 +516,7 @@ export default function PodDetails(props: PodDetailsProps) {
                     namespace: item.metadata.namespace,
                     name: item.spec.serviceAccountName || item.spec.serviceAccount,
                   }}
+                  activeCluster={item.cluster}
                 >
                   {item.spec.serviceAccountName || item.spec.serviceAccount}
                 </Link>

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -276,7 +276,12 @@ export function PodListRenderer(props: PodListProps) {
           getValue: pod => pod?.spec?.nodeName,
           render: pod =>
             pod?.spec?.nodeName && (
-              <Link routeName="node" params={{ name: pod.spec.nodeName }} tooltip>
+              <Link
+                routeName="node"
+                params={{ name: pod.spec.nodeName }}
+                activeCluster={pod.cluster}
+                tooltip
+              >
                 {pod.spec.nodeName}
               </Link>
             ),
@@ -287,7 +292,12 @@ export function PodListRenderer(props: PodListProps) {
           getValue: pod => pod?.status?.nominatedNodeName,
           render: pod =>
             !!pod?.status?.nominatedNodeName && (
-              <Link routeName="node" params={{ name: pod?.status?.nominatedNodeName }} tooltip>
+              <Link
+                routeName="node"
+                params={{ name: pod?.status?.nominatedNodeName }}
+                activeCluster={pod.cluster}
+                tooltip
+              >
                 {pod?.status?.nominatedNodeName}
               </Link>
             ),

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -23,19 +23,19 @@ import { Link } from '../common';
 import LabelListItem from '../common/LabelListItem';
 import ResourceListView from '../common/Resource/ResourceListView';
 
-function RoleLink(props: { role: string; namespace?: string }) {
-  const { role, namespace } = props;
+function RoleLink(props: { role: string; namespace?: string; cluster: string }) {
+  const { role, namespace, cluster } = props;
 
   if (namespace) {
     return (
-      <Link routeName="role" params={{ name: role, namespace }} tooltip>
+      <Link routeName="role" params={{ name: role, namespace }} activeCluster={cluster} tooltip>
         {role}
       </Link>
     );
   }
 
   return (
-    <Link routeName="clusterrole" params={{ name: role }} tooltip>
+    <Link routeName="clusterrole" params={{ name: role }} activeCluster={cluster} tooltip>
       {role}
     </Link>
   );
@@ -97,7 +97,11 @@ export default function RoleBindingList() {
           getValue: item => item.getNamespace() ?? t('translation|All namespaces'),
           render: item =>
             item.getNamespace() ? (
-              <Link routeName="namespace" params={{ name: item.getNamespace() }}>
+              <Link
+                routeName="namespace"
+                params={{ name: item.getNamespace() }}
+                activeCluster={item.cluster}
+              >
                 {item.getNamespace()}
               </Link>
             ) : (
@@ -109,7 +113,13 @@ export default function RoleBindingList() {
           id: 'role',
           label: t('glossary|Role'),
           getValue: item => item.roleRef.name,
-          render: item => <RoleLink role={item.roleRef.name} namespace={item.getNamespace()} />,
+          render: item => (
+            <RoleLink
+              role={item.roleRef.name}
+              namespace={item.getNamespace()}
+              cluster={item.cluster}
+            />
+          ),
         },
         {
           id: 'users',

--- a/frontend/src/components/storage/ClaimDetails.tsx
+++ b/frontend/src/components/storage/ClaimDetails.tsx
@@ -63,7 +63,12 @@ export default function VolumeClaimDetails(props: {
           {
             name: t('Storage Class'),
             value: (
-              <Link routeName="storageClass" params={{ name: item.spec!.storageClassName }} tooltip>
+              <Link
+                routeName="storageClass"
+                params={{ name: item.spec!.storageClassName }}
+                activeCluster={item.cluster}
+                tooltip
+              >
                 {item.spec!.storageClassName}
               </Link>
             ),

--- a/frontend/src/components/storage/ClaimList.tsx
+++ b/frontend/src/components/storage/ClaimList.tsx
@@ -41,7 +41,12 @@ export default function VolumeClaimList() {
               return '';
             }
             return (
-              <Link routeName="storageClass" params={{ name }} tooltip>
+              <Link
+                routeName="storageClass"
+                params={{ name }}
+                activeCluster={volumeClaim.cluster}
+                tooltip
+              >
                 {name}
               </Link>
             );
@@ -74,7 +79,12 @@ export default function VolumeClaimList() {
               return '';
             }
             return (
-              <Link routeName="persistentVolume" params={{ name }} tooltip>
+              <Link
+                routeName="persistentVolume"
+                params={{ name }}
+                activeCluster={volumeClaim.cluster}
+                tooltip
+              >
                 {name}
               </Link>
             );

--- a/frontend/src/components/storage/VolumeDetails.tsx
+++ b/frontend/src/components/storage/VolumeDetails.tsx
@@ -58,7 +58,12 @@ export default function VolumeDetails(props: { name?: string; cluster?: string }
           {
             name: t('Storage Class'),
             value: (
-              <Link routeName="storageClass" params={{ name: item.spec!.storageClassName }} tooltip>
+              <Link
+                routeName="storageClass"
+                params={{ name: item.spec!.storageClassName }}
+                activeCluster={item.cluster}
+                tooltip
+              >
                 {item.spec!.storageClassName}
               </Link>
             ),

--- a/frontend/src/components/storage/VolumeList.tsx
+++ b/frontend/src/components/storage/VolumeList.tsx
@@ -43,7 +43,12 @@ export default function VolumeList() {
               return '';
             }
             return (
-              <Link routeName="storageClass" params={{ name }} tooltip>
+              <Link
+                routeName="storageClass"
+                params={{ name }}
+                activeCluster={volume.cluster}
+                tooltip
+              >
                 {name}
               </Link>
             );
@@ -90,6 +95,7 @@ export default function VolumeList() {
               <Link
                 routeName="persistentVolumeClaim"
                 params={{ name: claim, namespace: claimNamespace }}
+                activeCluster={volume.cluster}
                 tooltip
               >
                 {claim}

--- a/frontend/src/components/webhookconfiguration/Details.tsx
+++ b/frontend/src/components/webhookconfiguration/Details.tsx
@@ -86,6 +86,7 @@ export default function WebhookConfigurationDetails(props: WebhookConfigurationD
                                   name: webhook.clientConfig?.service?.name,
                                   namespace: webhook.clientConfig?.service?.namespace,
                                 }}
+                                activeCluster={item.cluster}
                               >
                                 {t('translation|Service: {{namespace}}/{{name}}', {
                                   namespace: webhook.clientConfig?.service?.namespace,

--- a/frontend/src/lib/cluster.ts
+++ b/frontend/src/lib/cluster.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { without } from 'lodash';
 import { matchPath } from 'react-router';
 import { getBaseUrl } from '../helpers/getBaseUrl';
 import { isElectron } from '../helpers/isElectron';
@@ -67,6 +68,23 @@ export function getClusterPathParam(maybeUrlPath?: string): string | undefined {
 
   return clusterURLMatch?.params?.cluster;
 }
+
+/**
+ * Format cluster path URL parameter
+ *
+ * Cluster parameter contains selected clusters, with the first one being the current one
+ * usually used for details pages.
+ *
+ * @param selectedClusters - list of all selected clusters
+ * @param currentCluster - (optional) cluster name of the current cluster
+ * @returns formatted cluster parameter
+ */
+export const formatClusterPathParam = (selectedClusters: string[], currentCluster?: string) =>
+  (currentCluster
+    ? // Put current cluster as first
+      [currentCluster, ...without(selectedClusters, currentCluster)]
+    : selectedClusters
+  ).join('+');
 
 /**
  * Gets clusters.

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -18,7 +18,7 @@ import { JSONPath } from 'jsonpath-plus';
 import { cloneDeep, unset } from 'lodash';
 import React, { useMemo } from 'react';
 import { loadClusterSettings } from '../../helpers/clusterSettings';
-import { getCluster, getSelectedClusters } from '../cluster';
+import { formatClusterPathParam, getCluster, getSelectedClusters } from '../cluster';
 import { createRouteURL } from '../router';
 import { timeAgo } from '../util';
 import { useConnectApi, useSelectedClusters } from '.';
@@ -140,17 +140,12 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
   getDetailsLink() {
     const selectedClusters = getSelectedClusters();
 
-    let cluster = this.cluster;
-    if (selectedClusters.length > 1) {
-      const sortedClusters = selectedClusters.filter(it => it !== this.cluster);
-      sortedClusters.unshift(this.cluster);
-      cluster = sortedClusters.join('+');
-    }
+    const cluster = formatClusterPathParam(selectedClusters, this.cluster);
 
     const params = {
       namespace: this.getNamespace(),
       name: this.getName(),
-      cluster: cluster,
+      cluster,
     };
     const link = createRouteURL(this.detailsRoute, params);
     return link;

--- a/frontend/src/lib/k8s/api/v2/KubeList.test.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.test.ts
@@ -31,6 +31,8 @@ class MockKubeObject implements KubeObjectInterface {
   }
 }
 
+const cluster = 'cluster-name';
+
 describe('KubeList.applyUpdate', () => {
   const itemClass = MockKubeObject as unknown as KubeObjectClass;
   const initialList: KubeList<any> = {
@@ -54,7 +56,7 @@ describe('KubeList.applyUpdate', () => {
       },
     };
 
-    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass);
+    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass, cluster);
 
     expect(updatedList.items).toHaveLength(2);
     expect(updatedList.items[1].metadata.uid).toBe('2');
@@ -71,7 +73,7 @@ describe('KubeList.applyUpdate', () => {
       },
     };
 
-    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass);
+    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass, cluster);
 
     expect(updatedList.items).toHaveLength(1);
     expect(updatedList.items[0].metadata.resourceVersion).toBe('2');
@@ -88,7 +90,7 @@ describe('KubeList.applyUpdate', () => {
       },
     };
 
-    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass);
+    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass, cluster);
 
     expect(updatedList.items).toHaveLength(2);
     expect(updatedList.items[1].metadata.uid).toBe('3');
@@ -105,7 +107,7 @@ describe('KubeList.applyUpdate', () => {
       },
     };
 
-    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass);
+    const updatedList = KubeList.applyUpdate(initialList, updateEvent, itemClass, cluster);
 
     expect(updatedList.items).toHaveLength(0);
   });
@@ -121,7 +123,7 @@ describe('KubeList.applyUpdate', () => {
       },
     };
 
-    KubeList.applyUpdate(initialList, updateEvent, itemClass);
+    KubeList.applyUpdate(initialList, updateEvent, itemClass, cluster);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith('Error in update', updateEvent);
     consoleErrorSpy.mockRestore();
@@ -138,7 +140,7 @@ describe('KubeList.applyUpdate', () => {
       },
     };
 
-    KubeList.applyUpdate(initialList, updateEvent, itemClass);
+    KubeList.applyUpdate(initialList, updateEvent, itemClass, cluster);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith('Unknown update type', updateEvent);
     consoleErrorSpy.mockRestore();

--- a/frontend/src/lib/k8s/api/v2/KubeList.ts
+++ b/frontend/src/lib/k8s/api/v2/KubeList.ts
@@ -45,7 +45,8 @@ export const KubeList = {
   >(
     list: KubeList<KubeObject<ObjectInterface>>,
     update: KubeListUpdateEvent<ObjectInterface>,
-    itemClass: ObjectClass
+    itemClass: ObjectClass,
+    cluster: string
   ): KubeList<KubeObject<ObjectInterface>> {
     // Skip if the update's resource version is older than or equal to what we have
     if (
@@ -63,9 +64,9 @@ export const KubeList = {
       case 'ADDED':
       case 'MODIFIED':
         if (index !== -1) {
-          newItems[index] = new itemClass(update.object);
+          newItems[index] = new itemClass(update.object, cluster);
         } else {
-          newItems.push(new itemClass(update.object));
+          newItems.push(new itemClass(update.object, cluster));
         }
         break;
       case 'DELETED':

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -240,7 +240,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
           return oldResponse;
         }
 
-        const newList = KubeList.applyUpdate(oldResponse.list, update, kubeObjectClass);
+        const newList = KubeList.applyUpdate(oldResponse.list, update, kubeObjectClass, cluster);
 
         // Only update if the list actually changed
         if (newList === oldResponse.list) {
@@ -338,7 +338,12 @@ function useWatchKubeObjectListsLegacy<K extends KubeObject>({
           client.setQueryData(key, (oldResponse: ListResponse<any> | undefined | null) => {
             if (!oldResponse) return oldResponse;
 
-            const newList = KubeList.applyUpdate(oldResponse.list, update, kubeObjectClass);
+            const newList = KubeList.applyUpdate(
+              oldResponse.list,
+              update,
+              kubeObjectClass,
+              cluster
+            );
             return { ...oldResponse, list: newList };
           });
         },

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -178,15 +178,18 @@ class Event extends KubeObject<KubeEvent> {
     ];
     let objInstance: KubeObject | null = null;
     if (!!InvolvedObjectClass) {
-      objInstance = new InvolvedObjectClass({
-        kind: this.involvedObject.kind,
-        metadata: {
-          name: this.involvedObject.name,
-          namespace: InvolvedObjectClass.isNamespaced
-            ? this.involvedObject.namespace ?? this.getNamespace()
-            : undefined,
-        } as KubeMetadata,
-      });
+      objInstance = new InvolvedObjectClass(
+        {
+          kind: this.involvedObject.kind,
+          metadata: {
+            name: this.involvedObject.name,
+            namespace: InvolvedObjectClass.isNamespaced
+              ? this.involvedObject.namespace ?? this.getNamespace()
+              : undefined,
+          } as KubeMetadata,
+        },
+        this.cluster
+      );
     }
 
     return objInstance;

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -956,6 +956,12 @@ export function getRoutePath(route: Route) {
 }
 
 export interface RouteURLProps {
+  /**
+   * Selected clusters path parameter
+   *
+   * Check out {@link getClusterPathParam} and {@link formatClusterPathParam} function
+   * for working with this parameter
+   */
   cluster?: string;
   [prop: string]: any;
 }


### PR DESCRIPTION
Fix all links that point to a resource but don't use kubeObject property and just use routeName + name

 - Namespace column links
 - 'Definition' link in Custom Resource details*
 - 'Instance name' column in Custom Resource Instances list
 - 'CRD' column in Custom Resource Instances list
 - 'CRD' link at the top of the list in Custom Resource List
 - 'Resource' column in Custom Resource Definition details*
 - 'Resource' and 'Definition' columns in Custom Resource Definition list
 - Gateway Class link in Gateway details*
 - Gateway Class column in Gateway list
 - Ingress Class link in Ingress details*
 - Ingress Class link in Ingress list
 - Node link in Pod details*
 - Node, Nominated Node columns in Pod List
 - Role, Namespace columns in Binding list
 - Storage Class link in Claim details*
 - Storage class, Persistent Volume in Claim list
 - Storage Class in Volume details*
 - Storage Class in Volume list
 - Client Config in WebhookConfiguration details*

(*) - links in detail views already worked since the active cluster is already set to correct one, but I've added a cluster param anyway for better compatibility in the future

How to test:
 - Select 2 or more clusters
 - Try to click on links for resources from at least 2 different clusters
 - Verify that the resource loads properly

---

Fix websocket updates not having correct cluster in the instances

How to test:
 - Go to resource list (like Pods, or Events)
 - Create a new resource in 2 different clusters (or wait for new events)
 - Click on the new pods and verify that they're loading correctly

---

Fix missing cluster property in involvedObject in Event instances

How to test:
 - Go to cluster events
 - Click on resources from different clusters
 - Verify that the resource loads properly

---

Centralize cluster formatting, so we don't have to do split('+') or join('+') anywhere in the app