### PR TITLE
frontend: ObjectEventList: Add stories

### DIFF
--- a/frontend/src/components/common/InnerTable.stories.tsx
+++ b/frontend/src/components/common/InnerTable.stories.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box, Paper, Typography } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { TestContext } from '../../test';
+import InnerTable from './InnerTable';
+import { SimpleTableProps } from './SimpleTable';
+
+interface InnerTableStoryProps extends SimpleTableProps {}
+
+export default {
+  title: 'common/InnerTable',
+  component: InnerTable,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Paper elevation={3} sx={{ padding: 2, margin: 2, maxWidth: '800px' }}>
+          <Typography variant="h6" gutterBottom>
+            Outer Container Title
+          </Typography>
+          <Story />
+        </Paper>
+      </TestContext>
+    ),
+  ],
+  argTypes: {
+    columns: { control: 'object', description: 'Array of column definitions.' },
+    data: { control: 'object', description: 'Array of data objects for the table rows.' },
+    emptyMessage: { control: 'text' },
+    noTableHeader: { control: 'boolean' },
+  },
+} as Meta<typeof InnerTable>;
+
+const Template: StoryFn<InnerTableStoryProps> = args => <InnerTable {...args} />;
+
+const sampleData = [
+  { id: 1, name: 'Feature A', status: 'Enabled', priority: 'High' },
+  { id: 2, name: 'Feature B', status: 'Disabled', priority: 'Medium' },
+  { id: 3, name: 'Bug Fix C', status: 'In Progress', priority: 'High' },
+];
+
+const sampleColumns = [
+  {
+    label: 'ID',
+    datum: 'id',
+  },
+  {
+    label: 'Name',
+    datum: 'name',
+  },
+  {
+    label: 'Status',
+    datum: 'status',
+  },
+  {
+    label: 'Priority',
+    datum: 'priority',
+  },
+];
+
+export const Default = Template.bind({});
+Default.args = {
+  columns: sampleColumns,
+  data: sampleData,
+};
+Default.storyName = 'Basic Inner Table';
+
+export const WithFewRows = Template.bind({});
+WithFewRows.args = {
+  columns: sampleColumns,
+  data: [{ id: 1, name: 'Single Item', status: 'Active', priority: 'Low' }],
+};
+
+export const EmptyTable = Template.bind({});
+EmptyTable.args = {
+  columns: sampleColumns,
+  data: [],
+  emptyMessage: 'No inner data available.',
+};
+
+export const WithoutTableHeader = Template.bind({});
+WithoutTableHeader.args = {
+  columns: sampleColumns,
+  data: sampleData.slice(0, 2),
+  noTableHeader: true,
+};
+
+export const InsideAnotherComponent = () => (
+  <Box sx={{ border: '1px dashed grey', padding: 2 }}>
+    <Typography variant="subtitle1">Section Containing InnerTable</Typography>
+    <InnerTable
+      columns={[
+        { label: 'Key', datum: 'key' },
+        { label: 'Value', datum: 'value' },
+      ]}
+      data={[
+        { key: 'config_option_1', value: 'true' },
+        { key: 'config_option_2', value: '12345' },
+      ]}
+    />
+  </Box>
+);
+InsideAnotherComponent.storyName = 'Nested within a Box';

