### PR TITLE
docs: oidc: Add guidance for large JWTs and ingress header limits

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -198,6 +198,18 @@ ingress:
         - headlamp.example.com
 ```
 
+**Note for nginx ingress users:** If you're using OIDC with large JWT tokens (>8K), you may need to add the following annotation to prevent WebSocket connection issues:
+
+```yaml
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      large_client_header_buffers 4 64k;
+```
+
+For more details, see the [OIDC troubleshooting documentation](https://headlamp.dev/docs/latest/installation/in-cluster/oidc/#large-jwt-tokens-and-websocket-connection-issues).
+
 ### Resource Management
 
 | Key | Type | Default | Description |

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -47,7 +47,7 @@ kubectl apply -f https://raw.githubusercontent.com/kinvolk/headlamp/main/kuberne
 
 By default, Headlamp uses the default service account from the namespace it is deployed to, and generates a kubeconfig from it named `main`.
 
-If you wish to use another specific non-default kubeconfig file, then you can do it by mounting it to the default location at `/home/headlamp/.config/Headlamp/kubeconfigs/config`, or 
+If you wish to use another specific non-default kubeconfig file, then you can do it by mounting it to the default location at `/home/headlamp/.config/Headlamp/kubeconfigs/config`, or
 providing a custom path Headlamp with the ` -kubeconfig` argument or the KUBECONFIG env (through helm values.env)
 
 ### Use several kubeconfig files
@@ -76,6 +76,8 @@ and with that, you'll have a configured ingress file, so verify it and apply it:
 ```bash
 kubectl apply -f ./headlamp-ingress.yaml
 ```
+
+**Note:** If you're using nginx ingress controller with OIDC authentication and large JWT tokens, you may need additional configuration. See the [OIDC troubleshooting documentation](./oidc/#large-jwt-tokens-and-websocket-connection-issues) for details on configuring header buffer sizes.
 
 ## Exposing Headlamp with port-forwarding
 

--- a/kubernetes-headlamp-ingress-sample.yaml
+++ b/kubernetes-headlamp-ingress-sample.yaml
@@ -1,3 +1,6 @@
+# Sample ingress configuration for Headlamp using Contour ingress controller
+# For nginx ingress controller with large JWT tokens, see:
+# https://headlamp.dev/docs/latest/installation/in-cluster/oidc/#large-jwt-tokens-and-websocket-connection-issues
 kind: Ingress
 apiVersion: networking.k8s.io/v1
 metadata:


### PR DESCRIPTION
Fixes #1832

This commit adds comprehensive documentation for resolving WebSocket connection issues when using OIDC with large JWT tokens (>8K) behind nginx ingress controller.

Changes:
- Add troubleshooting section to OIDC documentation with symptoms, solution, and alternative configurations
- Include nginx annotation example for large_client_header_buffers
- Add cross-references in Helm chart README and installation guide
- Update sample ingress file with helpful comments

The issue occurs because nginx's default header buffer size (4x8K) is insufficient for large JWT tokens in WebSocket connections, while regular HTTP requests work fine. The solution increases buffer size to 4x64K using nginx.ingress.kubernetes.io/server-snippet annotation.
