### PR TITLE
github: Add hl-ci- as a branch name prefix

### DIFF
--- a/.github/workflows/pr-to-update-chart.yml
+++ b/.github/workflows/pr-to-update-chart.yml
@@ -49,7 +49,7 @@ jobs:
           CURRENT_CHART_VERSION=$(grep '^version:' ./charts/headlamp/Chart.yaml | cut -d' ' -f2)
           CURRENT_CHART_VERSION=$(echo $CURRENT_CHART_VERSION | awk -F. -v OFS=. '{$(NF - 1) += 1 ; print}')
           # Create branch
-          BRANCH=update_chart_headlamp_$LATEST_HEADLAMP_TAG
+          BRANCH=hl-ci-update_chart_headlamp_$LATEST_HEADLAMP_TAG
           if git branch -l | grep -q $BRANCH; then
             echo "deleting old branch from local to avoid conflict"
             git branch -D $BRANCH

--- a/.github/workflows/pr-to-update-choco.yml
+++ b/.github/workflows/pr-to-update-choco.yml
@@ -100,11 +100,11 @@ jobs:
           echo "Repository: ${{ github.repository }}"
           echo "Workspace: ${GITHUB_WORKSPACE}"
           pwd
-          echo echo "https://github.com/kubernetes-sigs/headlamp/pull/new/choco-update-$LATEST_HEADLAMP_TAG"
-          git checkout -b "choco-update-$LATEST_HEADLAMP_TAG"
+          echo echo "https://github.com/kubernetes-sigs/headlamp/pull/new/hl-ci-choco-update-$LATEST_HEADLAMP_TAG"
+          git checkout -b "hl-ci-choco-update-$LATEST_HEADLAMP_TAG"
           git add .
           git commit -s -m "chocolatey: Bump Headlamp version to $LATEST_HEADLAMP_TAG"
-          git push origin "choco-update-$LATEST_HEADLAMP_TAG"
+          git push origin "hl-ci-choco-update-$LATEST_HEADLAMP_TAG"
           gh pr create \
             --title "chocolatey: Bump Headlamp version to $LATEST_HEADLAMP_TAG" \
             --base main \

--- a/.github/workflows/pr-to-update-homebrew.yml
+++ b/.github/workflows/pr-to-update-homebrew.yml
@@ -56,22 +56,23 @@ jobs:
         run: |
           user=${{github.actor}}
           HEADLAMP_VERSION=${LATEST_HEADLAMP_TAG:1}
+          BRANCH_NAME="hl-ci-update_headlamp_$HEADLAMP_VERSION"
           if [ -z $user ]; then
             user=yolossn
           fi
           cd homebrew-cask
-          if git branch -l | grep -q "update_headlamp_$HEADLAMP_VERSION"; then
+          if git branch -l | grep -q "$BRANCH_NAME"; then
             echo "deleting old branch from local to avoid conflict"
-            git branch -D "update_headlamp_$HEADLAMP_VERSION"
+            git branch -D "$BRANCH_NAME"
           fi
-          if git branch -a | grep -q "origin/update_headlamp_$HEADLAMP_VERSION"; then
+          if git branch -a | grep -q "origin/$BRANCH_NAME"; then
             echo "deleting old branch from remote to avoid conflict"
-            git push origin --delete "update_headlamp_$HEADLAMP_VERSION"
+            git push origin --delete "$BRANCH_NAME"
           fi
           wget "https://github.com/kubernetes-sigs/headlamp/releases/download/$LATEST_HEADLAMP_TAG/checksums.txt"
           ARM_SHA=$(cat checksums.txt | grep .arm64.dmg | awk -F" " '{print $1}')
           INTEL_SHA=$(cat checksums.txt | grep .x64.dmg | awk -F" " '{print $1}')
-          git checkout -b "update_headlamp_$HEADLAMP_VERSION"
+          git checkout -b "$BRANCH_NAME"
           sed -i "s/version\ .*/version \"$HEADLAMP_VERSION\"/g" ./Casks/h/headlamp.rb
           if [ $ARM_SHA ]; then
             echo "replacing ARM SHA"
@@ -88,11 +89,11 @@ jobs:
           git commit --signoff -m "Update Headlamp version to $HEADLAMP_VERSION"
           git status
           git log -1
-          git push origin "update_headlamp_$HEADLAMP_VERSION" -f
+          git push origin "$BRANCH_NAME" -f
           gh pr create \
           --title "Upgrade Headlamp version to $HEADLAMP_VERSION" \
           --repo "Homebrew/homebrew-cask" \
