### PR TITLE
fix: import fix on ./frontend/storybook/main.ts

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { StorybookConfig } from '@storybook/react-vite';
+import type { StorybookConfig } from '@storybook/react-vite';
 
 export default {
   framework: '@storybook/react-vite',


### PR DESCRIPTION
### Import fix on main.ts of storybook 

So, I was facing an error while running first time the storybook using command directly 

Error Reproducing

- On a fresh repo clone, go to ./fontend/ and run Storybook
```
cd ./frontedn
npm install
npm run storybook
```
- You will see an error

#### Error Image

![image](https://github.com/user-attachments/assets/4b4dc333-605f-4456-a6cd-b8c46aca2f93)


#### Fixed using import as type in main.ts 

- check file change in PR

Thank you :slightly_smiling_face: 

let me know if any changes required 