### PR TITLE
backend: telemetry: disable tracing by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,19 @@ else
 	@cmd /c "set HEADLAMP_BACKEND_TOKEN=headlamp&& set HEADLAMP_CONFIG_METRICS_ENABLED=true&& set HEADLAMP_CONFIG_ENABLE_HELM=true&& set HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true&& backend\headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost"
 endif
 
+run-backend-with-traces:
+	@echo "**** Running backend with distributed tracing enabled ****"
+ifeq ($(UNIXSHELL),true)
+	HEADLAMP_BACKEND_TOKEN=headlamp \
+    HEADLAMP_CONFIG_TRACING_ENABLED=true \
+    HEADLAMP_CONFIG_ENABLE_HELM=true \
+    HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true \
+    ./backend/headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost
+else
+	@echo "**** Running on Windows without bash or zsh. ****"
+	@cmd /c "set HEADLAMP_BACKEND_TOKEN=headlamp&& set HEADLAMP_CONFIG_TRACING_ENABLED=true&& set HEADLAMP_CONFIG_ENABLE_HELM=true&& set HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true&& backend\headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost"
+endif
+
 run-frontend:
 ifeq ($(UNIXSHELL),true)
 	cd frontend && nice -16 npm start

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -223,7 +223,7 @@ func flagset() *flag.FlagSet {
 	// Telemetry flags.
 	f.String("service-name", "headlamp", "Service name for telemetry")
 	f.String("service-version", "0.30.0", "Service version for telemetry")
-	f.Bool("tracing-enabled", true, "Enable distributed tracing")
+	f.Bool("tracing-enabled", false, "Enable distributed tracing")
 	f.Bool("metrics-enabled", false, "Enable metrics collection")
 	f.String("otlp-endpoint", "localhost:4317", "OTLP collector endpoint")
 	f.Bool("use-otlp-http", false, "Use HTTP instead of gRPC for OTLP export")


### PR DESCRIPTION
## Description

- Disable tracing by default 
- Add make command to run the backend while tracing is enabled
 
fix #3439