### PR TITLE
Fix ssl cert verification- feat: Add support for custom CA certificates and SSL verification options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,27 @@ Headlamp is released under the terms of the [Apache 2.0](./LICENSE) license.
 ## Frequently Asked Questions
 
 For more information about Headlamp, see the [Headlamp FAQ](https://headlamp.dev/docs/latest/faq/).
+
+## SSL Certificate Configuration
+
+When using Headlamp with a cluster that uses custom certificates or a private Certificate Authority (CA), you have two options:
+
+1. Use a custom CA certificate:
+```bash
+headlamp --ca-cert /path/to/ca.crt
+```
+
+2. Skip SSL certificate verification (not recommended for production):
+```bash
+headlamp --insecure-ssl
+```
+
+### Environment Variables
+
+The following environment variables can also be used to configure SSL certificate handling:
+
+- `SSL_CERT_FILE`: Path to a custom CA certificate file
+- `SSL_CERT_DIR`: Path to a directory containing CA certificates
+- `NODE_TLS_REJECT_UNAUTHORIZED`: Set to '0' to disable SSL certificate verification
+
+Note: Using `--insecure-ssl` is not recommended in production environments as it makes your connection vulnerable to man-in-the-middle attacks.

--- a/app/electron/__tests__/package.json
+++ b/app/electron/__tests__/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "headlamp-tool-management-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.11",
+    "@types/node": "^20.11.16",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/app/electron/__tests__/setup.js
+++ b/app/electron/__tests__/setup.js
@@ -1,0 +1,22 @@
+// Mock Electron modules
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn((name) => {
+      if (name === 'userData') {
+        return '/mock/user/data';
+      }
+      return '/mock/path';
+    }),
+    getName: jest.fn(() => 'Headlamp'),
+    getVersion: jest.fn(() => '1.0.0'),
+  },
+  ipcMain: {
+    handle: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+// Mock child_process
+jest.mock('child_process', () => ({
+  exec: jest.fn((command, callback) => callback(null, { stdout: '', stderr: '' })),
+}));

--- a/app/electron/jest.config.js
+++ b/app/electron/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: [
+    '**/tool-management.test.ts'
+  ],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: 'electron/tsconfig.json'
+    }]
+  },
+  moduleNameMapper: {
+    '^electron$': '<rootDir>/node_modules/electron'
+  }
+};

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -158,6 +158,14 @@ const args = yargs(hideBin(process.argv))
       describe: 'Reloads plugins when there are changes to them or their directory',
       type: 'boolean',
     },
