### PR TITLE
frontend: PodDetails: Reset Logs state on item change

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -640,7 +640,7 @@ export default function PodDetails(props: PodDetailsProps) {
             id: 'headlamp.pod-logs',
             section: (
               <PodLogViewer
-                key="logs"
+                key={'logs-' + item.metadata.uid}
                 open={showLogs}
                 item={item}
                 onClose={() => {


### PR DESCRIPTION
fixes #3446 

PodLogViewer component seems to be struggling with rerendering with a different Pod (item)
To fix this we can completely reset the state of the component when Pod changes

Here's React docs about this if you want to understand how this works https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key