### PR TITLE
frontend: NavigationTabs: Fix to use cloneDeep instead of structuredClone

### DIFF
--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -18,6 +18,7 @@ import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import cloneDeep from 'lodash/cloneDeep';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router';
 import { getCluster, getClusterPrefixedPath } from '../../lib/cluster';
@@ -67,7 +68,8 @@ export default function NavigationTabs() {
   let defaultIndex = null;
   const listItemsOriginal = useSidebarItems(sidebar.selected.sidebar ?? undefined);
   // Making a copy because we're going to mutate it later in here
-  const listItems = structuredClone(listItemsOriginal);
+  const listItems = cloneDeep(listItemsOriginal);
+
   let navigationItem = listItems.find(item => item.name === sidebar.selected.item);
   if (!navigationItem) {
     const parent = findParentOfSubList(listItems, sidebar.selected.item);


### PR DESCRIPTION
There's something structuredClone doesn't handle...

> vendor-mui-Djh-99hi.js:40  DataCloneError: Failed to execute 'structuredClone' on 'Window': Symbol(react.element) could not be cloned.
>   at NavigationTabs (index-CgoiQPYG.js:1119:10657)