### PR TITLE
frontend: Refactoring mui named imports from top level to individual component imports

### DIFF
--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GlobalStyles } from '@mui/material';
+import GlobalStyles from '@mui/material/GlobalStyles';
 import { SnackbarProvider } from 'notistack';
 import React from 'react';
 import { BrowserRouter, HashRouter } from 'react-router-dom';

--- a/frontend/src/components/App/AppLogo.tsx
+++ b/frontend/src/components/App/AppLogo.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Theme } from '@mui/material';
+import { Theme } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
 import React, { isValidElement, ReactElement } from 'react';
 import { getThemeName, useNavBarMode } from '../../lib/themes';

--- a/frontend/src/components/App/CreateCluster/AddCluster.tsx
+++ b/frontend/src/components/App/CreateCluster/AddCluster.tsx
@@ -15,7 +15,12 @@
  */
 
 import { InlineIcon } from '@iconify/react';
-import { Button, Card, CardContent, CardHeader, Grid, Typography } from '@mui/material';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -15,8 +15,9 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Button, useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router-dom';

--- a/frontend/src/components/App/Home/RecentClusters.tsx
+++ b/frontend/src/components/App/Home/RecentClusters.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { Button, Grid, ToggleButton as MuiToggledButton, ToggleButtonGroup } from '@mui/material';
+import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
+import MuiToggledButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { styled } from '@mui/system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/App/Home/SquareButton.tsx
+++ b/frontend/src/components/App/Home/SquareButton.tsx
@@ -15,10 +15,10 @@
  */
 
 import { Icon } from '@iconify/react';
-import { useTheme } from '@mui/material';
 import ButtonBase, { ButtonBaseProps } from '@mui/material/ButtonBase';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
+import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 
 export interface SquareButtonProps extends ButtonBaseProps {

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Button } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import CssBaseline from '@mui/material/CssBaseline';
 import Link from '@mui/material/Link';

