### PR TITLE
frontend: NavigationTabs: Add Storybook stories

### DIFF
--- a/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { BrowserRouter, Route } from 'react-router-dom';
+import { initialState as configInitialState } from '../../redux/configSlice';
+import { TestContext } from '../../test';
+import NavigationTabs from './NavigationTabs';
+import {
+  DefaultSidebars,
+  initialState as sidebarInitialState,
+  SidebarEntry,
+  SidebarState,
+} from './sidebarSlice';
+
+const mockClusterSidebarEntries: Record<string, SidebarEntry> = {
+  cluster: {
+    name: 'cluster',
+    label: 'Cluster',
+    icon: 'mdi:hexagon-multiple-outline',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+  namespaces: {
+    name: 'namespaces',
+    label: 'Namespaces',
+    parent: 'cluster',
+    url: '/namespaces',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+  nodes: {
+    name: 'nodes',
+    label: 'Nodes',
+    parent: 'cluster',
+    url: '/nodes',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+  workloads: {
+    name: 'workloads',
+    label: 'Workloads',
+    icon: 'mdi:circle-slice-2',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+    url: '/workloads',
+  },
+  Pods: {
+    name: 'Pods',
+    label: 'Pods',
+    parent: 'workloads',
+    url: '/pods',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+  Deployments: {
+    name: 'Deployments',
+    label: 'Deployments',
+    parent: 'workloads',
+    url: '/deployments',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+  NoURLItem: {
+    name: 'NoURLItem',
+    label: 'Item Without URL',
+    parent: 'workloads',
+    sidebar: DefaultSidebars.IN_CLUSTER,
+  },
+};
+
+const mockHomeSidebarEntries: Record<string, SidebarEntry> = {
+  home: { name: 'home', label: 'Home', icon: 'mdi:home', url: '/', sidebar: DefaultSidebars.HOME },
+  settings: {
+    name: 'settings',
+    label: 'Settings',
+    icon: 'mdi:cog',
+    sidebar: DefaultSidebars.HOME,
+    url: '/settings/general',
+  },
+  settingsGeneral: {
+    name: 'settingsGeneral',
+    label: 'General',
+    parent: 'settings',
+    url: '/settings/general',
+    sidebar: DefaultSidebars.HOME,
+  },
+  plugins: {
+    name: 'plugins',
+    label: 'Plugins',
+    parent: 'settings',
+    url: '/settings/plugins',
+    sidebar: DefaultSidebars.HOME,
+  },
+};
+
+const createMockStoryStore = (sidebarConfig: Partial<SidebarState>) => {
+  const fullSidebarState: SidebarState = {
+    ...sidebarInitialState,
+    entries:
+      sidebarConfig.selected?.sidebar === DefaultSidebars.HOME
+        ? mockHomeSidebarEntries
+        : mockClusterSidebarEntries,
+    ...sidebarConfig,
+    isSidebarOpen: sidebarConfig.isSidebarOpen === undefined ? false : sidebarConfig.isSidebarOpen,
+  };
+
+  return configureStore({
+    reducer: {
+      sidebar: createSlice({ name: 'sidebar', initialState: fullSidebarState, reducers: {} })
+        .reducer,
+      config: (state = configInitialState) => state,
+      filter: (state = { namespaces: new Set() }) => state,
+      routes: (state = { routes: {}, routeFilters: [] }) => state,
+      ui: (state = { functionsToOverride: {} }) => state,
+    },
+  });
+};
+
+export default {
+  title: 'Sidebar/NavigationTabs',
+  component: NavigationTabs,
+  decorators: [
+    (Story, context: { args: { mockSidebarState?: Partial<SidebarState> } }) => {
+      const store = createMockStoryStore(context.args.mockSidebarState || {});
+      return (
+        <Provider store={store}>
+          <BrowserRouter>
+            <TestContext store={store}>
+              <Route path="/">
+                <div style={{ padding: '20px', backgroundColor: '#f5f5f5' }}>
+                  <Story />
+                </div>
+              </Route>
+            </TestContext>
+          </BrowserRouter>
+        </Provider>
+      );
+    },
+  ],
+  parameters: {
+    controls: { include: ['mockSidebarState'] },
+  },
+  argTypes: {
+    mockSidebarState: {
+      control: 'object',
+      description: 'Mock Redux sidebar state for the story.',
+    },
+  },
+} as Meta<typeof NavigationTabs>;
+
+const Template: StoryFn<{ mockSidebarState: Partial<SidebarState> }> = () => <NavigationTabs />;
+
+export const ClusterParentSelected = Template.bind({});
+ClusterParentSelected.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'cluster',
+      sidebar: DefaultSidebars.IN_CLUSTER,
+    },
+    isSidebarOpen: false,
+  },
+};
+ClusterParentSelected.storyName = 'Cluster View (Parent Selected)';
+
+export const WorkloadsParentSelected = Template.bind({});
+WorkloadsParentSelected.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'workloads',
+      sidebar: DefaultSidebars.IN_CLUSTER,
+    },
+    isSidebarOpen: false,
+  },
+};
+WorkloadsParentSelected.storyName = 'Workloads View (Parent Selected)';
+
+export const WorkloadsChildSelected = Template.bind({});
+WorkloadsChildSelected.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'Pods',
+      sidebar: DefaultSidebars.IN_CLUSTER,
+    },
+    isSidebarOpen: false,
+  },
+};
+WorkloadsChildSelected.storyName = "Workloads View (Child 'Pods' Selected)";
+
+export const ItemWithoutOwnURLSelected = Template.bind({});
+ItemWithoutOwnURLSelected.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'NoURLItem',
+      sidebar: DefaultSidebars.IN_CLUSTER,
+    },
+    isSidebarOpen: false,
+  },
+};
+ItemWithoutOwnURLSelected.storyName = "Workloads View (Child 'Item Without URL' Selected)";
+
+export const SettingsParentSelected = Template.bind({});
+SettingsParentSelected.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'settings',
+      sidebar: DefaultSidebars.HOME,
+    },
+    isSidebarOpen: false,
+  },
+};
+SettingsParentSelected.storyName = 'Settings View (Parent Selected)';
+
+export const NoSubList = Template.bind({});
+NoSubList.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'home',
+      sidebar: DefaultSidebars.HOME,
+    },
+    isSidebarOpen: false,
+  },
+};
+NoSubList.storyName = 'No Sub-List (Should Render Nothing)';
+
+export const SidebarOpen = Template.bind({});
+SidebarOpen.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'workloads',
+      sidebar: DefaultSidebars.IN_CLUSTER,
+    },
+    isSidebarOpen: true,
+  },
+};
+SidebarOpen.storyName = 'Sidebar Open (Should Render Nothing)';

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
@@ -1,0 +1,101 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    >
+      <nav
+        aria-label="Main Navigation"
+        class="MuiBox-root css-1qm1lh"
+      >
+        <div
+          class="MuiTabs-root css-4u6pf8-MuiTabs-root"
+        >
+          <div
+            class="MuiTabs-scrollableX MuiTabs-hideScrollbar css-oqr85h"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX css-69z67c-MuiTabs-scroller"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              aria-label="Navigation Tabs"
+              class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-controls="full-width-tabpanel-0-NavigationTabs-tabs-id"
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-0-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                Cluster
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-1-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-1-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Namespaces
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-2-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-2-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Nodes
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+        <div
+          aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          id="full-width-tabpanel-0-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-1-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-2-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+      </nav>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
@@ -1,0 +1,122 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    >
+      <nav
+        aria-label="Main Navigation"
+        class="MuiBox-root css-1qm1lh"
+      >
+        <div
+          class="MuiTabs-root css-4u6pf8-MuiTabs-root"
+        >
+          <div
+            class="MuiTabs-scrollableX MuiTabs-hideScrollbar css-oqr85h"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX css-69z67c-MuiTabs-scroller"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              aria-label="Navigation Tabs"
+              class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-controls="full-width-tabpanel-0-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-0-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Workloads
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-1-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-1-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Pods
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-2-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-2-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Deployments
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-3-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                Item Without URL
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+        <div
+          aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-0-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-1-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-2-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          id="full-width-tabpanel-3-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+      </nav>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NoSubList.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NoSubList.stories.storyshot
@@ -1,0 +1,7 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    />
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
@@ -1,0 +1,122 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    >
+      <nav
+        aria-label="Main Navigation"
+        class="MuiBox-root css-1qm1lh"
+      >
+        <div
+          class="MuiTabs-root css-4u6pf8-MuiTabs-root"
+        >
+          <div
+            class="MuiTabs-scrollableX MuiTabs-hideScrollbar css-oqr85h"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX css-69z67c-MuiTabs-scroller"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              aria-label="Navigation Tabs"
+              class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-controls="full-width-tabpanel-0-NavigationTabs-tabs-id"
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-0-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                Settings
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-1-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-1-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                General
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-2-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-2-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Plugins
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-3-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Cluster
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+        <div
+          aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          id="full-width-tabpanel-0-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-1-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-2-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-3-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+      </nav>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SidebarOpen.stories.storyshot
@@ -1,0 +1,7 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    />
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
@@ -1,0 +1,122 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    >
+      <nav
+        aria-label="Main Navigation"
+        class="MuiBox-root css-1qm1lh"
+      >
+        <div
+          class="MuiTabs-root css-4u6pf8-MuiTabs-root"
+        >
+          <div
+            class="MuiTabs-scrollableX MuiTabs-hideScrollbar css-oqr85h"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX css-69z67c-MuiTabs-scroller"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              aria-label="Navigation Tabs"
+              class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-controls="full-width-tabpanel-0-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-0-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Workloads
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-1-NavigationTabs-tabs-id"
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-1-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                Pods
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-2-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-2-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Deployments
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-3-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Item Without URL
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+        <div
+          aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-0-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          id="full-width-tabpanel-1-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-2-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-3-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+      </nav>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
@@ -1,0 +1,206 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    >
+      <nav
+        aria-label="Main Navigation"
+        class="MuiBox-root css-1qm1lh"
+      >
+        <div
+          class="MuiTabs-root css-4u6pf8-MuiTabs-root"
+        >
+          <div
+            class="MuiTabs-scrollableX MuiTabs-hideScrollbar css-oqr85h"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX css-69z67c-MuiTabs-scroller"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              aria-label="Navigation Tabs"
+              class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-controls="full-width-tabpanel-0-NavigationTabs-tabs-id"
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-0-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                Workloads
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-1-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-1-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Pods
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-2-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-2-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Deployments
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-3-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Stateful Sets
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-4-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-4-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Daemon Sets
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-5-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-5-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Replica Sets
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-6-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-6-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Jobs
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-7-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-7-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                CronJobs
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+        <div
+          aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          id="full-width-tabpanel-0-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-1-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-2-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-3-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-4-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-4-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-5-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-5-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-6-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-6-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-7-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-7-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+        />
+      </nav>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/InnerTable.stories.tsx
+++ b/frontend/src/components/common/InnerTable.stories.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box, Paper, Typography } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { TestContext } from '../../test';
+import InnerTable from './InnerTable';
+import { SimpleTableProps } from './SimpleTable';
+
+interface InnerTableStoryProps extends SimpleTableProps {}
+
+export default {
+  title: 'common/InnerTable',
+  component: InnerTable,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Paper elevation={3} sx={{ padding: 2, margin: 2, maxWidth: '800px' }}>
+          <Typography variant="h6" gutterBottom>
+            Outer Container Title
+          </Typography>
+          <Story />
+        </Paper>
+      </TestContext>
+    ),
+  ],
+  argTypes: {
+    columns: { control: 'object', description: 'Array of column definitions.' },
+    data: { control: 'object', description: 'Array of data objects for the table rows.' },
+    emptyMessage: { control: 'text' },
+    noTableHeader: { control: 'boolean' },
+  },
+} as Meta<typeof InnerTable>;
+
+const Template: StoryFn<InnerTableStoryProps> = args => <InnerTable {...args} />;
+
+const sampleData = [
+  { id: 1, name: 'Feature A', status: 'Enabled', priority: 'High' },
+  { id: 2, name: 'Feature B', status: 'Disabled', priority: 'Medium' },
+  { id: 3, name: 'Bug Fix C', status: 'In Progress', priority: 'High' },
+];
+
+const sampleColumns = [
+  {
+    label: 'ID',
+    datum: 'id',
+  },
+  {
+    label: 'Name',
+    datum: 'name',
+  },
+  {
+    label: 'Status',
+    datum: 'status',
+  },
+  {
+    label: 'Priority',
+    datum: 'priority',
+  },
+];
+
+export const Default = Template.bind({});
+Default.args = {
+  columns: sampleColumns,
+  data: sampleData,
+};
+Default.storyName = 'Basic Inner Table';
+
+export const WithFewRows = Template.bind({});
+WithFewRows.args = {
+  columns: sampleColumns,
+  data: [{ id: 1, name: 'Single Item', status: 'Active', priority: 'Low' }],
+};
+
+export const EmptyTable = Template.bind({});
+EmptyTable.args = {
+  columns: sampleColumns,
+  data: [],
+  emptyMessage: 'No inner data available.',
+};
+
+export const WithoutTableHeader = Template.bind({});
+WithoutTableHeader.args = {
+  columns: sampleColumns,
+  data: sampleData.slice(0, 2),
+  noTableHeader: true,
+};
+
+export const InsideAnotherComponent = () => (
+  <Box sx={{ border: '1px dashed grey', padding: 2 }}>
+    <Typography variant="subtitle1">Section Containing InnerTable</Typography>
+    <InnerTable
+      columns={[
+        { label: 'Key', datum: 'key' },
+        { label: 'Value', datum: 'value' },
+      ]}
+      data={[
+        { key: 'config_option_1', value: 'true' },
+        { key: 'config_option_2', value: '12345' },
+      ]}
+    />
+  </Box>
+);
+InsideAnotherComponent.storyName = 'Nested within a Box';