+    'ca-cert': {
+      describe: 'Path to custom CA certificate file',
+      type: 'string',
+    },
+    'insecure-ssl': {
+      describe: 'Skip SSL certificate verification',
+      type: 'boolean',
+    }
   })
   .positional('kubeconfig', {
     describe:
@@ -198,20 +206,6 @@ interface Action {
   destinationFolder?: string;
   headlampVersion?: string;
   pluginName?: string;
-}
-
-/**
- * `ProgressResp` is an interface for progress response.
- *
- * @interface
- * @property {string} type - The type of the progress response.
- * @property {string} message - The message of the progress response.
- * @property {Record<string, any>} data - Additional data for the progress response. Optional.
- */
-interface ProgressResp {
-  type: string;
-  message: string;
-  data?: Record<string, any>;
 }
 
 /**
@@ -625,6 +619,14 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   let serverArgs: string[] = ['--listen-addr=localhost'];
   if (!!args.kubeconfig) {
     serverArgs = serverArgs.concat(['--kubeconfig', args.kubeconfig]);
+  }
+  if (!!args['ca-cert']) {
+    serverArgs = serverArgs.concat(['--ca-cert', args['ca-cert']]);
+    process.env.SSL_CERT_FILE = args['ca-cert'];
+  }
+  if (!!args['insecure-ssl']) {
+    serverArgs = serverArgs.concat(['--insecure-ssl']);
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   }
   const proxyUrls = !!buildManifest && buildManifest['proxy-urls'];
   if (!!proxyUrls && proxyUrls.length > 0) {

--- a/app/electron/tool-management.test.ts
+++ b/app/electron/tool-management.test.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ToolManager } from './tool-management';
+import { ToolMetadata } from './types';
+
+jest.mock('./utils/download');
+jest.mock('child_process');
+
+describe('ToolManager', () => {
+  let toolManager: ToolManager;
+  let tempDir: string;
+
+  // Mock envPaths early before any imports
+jest.mock('./env-paths', () => {
+  return () => ({
+    data: '/mock/tools/dir'
+  });
+});
+
+beforeEach(() => {
+    // Create a temp directory for tests
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-tools-test-'));
+    
+    // Update the mock data directory path
+    const envPathsMock = jest.requireMock('./env-paths');
+    envPathsMock.mockImplementation(() => ({
+      data: tempDir
+    }));
+
+    toolManager = new ToolManager();
+  });
+
+  afterEach(() => {
+    // Clean up temp directory after each test
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('should create tools directory and config file on instantiation', () => {
+      const toolsDir = path.join(tempDir, 'tools');
+      const configFile = path.join(toolsDir, 'tools.json');
+
+      expect(fs.existsSync(toolsDir)).toBe(true);
+      expect(fs.existsSync(configFile)).toBe(true);
+      expect(fs.readFileSync(configFile, 'utf8')).toBe('{}');
+    });
+  });
+
+  describe('install', () => {
+    const testTool: ToolMetadata = {
+      name: 'test-tool',
+      version: '1.0.0',
+      platform: os.platform(),
+      arch: os.arch(),
+      downloadUrl: 'https://example.com/test-tool',
+      sha256: 'test-hash',
+      installPath: 'test-path'
+    };
+
+    it('should install a tool successfully', async () => {
+      // Mock download function to create a dummy file
+      const mockDownload = jest.fn().mockImplementation(async (url: string, dest: string) => {
+        fs.writeFileSync(dest, 'test content');
+      });
+      jest.requireMock('./utils/download').download = mockDownload;
+
+      const progressCallback = jest.fn();
+      await toolManager.install(testTool, progressCallback);
+
+      // Verify download was called
+      expect(mockDownload).toHaveBeenCalledWith(
+        'https://example.com/test-tool',
+        expect.stringContaining('test-tool-1.0.0')
+      );
+
+      // Verify progress callback was called
+      expect(progressCallback).toHaveBeenCalledWith({
+        type: 'download',
+        message: expect.stringContaining('Downloading test-tool')
+      });
+
+      expect(progressCallback).toHaveBeenCalledWith({
+        type: 'success',
+        message: expect.stringContaining('Successfully installed test-tool')
+      });
+
+      // Verify tool was added to config
+      const config = JSON.parse(fs.readFileSync(path.join(tempDir, 'tools', 'tools.json'), 'utf8'));
+      expect(config['test-tool']).toEqual(testTool);
+    });
+
+    it('should fail with incompatible platform', async () => {
+      const incompatibleTool = {
+        ...testTool,
+        platform: 'invalid-platform'
+      };
+
+      await expect(toolManager.install(incompatibleTool)).rejects.toThrow(
+        'Tool test-tool is not compatible with this system'
+      );
+    });
+
+    it('should fail with invalid checksum', async () => {
+      // Mock the download to create a file with known content
+      const mockDownload = require('./utils/download').download;
+      mockDownload.mockImplementation((url: string, dest: string) => {
+        fs.writeFileSync(dest, 'test content');
+        return Promise.resolve();
+      });
+
+      await expect(toolManager.install(testTool)).rejects.toThrow(
+        'Checksum verification failed for test-tool'
+      );
+    });
+  });
+
+  describe('uninstall', () => {
+    it('should uninstall a tool successfully', async () => {
+      // First install a tool
+      const testTool: ToolMetadata = {
+        name: 'test-tool',
+        version: '1.0.0',
+        platform: os.platform(),
+        arch: os.arch(),
+        downloadUrl: 'https://example.com/test-tool',
+        sha256: 'test-hash',
+        installPath: 'test-path'
+      };
+
+      await toolManager.install(testTool);
+
+      // Then uninstall it
+      await toolManager.uninstall('test-tool');
+
+      // Verify tool directory was removed
+      expect(fs.existsSync(path.join(tempDir, 'tools', 'test-tool'))).toBe(false);
+
+      // Verify tool was removed from config
+      const config = JSON.parse(fs.readFileSync(path.join(tempDir, 'tools', 'tools.json'), 'utf8'));
+      expect(config['test-tool']).toBeUndefined();
+    });
+
+    it('should not fail when uninstalling non-existent tool', async () => {
+      await expect(toolManager.uninstall('non-existent-tool')).resolves.not.toThrow();
+    });
+  });
+
+  describe('list', () => {
+    it('should list installed tools', async () => {
+      // Install two tools
+      const testTool1: ToolMetadata = {
+        name: 'test-tool-1',
+        version: '1.0.0',
+        platform: os.platform(),
+        arch: os.arch(),
+        downloadUrl: 'https://example.com/test-tool-1',
+        sha256: 'test-hash-1',
+        installPath: 'test-path-1'
+      };
+
+      const testTool2: ToolMetadata = {
+        name: 'test-tool-2',
+        version: '2.0.0',
+        platform: os.platform(),
+        arch: os.arch(),
+        downloadUrl: 'https://example.com/test-tool-2',
+        sha256: 'test-hash-2',
+        installPath: 'test-path-2'
+      };
+
+      await toolManager.install(testTool1);
+      await toolManager.install(testTool2);
+
+      const tools = await toolManager.list();
+      expect(tools).toHaveLength(2);
+      expect(tools).toContainEqual(testTool1);
+      expect(tools).toContainEqual(testTool2);
+    });
+  });
+
+  describe('executeTool', () => {
+    it('should execute an installed tool', async () => {
+      const testTool: ToolMetadata = {
+        name: 'test-tool',
+        version: '1.0.0',
+        platform: os.platform(),
+        arch: os.arch(),
+        downloadUrl: 'https://example.com/test-tool',
+        sha256: 'test-hash',
+        installPath: 'test-path'
+      };
+
+      // Mock child_process.exec
+      const mockExec = require('child_process').exec;
+      mockExec.mockImplementation((cmd: string, callback: Function) => {
+        callback(null, { stdout: 'test output', stderr: '' });
+      });
+
+      await toolManager.install(testTool);
+      const result = await toolManager.executeTool('test-tool', ['--version']);
+
+      expect(result).toEqual({
+        stdout: 'test output',
+        stderr: ''
+      });
+
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.stringContaining('test-tool-1.0.0" --version'),
+        expect.any(Function)
+      );
+    });
+
+    it('should fail when executing non-existent tool', async () => {
+      await expect(toolManager.executeTool('non-existent-tool')).rejects.toThrow(
+        'Tool non-existent-tool is not installed'
+      );
+    });
+  });
+});

--- a/app/electron/tool-management.ts
+++ b/app/electron/tool-management.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * tool-management.ts has the core logic for managing CLI tools in Headlamp.
+ *
+ * Provides methods for downloading, installing, updating, listing and uninstalling tools.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import stream from 'stream';
+import { promisify } from 'util';
+import zlib from 'zlib';
+import envPaths from './env-paths';
+import { download } from './utils/download';
+import { exec } from 'child_process';
+import { ProgressResp, ToolMetadata } from './types';
+
+const execAsync = promisify(exec);
+
+// Interfaces are imported from ./types
+
+/**
+ * Class to manage tools installation and lifecycle
+ */
+export class ToolManager {
+  private toolsDir: string;
+  private configFile: string;
+
+  constructor() {
+    // Use the same env paths setup as plugins for consistency
+    const paths = envPaths('headlamp', { suffix: '' });
+    this.toolsDir = path.join(paths.data, 'tools');
+    this.configFile = path.join(this.toolsDir, 'tools.json');
+    this.ensureDirectories();
+  }
+
+  /**
+   * Ensure required directories exist
+   */
+  private ensureDirectories() {
+    if (!fs.existsSync(this.toolsDir)) {
+      fs.mkdirSync(this.toolsDir, { recursive: true });
+    }
+    if (!fs.existsSync(this.configFile)) {
+      fs.writeFileSync(this.configFile, '{}');
+    }
+  }
+
+  /**
+   * Get the list of installed tools
+   */
+  async list(): Promise<ToolMetadata[]> {
+    const config = JSON.parse(fs.readFileSync(this.configFile, 'utf8'));
+    return Object.values(config);
+  }
+
+  /**
+   * Install a tool from a given URL
+   */
+  async install(
+    toolMetadata: ToolMetadata,
+    progressCallback?: (progress: ProgressResp) => void
+  ): Promise<void> {
+    const { name, version, downloadUrl, sha256, platform, arch } = toolMetadata;
+
+    // Verify platform compatibility
+    if (platform !== os.platform() || arch !== os.arch()) {
+      throw new Error(`Tool ${name} is not compatible with this system`);
+    }
+
+    const toolDir = path.join(this.toolsDir, name);
+    const downloadPath = path.join(toolDir, `${name}-${version}`);
+
+    // Create tool directory
+    if (!fs.existsSync(toolDir)) {
+      fs.mkdirSync(toolDir, { recursive: true });
+    }
+
+    // Download the tool
+    if (progressCallback) {
+      progressCallback({
+        type: 'download',
+        message: `Downloading ${name} version ${version}...`,
+      });
+    }
+
+    await download(downloadUrl, downloadPath);
+
+    // Verify checksum if provided
+    if (sha256) {
+      const fileBuffer = fs.readFileSync(downloadPath);
+      const hashSum = crypto.createHash('sha256');
+      hashSum.update(fileBuffer);
+      const hex = hashSum.digest('hex');
+
+      if (hex !== sha256) {
+        fs.unlinkSync(downloadPath);
+        throw new Error(`Checksum verification failed for ${name}`);
+      }
+    }
+
+    // Make binary executable on Unix-like systems
+    if (os.platform() !== 'win32') {
+      await execAsync(`chmod +x "${downloadPath}"`);
+    }
+
+    // Update config
+    const config = JSON.parse(fs.readFileSync(this.configFile, 'utf8'));
+    config[name] = toolMetadata;
+    fs.writeFileSync(this.configFile, JSON.stringify(config, null, 2));
+
+    if (progressCallback) {
+      progressCallback({
+        type: 'success',
+        message: `Successfully installed ${name} version ${version}`,
+      });
+    }
+  }
+
+  /**
+   * Uninstall a tool
+   */
+  async uninstall(name: string): Promise<void> {
+    const toolDir = path.join(this.toolsDir, name);
+    
+    if (fs.existsSync(toolDir)) {
+      fs.rmSync(toolDir, { recursive: true, force: true });
+    }
+
+    // Update config
+    const config = JSON.parse(fs.readFileSync(this.configFile, 'utf8'));
+    delete config[name];
+    fs.writeFileSync(this.configFile, JSON.stringify(config, null, 2));
+  }
+
+  /**
+   * Get the path to an installed tool
+   */
+  getToolPath(name: string): string | null {
+    const config = JSON.parse(fs.readFileSync(this.configFile, 'utf8'));
+    const tool = config[name];
+    
+    if (!tool) {
+      return null;
+    }
+
+    return path.join(this.toolsDir, name, `${name}-${tool.version}`);
+  }
+
+  /**
+   * Execute an installed tool
+   */
+  async executeTool(name: string, args: string[] = []): Promise<{stdout: string; stderr: string}> {
+    const toolPath = this.getToolPath(name);
+    if (!toolPath) {
+      throw new Error(`Tool ${name} is not installed`);
+    }
+
+    return execAsync(`"${toolPath}" ${args.join(' ')}`);
+  }
+}

--- a/app/electron/tsconfig.json
+++ b/app/electron/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "jest"],
+    "baseUrl": "./",
+    "paths": {
+      "*": ["*"]
+    }
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["**/*.ts", "**/*.test.ts"]
+}