--- a/frontend/src/components/App/Notifications/List/List.tsx
+++ b/frontend/src/components/App/Notifications/List/List.tsx
@@ -15,7 +15,13 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box, IconButton, Menu, MenuItem, Tooltip, Typography, useTheme } from '@mui/material';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import { useTheme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/components/App/Notifications/Notifications.tsx
+++ b/frontend/src/components/App/Notifications/Notifications.tsx
@@ -16,18 +16,16 @@
 
 import bellIcon from '@iconify/icons-mdi/bell';
 import { Icon } from '@iconify/react';
-import {
-  Badge,
-  Box,
-  Button,
-  Grid,
-  IconButton,
-  ListItem,
-  Popover,
-  Tooltip,
-  Typography,
-  useTheme,
-} from '@mui/material';
+import Badge from '@mui/material/Badge';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import ListItem from '@mui/material/ListItem';
+import Popover from '@mui/material/Popover';
+import { useTheme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-import { Switch, SwitchProps, Typography, useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
+import { useTheme } from '@mui/material/styles';
+import { SwitchProps } from '@mui/material/Switch';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
 import { MRT_Row } from 'material-react-table';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.stories.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.stories.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TextField } from '@mui/material';
+import TextField from '@mui/material/TextField';
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 import { PluginInfo, PluginSettingsDetailsProps } from '../../../plugin/pluginsSlice';

--- a/frontend/src/components/App/Settings/DrawerModeSettings.tsx
+++ b/frontend/src/components/App/Settings/DrawerModeSettings.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { FormControlLabel, Switch } from '@mui/material';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/components/App/Settings/NumRowsInput.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.tsx
@@ -15,18 +15,16 @@
  */
 
 import { Icon } from '@iconify/react';
-import {
-  Box,
-  Button,
-  FormControl,
-  IconButton,
-  ListItemSecondaryAction,
-  ListItemText,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-  TextField,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import IconButton from '@mui/material/IconButton';
+import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import { SelectChangeEvent } from '@mui/material/Select';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { Box, MenuItem, Select, Switch } from '@mui/material';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Switch from '@mui/material/Switch';
 import { capitalize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -15,18 +15,16 @@
  */
 
 import { Icon, InlineIcon } from '@iconify/react';
-import {
-  Box,
-  Chip,
-  FormControl,
-  IconButton,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
-  Typography,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import FormControl from '@mui/material/FormControl';
+import IconButton from '@mui/material/IconButton';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/components/App/VersionDialog.tsx
+++ b/frontend/src/components/App/VersionDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DialogContent } from '@mui/material';
+import DialogContent from '@mui/material/DialogContent';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { getProductName, getVersion } from '../../helpers/getProductInfo';

--- a/frontend/src/components/Sidebar/ListItemLink.tsx
+++ b/frontend/src/components/Sidebar/ListItemLink.tsx
@@ -15,9 +15,12 @@
  */
 
 import { Icon, IconProps } from '@iconify/react';
-import { alpha, ListItemButton, styled, Tooltip } from '@mui/material';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import { styled } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+import { alpha } from '@mui/system/colorManipulator';
 import React from 'react';
 import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
 

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Divider } from '@mui/material';
 import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -15,8 +15,8 @@
  */
 
 import { InlineIcon } from '@iconify/react';
-import { Button } from '@mui/material';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Drawer from '@mui/material/Drawer';
 import Grid from '@mui/material/Grid';
 import List from '@mui/material/List';

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import DialogActions from '@mui/material/DialogActions';
@@ -23,6 +22,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import Link from '@mui/material/Link';
 import Snackbar, { SnackbarCloseReason } from '@mui/material/Snackbar';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router-dom';

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -15,7 +15,8 @@
  */
 
 import { InlineIcon } from '@iconify/react';
-import { Box, Button } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import { styled } from '@mui/system';
 import _ from 'lodash';
 import React from 'react';

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -15,7 +15,6 @@
  */
 
 import { Icon, InlineIcon } from '@iconify/react';
-import { DialogActions, IconButton } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
@@ -23,9 +22,11 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Container from '@mui/material/Container';
 import Dialog, { DialogProps } from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';

--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -15,20 +15,18 @@
  */
 
 import { Icon } from '@iconify/react';
-import {
-  ListItemIcon,
-  ListSubheader,
-  MenuItem,
-  MenuList,
-  Popover,
-  useMediaQuery,
-} from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import ListSubheader from '@mui/material/ListSubheader';
+import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
+import Popover from '@mui/material/Popover';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath } from 'react-router';

--- a/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
+++ b/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { Alert, AlertTitle, Box, Button } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelectedClusters } from '../../lib/k8s';

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -15,9 +15,13 @@
  */
 
 import { InlineIcon } from '@iconify/react';
-import { Button, Checkbox, FormControl, Grid, Tooltip } from '@mui/material';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/system';
 import * as yaml from 'js-yaml';

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { FormControlLabel, Switch, Theme } from '@mui/material';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
+import { Theme } from '@mui/material/styles';
+import Switch from '@mui/material/Switch';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';

--- a/frontend/src/components/common/ActionButton/ActionButton.tsx
+++ b/frontend/src/components/common/ActionButton/ActionButton.tsx
@@ -15,8 +15,10 @@
  */
 
 import { Icon, IconifyIcon, IconProps } from '@iconify/react';
-import { ListItemIcon, ListItemText, MenuItem } from '@mui/material';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
 import React from 'react';
 

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Alert, Button, Typography } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { matchPath, useLocation } from 'react-router-dom';

--- a/frontend/src/components/common/Dialog.stories.tsx
+++ b/frontend/src/components/common/Dialog.stories.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { DialogContent, Typography } from '@mui/material';
+import DialogContent from '@mui/material/DialogContent';
+import Typography from '@mui/material/Typography';
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 import { Dialog as DialogComponent, DialogProps } from './Dialog';

--- a/frontend/src/components/common/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.tsx
@@ -15,13 +15,14 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Grid, Typography } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
 import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
 import { styled } from '@mui/system';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';

--- a/frontend/src/components/common/LogViewer.stories.tsx
+++ b/frontend/src/components/common/LogViewer.stories.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
 import { useCallback, useEffect, useState } from 'react';

