### PR TITLE
backend: auth: Extract ParseClusterAndToken from headlamp.go

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -999,17 +999,6 @@ func TestGetOidcCallbackURL(t *testing.T) {
 	}
 }
 
-func TestParseClusterAndToken(t *testing.T) {
-	ctx := context.Background()
-	req, err := http.NewRequestWithContext(ctx, "GET", "/clusters/test-cluster/api", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer test-token")
-
-	cluster, token := parseClusterAndToken(req)
-	assert.Equal(t, "test-cluster", cluster)
-	assert.Equal(t, "test-token", token)
-}
-
 func TestIsTokenAboutToExpire(t *testing.T) {
 	// Token that expires in 4 minutes
 	header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."


### PR DESCRIPTION
This change extracts the ParseClusterAndToken from headlamp.go into the new auth package.

Part of:
- #3482

### Updates
- Handles case-insensitive `Bearer` and trims spaces
- Reuses the compiled regex
- Validates cluster contexts and tokens
- Rejects multiple tokens and handles paths with no cluster

### Testing
```shell
cd backend
go test -v -p 1 ./... -run TestParseClusterAndToken
```

