### PR TITLE
frontend: Add hostIPs and podIPs to pod

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -529,8 +529,21 @@ export default function PodDetails(props: PodDetailsProps) {
             value: item.status.hostIP ?? '',
           },
           {
+            name: t('Host IPs'),
+            value: item.status.hostIPs
+              ? item.status.hostIPs.map(ipObj => ipObj.ip).join(', ')
+              : '',
+            hideLabel: item.status.hostIPs?.length === 0,
+          },
+          {
             name: t('Pod IP'),
             value: item.status.podIP ?? '',
+          },
+          {
+            name: t('Pod IPs'),
+            value: item.status.podIPs
+              ? item.status.podIPs.map(ipObj => ipObj.ip).join(', ')
+              : ''
           },
           {
             name: t('QoS Class'),

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -50,6 +50,8 @@ export interface KubePod extends KubeObjectInterface {
     initContainerStatuses?: KubeContainerStatus[];
     ephemeralContainerStatuses?: KubeContainerStatus[];
     hostIP?: string;
+    hostIPs?: {ip: string}[];
+    podIPs?: {ip: string}[];
     message?: string;
     phase: string;
     qosClass?: string;


### PR DESCRIPTION
In the pod Details view some pods could have multiple host and pod IPs so when rendering the pod Details view we should show these IPs as well.
fixes #3083