### PR TITLE
backend: auth: Extract IsTokenAboutToExpire from headlamp.go

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -989,23 +989,6 @@ func TestParseClusterAndToken(t *testing.T) {
 	assert.Equal(t, "test-token", token)
 }
 
-func TestIsTokenAboutToExpire(t *testing.T) {
-	// Token that expires in 4 minutes
-	header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-	originalPayload := "eyJleHAiOjE2MTIzNjE2MDB9"
-	signature := ".7vl9iBWGDQdXUTbEsqFHiHoaNWxKn4UwLhO9QDhXrpM"
-
-	token := header + originalPayload + signature
-	result := isTokenAboutToExpire(token)
-	assert.True(t, result)
-
-	modifiedPayload := strings.Replace(originalPayload, "J", "-", 1)
-
-	token = header + modifiedPayload + signature
-	result = isTokenAboutToExpire(token)
-	assert.False(t, result, "Expected to return false when payload decoding fails due to URL-safe characters")
-}
-
 func TestOIDCTokenRefreshMiddleware(t *testing.T) {
 	config := &HeadlampConfig{
 		cache:            cache.New[interface{}](),

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -89,3 +89,41 @@ func TestDecodeBase64JSON(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTokenAboutToExpire(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		expectTrue  bool
+		description string
+	}{
+		{
+			name:        "Token expiring soon",
+			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MTIzNjE2MDB9.7vl9iBWGDQdXUTbEsqFHiHoaNWxKn4UwLhO9QDhXrpM", // exp: Jan 2021
+			expectTrue:  true,
+			description: "Token has already expired",
+		},
+		{
+			name:        "Malformed token",
+			token:       "bad.token.string",
+			expectTrue:  false,
+			description: "Malformed token should return false",
+		},
+		{
+			name:        "Invalid payload characters",
+			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MTIzNjE2MDB9==.7vl9iBWGDQdXUTbEsqFHiHoaNWxKn4UwLhO9QDhXrpM",
+			expectTrue:  false,
+			description: "Base64 payload with invalid format should return false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := auth.IsTokenAboutToExpire(tt.token)
+			if result != tt.expectTrue {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expectTrue, result)
+			}
+		})
+	}
+}
+

--- a/backend/pkg/auth/token.go
+++ b/backend/pkg/auth/token.go
@@ -1,0 +1,43 @@
+﻿package auth
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+const JWTExpirationTTL = 10 * time.Second // seconds
+
+func IsTokenAboutToExpire(token string) bool {
+	const tokenParts = 3
+
+	parts := strings.Split(token, ".")
+	if len(parts) != tokenParts {
+		return false
+	}
+
+	payload, err := DecodeBase64JSON(parts[1])
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "failed to decode payload")
+		return false
+	}
+
+	expiryTime, err := GetExpiryTime(payload)
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "failed to get expiry time")
+		return false
+	}
+
+	return time.Until(expiryTime) <= JWTExpirationTTL
+}
+
+func GetExpiryTime(payload map[string]interface{}) (time.Time, error) {
+	exp, ok := payload["exp"].(float64)
+	if !ok {
+		return time.Time{}, errors.New("expiry time not found or invalid")
+	}
+
+	return time.Unix(int64(exp), 0), nil
+}


### PR DESCRIPTION

This change extracts the isTokenAboutToExpire logic from headlamp.go into the new auth package as IsTokenAboutToExpire.

Part of: 
- #3482 

Updates
 - Moved isTokenAboutToExpire to pkg/auth/token.go as IsTokenAboutToExpire
- Extracted expiry parsing logic into GetExpiryTime for clarity and reuse
- Introduced JWTExpirationTTL constant 
- Added logging for decoding and expiry parsing failures
- Removed the old inline logic from headlamp.go

Test 

```bash
=== RUN   TestIsTokenAboutToExpire
=== RUN   TestIsTokenAboutToExpire/Token_expiring_soon
--- PASS: TestIsTokenAboutToExpire/Token_expiring_soon (0.00s)
=== RUN   TestIsTokenAboutToExpire/Malformed_token
{"level":"error","source":"f:/headlamp/backend/pkg/auth/token.go","line":23,"error":"illegal base64 data at input byte 4","time":"2025-06-21T15:27:26+05:30","message":"failed to decode payload"}
--- PASS: TestIsTokenAboutToExpire/Malformed_token (0.00s)
=== RUN   TestIsTokenAboutToExpire/Invalid_payload_characters
{"level":"error","source":"f:/headlamp/backend/pkg/auth/token.go","line":23,"error":"illegal base64 data at input byte 24","time":"2025-06-21T15:27:26+05:30","message":"failed to decode payload"}
--- PASS: TestIsTokenAboutToExpire/Invalid_payload_characters (0.00s)
--- PASS: TestIsTokenAboutToExpire (0.00s)
PASS
ok      github.com/kubernetes-sigs/headlamp/backend/pkg/auth    1.139s
```