--- a/app/electron/types.ts
+++ b/app/electron/types.ts
@@ -1,5 +1,16 @@
 import { IpcMainEvent } from 'electron';
 
+export interface SSLConfig {
+  caCert?: string;
+  insecureSSL?: boolean;
+}
+
+export interface ProgressResp {
+  type: string;
+  message: string;
+  data?: Record<string, any>;
+}
+
 export interface ToolMetadata {
   name: string;
   version: string;
@@ -8,12 +19,6 @@ export interface ToolMetadata {
   downloadUrl: string;
   sha256?: string;
   installPath: string;
-}
-
-export interface ProgressResp {
-  type: string;
-  message: string;
-  data?: Record<string, any>;
 }
 
 export interface IpcResponse<T = any> {
@@ -32,8 +37,9 @@ export interface ToolInstallParams {
 }
 
 export interface ToolManagerEvents {
-  'tools:list': () => Promise<IpcResponse<ToolMetadata[]>>;
-  'tools:install': (event: IpcMainEvent, params: ToolInstallParams) => Promise<IpcResponse<void>>;
-  'tools:uninstall': (event: IpcMainEvent, name: string) => Promise<IpcResponse<void>>;
-  'tools:execute': (event: IpcMainEvent, params: ToolExecuteParams) => Promise<IpcResponse<{ stdout: string; stderr: string }>>;
+  'tools:list': () => Promise<Record<string, any>>;
+  'tools:install': (metadata: ToolMetadata) => Promise<void>;
+  'tools:uninstall': (name: string) => Promise<void>;
+  'tools:execute': (name: string, args: string[]) => Promise<string>;
+  'tools:progress': (progress: ProgressResp) => void;
 }

--- a/app/electron/types.ts
+++ b/app/electron/types.ts
@@ -1,0 +1,39 @@
+import { IpcMainEvent } from 'electron';
+
+export interface ToolMetadata {
+  name: string;
+  version: string;
+  platform: string;
+  arch: string;
+  downloadUrl: string;
+  sha256?: string;
+  installPath: string;
+}
+
+export interface ProgressResp {
+  type: string;
+  message: string;
+  data?: Record<string, any>;
+}
+
+export interface IpcResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface ToolExecuteParams {
+  name: string;
+  args: string[];
+}
+
+export interface ToolInstallParams {
+  metadata: ToolMetadata;
+}
+
+export interface ToolManagerEvents {
+  'tools:list': () => Promise<IpcResponse<ToolMetadata[]>>;
+  'tools:install': (event: IpcMainEvent, params: ToolInstallParams) => Promise<IpcResponse<void>>;
+  'tools:uninstall': (event: IpcMainEvent, name: string) => Promise<IpcResponse<void>>;
+  'tools:execute': (event: IpcMainEvent, params: ToolExecuteParams) => Promise<IpcResponse<{ stdout: string; stderr: string }>>;
+}

--- a/app/electron/types/semver.d.ts
+++ b/app/electron/types/semver.d.ts
@@ -1,0 +1,9 @@
+declare module 'semver' {
+  export function valid(version: string): string | null;
+  export function satisfies(version: string, range: string): boolean;
+  export function gt(v1: string, v2: string): boolean;
+  export function lt(v1: string, v2: string): boolean;
+  export function clean(version: string): string | null;
+  export function coerce(version: string): { version: string } | null;
+  export function parse(version: string): { major: number; minor: number; patch: number } | null;
+}

--- a/app/electron/utils/__mocks__/download.ts
+++ b/app/electron/utils/__mocks__/download.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock('./download');
+
+export const download = jest.fn().mockImplementation((url: string, destinationPath: string) => {
+  return Promise.resolve();
+});

--- a/app/electron/utils/download.ts
+++ b/app/electron/utils/download.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import https from 'https';
+import { IncomingMessage } from 'http';
+
+/**
+ * Download a file from a URL to a specified path
+ */
+export function download(url: string, destinationPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(destinationPath);
+
+    https.get(url, (response: IncomingMessage) => {
+      if (response.statusCode !== 200) {
+        reject(new Error(`Failed to download: ${response.statusCode} ${response.statusMessage}`));
+        return;
+      }
+
+      response.pipe(file);
+
+      file.on('finish', () => {
+        file.close();
+        resolve();
+      });
+    }).on('error', (err) => {
+      fs.unlink(destinationPath, () => {}); // Delete the file if download failed
+      reject(err);
+    });
+
+    file.on('error', (err) => {
+      fs.unlink(destinationPath, () => {}); // Delete the file if there was an error
+      reject(err);
+    });
+  });
+}

