### PR TITLE
fix : Fix plugin folder name to include scope prefix

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -358,8 +358,23 @@ async function createArchive(pluginDir, outputDir) {
     );
     return 1;
   }
+  let folderName;
+  try {
+    const pkgPath = path.join(pluginPath, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  
+    folderName = pkg.name
+      ? pkg.name.replace(/^@/, '').replace(/\//g, '-')
+      : path.basename(pluginPath);
+  } catch (e) {
+    folderName = path.basename(pluginPath);
+  }
+  const finalPath = path.join(outputDir, folderName);
+if (fs.existsSync(finalPath)) {
+  console.warn(`⚠️ Plugin folder "${folderName}" already exists. Potential duplicate plugin?`);
+}
 
-  const folderName = path.basename(pluginPath);
+
 
   // Create tarball
   await tar.c(


### PR DESCRIPTION
## Summary

This PR fixes a bug in headlamp-plugin start where scoped plugin names (e.g. @headlamp/test-plugin) were being placed in a folder like test-plugin, dropping the scope prefix. The new logic preserves the scope by converting the name to headlamp-test-plugin.

## Related Issue

Fixes #3493 


## Changes

- Updated folder name logic in plugins/headlamp-plugin/bin/headlamp-plugin.js to preserve the scope.

- Replaces @ and / in plugin package names with - to ensure folder names are valid and unique.

- Example: headlamp/test-plugin → headlamp-test-plugin.



## Steps to Test

1. npm install

2. npm start

3. /.config/headlamp/plugins/headlamp-test-plugin/  instead of  /.config/headlamp/plugins/test-plugin/


## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/6ea8e0ce-fe0e-4f1f-87ab-9990c7b2539f)



## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
