### PR TITLE
headlamp-plugin: Fix exports registerKubeObjectGlance ConfigStore

### DIFF
--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -47,7 +47,6 @@ import * as Router from '../lib/router';
 import * as Utils from '../lib/util';
 import { eventAction, HeadlampEventType } from '../redux/headlampEventSlice';
 import store from '../redux/stores/store';
-import { ConfigStore } from './configStore';
 import { Headlamp, Plugin } from './lib';
 import { PluginInfo } from './pluginsSlice';
 import Registry, * as registryToExport from './registry';
@@ -61,7 +60,6 @@ window.pluginLib = {
   },
   MonacoEditor,
   K8s,
-  ConfigStore,
   Crd: {
     ...Crd,
     // required for compatibility with plugins built with webpack

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -92,6 +92,7 @@ import { addOverviewChartsProcessor, OverviewChartsProcessor } from '../redux/ov
 import { setRoute, setRouteFilter } from '../redux/routesSlice';
 import store from '../redux/stores/store';
 import { UIPanel, uiSlice } from '../redux/uiSlice';
+import { ConfigStore } from './configStore';
 import {
   PluginSettingsComponentType,
   PluginSettingsDetailsProps,
@@ -1012,4 +1013,5 @@ export {
   getHeadlampAPIHeaders,
   runCommand,
   PluginManager,
+  ConfigStore,
 };

--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -26,13 +26,13 @@ import * as ApiProxy from './lib/k8s/apiProxy';
 import * as Notification from './lib/notification';
 import * as Router from './lib/router';
 import * as Utils from './lib/util';
-import { ConfigStore } from './plugin/configStore';
 import { Headlamp, Plugin } from './plugin/lib';
 import { PluginSettingsDetailsProps } from './plugin/pluginsSlice';
 import Registry, {
   AppLogoProps,
   clusterAction,
   ClusterChooserProps,
+  ConfigStore,
   DefaultSidebars,
   DetailsViewDefaultHeaderActions,
   DetailsViewSectionProps,
@@ -50,6 +50,7 @@ import Registry, {
   registerDetailsViewSection,
   registerGetTokenFunction,
   registerKindIcon,
+  registerKubeObjectGlance,
   registerMapSource,
   registerPluginSettings,
   registerResourceTableColumnsProcessor,
@@ -99,6 +100,7 @@ export {
   PluginManager,
   registerUIPanel,
   registerAppTheme,
+  registerKubeObjectGlance,
 };
 
 export type {


### PR DESCRIPTION
registerKubeObjectGlance, ConfigStore, and registerUIPanel can be imported in plugins again.

Put this into a plugin, and do `npm run tsc`... there should be no error.
```ts
import { registerUIPanel, ConfigStore, registerKubeObjectGlance } from '@kinvolk/headlamp-plugin/lib';
console.log(registerUIPanel, ConfigStore, registerKubeObjectGlance);
```

fixes #3426

Related:
- https://github.com/kubernetes-sigs/headlamp/issues/3426
- https://github.com/kubernetes-sigs/headlamp/issues/3427
