### PR TITLE
Accessibility [FastPass]: Fix settings general missing aria input labels 

### DIFF
--- a/frontend/src/components/App/Settings/NumRowsInput.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.tsx
@@ -31,9 +31,9 @@ import { useDispatch } from 'react-redux';
 import { getTablesRowsPerPage, setTablesRowsPerPage } from '../../../helpers/tablesRowsPerPage';
 import { defaultTableRowsPerPageOptions, setAppSettings } from '../../../redux/configSlice';
 
-export default function NumRowsInput(props: { defaultValue: number[] }) {
+export default function NumRowsInput(props: { defaultValue: number[]; nameLabelID?: string }) {
   const { t } = useTranslation(['frequent']);
-  const { defaultValue } = props;
+  const { defaultValue, nameLabelID } = props;
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [options, setOptions] = useState(defaultValue);
   const focusedRef = useCallback((node: HTMLElement) => {
@@ -157,6 +157,7 @@ export default function NumRowsInput(props: { defaultValue: number[] }) {
           renderValue={value => `${value}`}
           size="small"
           variant="outlined"
+          labelId={nameLabelID}
         >
           {options.map(option => {
             const isCustom = !defaultTableRowsPerPageOptions.includes(option);

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -78,6 +78,7 @@ export default function Settings() {
   }, [useEvict]);
 
   const sidebarLabelID = 'sort-sidebar-label';
+  const evictLabelID = 'use-evict-label';
 
   return (
     <SectionBox
@@ -146,8 +147,12 @@ export default function Settings() {
                 color="primary"
                 checked={useEvict}
                 onChange={e => setUseEvict(e.target.checked)}
+                inputProps={{
+                  'aria-labelledby': evictLabelID,
+                }}
               />
             ),
+            nameID: evictLabelID,
           },
         ]}
       />

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -80,6 +80,7 @@ export default function Settings() {
   const sidebarLabelID = 'sort-sidebar-label';
   const evictLabelID = 'use-evict-label';
   const tableRowsLabelID = 'rows-per-page-label';
+  const timezoneLabelID = 'timezone-label';
 
   return (
     <SectionBox
@@ -125,9 +126,11 @@ export default function Settings() {
                 <TimezoneSelect
                   initialTimezone={selectedTimezone}
                   onChange={name => setSelectedTimezone(name)}
+                  nameLabelID={timezoneLabelID}
                 />
               </Box>
             ),
+            nameID: timezoneLabelID,
           },
           {
             name: t('translation|Sort sidebar items alphabetically'),

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -79,6 +79,7 @@ export default function Settings() {
 
   const sidebarLabelID = 'sort-sidebar-label';
   const evictLabelID = 'use-evict-label';
+  const tableRowsLabelID = 'rows-per-page-label';
 
   return (
     <SectionBox
@@ -112,8 +113,10 @@ export default function Settings() {
             value: (
               <NumRowsInput
                 defaultValue={storedRowsPerPageOptions || defaultTableRowsPerPageOptions}
+                nameLabelID={tableRowsLabelID}
               />
             ),
+            nameID: tableRowsLabelID,
           },
           {
             name: t('translation|Timezone to display for dates'),

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -77,6 +77,8 @@ export default function Settings() {
     );
   }, [useEvict]);
 
+  const sidebarLabelID = 'sort-sidebar-label';
+
   return (
     <SectionBox
       title={t('translation|General Settings')}
@@ -130,8 +132,12 @@ export default function Settings() {
                 color="primary"
                 checked={sortSidebar}
                 onChange={e => setSortSidebar(e.target.checked)}
+                inputProps={{
+                  'aria-labelledby': sidebarLabelID,
+                }}
               />
             ),
+            nameID: sidebarLabelID,
           },
           {
             name: t('translation|Use evict for pod deletion'),

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -379,6 +379,7 @@
           </dd>
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-iqixpy-MuiGrid-root"
+            id="use-evict-label"
           >
             Use evict for pod deletion
           </dt>
@@ -392,6 +393,7 @@
                 class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-1emuodk-MuiButtonBase-root-MuiSwitch-switchBase"
               >
                 <input
+                  aria-labelledby="use-evict-label"
                   checked=""
                   class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
                   type="checkbox"

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -202,6 +202,7 @@
           </dd>
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+            id="rows-per-page-label"
           >
             Number of rows for tables
           </dt>
@@ -219,6 +220,7 @@
                   aria-controls=":mock-test-id:"
                   aria-expanded="false"
                   aria-haspopup="listbox"
+                  aria-labelledby="rows-per-page-label"
                   class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-oswssk-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
                   role="combobox"
                   tabindex="0"

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -264,6 +264,7 @@
           </dd>
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+            id="timezone-label"
           >
             Timezone to display for dates
           </dt>
@@ -287,6 +288,7 @@
                       aria-describedby="cluster-selector-autocomplete-helper-text"
                       aria-expanded="false"
                       aria-invalid="false"
+                      aria-labelledby="timezone-label"
                       autocapitalize="none"
                       autocomplete="off"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -347,6 +347,7 @@
           </dd>
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+            id="sort-sidebar-label"
           >
             Sort sidebar items alphabetically
           </dt>
@@ -360,6 +361,7 @@
                 class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1emuodk-MuiButtonBase-root-MuiSwitch-switchBase"
               >
                 <input
+                  aria-labelledby="sort-sidebar-label"
                   class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
                   type="checkbox"
                 />

--- a/frontend/src/components/common/NameValueTable/NameValueTable.tsx
+++ b/frontend/src/components/common/NameValueTable/NameValueTable.tsx
@@ -32,6 +32,8 @@ export interface NameValueTableRow {
   valueCellProps?: GridProps;
   /** Whether to highlight the row (used for titles, separators, etc.). */
   withHighlightStyle?: boolean;
+  /** The ID to use for the name element, useful for accessibility */
+  nameID?: string;
 }
 
 export interface NameValueTableProps {
@@ -87,7 +89,10 @@ export default function NameValueTable(props: NameValueTableProps) {
       })}
     >
       {visibleRows.flatMap(
-        ({ name, value, hide = false, withHighlightStyle = false, valueCellProps = {} }, i) => {
+        (
+          { name, nameID, value, hide = false, withHighlightStyle = false, valueCellProps = {} },
+          i
+        ) => {
           let shouldHide = false;
           if (typeof hide === 'function') {
             shouldHide = hide(value);
@@ -112,6 +117,7 @@ export default function NameValueTable(props: NameValueTableProps) {
               sm={hideValueGridItem ? 12 : 4}
               component="dt"
               className={className}
+              id={nameID}
               sx={theme => {
                 const extra = withHighlightStyle
                   ? {

--- a/frontend/src/components/common/TimezoneSelect/TimezoneSelect.tsx
+++ b/frontend/src/components/common/TimezoneSelect/TimezoneSelect.tsx
@@ -23,10 +23,12 @@ import spacetime from 'spacetime';
 export interface TimezoneSelectorProps {
   initialTimezone?: string;
   onChange: (timezone: string) => void;
+  /** The custom ID to be used when this component is inside NameValueTable for ARIA labelledby */
+  nameLabelID?: string;
 }
 
 export default function TimezoneSelect(props: TimezoneSelectorProps) {
-  const { onChange, initialTimezone } = props;
+  const { onChange, initialTimezone, nameLabelID } = props;
   const { i18n, t } = useTranslation();
   const timezoneOptions = React.useMemo(() => {
     const timezoneNames = spacetime.timezones();
@@ -51,7 +53,16 @@ export default function TimezoneSelect(props: TimezoneSelectorProps) {
       includeInputInList
       openOnFocus
       renderInput={params => (
-        <TextField {...params} helperText={t('Timezone')} size="small" variant="outlined" />
+        <TextField
+          {...params}
+          helperText={t('Timezone')}
+          size="small"
+          variant="outlined"
+          inputProps={{
+            ...params.inputProps,
+            'aria-labelledby': nameLabelID,
+          }}
+        />
       )}
       onChange={(_ev, value) => onChange(value.name)}
       value={timezoneOptions.find(option => option.name === initialTimezone)}


### PR DESCRIPTION
## Summary

This PR fixes accessibility related issues for the settings page, mainly just the issues found by FastPass on the `General` tab. 

These changes are part of a larger accessibility compliance goal from ADO (not sure if linking is allowed).

Issues are found using FastPass automated checks, feel free to download the tool and doublecheck if interested.


## Changes

These aria labels are now added to the settings view

- Add aria labelled by for `Sort sidebar items alphabetically` menu switch
- Add aria labelled by for `Use evict for pod deletion` menu switch
- Add aria label for `Number of rows for tables` source component
- Add aria label for `Timezone to display for dates` source component
- Add aria label for drawer mode switch
- Updates `Language` to use typography (was plain text before)

## Note
I have ran into issues with applying some aria attributes to the MUI components directly. I found that just attaching `aira-label` / `aira-labelledby` etc would only attach to the wrapper for the MUI component and not the input element itself. By adding the `inputProps` field we can attach aria labels to the actual input element.


## FastPass checks this solves

### Issue for `Number of rows for tables`
<img width="1916" height="833" alt="image" src="https://github.com/user-attachments/assets/d93c22b2-fbb5-44e1-97aa-e9526582d9d9" />
<img width="1631" height="332" alt="image" src="https://github.com/user-attachments/assets/05003404-18d6-4c32-ac39-2e1585b2b632" />



### Issue for `Timezone to display for dates`
<img width="1901" height="829" alt="image" src="https://github.com/user-attachments/assets/249f8ead-ab65-449f-a381-ae3859070b69" />
<img width="1620" height="609" alt="image" src="https://github.com/user-attachments/assets/ae13beb8-a0df-4de0-bf3f-f06957fb676c" />

### issue for `Sort sidebar items alphabetically`
<img width="1900" height="826" alt="image" src="https://github.com/user-attachments/assets/2923fd60-1857-4fab-9f1c-3468c23fe743" />
<img width="1617" height="424" alt="image" src="https://github.com/user-attachments/assets/43722059-750e-4d16-ac11-0395484e42a0" />

### issue for `Use evict for pod deletion`
<img width="1900" height="832" alt="image" src="https://github.com/user-attachments/assets/1ab0e8ee-dc35-41cf-9628-ad3ff3005f87" />
<img width="1606" height="413" alt="image" src="https://github.com/user-attachments/assets/1c1f0a9b-d11f-4f29-a033-6d6a10bcd1bd" />
