### PR TITLE
frontend: docs: Fix broken link in plugins functionality

### DIFF
--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -187,7 +187,7 @@ After registering your theme it will be available in the General Settings, under
 
 ### UI Panels
 
-Register a side panel using [reigsterUIPanel](../../api/plugin/registry/functions/registerUIPanel).
+Register a side panel using [registerUIPanel](../../api/plugin/registry/functions/registerUIPanel).
 Side panel is a UI element that renders on one side of the application, you can define more than panel per side.
 Each panel should have a unique ID, a side (top, left, right, bottom) and a React component to render.
 


### PR DESCRIPTION
This PR fixes the broken link for UI Panels plugin functionality

Fixes #3467 

![Screenshot from 2025-06-12 00-38-27](https://github.com/user-attachments/assets/633d5ccb-0a9b-4f12-92a6-777d521011a8)
