### PR TITLE
frontend: Ingress: Mark rules field as optional

### DIFF
--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -79,7 +79,7 @@ export function LinkStringFormat({ url, item, urlPath }: LinkStringFormatProps) 
     /*
      * Since we cannot access the prefix from the ingress object, we have to access it from the rules array
      */
-    const rules: any[] = item.spec.rules;
+    const rules: any[] | undefined = item.spec.rules;
     let currentPathType;
     if (rules) {
       for (let i = 0; i < rules.length; i++) {

--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -155,7 +155,7 @@ const endpointsToServices = makeRelation(
 );
 
 const ingressToService = makeRelation(Ingress, Service, (ingress, service) =>
-  ingress.spec.rules.find((rule: any) =>
+  ingress.spec.rules?.find((rule: any) =>
     rule.http?.paths?.find((path: any) => service.metadata.name === path?.backend?.service?.name)
   )
 );

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -60,7 +60,7 @@ export interface IngressBackend {
 export interface KubeIngress extends KubeObjectInterface {
   spec: {
     ingressClassName?: string;
-    rules: IngressRule[] | LegacyIngressRule[];
+    rules?: IngressRule[] | LegacyIngressRule[];
     tls?: {
       hosts: string[];
       secretName: string;
@@ -130,7 +130,7 @@ class Ingress extends KubeObject<KubeIngress> {
   }
 
   getHosts() {
-    return this.spec!.rules.map(({ host }) => host).join(' | ');
+    return this.spec.rules?.map(({ host }) => host).join(' | ');
   }
 
   getRules(): IngressRule[] {


### PR DESCRIPTION
This PR marks `rules` field in the Ingress object as optional, and updates usages accordingly

## Related Issue

Fixes #3522

## Steps to Test

1. Create Ingress without rules
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: my-ingress
spec:
  defaultBackend:
    service:
      name: my-service
      port:
        number: 80
```
2. Go to Map and make sure it doesn't crash


