### PR TITLE
frontend: InnerTable: Add storybook stories

### DIFF
--- a/frontend/src/components/common/InnerTable.stories.tsx
+++ b/frontend/src/components/common/InnerTable.stories.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box, Paper, Typography } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { TestContext } from '../../test';
+import InnerTable from './InnerTable';
+import { SimpleTableProps } from './SimpleTable';
+
+interface InnerTableStoryProps extends SimpleTableProps {}
+
+export default {
+  title: 'common/InnerTable',
+  component: InnerTable,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Paper elevation={3} sx={{ padding: 2, margin: 2, maxWidth: '800px' }}>
+          <Typography variant="h6" gutterBottom>
+            Outer Container Title
+          </Typography>
+          <Story />
+        </Paper>
+      </TestContext>
+    ),
+  ],
+  argTypes: {
+    columns: { control: 'object', description: 'Array of column definitions.' },
+    data: { control: 'object', description: 'Array of data objects for the table rows.' },
+    emptyMessage: { control: 'text' },
+    noTableHeader: { control: 'boolean' },
+  },
+} as Meta<typeof InnerTable>;
+
+const Template: StoryFn<InnerTableStoryProps> = args => <InnerTable {...args} />;
+
+const sampleData = [
+  { id: 1, name: 'Feature A', status: 'Enabled', priority: 'High' },
+  { id: 2, name: 'Feature B', status: 'Disabled', priority: 'Medium' },
+  { id: 3, name: 'Bug Fix C', status: 'In Progress', priority: 'High' },
+];
+
+const sampleColumns = [
+  {
+    label: 'ID',
+    datum: 'id',
+  },
+  {
+    label: 'Name',
+    datum: 'name',
+  },
+  {
+    label: 'Status',
+    datum: 'status',
+  },
+  {
+    label: 'Priority',
+    datum: 'priority',
+  },
+];
+
+export const Default = Template.bind({});
+Default.args = {
+  columns: sampleColumns,
+  data: sampleData,
+};
+Default.storyName = 'Basic Inner Table';
+
+export const WithFewRows = Template.bind({});
+WithFewRows.args = {
+  columns: sampleColumns,
+  data: [{ id: 1, name: 'Single Item', status: 'Active', priority: 'Low' }],
+};
+
+export const EmptyTable = Template.bind({});
+EmptyTable.args = {
+  columns: sampleColumns,
+  data: [],
+  emptyMessage: 'No inner data available.',
+};
+
+export const WithoutTableHeader = Template.bind({});
+WithoutTableHeader.args = {
+  columns: sampleColumns,
+  data: sampleData.slice(0, 2),
+  noTableHeader: true,
+};
+
+export const InsideAnotherComponent = () => (
+  <Box sx={{ border: '1px dashed grey', padding: 2 }}>
+    <Typography variant="subtitle1">Section Containing InnerTable</Typography>
+    <InnerTable
+      columns={[
+        { label: 'Key', datum: 'key' },
+        { label: 'Value', datum: 'value' },
+      ]}
+      data={[
+        { key: 'config_option_1', value: 'true' },
+        { key: 'config_option_2', value: '12345' },
+      ]}
+    />
+  </Box>
+);
+InsideAnotherComponent.storyName = 'Nested within a Box';

--- a/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
@@ -1,0 +1,129 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                ID
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Name
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Status
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Priority
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Enabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                2
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature B
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Disabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Medium
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                3
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Bug Fix C
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                In Progress
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
@@ -1,0 +1,26 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-19midj6"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+          >
+            No inner data available.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
@@ -1,0 +1,82 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiBox-root css-v0ml89"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+        >
+          Section Containing InnerTable
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Key
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Value
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  config_option_1
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  true
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  config_option_2
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  12345
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
@@ -1,0 +1,81 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                ID
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Name
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Status
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Priority
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Single Item
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Active
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Low
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
@@ -1,0 +1,73 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Enabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                2
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature B
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Disabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Medium
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
This PR adds Storybook stories for the `InnerTable` component, which is a wrapper around the `SimpleTable` component. The stories demonstrate various use cases and configurations of the component.

- Added `InnerTable.stories.tsx` with 5 different stories:
    - Default (Basic Inner Table): Shows a standard table with multiple rows
    - WithFewRows: Demonstrates a table with a single row
    - EmptyTable: Shows how the table handles empty data with a custom message
    - WithoutTableHeader: Demonstrates the table without column headers
    - InsideAnotherComponent: Shows how the table can be nested within other components

![Screenshot from 2025-05-24 19-07-37](https://github.com/user-attachments/assets/b8f6005c-6423-4ba5-8a45-9ce2d5ad1eb4)
![Screenshot from 2025-05-24 19-07-33](https://github.com/user-attachments/assets/ba889cc7-34cf-4feb-b144-e9b776092f21)
![Screenshot from 2025-05-24 19-07-30](https://github.com/user-attachments/assets/0c9ed3f3-1c2d-4344-a9be-57a17ff85ef6)
![Screenshot from 2025-05-24 19-07-25](https://github.com/user-attachments/assets/272d3cee-913c-4332-93b9-015961c20d0b)
![Screenshot from 2025-05-24 19-07-18](https://github.com/user-attachments/assets/a316e43e-72fc-4ba4-bc88-cb3b410dec02)
