### PR TITLE
fix: Use HTTPS for Kubernetes Contributor Guide Link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,5 @@ For contributing to the Headlamp project, please refer check out our:
 Since Headlamp is part of the Kubernetes Community, please read also:
 
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
-- [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
+- [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](https://git.k8s.io/community/contributors/guide#contributing)
 - [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet/README.md) - Common resources for existing developers


### PR DESCRIPTION

This pull request updates the Kubernetes Contributor Guide link in the `CONTRIBUTING.md` file to use **HTTPS** instead of **HTTP**.

### 🔍 Change Details

- **Before:**  
  `http://git.k8s.io/community/contributors/guide`

- **After:**  
  `https://git.k8s.io/community/contributors/guide`

### ✅ Reason for Change

- Ensures secure and encrypted connection by default.
- Follows best practices for open source and documentation hygiene.
- Prevents potential issues with HTTP-to-HTTPS redirection.

### 📄 Affected File

- `CONTRIBUTING.md`
