### PR TITLE
docs: update ingress example

### DIFF
--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -68,7 +68,7 @@ Assuming your URL is `headlamp.mydeployment.io`, getting the sample ingress
 file and changing the URL can quickly be done by:
 
 ```bash
-curl -s https://raw.githubusercontent.com/kinvolk/headlamp/main/kubernetes-headlamp-ingress-sample.yaml | sed -e s/__URL__/headlamp.mydeployment.io/ > headlamp-ingress.yaml
+curl -s https://raw.githubusercontent.com/kubernetes-sigs/headlamp/main/kubernetes-headlamp-ingress-sample.yaml | sed -e s/__URL__/headlamp.mydeployment.io/ > headlamp-ingress.yaml
 ```
 
 and with that, you'll have a configured ingress file, so verify it and apply it:

--- a/kubernetes-headlamp-ingress-sample.yaml
+++ b/kubernetes-headlamp-ingress-sample.yaml
@@ -6,8 +6,8 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-production"
-    kubernetes.io/ingress.class: contour
 spec:
+  ingressClassName: contour
   tls:
   - secretName: headlamp
     hosts:


### PR DESCRIPTION
Updated the in-cluster installation docs to use the correct GitHub repo URL (`kubernetes-sigs/headlamp` instead of `kinvolk/headlamp`). Also updated the ingress manifest to use the `ingressClassName` field instead of the deprecated `kubernetes.io/ingress.class` annotation, for better compatibility with newer Kubernetes versions.