-          --head "headlamp-k8s:update_headlamp_$HEADLAMP_VERSION" \
+          --head "headlamp-k8s:$BRANCH_NAME" \
           --base "master"  \
           --assignee "$user" \
           --body "Upgrade Headlamp version to $HEADLAMP_VERSION

--- a/.github/workflows/pr-to-update-minikube.yml
+++ b/.github/workflows/pr-to-update-minikube.yml
@@ -56,19 +56,20 @@ jobs:
             user=yolossn
           fi
           HEADLAMP_VERSION=${LATEST_HEADLAMP_TAG:1}
+          BRANCH_NAME="hl-ci-update_headlamp_$HEADLAMP_VERSION"
           LATEST_HEADLAMP_SHA=$(gh api \
           "/orgs/headlamp-k8s/packages/container/headlamp/versions" --jq "map(select(.metadata.container.tags[] | contains(\"$LATEST_HEADLAMP_TAG\"))) | .[].name")
           echo $LATEST_HEADLAMP_SHA
           cd minikube
-          if git branch -l | grep -q "update_headlamp_$HEADLAMP_VERSION"; then
+          if git branch -l | grep -q "$BRANCH_NAME"; then
             echo "deleting old branch from local to avoid conflict"
-            git branch -D "update_headlamp_$HEADLAMP_VERSION"
+            git branch -D "$BRANCH_NAME"
           fi
-          if git branch -a | grep -q "origin/update_headlamp_$HEADLAMP_VERSION"; then
+          if git branch -a | grep -q "origin/$BRANCH_NAME"; then
             echo "deleting old branch from remote to avoid conflict"
-            git push origin --delete "update_headlamp_$HEADLAMP_VERSION"
+            git push origin --delete "$BRANCH_NAME"
           fi
-          git checkout -b "update_headlamp_$HEADLAMP_VERSION"
+          git checkout -b "$BRANCH_NAME"
           OLD_HEADLAMP_VERSION=$(DEP=headlamp make get-dependency-version)
           sed -i "s/headlamp-k8s\/headlamp:v.*/headlamp-k8s\/headlamp:$LATEST_HEADLAMP_TAG@$LATEST_HEADLAMP_SHA\",/g" ./pkg/minikube/assets/addons.go
           NEW_HEADLAMP_VERSION=$(DEP=headlamp make get-dependency-version)
@@ -78,11 +79,11 @@ jobs:
           git commit --signoff -m "Addon headlamp: Update headlamp-k8s/headlamp image from $OLD_HEADLAMP_VERSION to $NEW_HEADLAMP_VERSION"
           git status
           git log -1
-          git push origin "update_headlamp_$HEADLAMP_VERSION" -f
+          git push origin "$BRANCH_NAME" -f
           gh pr create \
           --title "Addon headlamp: Update headlamp-k8s/headlamp image from $OLD_HEADLAMP_VERSION to $NEW_HEADLAMP_VERSION" \
           --repo "kubernetes/minikube" \
-          --head "headlamp-k8s:update_headlamp_$HEADLAMP_VERSION" \
+          --head "headlamp-k8s:$BRANCH_NAME" \
           --base "master"  \
           --assignee "$user" \
           --body "Upgrade Headlamp version to $HEADLAMP_VERSION

--- a/.github/workflows/pr-to-update-winget.yml
+++ b/.github/workflows/pr-to-update-winget.yml
@@ -98,10 +98,10 @@ jobs:
           cd $GITHUB_WORKSPACE/winget-pkgs/manifests/h/Headlamp/Headlamp
           pwd
           ls
-          git checkout -b "winget-update-$LATEST_HEADLAMP_TAG"
+          git checkout -b "hl-ci-winget-update-$LATEST_HEADLAMP_TAG"
           git add .
           git commit -s -m "Update winget package $LATEST_HEADLAMP_TAG"
-          git push origin "winget-update-$LATEST_HEADLAMP_TAG"
+          git push origin "hl-ci-winget-update-$LATEST_HEADLAMP_TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.KINVOLK_REPOS_TOKEN }}
 
@@ -109,4 +109,4 @@ jobs:
         run: |
           echo "Create pull request"
           echo "continue with the following link"
-          echo "https://github.com/headlamp-k8s/winget-pkgs/pull/new/winget-update-$LATEST_HEADLAMP_TAG"
+          echo "https://github.com/headlamp-k8s/winget-pkgs/pull/new/hl-ci-winget-update-$LATEST_HEADLAMP_TAG"


### PR DESCRIPTION
## Summary

This PR updates the branches used in CI workflows so they have the hl-ci- prefix, which doesn't get protected by the kubernetes branch policies, thus allowing us to delete/update them easily.

## Notes for the Reviewer

No test needed since this will be related to the release. Just double check if the logic makes sense and there are no typos or things like that.