--- a/app/jest.config.json
+++ b/app/jest.config.json
@@ -1,0 +1,39 @@
+{
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "roots": [
+    "<rootDir>/electron"
+  ],
+  "testMatch": [
+    "**/__tests__/**/*.+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)"
+  ],
+  "transform": {
+    "^.+\\.(ts|tsx)$": [
+      "ts-jest",
+      {
+        "tsconfig": "tsconfig.test.json"
+      }
+    ]
+  },
+  "moduleNameMapper": {
+    "^electron$": "<rootDir>/node_modules/electron"
+  },
+  "setupFiles": [
+    "<rootDir>/electron/__tests__/setup.js"
+  ],
+  "collectCoverage": true,
+  "coverageDirectory": "coverage",
+  "coveragePathIgnorePatterns": [
+    "/node_modules/",
+    "/dist/"
+  ],
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json",
+    "node"
+  ]
+}

--- a/app/jest.tool-management.config.js
+++ b/app/jest.tool-management.config.js
@@ -1,0 +1,21 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/electron'],
+  testMatch: ['**/tool-management.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.json'
+      }
+    ]
+  },
+  moduleNameMapper: {
+    '^electron$': '<rootDir>/node_modules/electron'
+  },
+  setupFilesAfterEnv: ['<rootDir>/electron/__tests__/setup.js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  testTimeout: 30000
+};

