### PR TITLE
Makefile: Add better failure message for make frontend-i18n-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,13 @@ frontend-tsc:
 
 .PHONY: frontend-i18n-check
 frontend-i18n-check:
-	@echo "Checking translations. If this fails use: 'npm run i18n'"
-	cd frontend && npm run i18n -- --fail-on-update
+ifeq ($(UNIXSHELL),true)
+	@echo "Checking translations. If this fails use: 'make i18n' or 'npm run i18n'"
+	@cd frontend && npm run i18n -- --fail-on-update || echo "⚠️  Translation check failed. Run 'make i18n' or 'npm run i18n' to update translations." && exit 1
+else
+	@echo "Checking translations. If this fails use: 'make i18n' or 'npm run i18n'"
+	@cmd /C "cd frontend && npm run i18n -- --fail-on-update || echo Translation check failed. Run 'make i18n' or 'npm run i18n' to update translations. && exit 1"
+endif
 
 frontend-test:
 	cd frontend && npm run test -- --coverage


### PR DESCRIPTION
So that when it fails the people know what to do.

Often the check fails, but it does not write the changed files. So people need to run `make i18n`. 

People don't see the warning message at the top of several pages of output, so it's at the bottom.

They are running a make file, so they are told the make command to run (not an npm one).

