### PR TITLE
fix: Standardize theme breakpoints and clean up configuration

### DIFF
--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -60,14 +60,13 @@ export const useNavBarMode = () => {
  */
 export function createMuiTheme(currentTheme: AppTheme) {
   const commonRules = {
-    // @todo: Remove this once we have tested and fixed the theme for the new breakpoints.
     breakpoints: {
       values: {
         xs: 0,
         sm: 600,
-        md: 960,
-        lg: 1280,
-        xl: 1920,
+        md: 900,
+        lg: 1200,
+        xl: 1536,
       },
     },
     mixins: {


### PR DESCRIPTION
## Description
This PR standardizes the theme breakpoints and cleans up the configuration:

1. **Breakpoint Standardization**
   - Updated breakpoint values to match Material-UI standards:
     - xs: 0
     - sm: 600
     - md: 900
     - lg: 1200
     - xl: 1536
   - Removed custom breakpoint values that deviated from Material-UI standards

2. **Configuration Cleanup**
   - Removed the TODO comment about breakpoint configuration
   - Maintained the toolbar mixin configuration for responsive behavior
   - Kept the mobile breakpoint (600px) for toolbar height adjustment

## Testing
- Verify that the theme breakpoints work correctly across different screen sizes
- Check that the toolbar height adjusts properly on mobile devices
- Confirm that the theme layout remains consistent with Material-UI standards

## Checklist
- [ ] Breakpoint values match Material-UI standards
- [ ] Toolbar height adjusts correctly on mobile
- [ ] No TODO comments in the code