--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { Box, Button, DialogContent, Grid, InputBase, Paper } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import DialogContent from '@mui/material/DialogContent';
+import Grid from '@mui/material/Grid';
+import InputBase from '@mui/material/InputBase';
+import Paper from '@mui/material/Paper';
 import { FitAddon } from '@xterm/addon-fit';
 import { ISearchOptions, SearchAddon } from '@xterm/addon-search';
 import { Terminal as XTerminal } from '@xterm/xterm';

--- a/frontend/src/components/common/NameValueTable/NameValueTable.tsx
+++ b/frontend/src/components/common/NameValueTable/NameValueTable.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Grid, GridProps } from '@mui/material';
+import { GridProps } from '@mui/material/Grid';
+import Grid from '@mui/material/Grid';
 import React, { ReactNode } from 'react';
 import { ValueLabel } from '../Label';
 

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -15,7 +15,11 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box, Dialog, DialogContent, IconButton, Link } from '@mui/material';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';

--- a/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
+++ b/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
@@ -15,7 +15,9 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box, Button, Snackbar } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Snackbar from '@mui/material/Snackbar';
 import { styled } from '@mui/system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/common/Resource/DeleteButton.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { FormControlLabel, Grid, Switch } from '@mui/material';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import Switch from '@mui/material/Switch';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/components/common/Resource/DetailsDrawer.tsx
+++ b/frontend/src/components/common/Resource/DetailsDrawer.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Box, useMediaQuery, useTheme } from '@mui/material';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router';

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-import { Box, FormControl, InputLabel, MenuItem, Select, styled, Switch } from '@mui/material';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import { styled } from '@mui/material/styles';
+import Switch from '@mui/material/Switch';
 import { Terminal as XTerminal } from '@xterm/xterm';
 import { useSnackbar } from 'notistack';
 import React, { useState } from 'react';

--- a/frontend/src/components/common/Resource/MatchExpressions.tsx
+++ b/frontend/src/components/common/Resource/MatchExpressions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 import { matchExpressionSimplifier, matchLabelsSimplifier } from '../../../lib/k8s';
 import { LabelSelector } from '../../../lib/k8s/cluster';
 import { metadataStyles } from '.';

--- a/frontend/src/components/common/Resource/MetadataDisplay.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.tsx
@@ -15,8 +15,9 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box, Theme } from '@mui/material';
+import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+import { Theme } from '@mui/material/styles';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/common/Resource/PortForward.tsx
+++ b/frontend/src/components/common/Resource/PortForward.tsx
@@ -15,10 +15,14 @@
  */
 
 import { InlineIcon } from '@iconify/react';
-import { Box, Button, CircularProgress, Tooltip, Typography } from '@mui/material';
-import { Alert } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import { grey } from '@mui/material/colors';
 import MuiLink from '@mui/material/Link';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { isDockerDesktop } from '../../../helpers/isDockerDesktop';

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -16,12 +16,13 @@
 
 import { Icon } from '@iconify/react';
 import Editor from '@monaco-editor/react';
-import { Button, InputLabel } from '@mui/material';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import Grid, { GridProps, GridSize } from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 import Input, { InputProps } from '@mui/material/Input';
+import InputLabel from '@mui/material/InputLabel';
 import Paper from '@mui/material/Paper';
 import { BaseTextFieldProps } from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { Box, MenuItem, TableCellProps } from '@mui/material';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/material/styles';
+import { TableCellProps } from '@mui/material/TableCell';
 import { MRT_FilterFns, MRT_Row, MRT_SortingFn, MRT_TableInstance } from 'material-react-table';
 import { ComponentProps, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/common/Resource/ResourceTableMultiActions.tsx
+++ b/frontend/src/components/common/Resource/ResourceTableMultiActions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Grid } from '@mui/material';
+import Grid from '@mui/material/Grid';
 import { MRT_TableInstance } from 'material-react-table';
 import { useCallback } from 'react';
 import { KubeObject } from '../../../lib/k8s/KubeObject';

--- a/frontend/src/components/common/Resource/ScaleButton.tsx
+++ b/frontend/src/components/common/Resource/ScaleButton.tsx
@@ -15,14 +15,15 @@
  */
 
 import { Icon } from '@iconify/react';