--- a/frontend/src/components/common/ObjectEventList.stories.tsx
+++ b/frontend/src/components/common/ObjectEventList.stories.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { getTestDate } from '../../helpers/testHelpers';
+import { KubeEvent } from '../../lib/k8s/event';
+import { KubeObject } from '../../lib/k8s/KubeObject';
+import store from '../../redux/stores/store';
+import { TestContext } from '../../test';
+import ObjectEventList, { ObjectEventListProps } from './ObjectEventList';
+
+const mockOwnerObject = new KubeObject({
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'test-pod-for-events',
+    namespace: 'default',
+    uid: 'owner-pod-uid-123',
+    creationTimestamp: getTestDate().toISOString(),
+  },
+});
+
+const mockOwnerObjectNoEvents = new KubeObject({
+  kind: 'Deployment',
+  apiVersion: 'apps/v1',
+  metadata: {
+    name: 'test-deployment-no-events',
+    namespace: 'kube-system',
+    uid: 'owner-deployment-uid-456',
+    creationTimestamp: getTestDate().toISOString(),
+  },
+});
+
+const mockEvents: KubeEvent[] = [
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event1.123',
+      namespace: 'default',
+      uid: 'event-uid-1',
+      creationTimestamp: new Date(getTestDate().getTime() - 5 * 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-for-events',
+      uid: 'owner-pod-uid-123',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'Scheduled',
+    message: 'Successfully assigned default/test-pod-for-events to worker-node-1',
+    source: { component: 'default-scheduler' },
+    firstTimestamp: new Date(getTestDate().getTime() - 5 * 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 5 * 60 * 1000).toISOString(),
+    count: 1,
+    type: 'Normal',
+  },
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event2.456',
+      namespace: 'default',
+      uid: 'event-uid-2',
+      creationTimestamp: new Date(getTestDate().getTime() - 2 * 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-for-events',
+      uid: 'owner-pod-uid-123',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'Pulled',
+    message: 'Container image "nginx:latest" already present on machine',
+    source: { component: 'kubelet' },
+    firstTimestamp: new Date(getTestDate().getTime() - 2 * 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 2 * 60 * 1000).toISOString(),
+    count: 1,
+    type: 'Normal',
+  },
+];
+
+export default {
+  title: 'common/ObjectEventList',
+  component: ObjectEventList,
+  decorators: [
+    Story => (
+      <Provider store={store}>
+        <TestContext>
+          <Story />
+        </TestContext>
+      </Provider>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/v1/namespaces/:namespace/events', ({ params, request }) => {
+          const url = new URL(request.url);
+          const fieldSelector = url.searchParams.get('fieldSelector');
+          const reqNamespace = params.namespace;
+
+          if (
+            reqNamespace === mockOwnerObject.metadata.namespace &&
+            fieldSelector &&
+            fieldSelector.includes(`involvedObject.kind=${mockOwnerObject.kind}`) &&
+            fieldSelector.includes(`involvedObject.name=${mockOwnerObject.metadata.name}`)
+          ) {
+            return HttpResponse.json({
+              kind: 'EventList',
+              items: mockEvents,
+              metadata: {},
+            });
+          }
+          if (
+            reqNamespace === mockOwnerObjectNoEvents.metadata.namespace &&
+            fieldSelector &&
+            fieldSelector.includes(`involvedObject.kind=${mockOwnerObjectNoEvents.kind}`) &&
+            fieldSelector.includes(`involvedObject.name=${mockOwnerObjectNoEvents.metadata.name}`)
+          ) {
+            return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
+          }
+          return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
+        }),
+      ],
+    },
+  },
+  argTypes: {
+    object: {
+      control: false,
+      description: 'The KubeObject for which to display events.',
+    },
+  },
+} as Meta<typeof ObjectEventList>;
+
+const Template: StoryFn<ObjectEventListProps> = args => <ObjectEventList {...args} />;
+
+export const WithEvents = Template.bind({});
+WithEvents.args = {
+  object: mockOwnerObject,
+};
+WithEvents.storyName = 'Displaying Events for an Object';
+
+export const NoEventsForObject = Template.bind({});
+NoEventsForObject.args = {
+  object: mockOwnerObjectNoEvents,
+};
+NoEventsForObject.storyName = 'No Events for an Object';
+
+export const ErrorFetching = Template.bind({});
+ErrorFetching.args = {
+  object: new KubeObject({
+    kind: 'Secret',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'error-secret',
+      namespace: 'errors',
+      uid: 'secret-err-uid',
+      creationTimestamp: getTestDate().toISOString(),
+    },
+  }),
+};
+ErrorFetching.parameters = {
+  msw: {
+    handlers: [
+      http.get('/api/v1/namespaces/errors/events', ({ request }) => {
+        const url = new URL(request.url);
+        const fieldSelector = url.searchParams.get('fieldSelector');
+        if (fieldSelector && fieldSelector.includes('involvedObject.name=error-secret')) {
+          return HttpResponse.json(
+            { message: 'Simulated server error fetching events' },
+            { status: 500 }
+          );
+        }
+        return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
+      }),
+    ],
+  },
+};
+ErrorFetching.storyName = 'Error Fetching Events';

