### PR TITLE
fix(codeSign) shell command built from environment values

### DIFF
--- a/app/mac/scripts/codeSign.js
+++ b/app/mac/scripts/codeSign.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 
 exports.default = async function codeSign(config) {
@@ -14,8 +14,9 @@ exports.default = async function codeSign(config) {
 
   let exitCode = 0;
   try {
-    execSync(
-      `codesign -s ${teamID} --deep --force --options runtime --entitlements ${entitlementsPath} ${config.app}`
+    execFileSync(
+      'codesign',
+      ['-s', teamID, '--deep', '--force', '--options', 'runtime', '--entitlements', entitlementsPath, config.app]
     );
   } catch (e) {
     exitCode = e.status !== null ? e.status : 1;


### PR DESCRIPTION
https://github.com/kubernetes-sigs/headlamp/blob/5a334017cc02bb6aec597a2aef2ae66f0b7c6590/app/mac/scripts/codeSign.js#L2-L2

https://github.com/kubernetes-sigs/headlamp/blob/5a334017cc02bb6aec597a2aef2ae66f0b7c6590/app/mac/scripts/codeSign.js#L17-L18

Fix the issue will replace the use of `execSync` with `execFileSync`, which allows us to pass the command and its arguments separately. This approach avoids shell interpretation of the arguments, mitigating the risk of command injection. Specifically:
1. The `codesign` command will be passed as the first argument to `execFileSync`.
2. The dynamic components (`teamID`, `entitlementsPath`, and `config.app`) will be passed as separate arguments in an array.
3. This change ensures that special characters in the inputs are treated as literal values and not interpreted by the shell.