-import { DialogContentText, OutlinedInput } from '@mui/material';
 import Button from '@mui/material/Button';
 import Dialog, { DialogProps } from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Fab from '@mui/material/Fab';
 import Grid from '@mui/material/Grid';
+import OutlinedInput from '@mui/material/OutlinedInput';
 import { styled, useTheme } from '@mui/material/styles';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/common/SectionHeader.tsx
+++ b/frontend/src/components/common/SectionHeader.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import { Variant } from '@mui/material/styles/createTypography';
 import Typography from '@mui/material/Typography';

--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.stories.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.stories.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import { Meta, StoryFn } from '@storybook/react';
 import ShowHideLabel, { ShowHideLabelProps } from './ShowHideLabel';
 

--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
@@ -15,7 +15,8 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box, IconButton } from '@mui/material';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/frontend/src/components/common/SimpleTable.stories.tsx
+++ b/frontend/src/components/common/SimpleTable.stories.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
 import { useLocation } from 'react-router-dom';

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -15,14 +15,19 @@
  */
 
 import { Icon, InlineIcon } from '@iconify/react';
-import { Button, IconButton, Paper, SxProps, TableContainer, Theme } from '@mui/material';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import { Theme } from '@mui/material/styles';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
+import { SxProps } from '@mui/system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTablesRowsPerPage, setTablesRowsPerPage } from '../../helpers/tablesRowsPerPage';

--- a/frontend/src/components/common/Table/Table.stories.tsx
+++ b/frontend/src/components/common/Table/Table.stories.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
 import { useLocation } from 'react-router-dom';

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-import { Box, Paper, Table as MuiTable, TableCellProps, TableHead } from '@mui/material';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
 import { useTheme } from '@mui/material/styles';
+import MuiTable from '@mui/material/Table';
+import { TableCellProps } from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
 import { alpha, styled } from '@mui/system';
 import {
   MRT_BottomToolbar,

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Theme } from '@mui/material';
+import { Theme } from '@mui/material/styles';
 import MuiTab from '@mui/material/Tab';
 import MuiTabs from '@mui/material/Tabs';
 import Typography, { TypographyProps } from '@mui/material/Typography';

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -15,7 +15,7 @@
  */
 
 import '@xterm/xterm/css/xterm.css';
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import { DialogProps } from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import FormControl from '@mui/material/FormControl';

--- a/frontend/src/components/common/TileChart/TileChart.tsx
+++ b/frontend/src/components/common/TileChart/TileChart.tsx
@@ -15,7 +15,9 @@
  */
 
 import '../../../i18n/config';
-import { Box, Paper, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
 import { PercentageCircle, PercentageCircleProps } from '../Chart';
 import { TooltipIcon } from '../Tooltip';
 

--- a/frontend/src/components/common/TimezoneSelect/TimezoneSelect.tsx
+++ b/frontend/src/components/common/TimezoneSelect/TimezoneSelect.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { TextField } from '@mui/material';
-import { Autocomplete } from '@mui/material';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import spacetime from 'spacetime';

--- a/frontend/src/components/configmap/Details.tsx
+++ b/frontend/src/components/configmap/Details.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Button } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Alert, AlertTitle } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CRD from '../../lib/k8s/crd';

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import { JSONPath } from 'jsonpath-plus';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Input,
-  InputLabel,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Input from '@mui/material/Input';
+import InputLabel from '@mui/material/InputLabel';
 import _ from 'lodash';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/deployments/List.tsx
+++ b/frontend/src/components/deployments/List.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import { useTranslation } from 'react-i18next';
 import { KubeContainer } from '../../lib/k8s/cluster';
 import Deployment from '../../lib/k8s/deployment';

--- a/frontend/src/components/gateway/ClassList.tsx
+++ b/frontend/src/components/gateway/ClassList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import { useTranslation } from 'react-i18next';
 import GatewayClass from '../../lib/k8s/gatewayClass';
 import { LightTooltip, StatusLabel, StatusLabelProps } from '../common';

