### PR TITLE
frontend: HeadLampButton: Add storybook stories

### DIFF
--- a/frontend/src/components/Sidebar/HeadlampButton.stories.tsx
+++ b/frontend/src/components/Sidebar/HeadlampButton.stories.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Paper } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import store from '../../redux/stores/store';
+import { TestContext } from '../../test';
+import HeadlampButton, { HeadlampButtonProps } from './HeadlampButton';
+export default {
+  title: 'Sidebar/HeadlampButton',
+  component: HeadlampButton,
+  decorators: [
+    Story => (
+      <Provider store={store}>
+        <TestContext>
+          <Paper
+            elevation={0}
+            sx={{ padding: 2, display: 'inline-block', backgroundColor: 'sidebar.background' }}
+          >
+            <Story />
+          </Paper>
+        </TestContext>
+      </Provider>
+    ),
+  ],
+  argTypes: {
+    open: {
+      control: 'boolean',
+      description:
+        'Whether the sidebar is considered open (displays expanded logo and backburger).',
+    },
+    mobileOnly: {
+      control: 'boolean',
+      description: 'If true, only shows on mobile when sidebar is closed.',
+    },
+    onToggleOpen: { action: 'toggled', description: 'Callback when the button is clicked.' },
+    disabled: { control: 'boolean', description: 'If true, the button is disabled.' },
+  },
+} as Meta<typeof HeadlampButton>;
+
+const Template: StoryFn<HeadlampButtonProps> = args => <HeadlampButton {...args} />;
+
+export const ExpandedSidebar = Template.bind({});
+ExpandedSidebar.args = {
+  open: true,
+  onToggleOpen: () => console.log('Toggle open/closed'),
+};
+ExpandedSidebar.storyName = 'Sidebar Open (Expanded View)';
+
+export const CollapsedSidebar = Template.bind({});
+CollapsedSidebar.args = {
+  open: false,
+  onToggleOpen: () => console.log('Toggle open/closed'),
+};
+CollapsedSidebar.storyName = 'Sidebar Closed (Collapsed View)';
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  open: true,
+  disabled: true,
+  onToggleOpen: () => console.log('Toggle open/closed (should not fire)'),
+};
+export const MobileOnlyVisible = Template.bind({});
+MobileOnlyVisible.args = {
+  open: false,
+  mobileOnly: true,
+  onToggleOpen: () => console.log('Toggle open/closed'),
+};
+MobileOnlyVisible.storyName = 'MobileOnly (Simulated: Small Screen, Sidebar Closed)';
+MobileOnlyVisible.parameters = {
+  viewport: {
+    defaultViewport: 'iphonex',
+  },
+};
+
+export const MobileOnlyHidden = Template.bind({});
+MobileOnlyHidden.args = {
+  open: true,
+  mobileOnly: true,
+  onToggleOpen: () => console.log('Toggle open/closed'),
+};
+MobileOnlyHidden.storyName = 'MobileOnly (Simulated: Sidebar Open or Not Mobile)';

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.CollapsedSidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.CollapsedSidebar.stories.storyshot
@@ -1,0 +1,25 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1if9c89-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <button
+          aria-label="Expand sidebar"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1rafjp7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          />
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.Disabled.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.Disabled.stories.storyshot
@@ -1,0 +1,23 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1if9c89-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <button
+          aria-label="Shrink sidebar"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1rafjp7-MuiButtonBase-root-MuiButton-root"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.ExpandedSidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.ExpandedSidebar.stories.storyshot
@@ -1,0 +1,25 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1if9c89-MuiPaper-root"
+    >
+      <div
+        class="MuiBox-root css-0"
+      >
+        <button
+          aria-label="Shrink sidebar"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1rafjp7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          />
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.MobileOnlyHidden.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.MobileOnlyHidden.stories.storyshot
@@ -1,0 +1,7 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1if9c89-MuiPaper-root"
+    />
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.MobileOnlyVisible.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/HeadlampButton.MobileOnlyVisible.stories.storyshot
@@ -1,0 +1,7 @@
+<body>
+  <div>
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1if9c89-MuiPaper-root"
+    />
+  </div>
+</body>


### PR DESCRIPTION
Add Storybook stories for HeadLampButton component:
- Expanded Sidebar View
- Collapsed Sidebar View
- Disabled State
- Mobile-Only States (Visible/Hidden)

![Screenshot from 2025-05-25 12-30-55](https://github.com/user-attachments/assets/8a609796-10ee-4f00-8a8d-4036b885a887)
![Screenshot from 2025-05-25 12-30-52](https://github.com/user-attachments/assets/a91b044a-a77e-48ae-b068-648f94e61ee0)
![Screenshot from 2025-05-25 12-30-48](https://github.com/user-attachments/assets/b07dd6ca-4bd3-4ea2-9ecd-53572aa83318)
![Screenshot from 2025-05-25 12-30-42](https://github.com/user-attachments/assets/0238abe9-2044-4177-bcc1-c02e2a272115)
![Screenshot from 2025-05-25 12-30-35](https://github.com/user-attachments/assets/f8635d2e-2a08-4132-aa4f-1dd7175b84df)
