### PR TITLE
Add "make lint" and "lint-fix" targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,12 @@ frontend-i18n-check:
 frontend-test:
 	cd frontend && npm run test -- --coverage
 
+.PHONY: lint
+lint: backend-lint frontend-lint
+
+.PHONY: lint-fix
+lint-fix: backend-lint-fix frontend-lint-fix
+
 plugins-test:
 	cd plugins/headlamp-plugin && npm install && ./test-headlamp-plugin.js
 	cd plugins/headlamp-plugin && ./test-plugins-examples.sh


### PR DESCRIPTION
## Summary

This PR adds `make lint` and `make lint-fix` targets for convenience.

## Related Issue

See #3534

## Changes

- Added target to Makefile

## Steps to Test

1. Check out the branch and run `make lint` and `make lint-fix`
2. Verify that it runs both sub-targets successfully

## Notes for the Reviewer
