### PR TITLE
frontend: Table: Add Global filter

### DIFF
--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -86,7 +86,7 @@
                       id="table-search-field"
                       placeholder="Search"
                       type="text"
-                      value="value1"
+                      value=""
                     />
                     <div
                       class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
@@ -98,8 +98,9 @@
                       >
                         <button
                           aria-label="Clear search"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
-                          tabindex="0"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
                           type="button"
                         >
                           <svg
@@ -113,9 +114,6 @@
                               d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
                             />
                           </svg>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
                         </button>
                       </span>
                     </div>
@@ -218,12 +216,12 @@
                   Name
                 </div>
                 <span
-                  aria-label="Sort by Name descending"
+                  aria-label="Sort by Name ascending"
                   class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                   data-mui-internal-clone-element="true"
                 >
                   <span
-                    aria-label="Sort by Name descending"
+                    aria-label="Sort by Name ascending"
                     class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                     role="button"
                     tabindex="0"
@@ -273,12 +271,12 @@
                   Namespace
                 </div>
                 <span
-                  aria-label="Sort by Namespace descending"
+                  aria-label="Sort by Namespace ascending"
                   class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                   data-mui-internal-clone-element="true"
                 >
                   <span
-                    aria-label="Sort by Namespace descending"
+                    aria-label="Sort by Namespace ascending"
                     class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                     role="button"
                     tabindex="0"
@@ -328,12 +326,12 @@
                   UID
                 </div>
                 <span
-                  aria-label="Sort by UID descending"
+                  aria-label="Sort by UID ascending"
                   class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                   data-mui-internal-clone-element="true"
                 >
                   <span
-                    aria-label="Sort by UID descending"
+                    aria-label="Sort by UID ascending"
                     class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                     role="button"
                     tabindex="0"
@@ -422,7 +420,106 @@
       </thead>
       <tbody
         class="css-1obf64m"
-      />
+      >
+        <tr
+          class="css-1ospngb"
+          data-selected="false"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
+          >
+            mydefinition.phonyresources0.io
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+          >
+            MyNamespace0
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+          >
+            phony0
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+          />
+        </tr>
+        <tr
+          class="css-1ospngb"
+          data-selected="false"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
+          >
+            mydefinition.phonyresources1.io
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+          >
+            MyNamespace1
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+          >
+            phony1
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+          >
+            {"mylabel1":"myvalue1"}
+          </td>
+        </tr>
+        <tr
+          class="css-1ospngb"
+          data-selected="false"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
+          >
+            mydefinition.phonyresources2.io
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+          >
+            MyNamespace2
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+          >
+            phony2
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+          >
+            {"mykey2":"mylabel"}
+          </td>
+        </tr>
+        <tr
+          class="css-1ospngb"
+          data-selected="false"
+        >
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
+          >
+            mydefinition.phonyresources3.io
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+          >
+            MyNamespace3
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+          >
+            phony3
+          </td>
+          <td
+            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+          >
+            {"mykey3":"myvalue3"}
+          </td>
+        </tr>
+      </tbody>
     </table>
     <div
       class="MuiBox-root css-1bxknjp"

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -138,6 +138,7 @@ export default function Overview() {
       </SectionBox>
       <ResourceListView
         title={t('Workloads')}
+        reflectInURL
         columns={[
           'kind',
           {


### PR DESCRIPTION
### PR Description:
This PR introduces a feature to preserve the search filter state when navigating backward or forward within the application. Users will no longer need to reapply the filter repeatedly during navigation.

### Browser (Uses BrowserRouter)
https://github.com/user-attachments/assets/33faa95a-783f-48bf-b808-fdf73e8fc40a

### Electron (Uses HashRouter)
https://github.com/user-attachments/assets/e31f0186-fddf-450b-8324-7591c2634e2d

With this feature, the `URL` now includes the applied filter, making it look like:

> `{application_url}/c/my-new-profile/pods?filter={filter}`

This ensures the filter state is preserved during navigation.

### Related to: 
[Remember filter when going back #3175](https://github.com/kubernetes-sigs/headlamp/issues/3175)
