### PR TITLE
Backend: Improve cluster metadata and add clusterID

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1298,14 +1298,25 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 			continue
 		}
 
+		kubeconfigPath := context.KubeConfigPath
+
+		source := context.SourceStr()
+
+		clusterID := context.ClusterID
+
 		clusters = append(clusters, Cluster{
 			Name:     context.Name,
 			Server:   context.Cluster.Server,
 			AuthType: context.AuthType(),
 			Metadata: map[string]interface{}{
-				"source":     context.SourceStr(),
+				"source":     source,
 				"namespace":  context.KubeContext.Namespace,
 				"extensions": context.KubeContext.Extensions,
+				"origin": map[string]interface{}{
+					"kubeconfig": kubeconfigPath,
+				},
+				"originalName": context.Name,
+				"clusterID":    clusterID,
 			},
 		})
 	}

--- a/backend/pkg/kubeconfig/test_data/kubeconfig_metadata
+++ b/backend/pkg/kubeconfig/test_data/kubeconfig_metadata
@@ -1,0 +1,44 @@
+apiVersion: v1
+clusters:
+  - cluster:
+      certificate-authority-data: dGVzdA==
+      server: https://kubernetes.docker.internal:6443
+    name: random-cluster-x
+  - cluster:
+      certificate-authority-data: dGVzdA==
+      extensions:
+        - extension:
+            last-update: Mon, 26 Dec 2022 20:33:03 IST
+            provider: random-cluster-y.sigs.k8s.io
+            version: v1.28.0
+          name: cluster_info
+      server: https://127.0.0.1:60279
+    name: random-cluster-y
+contexts:
+  - context:
+      cluster: random-cluster-x
+      user: random-cluster-x
+    name: random-cluster-x
+  - context:
+      cluster: random-cluster-y
+      extensions:
+        - extension:
+            last-update: Mon, 26 Dec 2022 20:33:03 IST
+            provider: random-cluster-y.sigs.k8s.io
+            version: v1.28.0
+          name: context_info
+      namespace: default
+      user: random-cluster-y
+    name: random-cluster-y
+current-context: random-cluster-y
+kind: Config
+preferences: {}
+users:
+  - name: random-cluster-x
+    user:
+      client-certificate-data: dGVzdA==
+      client-key-data: dGVzdA==
+  - name: random-cluster-y
+    user:
+      client-certificate-data: dGVzdA==
+      client-key-data: dGVzdA==

--- a/backend/pkg/kubeconfig/test_data/kubeconfig_metadata_duplicate
+++ b/backend/pkg/kubeconfig/test_data/kubeconfig_metadata_duplicate
@@ -1,0 +1,44 @@
+apiVersion: v1
+clusters:
+  - cluster:
+      certificate-authority-data: dGVzdA==
+      server: https://kubernetes.docker.internal:6443
+    name: random-cluster-x
+  - cluster:
+      certificate-authority-data: dGVzdA==
+      extensions:
+        - extension:
+            last-update: Mon, 26 Dec 2022 20:33:03 IST
+            provider: random-cluster-y.sigs.k8s.io
+            version: v1.28.0
+          name: cluster_info
+      server: https://127.0.0.1:60279
+    name: random-cluster-y
+contexts:
+  - context:
+      cluster: random-cluster-x
+      user: random-cluster-x
+    name: random-cluster-x
+  - context:
+      cluster: random-cluster-y
+      extensions:
+        - extension:
+            last-update: Mon, 26 Dec 2022 20:33:03 IST
+            provider: random-cluster-y.sigs.k8s.io
+            version: v1.28.0
+          name: context_info
+      namespace: default
+      user: random-cluster-y
+    name: random-cluster-y
+current-context: random-cluster-y
+kind: Config
+preferences: {}
+users:
+  - name: random-cluster-x
+    user:
+      client-certificate-data: dGVzdA==
+      client-key-data: dGVzdA==
+  - name: random-cluster-y
+    user:
+      client-certificate-data: dGVzdA==
+      client-key-data: dGVzdA==


### PR DESCRIPTION
This PR introduces `clusterID` to be later used for non dynamic cluster actions (rename / delete) only. At current, cluster actions like rename and delete are done by locating the cluster by its `name` field. ClusterID is needed in order to separate non dynamic clusters from being impacted by overlapping action side effects of all other clusters. 

- Expands metadata field for clusters, metadata field now includes:
  - Source  `cluster.metadata.origin.kubeconfig` : File path of the kubeconfig
  - OriginalName `cluster.metadata.originalName` : Original name the cluster was created with
  - ClusterID  `cluster.metadata.clusterID` : Unique ID for finding cluster, source + originalName

---

part 1/3 from - https://github.com/kubernetes-sigs/headlamp/pull/3121