### PR TITLE
backend: Update go toolchain to 1.24.4

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/headlamp/backend
 
 go 1.24
 
-toolchain go1.24.0
+toolchain go1.24.4
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
There's CVE in net/http module 1.24.0 https://artifacthub.io/packages/helm/headlamp/headlamp?modal=security-report&image=ghcr.io%2Fheadlamp-k8s%2Fheadlamp%3Av0.31.0&target=headlamp%2Fheadlamp-server

So this PR updates the toolchain to the latest stable one