### PR TITLE
frontend: workload: Stop loading list infinitely

### DIFF
--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -89,7 +89,7 @@ export default function Overview() {
     joint = joint.filter(Boolean);
 
     // Return null if no items are yet loaded, so we show the spinner in the table.
-    if (joint.length === 0) {
+    if (joint.some(it => it === undefined)) {
       return null;
     }
 


### PR DESCRIPTION
This change adjusts how we determine when to stop loading the workloads list, stopping the case where it loads infinitely.

Fixes: #3112 

### Testing
- [x] Follow the steps as outlined in issue #3112 
- [x] Navigate to the workloads list and notice that the workloads list does not continuously load