### PR TITLE
Added env var config to plugin manager

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -259,7 +259,6 @@ spec:
           {{- end }}
         {{- if .Values.pluginsManager.enabled }}
         - name: headlamp-plugin
-
           image: {{ .Values.pluginsManager.baseImage }}
           command: ["/bin/sh", "-c"]
           env:

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -262,6 +262,8 @@ spec:
 
           image: {{ .Values.pluginsManager.baseImage }}
           command: ["/bin/sh", "-c"]
+          env:
+            {{- toYaml .Values.pluginsManager.env | nindent 12 }}
           args:
             - |
               echo "Installing headlamp-plugin globally..."

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -243,6 +243,10 @@ pluginsManager:
   baseImage: node:lts-alpine
   # -- Headlamp plugin package version to install
   version: latest
+  # -- Plugin manager env variable configuration
+  # env:
+  # - name: HTTPS_PROXY
+  #   value: "proxy.example.com:8080"
   # -- Specify resrouces
   # resources:
   #   requests:


### PR DESCRIPTION
## Summary

This PR adds the ability to configure the plugin manager via env vars. This allows the user to set a proxy or even set npm settings like the registry. 

## Changes

- Added templating for env vars in the plugin manager

## Steps to Test

1. Set .Values.pluginsManager.env
2. Watch the envs vars get populated

