### PR TITLE
ci: Update windows version to windows-2025

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         make app-linux
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-2025
     strategy:
       matrix:
         node-version: [20.x]


### PR DESCRIPTION
windows-2019 is being deprecated, see more here https://github.com/actions/runner-images/issues/12045