--- a/frontend/src/components/common/ObjectEventList.stories.tsx
+++ b/frontend/src/components/common/ObjectEventList.stories.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { getTestDate } from '../../helpers/testHelpers';
+import { KubeEvent } from '../../lib/k8s/event';
+import { KubeObject } from '../../lib/k8s/KubeObject';
+import store from '../../redux/stores/store';
+import { TestContext } from '../../test';
+import ObjectEventList, { ObjectEventListProps } from './ObjectEventList';
+
+const mockOwnerObject = new KubeObject({
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'test-pod-for-events',
+    namespace: 'default',
+    uid: 'owner-pod-uid-123',
+    creationTimestamp: getTestDate().toISOString(),
+  },
+});
+
+const mockOwnerObjectNoEvents = new KubeObject({
+  kind: 'Deployment',
+  apiVersion: 'apps/v1',
+  metadata: {
+    name: 'test-deployment-no-events',
+    namespace: 'kube-system',
+    uid: 'owner-deployment-uid-456',
+    creationTimestamp: getTestDate().toISOString(),
+  },
+});
+
+const mockEvents: KubeEvent[] = [
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event1.123',
+      namespace: 'default',
+      uid: 'event-uid-1',
+      creationTimestamp: new Date(getTestDate().getTime() - 5 * 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-for-events',
+      uid: 'owner-pod-uid-123',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'Scheduled',
+    message: 'Successfully assigned default/test-pod-for-events to worker-node-1',
+    source: { component: 'default-scheduler' },
+    firstTimestamp: new Date(getTestDate().getTime() - 5 * 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 5 * 60 * 1000).toISOString(),
+    count: 1,
+    type: 'Normal',
+  },
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event2.456',
+      namespace: 'default',
+      uid: 'event-uid-2',
+      creationTimestamp: new Date(getTestDate().getTime() - 2 * 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-for-events',
+      uid: 'owner-pod-uid-123',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'Pulled',
+    message: 'Container image "nginx:latest" already present on machine',
+    source: { component: 'kubelet' },
+    firstTimestamp: new Date(getTestDate().getTime() - 2 * 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 2 * 60 * 1000).toISOString(),
+    count: 1,
+    type: 'Normal',
+  },
+];
+
+export default {
+  title: 'common/ObjectEventList',
+  component: ObjectEventList,
+  decorators: [
+    Story => (
+      <Provider store={store}>
+        <TestContext>
+          <Story />
+        </TestContext>
+      </Provider>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/v1/namespaces/:namespace/events', ({ params, request }) => {
+          const url = new URL(request.url);
+          const fieldSelector = url.searchParams.get('fieldSelector');
+          const reqNamespace = params.namespace;
+
+          if (
+            reqNamespace === mockOwnerObject.metadata.namespace &&
+            fieldSelector &&
+            fieldSelector.includes(`involvedObject.kind=${mockOwnerObject.kind}`) &&
+            fieldSelector.includes(`involvedObject.name=${mockOwnerObject.metadata.name}`)
+          ) {
+            return HttpResponse.json({
+              kind: 'EventList',
+              items: mockEvents,
+              metadata: {},
+            });
+          }
+          if (
+            reqNamespace === mockOwnerObjectNoEvents.metadata.namespace &&
+            fieldSelector &&
+            fieldSelector.includes(`involvedObject.kind=${mockOwnerObjectNoEvents.kind}`) &&
+            fieldSelector.includes(`involvedObject.name=${mockOwnerObjectNoEvents.metadata.name}`)
+          ) {
+            return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
+          }
+          return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
+        }),
+      ],
+    },
+  },
+  argTypes: {
+    object: {
+      control: false,
+      description: 'The KubeObject for which to display events.',
+    },
+  },
+} as Meta<typeof ObjectEventList>;
+
+const Template: StoryFn<ObjectEventListProps> = args => <ObjectEventList {...args} />;
+
+export const WithEvents = Template.bind({});
+WithEvents.args = {
+  object: mockOwnerObject,
+};
+WithEvents.storyName = 'Displaying Events for an Object';
+
+export const NoEventsForObject = Template.bind({});
+NoEventsForObject.args = {
+  object: mockOwnerObjectNoEvents,
+};
+NoEventsForObject.storyName = 'No Events for an Object';
+
+export const ErrorFetching = Template.bind({});
+ErrorFetching.args = {
+  object: new KubeObject({
+    kind: 'Secret',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'error-secret',
+      namespace: 'errors',
+      uid: 'secret-err-uid',
+      creationTimestamp: getTestDate().toISOString(),
+    },
+  }),
+};
+ErrorFetching.parameters = {
+  msw: {
+    handlers: [
+      http.get('/api/v1/namespaces/errors/events', ({ request }) => {
+        const url = new URL(request.url);
+        const fieldSelector = url.searchParams.get('fieldSelector');
+        if (fieldSelector && fieldSelector.includes('involvedObject.name=error-secret')) {
+          return HttpResponse.json(
+            { message: 'Simulated server error fetching events' },
+            { status: 500 }
+          );
+        }
+        return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
+      }),
+    ],
+  },
+};
+ErrorFetching.storyName = 'Error Fetching Events';

--- a/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
@@ -1,0 +1,129 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                ID
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Name
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Status
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Priority
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Enabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                2
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature B
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Disabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Medium
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                3
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Bug Fix C
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                In Progress
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
@@ -1,0 +1,26 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-19midj6"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+          >
+            No inner data available.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
@@ -1,0 +1,82 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiBox-root css-v0ml89"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+        >
+          Section Containing InnerTable
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Key
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Value
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  config_option_1
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  true
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  config_option_2
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  12345
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
@@ -1,0 +1,81 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                ID
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Name
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Status
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Priority
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Single Item
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Active
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Low
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
@@ -1,0 +1,73 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Enabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                2
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature B
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Disabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Medium
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
Add Storybook stories for ObjectEventList component

-Adds ObjectEventList.stories.tsx with three cases:
    -WithEvents: Pod with multiple events
    -NoEventsForObject: Deployment with no events
    -ErrorFetching: Simulates fetch failure

![Screenshot from 2025-05-25 00-26-45](https://github.com/user-attachments/assets/3be4a8d8-a069-4df8-b1f3-a6d310e4fea0)
![Screenshot from 2025-05-25 00-26-39](https://github.com/user-attachments/assets/6acd2412-0cfc-4d18-be32-6ae2bb826079)
![Screenshot from 2025-05-25 00-26-33](https://github.com/user-attachments/assets/dcf5cef7-ca36-44e6-bd33-afaabf7272a5)
![Screenshot from 2025-05-25 00-26-49](https://github.com/user-attachments/assets/1b9428db-1145-4883-a96c-a4c695b52e4e)
