### PR TITLE
frontend: ResourceTable: Preserve column filter state

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -32,6 +32,7 @@ import { HeadlampEventType, useEventCallback } from '../../../redux/headlampEven
 import { useTypedSelector } from '../../../redux/hooks';
 import { useSettings } from '../../App/Settings/hook';
 import { ClusterGroupErrorMessage } from '../../cluster/ClusterGroupErrorMessage';
+import { useLocalStorageState } from '../../globalSearch/useLocalStorageState';
 import { DateLabel } from '../Label';
 import Link from '../Link';
 import Table, { TableColumn } from '../Table';
@@ -315,6 +316,14 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
   const [columnVisibility, setColumnVisibility] = useState(() =>
     initColumnVisibilityState(columns, id)
   );
+  const [columnFilters, setColumnFilters] = useLocalStorageState<any[]>(
+    `table_filters.${id || ''}`,
+    []
+  );
+
+  function handleColumnFiltersChange(updater: any) {
+    setColumnFilters(prev => (typeof updater === 'function' ? updater(prev) : updater));
+  }
 
   const [tableSettings] = useState<{ id: string; show: boolean }[]>(
     !!id ? loadTableSettings(id) : []
@@ -583,9 +592,11 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
         rowsPerPage={storeRowsPerPageOptions}
         state={{
           columnVisibility,
+          columnFilters,
         }}
         reflectInURL={reflectInURL}
         onColumnVisibilityChange={onColumnsVisibilityChange as any}
+        onColumnFiltersChange={handleColumnFiltersChange as any}
         enableRowActions={enableRowActions}
         renderRowActionMenuItems={renderRowActionMenuItems as any}
         filterFns={{


### PR DESCRIPTION
This change saves the table column filters to localStorage so that they may persist through navigation and reloads.

Fixes: #2554 

### Testing
- [X] Navigate to any resource page in Headlamp (i.e. Pods)
- [X] Set a filter in the table
- [X] Restart the page or navigate away and back to the page and ensure that the filter state persists