### PR TITLE
backend:bug: Fixes the bug that caused breaking of app-linux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ frontend-build:
 frontend-build-storybook:
 	cd frontend && npm run build-storybook
 
-run-backend:
+run-backend: backend
 	@echo "**** Warning: Running with Helm and dynamic-clusters endpoints enabled. ****"
 
 ifeq ($(UNIXSHELL),true)


### PR DESCRIPTION
## Summary

This PR fixes a bug  in which  app-linux target did not automatically build the backend for the current (Host) OS which caused binary exec error due to an architecture mismatch. Now the makefile ensures that backend is built for the appropriate architecture before running the backend server

## Related Issue

Fixes #3162

## Changes

- Added backend in makefile so as to make sure backend is built for the appropriate architecture  before running backend server 

## Steps to Test

1. make app-linux
2. make run-backend

## Screenshots (if applicable)
[Screencast from 2025-07-02 19-38-57.webm](https://github.com/user-attachments/assets/4329350d-07a1-426a-a2d0-31010241aa2d)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
