### PR TITLE
Makefile: Update frontend-lint-fix command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ run-only-app:
 frontend-lint:
 	cd frontend && npm run lint -- --max-warnings 0 && npm run format-check
 
-frontend-fixlint:
+frontend-lint-fix:
 	cd frontend && npm run lint -- --fix && npm run format
 
 .PHONY: frontend-tsc


### PR DESCRIPTION
This change updates the frontend lint fix make command from `make frontend-fixlint` to `make frontend-lint-fix`, in line with the backend lint commands.