### PR TITLE
docs: add essential step to build local Docker image for setup

### DIFF
--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -192,6 +192,7 @@ ones made in the local docker environment.
 
 ```bash
 eval $(minikube docker-env)
+docker build -t headlamp-k8s/headlamp:development
 DOCKER_IMAGE_VERSION=development make image
 ```
 


### PR DESCRIPTION
Included a necessary command in the setup documentation to build the Headlamp Docker image locally. This step ensures the image is available for local Kubernetes environments like Minikube, where the imagePullPolicy is set to Never. It is crucial for successfully deploying Headlamp during development.