### PR TITLE
feat: Add validate-artifacthub CLI command to Headlamp plugin toolkit (#3023)

### DIFF
--- a/plugins/headlamp-plugin/artifacthub-pkg.schema.json
+++ b/plugins/headlamp-plugin/artifacthub-pkg.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ArtifactHub Package",
+  "type": "object",
+  "required": [
+    "name",
+    "version",
+    "description",
+    "keywords",
+    "links",
+    "maintainers"
+  ],
+  "properties": {
+    "name": { "type": "string" },
+    "version": { "type": "string" },
+    "description": { "type": "string" },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "url"],
+        "properties": {
+          "name": { "type": "string" },
+          "url": { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "maintainers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "email"],
+        "properties": {
+          "name": { "type": "string" },
+          "email": { "type": "string", "format": "email" }
+        }
+      }
+    },
+    "provider": { "type": "string" },
+    "repository": { "type": "string" },
+    "license": { "type": "string" },
+    "homeURL": { "type": "string", "format": "uri" },
+    "readme": { "type": "string" },
+    "install": { "type": "string" },
+    "changes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/plugins/headlamp-plugin/artifacthub-pkg.yml
+++ b/plugins/headlamp-plugin/artifacthub-pkg.yml
@@ -1,0 +1,2 @@
+name: test-plugin
+version: 1.0.0

--- a/plugins/headlamp-plugin/test-headlamp-plugin.js
+++ b/plugins/headlamp-plugin/test-headlamp-plugin.js
@@ -26,6 +26,21 @@ Assumes being run within the plugins/headlamp-plugin folder
 const PACKAGE_NAME = 'headlamp-myfancy';
 
 function testHeadlampPlugin() {
+  const validYml = `name: test-plugin\nversion: 1.0.0\ndescription: Test plugin\nkeywords:\n  - test\nlinks:\n  - name: homepage\n    url: https://example.com\nmaintainers:\n  - name: Tester\n    email: tester@example.com\n`;
+  fs.writeFileSync('artifacthub-pkg.yml', validYml);
+  run('node', ['bin/headlamp-plugin.js', 'validate-artifacthub', 'artifacthub-pkg.yml']);
+  const invalidYml = `name: test-plugin\nversion: 1.0.0\n`;
+  fs.writeFileSync('artifacthub-pkg.yml', invalidYml);
+  let failed = false;
+  try {
+    run('node', ['bin/headlamp-plugin.js', 'validate-artifacthub', 'artifacthub-pkg.yml']);
+  } catch (e) {
+    failed = true;
+  }
+  if (!failed) {
+    exit('Error: validate-artifacthub did not fail on invalid input');
+  }
+  fs.rmSync('artifacthub-pkg.yml');
   // remove some temporary files.
   cleanup();
 


### PR DESCRIPTION
This PR adds a new CLI command to the Headlamp plugin toolkit:
**`validate-artifacthub [file]`**

This command allows users to validate an `artifacthub-pkg.yml` file against the official ArtifactHub schema locally, so plugin authors can check their metadata before publishing or waiting for ArtifactHub rescans.

- **New command:**  
  `validate-artifacthub [file]` (defaults to `artifacthub-pkg.yml` if no file is provided)
## Testing

- Added automated tests in `test-headlamp-plugin.js`:
  - Checks that the command succeeds for a valid file.
  - Checks that the command fails for an invalid file (missing required fields).
- Manual testing also performed via CLI.

This feature was requested in [#3023](https://github.com/kubernetes-sigs/headlamp/issues/3023) to help plugin authors catch metadata issues early and improve the development workflow for Headlamp plugins.
---

Closes: #3023

/cc @illume 