--- a/frontend/src/components/globalSearch/Delayed.tsx
+++ b/frontend/src/components/globalSearch/Delayed.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, styled } from '@mui/material';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
 
 /**
  * Displays children after a delay

--- a/frontend/src/components/globalSearch/GlobalSearch.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearch.tsx
@@ -15,16 +15,14 @@
  */
 
 import { Icon } from '@iconify/react';
-import {
-  alpha,
-  Box,
-  CircularProgress,
-  IconButton,
-  InputAdornment,
-  TextField,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import { useTheme } from '@mui/material/styles';
+import TextField from '@mui/material/TextField';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { alpha } from '@mui/system/colorManipulator';
 import { lazy, Suspense, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { Trans, useTranslation } from 'react-i18next';

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -15,16 +15,14 @@
  */
 
 import { Icon } from '@iconify/react';
-import {
-  Box,
-  CircularProgress,
-  Paper,
-  Popper,
-  TextField,
-  Typography,
-  useAutocomplete,
-  UseAutocompleteReturnValue,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Paper from '@mui/material/Paper';
+import Popper from '@mui/material/Popper';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import useAutocomplete from '@mui/material/useAutocomplete';
+import { UseAutocompleteReturnValue } from '@mui/material/useAutocomplete';
 import Fuse from 'fuse.js';
 import { capitalize } from 'lodash';
 import { lazy, Suspense, useMemo, useRef, useState } from 'react';

--- a/frontend/src/components/horizontalPodAutoscaler/List.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/List.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Chip } from '@mui/material';
+import Chip from '@mui/material/Chip';
 import { styled } from '@mui/system';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Box, Link as MuiLink, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import MuiLink from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import Ingress, { IngressBackend, IngressRule } from '../../lib/k8s/ingress';

--- a/frontend/src/components/job/List.tsx
+++ b/frontend/src/components/job/List.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import { useTranslation } from 'react-i18next';
 import { ApiError } from '../../lib/k8s/api/v2/ApiError';
 import { KubeContainer } from '../../lib/k8s/cluster';

--- a/frontend/src/components/limitRange/Details.tsx
+++ b/frontend/src/components/limitRange/Details.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { LimitRange } from '../../lib/k8s/limitRange';

--- a/frontend/src/components/namespace/CreateNamespaceButton.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.tsx
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  TextField,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/components/networkpolicy/Details.tsx
+++ b/frontend/src/components/networkpolicy/Details.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { matchExpressionSimplifier, matchLabelsSimplifier } from '../../lib/k8s';

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -15,9 +15,9 @@
  */
 
 import { InlineIcon } from '@iconify/react';
-import { Paper } from '@mui/material';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
 import _ from 'lodash';
 import { useSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import DialogContent from '@mui/material/DialogContent';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as XTerminal } from '@xterm/xterm';

--- a/frontend/src/components/node/utils.tsx
+++ b/frontend/src/components/node/utils.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Box, Chip, Tooltip } from '@mui/material';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
 import { styled } from '@mui/system';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/oidcauth/index.tsx
+++ b/frontend/src/components/oidcauth/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ApiError } from '../../lib/k8s/apiProxy';

--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -15,8 +15,11 @@
  */
 
 import { Icon, InlineIcon } from '@iconify/react';
-import { Box, IconButton, Menu, MenuItem } from '@mui/material';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
 import MuiLink from '@mui/material/Link';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/system';
 import { useSnackbar } from 'notistack';
 import React from 'react';

--- a/frontend/src/components/resourceMap/GraphControls.tsx
+++ b/frontend/src/components/resourceMap/GraphControls.tsx
@@ -15,7 +15,9 @@
  */
 
 import { Icon } from '@iconify/react';
-import { Box, Button, ButtonGroup } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
 import { useReactFlow, useStore } from '@xyflow/react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/resourceMap/GraphRenderer.tsx