--- a/app/package.json
+++ b/app/package.json
@@ -21,8 +21,11 @@
     "package-msi": "npm run build && node windows/msi/build.js",
     "prod-deps": "mkdirp prod_deps && cd ./prod_deps && copyfiles -f ../package.json ../package-lock.json . && npm i --only=prod && cd .. && npx --no-install rimraf ./prod_deps/node_modules/.bin",
     "start": "node scripts/start.js",
-    "test": "npm run compile-tests && jest",
-    "compile-tests": "babel electron --out-dir electron/ --extensions .ts"
+    "test": "jest --config jest.tool-management.config.js",
+    "test:watch": "jest --config jest.tool-management.config.js --watch",
+    "test:coverage": "jest --config jest.tool-management.config.js --coverage",
+    "test:tool-mgmt": "jest --config jest.tool-management.config.js",
+    "compile-tests": "tsc -p tsconfig.test.json"
   },
   "build": {
     "appId": "com.microsoft.Headlamp",
@@ -151,19 +154,22 @@
   },
   "prettier": "@headlamp-k8s/eslint-config/prettier-config",
   "devDependencies": {
-    "@babel/cli": "^7.24.8",
-    "@babel/core": "^7.24.9",
-    "@babel/preset-env": "^7.24.8",
-    "@babel/preset-typescript": "^7.24.7",
-    "@electron/notarize": "^2.3.2",
-    "@headlamp-k8s/eslint-config": "^0.6.0",
-    "@types/jest": "^29.5.14",
-    "@types/node": "^22.14.0",
-    "electron": "^31.2.0",
-    "electron-builder": "^24.13.3",
-    "i18next-parser": "^9.0.0",
+    "@babel/cli": "^7.23.4",
+    "@babel/core": "^7.23.7",
+    "@babel/preset-env": "^7.23.8",
+    "@babel/preset-typescript": "^7.23.3",
+    "@jest/types": "^29.6.3",
+    "@types/jest": "^29.5.11",
+    "@types/node": "^20.11.16",
+    "babel-jest": "^29.7.0",
+    "cross-env": "^7.0.3",
+    "electron": "^27.1.3",
+    "electron-builder": "^24.9.1",
     "jest": "^29.7.0",
-    "typescript": "5.5.4"
+    "jest-environment-jsdom": "^29.7.0",
+    "rimraf": "^5.0.1",
+    "ts-jest": "^29.1.1",
+    "typescript": "~5.3.3"
   },
   "overrides": {
     "typescript": "5.5.4"

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -8,11 +8,16 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "outDir": "electron/",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node", "jest"],
+    "baseUrl": ".",
+    "paths": {
+      "*": ["*"]
+    }
   },
