### PR TITLE
Add cloud build / push to gcr.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,14 @@ export GO111MODULE
 
 SERVER_EXE_EXT ?=
 DOCKER_CMD ?= docker
+DOCKER_BUILDX_CMD ?= buildx
 DOCKER_REPO ?= ghcr.io/headlamp-k8s
 DOCKER_EXT_REPO ?= docker.io/headlamp
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_PLUGINS_IMAGE_NAME ?= plugins
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --always --dirty)
 DOCKER_PLATFORM ?= local
+DOCKER_PUSH ?= false
 
 ifeq ($(OS), Windows_NT)
 	SERVER_EXE_EXT = .exe
@@ -162,26 +164,28 @@ image:
 	else \
 		BUILD_ARG=""; \
 	fi; \
-	$(DOCKER_CMD) buildx build \
+	$(DOCKER_CMD) $(DOCKER_BUILDX_CMD) build \
 	--pull \
 	--platform=$(DOCKER_PLATFORM) \
 	$$BUILD_ARG \
+	--push=$(DOCKER_PUSH) \
 	-t $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
 	Dockerfile \
 	.
 
 .PHONY: build-plugins-container
 build-plugins-container:
-	$(DOCKER_CMD) buildx build \
+	$(DOCKER_CMD) $(DOCKER_BUILDX_CMD) build \
 	--pull \
 	--platform=linux/amd64 \
+	--push=$(DOCKER_PUSH) \
 	-t $(DOCKER_REPO)/$(DOCKER_PLUGINS_IMAGE_NAME):$(DOCKER_IMAGE_VERSION) -f \
 	Dockerfile.plugins \
 	.
 
 docker-ext:
 	$(eval LATEST_TAG=$(shell git tag --list --sort=version:refname 'v*' | tail -1 | sed 's/^.//'))
-	$(DOCKER_CMD) buildx build \
+	$(DOCKER_CMD) $(DOCKER_BUILDX_CMD) build \
 	--platform=linux/amd64,linux/arm64 \
 	--push \
 	-t $(DOCKER_EXT_REPO)/$(DOCKER_IMAGE_NAME)-docker-extension:${LATEST_TAG} \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,27 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 3000s
+# A build step specifies an action that you want cloudbuild to perform.
+# For each build step, cloudbuild executes a docker container.
+steps:
+  # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079'
+    entrypoint: make
+    args:
+      - image
+    env:
+      - DOCKER_CMD= # Because we are using a custom entrypoint, we need to set DOCKER_CMD to empty
+      - DOCKER_BUILDX_CMD=/buildx-entrypoint
+      - DOCKER_PUSH=true
+      - DOCKER_REPO=gcr.io/k8s-staging-headlamp
+      - DOCKER_IMAGE_NAME=headlamp
+      - DOCKER_IMAGE_VERSION=$_PULL_BASE_REF
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '0.0.0'
+  # _PULL_BASE_REF will contain the ref that was pushed to trigger this build -
+  # a branch like 'main' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'main'
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'E2_HIGHCPU_32'


### PR DESCRIPTION
Added this cloudbuild.yaml based on https://github.com/kubernetes-sigs/kwok/blob/main/cloudbuild.yaml .
@xmudrii , I am not sure if we are still missing adding k8s-staging-headlamp to https://github.com/kubernetes/k8s.io/blob/main/infra/gcp/infra.yaml . I have added you as a reviewer because no one in the Headlamp is likely to be able to do a better check. I appreciate any guidance here.

Once we have this in, we need a ProwJob as in https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md .