### PR TITLE
Fixed container port in port-forwarding docs

### DIFF
--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -83,7 +83,7 @@ If you want to quickly access Headlamp (after having its service running) and
 don't want to set up an ingress for it, you can run use port-forwarding as follows:
 
 ```bash
-kubectl port-forward -n kube-system service/headlamp 8080:80
+kubectl port-forward -n kube-system service/headlamp 8080:4466
 ```
 
 and then you can access `localhost:8080` in your browser.


### PR DESCRIPTION
This PR fixes issue #3199 where the container port in the port-forwarding documentation was incorrectly specified as 80, while the Dockerfile actually exposes port 4466.

The fix updates the port-forwarding command in the in-cluster installation documentation to use the correct container port 4466 instead of 80.

Previous:
kubectl port-forward -n kube-system service/headlamp 8080:80
Currenet:
kubectl port-forward -n kube-system service/headlamp 8080:4466

Refer this attachment for better understanding of fix,
![Screenshot from 2025-05-17 10-17-34](https://github.com/user-attachments/assets/3af11379-3266-4c9a-8b6f-787b2dece730)