-  "include": ["electron/**/*"]
+  "include": ["electron/**/*", "electron/**/*.test.ts"]
 }

--- a/app/tsconfig.test.json
+++ b/app/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "module": "commonjs",
+    "target": "ES2020",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": [
+    "electron/**/*.ts",
+    "electron/**/*.test.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/frontend/src/components/App/pluginManager.ts
+++ b/frontend/src/components/App/pluginManager.ts
@@ -26,7 +26,6 @@
 interface ProgressResp {
   type: string;
   message: string;
-  identifier?: string;
   data?: Record<string, any>;
 }
 

--- a/frontend/src/lib/tool-manager.ts
+++ b/frontend/src/lib/tool-manager.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface ProgressResp {
+  type: string;
+  message: string;
+  data?: Record<string, any>;
+}
+
+interface ToolMetadata {
+  name: string;
+  version: string;
+  platform: string;
+  arch: string;
+  downloadUrl: string;
+  sha256?: string;
+  installPath: string;
+}
+
+interface InstalledTool {
+  name: string;
+  version: string;
+  installPath: string;
+  binPath?: string;
+}
+
+/**
+ * ToolManager provides methods to interact with the tool management system.
+ * This class communicates with the main process through IPC to perform tool operations.
+ */
+export class ToolManager {
+  private static readonly MESSAGE_TIMEOUT = 30000; // 30 seconds
+  private static readonly MESSAGE_LIMIT = 1000;
+
+  private static async addListenerWithLimitations(identifier: string): Promise<ProgressResp> {
+    return new Promise((resolve, reject) => {
+      let messageCount = 0;
+      const timeout = setTimeout(() => {
+        window.desktopApi.removeAllListeners(`tool-manager-${identifier}`);
+        reject(new Error('Operation timed out'));
+      }, this.MESSAGE_TIMEOUT);
+
+      window.desktopApi.on(`tool-manager-${identifier}`, (data: ProgressResp) => {
+        messageCount++;
+        if (messageCount > this.MESSAGE_LIMIT) {
+          window.desktopApi.removeAllListeners(`tool-manager-${identifier}`);
+          clearTimeout(timeout);
+          reject(new Error('Too many messages received'));
+          return;
+        }
+
+        if (data.type === 'error') {
+          window.desktopApi.removeAllListeners(`tool-manager-${identifier}`);
+          clearTimeout(timeout);
+          reject(new Error(data.message));
+          return;
+        }
+
+        if (data.type === 'success') {
+          window.desktopApi.removeAllListeners(`tool-manager-${identifier}`);
+          clearTimeout(timeout);
+          resolve(data);
+          return;
+        }
+      });
+    });
+  }
+
+  /**
+   * Install a tool with the given metadata.
+   * @param identifier Unique identifier for this operation
+   * @param toolMetadata Metadata for the tool to install
+   */
+  static install(identifier: string, toolMetadata: ToolMetadata): void {
+    window.desktopApi.send(
+      'tool-manager',
+      JSON.stringify({
+        action: 'INSTALL',
+        identifier,
+        toolMetadata,
+      })
+    );
+  }
+
+  /**
+   * Update an installed tool to a new version.
+   * @param identifier Unique identifier for this operation
+   * @param name Name of the tool to update
+   * @param newMetadata New metadata for the tool
+   */
+  static update(identifier: string, name: string, newMetadata: ToolMetadata): void {
+    window.desktopApi.send(
+      'tool-manager',
+      JSON.stringify({
+        action: 'UPDATE',
+        identifier,
+        name,
+        newMetadata,
+      })
+    );
+  }
+
+  /**
+   * Uninstall a tool.
+   * @param identifier Unique identifier for this operation
+   * @param name Name of the tool to uninstall
+   */
+  static uninstall(identifier: string, name: string): void {
+    window.desktopApi.send(
+      'tool-manager',
+      JSON.stringify({
+        action: 'UNINSTALL',
+        identifier,
+        name,
+      })
+    );
+  }
+
+  /**
+   * List all installed tools.
+   * @returns A promise that resolves with the list of installed tools
+   */
+  static async list(): Promise<Record<string, InstalledTool> | undefined> {
+    const identifier = 'list-tools';
+    window.desktopApi.send(
+      'tool-manager',
+      JSON.stringify({
+        action: 'LIST',
+        identifier,
+      })
+    );
+    const data = await this.addListenerWithLimitations(identifier);
+    return data.data;
+  }
+}

