### PR TITLE
frontend: Pod: Reorder unescaped string literals

### DIFF
--- a/frontend/src/components/pod/PodLogs.stories.tsx
+++ b/frontend/src/components/pod/PodLogs.stories.tsx
@@ -265,12 +265,12 @@ function getLogs(
 
 function unescapeStringLiterals(str: string): string {
   return str
-    .replace(/\\\\/g, '\\')
     .replace(/\\r\\n/g, '\r\n')
     .replace(/\\n/g, '\n')
     .replace(/\\t/g, '\t')
     .replace(/\\"/g, '"')
-    .replace(/\\'/g, "'");
+    .replace(/\\'/g, "'")
+    .replace(/\\\\/g, '\\');
 }
 
 export const PlainLogs = Template.bind({});

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -172,12 +172,12 @@ class Pod extends KubeObject<KubePod> {
 
     function unescapeStringLiterals(str: string): string {
       return str
-        .replace(/\\\\/g, '\\') // Backslash
         .replace(/\\r\\n/g, '\r\n') // Carriage return + newline
         .replace(/\\n/g, '\n') // Newline
         .replace(/\\t/g, '\t') // Tab
         .replace(/\\"/g, '"') // Double quote
-        .replace(/\\'/g, "'"); // Single quote
+        .replace(/\\'/g, "'") // Single quote
+        .replace(/\\\\/g, '\\'); // Backslash
     }
 
     function prettifyLogLine(logLine: string): string {


### PR DESCRIPTION
This change reorders the unescaped string literals to ensure that any \ characters introduced by earlier replacements are not unintentionally unescaped again.