### PR TITLE
fix(drawer):close drawer when click outside the box

### DIFF
--- a/frontend/src/components/common/Resource/DetailsDrawer.tsx
+++ b/frontend/src/components/common/Resource/DetailsDrawer.tsx
@@ -15,6 +15,7 @@
  */
 
 import Box from '@mui/material/Box';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
@@ -41,44 +42,46 @@ export default function DetailsDrawer() {
   }
 
   return (
-    <Box
-      sx={{
-        position: 'absolute',
-        backgroundColor: 'background.paper',
-        width: '60vw',
-        right: 0,
-        height: '100%',
-        overflowY: 'auto',
-        boxShadow: '-5px 0 20px rgba(0,0,0,0.08)',
-        borderRadius: '10px 0 0 10px',
-        zIndex: 1,
-        border: '1px solid',
-        borderColor: theme.palette.divider,
-      }}
-      role="complementary"
-      aria-describedby="resource-details-content"
-    >
+    <ClickAwayListener onClickAway={closeDrawer}>
       <Box
         sx={{
-          display: 'flex',
-          padding: '1rem',
-          justifyContent: 'right',
+          position: 'absolute',
+          backgroundColor: 'background.paper',
+          width: '60vw',
+          right: 0,
+          height: '100%',
+          overflowY: 'auto',
+          boxShadow: '-5px 0 20px rgba(0,0,0,0.08)',
+          borderRadius: '10px 0 0 10px',
+          zIndex: 1,
+          border: '1px solid',
+          borderColor: theme.palette.divider,
         }}
+        role="complementary"
+        aria-describedby="resource-details-content"
       >
-        <ActionButton onClick={() => closeDrawer()} icon="mdi:close" description={t('Close')} />
+        <Box
+          sx={{
+            display: 'flex',
+            padding: '1rem',
+            justifyContent: 'right',
+          }}
+        >
+          <ActionButton onClick={() => closeDrawer()} icon="mdi:close" description={t('Close')} />
+        </Box>
+        <Box id="resource-details-content">
+          {selectedResource && (
+            <KubeObjectDetails
+              resource={{
+                kind: selectedResource.kind,
+                metadata: selectedResource.metadata,
+                cluster: selectedResource.cluster,
+              }}
+              customResourceDefinition={selectedResource.customResourceDefinition}
+            />
+          )}
+        </Box>
       </Box>
-      <Box id="resource-details-content">
-        {selectedResource && (
-          <KubeObjectDetails
-            resource={{
-              kind: selectedResource.kind,
-              metadata: selectedResource.metadata,
-              cluster: selectedResource.cluster,
-            }}
-            customResourceDefinition={selectedResource.customResourceDefinition}
-          />
-        )}
-      </Box>
-    </Box>
+    </ClickAwayListener>
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes a UX issue where the side drawer in Headlamp does not close when the user clicks outside of it.  
The drawer is now wrapped in MUI's `ClickAwayListener` to detect and handle outside clicks by closing the drawer.

---

## Related Issue

Fixes #3569 

---

## Changes

- Wrapped the resource details drawer (`DetailsDrawer.tsx`) with `ClickAwayListener`
- Connected `onClickAway` to `closeDrawer()` function
- Improved user experience by auto-closing the drawer on outside interaction

---

## Steps to Test

1. Navigate to a resource list (e.g., Pods)
2. Click on a resource to open the side drawer
3. Click anywhere outside the drawer area
4. The drawer should now close automatically


---
# note 
- can add keyframes to drawer , for smooth close and open 
