### PR TITLE
frontend Terminal: Add workaround for inputting pipe character

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -80,8 +80,23 @@ export default function Terminal(props: TerminalProps) {
 
     xterm.open(containerRef);
 
+    let lastKeyPressEvent: KeyboardEvent | null = null;
     xterm.onData(data => {
-      send(0, data);
+      let dataToSend = data;
+
+      // On MacOS with a German layout, the Alt+7 should yield a | character, but
+      // the onData event doesn't get it. So we need to add a custom key handler.
+      // No need to check for the actual platform because the key patterns should
+      // be good enough.
+      if (
+        data === '\u001b7' &&
+        lastKeyPressEvent?.key === '|' &&
+        lastKeyPressEvent.code === 'Digit7'
+      ) {
+        dataToSend = '|';
+      }
+
+      send(0, dataToSend);
     });
 
     xterm.onResize(size => {
@@ -90,6 +105,12 @@ export default function Terminal(props: TerminalProps) {
 
     // Allow copy/paste in terminal
     xterm.attachCustomKeyEventHandler(arg => {
+      if (arg.type === 'keydown') {
+        lastKeyPressEvent = arg;
+      } else {
+        lastKeyPressEvent = null;
+      }
+
       if (arg.ctrlKey && arg.type === 'keydown') {
         if (arg.code === 'KeyC') {
           const selection = xterm.getSelection();


### PR DESCRIPTION
In the Terminal component, while on Mac computers with a German layout, the pipe command was not being correctly inputted.

This commit adds a workaround till we find a better fix. I have filed https://github.com/xtermjs/xterm.js/issues/5341 to see if there's a fix possible in xterm.

fixes #3165 

## How to test

1. While on a Mac with the German keyboard layout, open the shell in a pod and try to type the pipe character `|` (Alt+7) -> verify the pipe character is indeed inputted
2. Test the same key combo with other layouts to see that there are no regressions
