### PR TITLE
frontend: Update Code of Conduct link in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ kubeconfig).
 
 Check out our: 
 - [Guidelines](https://headlamp.dev/docs/latest/contributing/)
-- [Code of Conduct](./CODE_OF_CONDUCT.md),
+- [Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md)
 - [#headlamp](https://kubernetes.slack.com/messages/headlamp) slack channel in the Kubernetes Slack 
 - [Monthly Community Meeting](https://zoom-lfx.platform.linuxfoundation.org/meetings/headlamp)
 


### PR DESCRIPTION
Head over to
https://headlamp.dev/docs/latest/
The Code of Conduct link redirects to a wrong url

I have updated and fixed the link 

fixes #3266