--- a/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.Default.stories.storyshot
@@ -1,0 +1,129 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                ID
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Name
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Status
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Priority
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Enabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                2
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature B
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Disabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Medium
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                3
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Bug Fix C
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                In Progress
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.EmptyTable.stories.storyshot
@@ -1,0 +1,26 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-19midj6"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+          >
+            No inner data available.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.InsideAnotherComponent.stories.storyshot
@@ -1,0 +1,82 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiBox-root css-v0ml89"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+        >
+          Section Containing InnerTable
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Key
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Value
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  config_option_1
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  true
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  config_option_2
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  12345
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithFewRows.stories.storyshot
@@ -1,0 +1,81 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                ID
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Name
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Status
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                scope="col"
+              >
+                Priority
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Single Item
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Active
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Low
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/InnerTable.WithoutTableHeader.stories.storyshot
@@ -1,0 +1,73 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-e1wsad-MuiPaper-root"
+    >
+      <h6
+        class="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom css-r34k9t-MuiTypography-root"
+      >
+        Outer Container Title
+      </h6>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-qzmaqi-MuiTable-root"
+        >
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                1
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature A
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Enabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                High
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                2
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Feature B
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Disabled
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+              >
+                Medium
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
Adds comprehensive Storybook stories for the NavigationTabs component, demonstrating various navigation states and sidebar interactions.

