### PR TITLE
frontend: Home: Display true kubeconfig origin

### DIFF
--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -112,8 +112,8 @@ export default function ClusterTable({
    */
   function getOrigin(cluster: Cluster): string {
     if (cluster.meta_data?.source === 'kubeconfig') {
-      const kubeconfigPath = process.env.KUBECONFIG ?? '~/.kube/config';
-      return `Kubeconfig: ${kubeconfigPath}`;
+      const sourcePath = cluster.meta_data?.origin?.kubeconfig;
+      return sourcePath ? `Kubeconfig: ${sourcePath}` : 'Kubeconfig';
     } else if (cluster.meta_data?.source === 'dynamic_cluster') {
       return t('translation|Plugin');
     } else if (cluster.meta_data?.source === 'in_cluster') {


### PR DESCRIPTION
Displays the actual kubeconfig path for cluster in the `origin` field when on the home view. 

## Home View

![image](https://github.com/user-attachments/assets/d19289bb-e369-4d3b-91e9-87e4b8929b2b)
- UI fix for App home view, `Origin` now displays correct Kubeconfig path

### How to test actual origin in app mode
- Run headlamp in App mode
- Create a non dynamic cluster and let it load at home view
- At the home view: notice the specific Kubeconfig path under `Origin` on the table

--- 

part 2/3 from - https://github.com/kubernetes-sigs/headlamp/pull/3121