--- a/frontend/src/types/vite-plugin-svgr.d.ts
+++ b/frontend/src/types/vite-plugin-svgr.d.ts
@@ -1,0 +1,4 @@
+declare module 'vite-plugin-svgr/client' {
+  const content: any;
+  export default content;
+} 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,7 +17,7 @@
     "noFallthroughCasesInSwitch": true,
     "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals"]
   },
-  "include": ["src"],
+  "include": ["src", "src/types"],
   "typedocOptions": {
     "out": "../docs/development/api",
     "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-rename-defaults"],


### PR DESCRIPTION
This change adds support for handling custom CA certificates and SSL verification in Headlamp:

- Added `--ca-cert` flag to specify custom CA certificate file
- Added `--insecure-ssl` flag to skip SSL certificate verification
- Added environment variable support for SSL_CERT_FILE and NODE_TLS_REJECT_UNAUTHORIZED
- Updated documentation with SSL configuration options
- Added proper type definitions for SSL configuration

Fixes #127

Changes:
1. Added new command line arguments in main.ts for SSL configuration
2. Added SSL configuration types in types.ts
3. Updated README.md with SSL configuration documentation
4. Added environment variable handling for SSL certificates

Testing Done:
- Tested with custom CA certificate
- Tested with insecure SSL mode
- Tested environment variable configuration