### PR TITLE
frontend: CronJob: Spawn new job using cronjob's namespace

### DIFF
--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -50,7 +50,6 @@ const maxNameLength = 63;
 
 function SpawnJobDialog(props: { cronJob: CronJob; onClose: () => void }) {
   const { cronJob, onClose } = props;
-  const { namespace } = useParams<{ namespace: string }>();
   const { t } = useTranslation(['translation']);
   const dispatch: AppDispatch = useDispatch();
 
@@ -65,7 +64,7 @@ function SpawnJobDialog(props: { cronJob: CronJob; onClose: () => void }) {
     // set all the fields that are assumed on the jobTemplate
     job.kind = 'Job';
     job.metadata = _.cloneDeep(job.metadata) || {};
-    job.metadata.namespace = namespace;
+    job.metadata.namespace = cronJob.metadata.namespace;
     job.apiVersion = 'batch/v1';
     job.metadata.name = jobName;
     job.metadata.annotations = {


### PR DESCRIPTION
This change sets a newly spawn job's namespace to the namespace of its cron job, rather than defaulting to the `default` namespace.

### Testing
- [X] Open a cronjob in Headlamp
- [X] Spawn a new job and inspect the network requests
- [X] Ensure that the cronjob's namespace, rather than the default one, is displayed in the POST request headers

![image](https://github.com/user-attachments/assets/e6a452d7-5c6c-4eb0-bda7-b112c1142f87)
