### PR TITLE
frontend: ingress: Display missing port for default backend

### DIFF
--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -204,7 +204,7 @@ export default function IngressDetails(props: {
   function getDefaultBackend(item: Ingress) {
     const { service, resource } = item.spec?.defaultBackend || {};
     return (
-      (service && service.name + ':' + service.port.toString()) ||
+      (service && service.name + ':' + (service.port.number ?? service.port.name ?? '-')) ||
       (resource && resource.kind + '/' + resource.name) ||
       '-'
     );


### PR DESCRIPTION
This change displays the proper port number for the default backend, which was previously not shown. When no port is given, it falls back to the port name.