### PR TITLE
frontend: themeSlice: Use useSelector to fix import cycle

### DIFF
--- a/frontend/src/components/App/themeSlice.ts
+++ b/frontend/src/components/App/themeSlice.ts
@@ -15,9 +15,9 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { useSelector } from 'react-redux';
 import { AppTheme } from '../../lib/AppTheme';
 import { getThemeName, setTheme as setAppTheme } from '../../lib/themes';
-import { useTypedSelector } from '../../redux/reducers/reducers';
 import { AppLogoType } from './AppLogo';
 
 export interface ThemeState {
@@ -148,14 +148,14 @@ const themeSlice = createSlice({
   },
 });
 
-export const useAppThemes = () => {
-  return useTypedSelector(state => state.theme.appThemes);
+export const useAppThemes = (): AppTheme[] => {
+  return useSelector((state: any) => state.theme.appThemes);
 };
 
 const currentThemeCacheKey = 'cached-current-theme';
 
 export const useCurrentAppTheme = () => {
-  let themeName = useTypedSelector(state => state.theme.name);
+  let themeName = useSelector((state: any) => state.theme.name);
   if (!themeName) {
     themeName = getThemeName();
   }


### PR DESCRIPTION
This change replaces useTypedSelector in the themeSlice file with react-redux's useSelector address a circular import between the themeSlice and reducers files.

Fixes: #3198 