### PR TITLE
frontend: Sidebar: Fix conditional expansion description text

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -120,7 +120,7 @@ function SidebarToggleButton() {
           dispatch(setWhetherSidebarOpen(!isOpen));
         }}
         icon={isOpen ? 'mdi:chevron-left-box-outline' : 'mdi:chevron-right-box-outline'}
-        description={t('translation|Collapse Sidebar')}
+        description={isOpen ? t('translation|Shrink sidebar') : t('translation|Expand sidebar')}
       />
     </Box>
   );

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -187,7 +187,7 @@
                       class="MuiBox-root css-xi606m"
                     >
                       <button
-                        aria-label="Collapse Sidebar"
+                        aria-label="Expand sidebar"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lr7sro-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
@@ -208,7 +208,7 @@
                       class="MuiBox-root css-s2uf1z"
                     >
                       <button
-                        aria-label="Collapse Sidebar"
+                        aria-label="Shrink sidebar"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lr7sro-MuiButtonBase-root-MuiIconButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -1287,7 +1287,7 @@
                         class="MuiBox-root css-xi606m"
                       >
                         <button
-                          aria-label="Collapse Sidebar"
+                          aria-label="Expand sidebar"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lr7sro-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
                           tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -1359,7 +1359,7 @@
                         class="MuiBox-root css-s2uf1z"
                       >
                         <button
-                          aria-label="Collapse Sidebar"
+                          aria-label="Shrink sidebar"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lr7sro-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
                           tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -1359,7 +1359,7 @@
                         class="MuiBox-root css-s2uf1z"
                       >
                         <button
-                          aria-label="Collapse Sidebar"
+                          aria-label="Shrink sidebar"
                           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-lr7sro-MuiButtonBase-root-MuiIconButton-root"
                           data-mui-internal-clone-element="true"
                           tabindex="0"

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -452,7 +452,6 @@
   "Expand sidebar": "Seitenleiste erweitern",
   "Main Navigation": "Hauptnavigation",
   "Navigation Tabs": "Navigationstabs",
-  "Collapse Sidebar": "Seitenleiste einklappen",
   "Navigation": "Navigation",
   "General": "",
   "Clusters": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -452,7 +452,6 @@
   "Expand sidebar": "Expand sidebar",
   "Main Navigation": "Main Navigation",
   "Navigation Tabs": "Navigation Tabs",
-  "Collapse Sidebar": "Collapse Sidebar",
   "Navigation": "Navigation",
   "General": "General",
   "Clusters": "Clusters",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -453,7 +453,6 @@
   "Expand sidebar": "Expandir barra lateral",
   "Main Navigation": "Navegación principal",
   "Navigation Tabs": "Pestañas de navegación",
-  "Collapse Sidebar": "Contraer barra lateral",
   "Navigation": "Navegación",
   "General": "General",
   "Clusters": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -453,7 +453,6 @@
   "Expand sidebar": "Développer la barre latérale",
   "Main Navigation": "Navigation principale",
   "Navigation Tabs": "Onglets de navigation",
-  "Collapse Sidebar": "Réduire la barre latérale",
   "Navigation": "Navigation",
   "General": "",
   "Clusters": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -453,7 +453,6 @@
   "Expand sidebar": "Espandi barra laterale",
   "Main Navigation": "Navigazione Principale",
   "Navigation Tabs": "Schede di Navigazione",
-  "Collapse Sidebar": "Comprimi Barra Laterale",
   "Navigation": "Navigazione",
   "General": "Generale",
   "Clusters": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -451,7 +451,6 @@
   "Expand sidebar": "サイドバーを展開",
   "Main Navigation": "メインナビゲーション",
   "Navigation Tabs": "ナビゲーションタブ",
-  "Collapse Sidebar": "サイドバーを折りたたむ",
   "Navigation": "ナビゲーション",
   "General": "一般",
   "Clusters": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -451,7 +451,6 @@
   "Expand sidebar": "사이드바 확장",
   "Main Navigation": "메인 탐색",
   "Navigation Tabs": "탐색 탭",
-  "Collapse Sidebar": "사이드바 축소",
   "Navigation": "Navigation",
   "General": "일반",
   "Clusters": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -453,7 +453,6 @@
   "Expand sidebar": "Expandir barra lateral",
   "Main Navigation": "Navegação Principal",
   "Navigation Tabs": "Separadores de Navegação",
-  "Collapse Sidebar": "Encolher Barra Lateral",
   "Navigation": "Navegação",
   "General": "Geral",
   "Clusters": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -451,7 +451,6 @@
   "Expand sidebar": "展開側邊欄",
   "Main Navigation": "主導航",
   "Navigation Tabs": "導航標籤",
-  "Collapse Sidebar": "折疊側邊欄",
   "Navigation": "導航",
   "General": "一般",
   "Clusters": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -451,7 +451,6 @@
   "Expand sidebar": "展开侧边栏",
   "Main Navigation": "主导航",
   "Navigation Tabs": "导航标签",
-  "Collapse Sidebar": "折叠侧边栏",
   "Navigation": "导航",
   "General": "一般",
   "Clusters": "",


### PR DESCRIPTION
## Note for reviewers:
Changed the description of the left chevron and right chevron button in the sidebar. 

fixes: #3276 

![image](https://github.com/user-attachments/assets/dcd60f0c-16b8-4ce6-b3a7-0aca564563f2)
![image](https://github.com/user-attachments/assets/89c5f5a3-1e74-4ec6-83df-5639c32cff1a)


Renamed Collapse sidebar to Shrink sidebar as the i18n support for Collapse Sidebar was there with a block 'S' but not the same for Expand Sidebar. Attached a screenshot of the translation.json for more context:
![image](https://github.com/user-attachments/assets/3fe31ea1-b50f-42e6-ae5c-38b9c26d93a0)
This is why some tests expecting Collapse Sidebar are failing as well.