### PR TITLE
Misc release fixes

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -68,7 +68,7 @@ jobs:
         echo "CONTAINER_TAGS=${{ env.CONTAINER_TAGS }}"
     - name: checkout to build branch
       run: |
-        git fetch origin
+        git fetch --tags origin
         git checkout ${{ env.BUILD_TAG }}
     - name: Log in to the Container registry
       uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ github.token }}
+        password: ${{ secrets.GHCR_IMAGES }}
     - name: Build and push Docker image
       uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
       with:

--- a/app/scripts/push-release-assets/push-release-assets.js
+++ b/app/scripts/push-release-assets/push-release-assets.js
@@ -16,7 +16,7 @@ import process from 'process';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const owner = 'headlamp-k8s';
+const owner = 'kubernetes-sigs';
 const repo = 'headlamp';
 const client = new Octokit({ auth: process.env.GITHUB_TOKEN });
 


### PR DESCRIPTION
These changes fix:
1. The target org for the push-release-assets script (which was still headlamp-k8s).
2. The token to use when pushing to ghcr (till we move completely to gcr/k8s registry)
3. Fetching the tags for building the container