### PR TITLE
frontend: PodLogViewer: Scale down and Rename toggle buttons

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -49,7 +49,7 @@ import { makePodStatusLabel } from './List';
 const PaddedFormControlLabel = styled(FormControlLabel)(({ theme }) => ({
   margin: 0,
   paddingTop: theme.spacing(2),
-  paddingRight: theme.spacing(2),
+  paddingRight: theme.spacing(1),
 }));
 
 interface PodLogViewerProps extends Omit<LogViewerProps, 'logs'> {
@@ -286,7 +286,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
           }
         >
           <PaddedFormControlLabel
-            label={t('translation|Show previous')}
+            label={t('translation|Previous')}
             disabled={!hasContainerRestarted()}
             control={
               <Switch
@@ -295,6 +295,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
                 name="checkPrevious"
                 color="primary"
                 size="small"
+                sx={{ transform: 'scale(0.8)' }}
               />
             }
           />
@@ -308,6 +309,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
               name="checkTimestamps"
               color="primary"
               size="small"
+              sx={{ transform: 'scale(0.8)' }}
             />
           }
         />,
@@ -320,6 +322,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
               name="follow"
               color="primary"
               size="small"
+              sx={{ transform: 'scale(0.8)' }}
             />
           }
         />,

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -418,6 +418,7 @@
   "Software": "Software",
   "Redirecting to main page…": "Weiterleiten zur Hauptseite…",
   "Lines": "Zeilen",
+  "Previous": "",
   "Max Unavailable": "Max Nicht verfügbar",
   "Min Available": "Min verfügbar",
   "Allowed disruptions": "Erlaubte Unterbrechungen",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -418,6 +418,7 @@
   "Software": "Software",
   "Redirecting to main page…": "Redirecting to main page…",
   "Lines": "Lines",
+  "Previous": "Previous",
   "Max Unavailable": "Max Unavailable",
   "Min Available": "Min Available",
   "Allowed disruptions": "Allowed disruptions",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -419,6 +419,7 @@
   "Software": "Software",
   "Redirecting to main page…": "Redireccionando a la página principal…",
   "Lines": "Líneas",
+  "Previous": "",
   "Max Unavailable": "Máx. Disponible",
   "Min Available": "Min. Disponible",
   "Allowed disruptions": "Perturbaciones permitidas",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -419,6 +419,7 @@
   "Software": "Logiciel",
   "Redirecting to main page…": "Redirection vers la page principale…",
   "Lines": "Lignes",
+  "Previous": "",
   "Max Unavailable": "Max Indisponible",
   "Min Available": "Min Disponible",
   "Allowed disruptions": "Perturbations autorisées",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -418,6 +418,7 @@
   "Software": "",
   "Redirecting to main page…": "",
   "Lines": "",
+  "Previous": "",
   "Max Unavailable": "",
   "Min Available": "",
   "Allowed disruptions": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -419,6 +419,7 @@
   "Software": "Software",
   "Redirecting to main page…": "Reindirizzamento alla pagina principale…",
   "Lines": "Linee",
+  "Previous": "",
   "Max Unavailable": "Massimo Non Disponibile",
   "Min Available": "Minimo Disponibile",
   "Allowed disruptions": "Interruzioni Consentite",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -417,6 +417,7 @@
   "Software": "ソフトウェア",
   "Redirecting to main page…": "メインページへリダイレクト中…",
   "Lines": "行",
+  "Previous": "",
   "Max Unavailable": "最大利用不可",
   "Min Available": "最小利用可能",
   "Allowed disruptions": "許可された中断",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -417,6 +417,7 @@
   "Software": "소프트웨어",
   "Redirecting to main page…": "메인 페이지로 리디렉션 중…",
   "Lines": "줄",
+  "Previous": "",
   "Max Unavailable": "최대 Unavailable",
   "Min Available": "최소 Available",
   "Allowed disruptions": "허용된 장애",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -419,6 +419,7 @@
   "Software": "Software",
   "Redirecting to main page…": "A redireccionar para a página principal…",
   "Lines": "Linhas",
+  "Previous": "",
   "Max Unavailable": "Máx. Indisponíveis",
   "Min Available": "Mín. Disponíveis",
   "Allowed disruptions": "Perturbações permitidas",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -417,6 +417,7 @@
   "Software": "軟體",
   "Redirecting to main page…": "正在重定向到首頁…",
   "Lines": "行",
+  "Previous": "",
   "Max Unavailable": "最大不可用",
   "Min Available": "最小可用",
   "Allowed disruptions": "允許的中斷",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -417,6 +417,7 @@
   "Software": "软件",
   "Redirecting to main page…": "正在重定向到首页…",
   "Lines": "行",
+  "Previous": "",
   "Max Unavailable": "最大不可用",
   "Min Available": "最小可用",
   "Allowed disruptions": "允许的中断",


### PR DESCRIPTION
### PR Description

This PR reduces the size of the toggle button and updates the *Show Previous* label to *Previous* to create room for potential additional toggle buttons in the future.

### Screenshot of the changes
<img width="506" alt="Screenshot 2025-05-26 at 12 37 43 AM" src="https://github.com/user-attachments/assets/24ed946a-57b0-4bd6-9bcd-943fc4b67fd3" />
<img width="681" alt="Screenshot 2025-05-26 at 12 37 07 AM" src="https://github.com/user-attachments/assets/d0ecf596-43cd-413c-8285-b5513d12994d" />
<img width="1439" alt="Screenshot 2025-05-26 at 12 36 53 AM" src="https://github.com/user-attachments/assets/724a8033-f6ac-49b9-87e1-a879b75a9e9a" />


Discussed here: [Issue Comment](https://github.com/kubernetes-sigs/headlamp/pull/3331#issuecomment-2907860785)