### PR TITLE
frontend: notifications: Fix storybook crash due to missing context

### DIFF
--- a/frontend/src/components/App/Notifications/List/List.stories.tsx
+++ b/frontend/src/components/App/Notifications/List/List.stories.tsx
@@ -17,6 +17,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
 import { initialState as CONFIG_INITIAL_STATE } from '../../../../redux/configSlice';
+import { drawerModeSlice } from '../../../../redux/drawerModeSlice';
 import { initialState as FILTER_INITIAL_STATE } from '../../../../redux/filterSlice';
 import { uiSlice } from '../../../../redux/uiSlice';
 import { TestContext } from '../../../../test';
@@ -49,6 +50,7 @@ const store = configureStore({
       filter: { ...FILTER_INITIAL_STATE },
       config: { ...CONFIG_INITIAL_STATE },
       ui: { ...uiSlice.getInitialState() },
+      drawerMode: { ...drawerModeSlice.getInitialState() },
     }
   ) => state,
   preloadedState: {
@@ -74,6 +76,9 @@ const store = configureStore({
     },
     notifications: {
       notifications: loadNotifications(),
+    },
+    drawerMode: {
+      ...drawerModeSlice.getInitialState(),
     },
   },
 });

--- a/frontend/src/redux/drawerModeSlice.ts
+++ b/frontend/src/redux/drawerModeSlice.ts
@@ -39,7 +39,7 @@ const initialState: DrawerModeState = {
   selectedResource: undefined,
 };
 
-const drawerModeSlice = createSlice({
+export const drawerModeSlice = createSlice({
   name: 'drawerMode',
   initialState,
   reducers: {


### PR DESCRIPTION
Resolved a TypeError in the Notifications Docs and List stories by adding missing context providers. The drawer relied on Redux state which was not available without decorators in the story setup.


---

### Summary

This PR fixes a rendering issue in the Notifications Docs and List stories in Storybook. The error was caused by missing Redux context, which resulted in a `TypeError` when accessing `isDetailDrawerEnabled`.

### Fix

* Added necessary decorators to wrap the stories with required providers.
* Ensured proper rendering of the Notification Drawer in Storybook.

###  How to Test

1. Run Storybook locally.
2. Navigate to:

   * http://localhost:6006/?path=/story/notifications--list
   * http://localhost:6006/?path=/docs/notifications--docs
3. Confirm the docs and list render without errors.

---

#### Screenshot of the changes: 

|Before(Docs) |After (Docs) |
|----|----|
|<img width="1440" alt="Screenshot 2025-05-20 at 2 33 08 AM" src="https://github.com/user-attachments/assets/08620ed3-2883-4d74-b248-65412daaf995" />|<img width="1440" alt="Screenshot 2025-05-20 at 2 21 59 AM" src="https://github.com/user-attachments/assets/794ad51d-87f6-42c8-876d-3547b2a39b90" />|

|Before (list)|After (list)|
|----|----|
|<img width="1440" alt="Screenshot 2025-05-20 at 2 34 32 AM" src="https://github.com/user-attachments/assets/0480a643-7c51-4440-a0d5-979dbee50244" />|<img width="1440" alt="Screenshot 2025-05-20 at 2 22 08 AM" src="https://github.com/user-attachments/assets/a55dbe38-f09f-4b44-a1a9-8fe53a44b77d" />|

Related to

*  #3267




