### PR TITLE
backend: Add missing space before token in the Authorization header in multiplexed websocket connection

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -364,7 +364,7 @@ func (m *Multiplexer) dialWebSocket(
 	}
 
 	if token != nil {
-		headers.Set("Authorization", "Bearer"+*token)
+		headers.Set("Authorization", "Bearer "+*token)
 	}
 
 	conn, resp, err := dialer.Dial(


### PR DESCRIPTION
Malformed authorization header was causing issues with the websocket connections when multiplexer is enabled

Steps to reproduce:

1. Login into cluster using Token
2. Open any resource list page
3. Verify that there are no "bad handshake" messages in the /wsMultiplexer websocket connection