+++ b/frontend/src/components/resourceMap/GraphRenderer.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Box, Typography, useTheme } from '@mui/material';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
 import {
   Background,
   BackgroundVariant,

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -17,7 +17,11 @@
 import '@xyflow/react/dist/base.css';
 import './GraphView.css';
 import { Icon } from '@iconify/react';
-import { Box, Chip, styled, Theme, ThemeProvider } from '@mui/material';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
+import ThemeProvider from '@mui/system/ThemeProvider';
 import { Edge, Node, Panel, ReactFlowProvider } from '@xyflow/react';
 import {
   createContext,

--- a/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
+++ b/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Box, Breadcrumbs, Link } from '@mui/material';
+import Box from '@mui/material/Box';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
 import { useTranslation } from 'react-i18next';
 import { getMainNode } from './graph/graphGrouping';
 import { GraphNode } from './graph/graphModel';

--- a/frontend/src/components/resourceMap/details/GraphNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/GraphNodeDetails.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Card } from '@mui/material';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
 import { useTranslation } from 'react-i18next';
 import { ActionButton } from '../../common';
 import { GraphNode } from '../graph/graphModel';

--- a/frontend/src/components/resourceMap/edges/GraphEdgeComponent.tsx
+++ b/frontend/src/components/resourceMap/edges/GraphEdgeComponent.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { alpha, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { alpha } from '@mui/system/colorManipulator';
 import { BaseEdge, EdgeProps } from '@xyflow/react';
 import { memo } from 'react';
 import { GraphEdge } from '../graph/graphModel';

--- a/frontend/src/components/resourceMap/kubeIcon/KubeIcon.tsx
+++ b/frontend/src/components/resourceMap/kubeIcon/KubeIcon.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { alpha, Box } from '@mui/material';
+import Box from '@mui/material/Box';
+import { alpha } from '@mui/system/colorManipulator';
 import { useTypedSelector } from '../../../redux/reducers/reducers';
 import CRoleIcon from './img/c-role.svg?react';
 import CmIcon from './img/cm.svg?react';

--- a/frontend/src/components/resourceMap/nodes/GroupNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/GroupNode.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { alpha, Box, styled } from '@mui/material';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import { alpha } from '@mui/system/colorManipulator';
 import { memo } from 'react';
 import { useGraphView, useNode } from '../GraphView';
 import { KubeIcon } from '../kubeIcon/KubeIcon';

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -15,7 +15,9 @@
  */
 
 import { Icon } from '@iconify/react';
-import { alpha, styled, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
+import { alpha } from '@mui/system/colorManipulator';
 import { Handle, NodeProps, Position } from '@xyflow/react';
 import { memo, useEffect, useState } from 'react';
 import { getMainNode } from '../graph/graphGrouping';

--- a/frontend/src/components/resourceMap/sources/GraphSourcesView.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSourcesView.tsx
@@ -15,18 +15,16 @@
  */
 
 import { Icon } from '@iconify/react';
-import {
-  alpha,
-  Badge,
-  Box,
-  Checkbox,
-  Chip,
-  CircularProgress,
-  Popover,
-  Stack,
-  styled,
-  Typography,
-} from '@mui/material';
+import Badge from '@mui/material/Badge';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Popover from '@mui/material/Popover';
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/system/colorManipulator';
 import { memo, useState } from 'react';
 import { GraphSource } from '../graph/graphModel';
 import { SourceData } from './GraphSources';

--- a/frontend/src/components/resourceQuota/List.tsx
+++ b/frontend/src/components/resourceQuota/List.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Chip } from '@mui/material';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 import { styled } from '@mui/system';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/secret/Details.tsx
+++ b/frontend/src/components/secret/Details.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Box, Button } from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import { Base64 } from 'js-base64';
 import _ from 'lodash';
 import React from 'react';

--- a/frontend/src/components/service/Details.tsx
+++ b/frontend/src/components/service/Details.tsx
@@ -15,7 +15,7 @@
  */
 
 import { InlineIcon } from '@iconify/react';
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/verticalPodAutoscaler/List.tsx
+++ b/frontend/src/components/verticalPodAutoscaler/List.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Link, Paper, Typography } from '@mui/material';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import VPA from '../../lib/k8s/vpa';


### PR DESCRIPTION
For mui. This has some benefits for faster loading, and tree shaking.

## Testing done

- tried all the pages manually locally
- ran as app on WSL / Ubuntu, and clicked about