- Cluster View (Parent Selected)
- Workloads View (Parent Selected)
- Workloads View (Child 'Pods' Selected)
- Workloads View (Child 'Item Without URL' Selected)
- Settings View (Parent Selected)
- No Sub-List View
- Sidebar Open State

![Screenshot from 2025-05-25 01-23-36](https://github.com/user-attachments/assets/23706d0e-30e2-41ad-8825-4bc8a524fee4)
![Screenshot from 2025-05-25 01-23-29](https://github.com/user-attachments/assets/1c3bb8aa-8b5f-4032-8595-32f079cd323e)
![Screenshot from 2025-05-25 01-23-25](https://github.com/user-attachments/assets/1a6f55df-afef-4bd2-b46f-1d2e1590a681)
![Screenshot from 2025-05-25 01-23-20](https://github.com/user-attachments/assets/9857fc86-0c53-4bb9-aa0b-92aa58b31876)
![Screenshot from 2025-05-25 01-23-16](https://github.com/user-attachments/assets/92736566-3961-4381-9427-9c3a82d89ba0)
![Screenshot from 2025-05-25 01-23-03](https://github.com/user-attachments/assets/a4cf6cd1-2eea-4c05-9bb6-75f2b81b643f)
![Screenshot from 2025-05-25 01-22-58](https://github.com/user-attachments/assets/58e4bbb8-26fc-41ff-bf05-9495502e821c)
