### PR TITLE
frontend : Sidebar : Fixed "Network" Icon inconsistency between Sidebar and ResourceMap

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.ts
+++ b/frontend/src/components/Sidebar/useSidebarItems.ts
@@ -185,7 +185,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
       {
         name: 'network',
         label: t('glossary|Network'),
-        icon: 'mdi:folder-network-outline',
+        icon: 'mdi:lan',
         subList: [
           {
             name: 'services',


### PR DESCRIPTION
### Summary
This PR fixes the inconsistent Network icon in Sidebar and ResourceMap.

Fixes #3485 

### Changes Made
-Updated the useSidebarItems.ts to use the better mdi, i.e. lan instead of  folder-network-outline.

![image](https://github.com/user-attachments/assets/309024b0-0bf9-43e7-a626-5ca7eeadc8e5)
![image](https://github.com/user-attachments/assets/e2c5d730-8084-4943-b894-166a21dd9d3f)
