### PR TITLE
frontend: map: Add Custom Resources support

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -58,7 +58,7 @@ import { GraphControlButton } from './GraphControls';
 import { GraphRenderer } from './GraphRenderer';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
 import { kubeObjectRelations } from './sources/definitions/relations';
-import { allSources } from './sources/definitions/sources';
+import { getAllSources } from './sources/definitions/sources';
 import { GraphSourceManager, useSources } from './sources/GraphSources';
 import { GraphSourcesView } from './sources/GraphSourcesView';
 import { useGraphViewport } from './useGraphViewport';
@@ -450,7 +450,7 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
  * @returns
  */
 export function GraphView(props: GraphViewContentProps) {
-  const propsSources = props.defaultSources ?? allSources;
+  const propsSources = props.defaultSources ?? getAllSources();
 
   // Load plugin defined sources
   const pluginGraphSources = useTypedSelector(state => state.graphView.graphSources);

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -53,11 +53,11 @@ import {
 } from './graph/graphGrouping';
 import { applyGraphLayout } from './graph/graphLayout';
 import { GraphLookup, makeGraphLookup } from './graph/graphLookup';
-import { forEachNode, GraphEdge, GraphNode, GraphSource } from './graph/graphModel';
+import { forEachNode, GraphEdge, GraphNode, GraphSource, Relation } from './graph/graphModel';
 import { GraphControlButton } from './GraphControls';
 import { GraphRenderer } from './GraphRenderer';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
-import { kubeObjectRelations } from './sources/definitions/relations';
+import { getAllRelations } from './sources/definitions/relations';
 import { getAllSources } from './sources/definitions/sources';
 import { GraphSourceManager, useSources } from './sources/GraphSources';
 import { GraphSourcesView } from './sources/GraphSourcesView';
@@ -95,6 +95,12 @@ interface GraphViewContentProps {
    * See {@link GraphSource} for more information
    */
   defaultSources?: GraphSource[];
+  /**
+   * List of Graph Relations to display
+   *
+   * See {@link GraphSource} for more information
+   */
+  defaultRelations?: Relation[];
 
   /** Default filters to apply */
   defaultFilters?: GraphFilter[];
@@ -451,6 +457,7 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
  */
 export function GraphView(props: GraphViewContentProps) {
   const propsSources = props.defaultSources ?? getAllSources();
+  const propsRelations = props.defaultRelations ?? getAllRelations();
 
   // Load plugin defined sources
   const pluginGraphSources = useTypedSelector(state => state.graphView.graphSources);
@@ -463,7 +470,7 @@ export function GraphView(props: GraphViewContentProps) {
   return (
     <StrictMode>
       <ReactFlowProvider>
-        <GraphSourceManager sources={sources} relations={kubeObjectRelations}>
+        <GraphSourceManager sources={sources} relations={propsRelations}>
           <GraphViewContent {...props} defaultSources={sources} />
         </GraphSourceManager>
       </ReactFlowProvider>

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -57,8 +57,8 @@ import { forEachNode, GraphEdge, GraphNode, GraphSource, Relation } from './grap
 import { GraphControlButton } from './GraphControls';
 import { GraphRenderer } from './GraphRenderer';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
-import { getAllRelations } from './sources/definitions/relations';
-import { getAllSources } from './sources/definitions/sources';
+import { useGetAllRelations } from './sources/definitions/relations';
+import { useGetAllSources } from './sources/definitions/sources';
 import { GraphSourceManager, useSources } from './sources/GraphSources';
 import { GraphSourcesView } from './sources/GraphSourcesView';
 import { useGraphViewport } from './useGraphViewport';
@@ -125,7 +125,7 @@ const ChipGroup = styled(Box)({
 function GraphViewContent({
   height,
   defaultNodeSelection,
-  defaultSources = getAllSources(),
+  defaultSources = useGetAllSources(),
   defaultFilters = defaultFiltersValue,
 }: GraphViewContentProps) {
   const { t } = useTranslation();
@@ -456,8 +456,8 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
  * @returns
  */
 export function GraphView(props: GraphViewContentProps) {
-  const propsSources = props.defaultSources ?? getAllSources();
-  const propsRelations = props.defaultRelations ?? getAllRelations();
+  const propsSources = props.defaultSources ?? useGetAllSources();
+  const propsRelations = props.defaultRelations ?? useGetAllRelations();
 
   // Load plugin defined sources
   const pluginGraphSources = useTypedSelector(state => state.graphView.graphSources);

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -119,7 +119,7 @@ const ChipGroup = styled(Box)({
 function GraphViewContent({
   height,
   defaultNodeSelection,
-  defaultSources = allSources,
+  defaultSources = getAllSources(),
   defaultFilters = defaultFiltersValue,
 }: GraphViewContentProps) {
   const { t } = useTranslation();

--- a/frontend/src/components/resourceMap/details/GraphNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/GraphNodeDetails.tsx
@@ -71,7 +71,12 @@ export function GraphNodeDetails({ node, close }: GraphNodeDetailsProps) {
       </Box>
 
       {node.detailsComponent && <node.detailsComponent node={node} />}
-      {node.kubeObject && <KubeObjectDetails resource={node.kubeObject} />}
+      {node.kubeObject && (
+        <KubeObjectDetails
+          resource={node.kubeObject}
+          customResourceDefinition={node.customResourceDefinition}
+        />
+      )}
     </Card>
   );
 }

--- a/frontend/src/components/resourceMap/graph/graphModel.tsx
+++ b/frontend/src/components/resourceMap/graph/graphModel.tsx
@@ -16,7 +16,6 @@
 
 import { ComponentType, ReactNode } from 'react';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
-
 export type GraphNode = {
   /**
    * Unique ID for this node.
@@ -46,6 +45,8 @@ export type GraphNode = {
   detailsComponent?: ComponentType<{ node: GraphNode }>;
   /** Any custom data */
   data?: any;
+  /** CustomResourceDefinition for this node */
+  customResourceDefinition?: string;
 };
 
 /**

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -55,7 +55,7 @@ export const useSources = () => useContext(Context);
 /**
  * Returns a flat list of all the sources
  */
-function getFlatSources(sources: GraphSource[], result: GraphSource[] = []): GraphSource[] {
+export function getFlatSources(sources: GraphSource[], result: GraphSource[] = []): GraphSource[] {
   for (const source of sources) {
     if ('sources' in source) {
       getFlatSources(source.sources, result);

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -80,6 +80,20 @@ export const kubeOwnersEdges = (obj: KubeObject): GraphEdge[] => {
 };
 
 /**
+ * Create reverse Edges from object's ownerReferences
+ */
+export const kubeOwnersEdgesReversed = (obj: KubeObject): GraphEdge[] => {
+  return (
+    obj.metadata.ownerReferences?.map(owner => ({
+      id: `${owner.uid}-${obj.metadata.uid}`,
+      type: 'kubeRelation',
+      source: owner.uid,
+      target: obj.metadata.uid,
+    })) ?? []
+  );
+};
+
+/**
  * Create an object from any Kube object
  */
 export const makeKubeObjectNode = (obj: KubeObject): GraphNode => {

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -26,7 +26,6 @@ import {
   useState,
 } from 'react';
 import { KubeObject } from '../../../lib/k8s/cluster';
-import { isCustomResource } from '../../../lib/k8s/crd';
 import { GraphEdge, GraphNode, GraphSource, Relation } from '../graph/graphModel';
 
 /**
@@ -84,9 +83,8 @@ export const kubeOwnersEdges = (obj: KubeObject): GraphEdge[] => {
  * Create an object from any Kube object
  */
 export const makeKubeObjectNode = (obj: KubeObject): GraphNode => {
-  if (isCustomResource(obj)) {
-    const crd = obj.constructor.customResourceDefinition;
-    // `obj` is now narrowed and the extra property is added only here
+  const crd = (obj.constructor as any)?.customResourceDefinition;
+  if (crd && typeof crd.getMainAPIGroup === 'function') {
     const [group, , plural] = crd.getMainAPIGroup();
     return {
       id: obj.metadata.uid,

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -26,6 +26,7 @@ import {
   useState,
 } from 'react';
 import { KubeObject } from '../../../lib/k8s/cluster';
+import { isCustomResource } from '../../../lib/k8s/crd';
 import { GraphEdge, GraphNode, GraphSource, Relation } from '../graph/graphModel';
 
 /**
@@ -83,6 +84,17 @@ export const kubeOwnersEdges = (obj: KubeObject): GraphEdge[] => {
  * Create an object from any Kube object
  */
 export const makeKubeObjectNode = (obj: KubeObject): GraphNode => {
+  if (isCustomResource(obj)) {
+    const crd = obj.constructor.customResourceDefinition;
+    // `obj` is now narrowed and the extra property is added only here
+    const [group, , plural] = crd.getMainAPIGroup();
+    return {
+      id: obj.metadata.uid,
+      kubeObject: obj,
+      customResourceDefinition: plural + '.' + group,
+    };
+  }
+
   return {
     id: obj.metadata.uid,
     kubeObject: obj,

--- a/frontend/src/components/resourceMap/sources/GraphSourcesView.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSourcesView.tsx
@@ -62,8 +62,6 @@ function GraphSourceView({
   source,
   sourceData,
   selection,
-  activeItemIds,
-  toggleActiveItemIds,
   toggleSelection,
 }: {
   /** Source definition */
@@ -72,11 +70,9 @@ function GraphSourceView({
   sourceData: SourceData;
   /** Set of selected source ids */
   selection: Set<string>;
-  /** Active (expanded) source */
-  activeItemIds: string[];
   toggleSelection: (source: GraphSource) => void;
-  toggleActiveItemIds: (add: boolean, id: string) => void;
 }) {
+  const [isActive, setIsActive] = useState(false);
   const hasChildren = 'sources' in source;
   const isSelected = (source: GraphSource): boolean =>
     'sources' in source ? source.sources.every(s => isSelected(s)) : selection.has(source.id);
@@ -128,18 +124,16 @@ function GraphSourceView({
     );
   }
 
-  const isActive = activeItemIds.includes(source.id);
-
   return (
     <Node>
       <NodeHeader
         role="button"
         tabIndex={0}
-        onClick={() => toggleActiveItemIds(!isActive, source.id)}
+        onClick={() => setIsActive(!isActive)}
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            toggleActiveItemIds(!isActive, source.id);
+            setIsActive(!isActive);
           }
         }}
       >
@@ -154,7 +148,7 @@ function GraphSourceView({
       </NodeHeader>
 
       <Stack ml={3}>
-        {activeItemIds.includes(source.id) &&
+        {isActive &&
           source.sources?.map(source => (
             <GraphSourceView
               source={source}
@@ -162,8 +156,6 @@ function GraphSourceView({
               toggleSelection={toggleSelection}
               key={source.id}
               sourceData={sourceData}
-              activeItemIds={activeItemIds}
-              toggleActiveItemIds={toggleActiveItemIds}
             />
           ))}
       </Stack>
@@ -185,7 +177,6 @@ export interface GraphSourcesViewProps {
 export const GraphSourcesView = memo(
   ({ sources, sourceData, selectedSources, toggleSource }: GraphSourcesViewProps) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-    const [activeItemIds, toggleActiveItemIds] = useState<string[]>([]);
 
     const selected = sources.filter(source => {
       const isSelected = selectedSources.has(source.id);
@@ -239,22 +230,6 @@ export const GraphSourcesView = memo(
                 toggleSelection={toggleSource}
                 key={index}
                 sourceData={sourceData}
-                activeItemIds={activeItemIds}
-                toggleActiveItemIds={(add, id) => {
-                  let clone: string[] = [];
-
-                  for (const activeItemId of activeItemIds) {
-                    clone.push(activeItemId);
-                  }
-
-                  if (add) {
-                    clone.push(id);
-                  } else {
-                    const firstIdx = clone.indexOf(id);
-                    clone = clone.slice(0, firstIdx);
-                  }
-                  toggleActiveItemIds(clone);
-                }}
               />
             ))}
           </Box>

--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -203,7 +203,7 @@ const pvcToPods = makeRelation(PersistentVolumeClaim, Pod, (pvc, pod) =>
 const podToOwner = makeOwnerRelation(Pod);
 const repliaceSetToOwner = makeOwnerRelation(ReplicaSet);
 
-const getCRToOwnerRelations = () => {
+const useGetCRToOwnerRelations = () => {
   const namespace = useNamespaces();
   const { items: crds } = CustomResourceDefinition.useList({ namespace });
 
@@ -221,8 +221,7 @@ const jobToCronJob = makeRelation(Job, CronJob, (job, cronJob) =>
   job.metadata.ownerReferences?.find(owner => owner.uid === cronJob.metadata.uid)
 );
 
-
-export function getAllRelations(): Relation[] {
+export function useGetAllRelations(): Relation[] {
   const staticRelations = [
     configMapUsedInPods,
     configMapUsedInJobs,
@@ -247,7 +246,7 @@ export function getAllRelations(): Relation[] {
     jobToCronJob,
   ];
 
-  const crdRelations = getCRToOwnerRelations();
+  const crdRelations = useGetCRToOwnerRelations();
 
   return [...staticRelations, ...crdRelations];
 }

--- a/frontend/src/components/resourceMap/sources/definitions/sources.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/sources.tsx
@@ -85,7 +85,7 @@ const generateCRSources = (crds: CRD[]): GraphSource[] => {
   return finalSources;
 };
 
-export function getAllSources(): GraphSource[] {
+export function useGetAllSources(): GraphSource[] {
   const { items: CustomResourceDefinition } = CRD.useList({ namespace: useNamespaces() });
 
   const sources = [

--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -147,8 +147,6 @@ export interface CRClassArgs {
   customResourceDefinition: CustomResourceDefinition;
 }
 
-const IS_CUSTOM_RESOURCE = Symbol.for('isCustomResource');
-
 /** @deprecated Use the version of the function that receives an object as its argument. */
 export function makeCustomResourceClass(
   args: [group: string, version: string, pluralName: string][],
@@ -190,18 +188,8 @@ export function makeCustomResourceClass(
     );
     static isNamespaced = objArgs.isNamespaced;
     static apiEndpoint = apiFunc(...apiInfoArgs);
-    static [IS_CUSTOM_RESOURCE] = true;
     static customResourceDefinition = crClassArgs.customResourceDefinition;
   };
-}
-
-export function isCustomResource(obj: KubeObject): obj is KubeObject & {
-  constructor: {
-    customResourceDefinition: CustomResourceDefinition;
-    [IS_CUSTOM_RESOURCE]: true;
-  };
-} {
-  return Boolean((obj.constructor as any)?.[IS_CUSTOM_RESOURCE]);
 }
 
 export default CustomResourceDefinition;

--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -127,6 +127,7 @@ class CustomResourceDefinition extends KubeObject<KubeCRD> {
       isNamespaced: this.spec.scope === 'Namespaced',
       singularName: this.spec.names.singular,
       pluralName: this.spec.names.plural,
+      customResourceDefinition: this,
     });
   }
 
@@ -143,7 +144,10 @@ export interface CRClassArgs {
   pluralName: string;
   singularName: string;
   isNamespaced: boolean;
+  customResourceDefinition: CustomResourceDefinition;
 }
+
+const IS_CUSTOM_RESOURCE = Symbol.for('isCustomResource');
 
 /** @deprecated Use the version of the function that receives an object as its argument. */
 export function makeCustomResourceClass(
@@ -186,7 +190,18 @@ export function makeCustomResourceClass(
     );
     static isNamespaced = objArgs.isNamespaced;
     static apiEndpoint = apiFunc(...apiInfoArgs);
+    static [IS_CUSTOM_RESOURCE] = true;
+    static customResourceDefinition = crClassArgs.customResourceDefinition;
   };
+}
+
+export function isCustomResource(obj: KubeObject): obj is KubeObject & {
+  constructor: {
+    customResourceDefinition: CustomResourceDefinition;
+    [IS_CUSTOM_RESOURCE]: true;
+  };
+} {
+  return Boolean((obj.constructor as any)?.[IS_CUSTOM_RESOURCE]);
 }
 
 export default CustomResourceDefinition;


### PR DESCRIPTION
This PR adds Custom Resources to the Map in the frontend.

**Filter dropdown**

Custom Resources are grouped by API group in the dropdown and can be individually selected:

![Screenshot 2025-05-23 at 16 14 26](https://github.com/user-attachments/assets/7d8f759a-4715-4809-91e9-0a4928676f81)

**Edges**

Edges between Custom Resources are shown for the Owner Reference in reverse order:

![Screenshot 2025-05-23 at 16 21 36](https://github.com/user-attachments/assets/536a341d-f668-4cdf-942b-d205e3139d39)

**Details View**

The same details view as in the Custom Resources Section is also shown in the Map:

![Screenshot 2025-05-23 at 16 22 55](https://github.com/user-attachments/assets/9d894a9c-1bcb-4cc4-801c-d0aa2c9aa760)

**Approach for adding Custom Resources**

For now we have not squashed all the commits to show multiple ideas of how to add the CR details view. It was not clear for us which approach would be the best for this project, the latest one being the best integrated one from our point of view. Some changes were necessary since we dynamically load the CRD list, compared to the static approach of the base objects. If you think another approach would be better please let us know.

- 4570773ea82fc353992c29eb243c1a13692baee4 shows the first implementation which manually adds the details section.
- b7255fbaa10057d08f6db53f15197adc7f22950c uses the customResourceDefinition parameter in the KubeObjectDetails view.
- a34d579ed6d31d0a4d81b3e8e9fad7223d29d869 simplifies the CustomResourceDefinition Class by using duck-typing for detecting the object type instead of using a marker.


