### PR TITLE
frontend: Overview: Use selected namespaces for events

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -25,6 +25,7 @@ import Event from '../../lib/k8s/event';
 import Node from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
 import { useFilterFunc } from '../../lib/util';
+import { useNamespaces } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { OverviewChart } from '../../redux/overviewChartsSlice';
 import { DateLabel } from '../common/Label';
@@ -117,7 +118,11 @@ function EventsSection() {
       )
     )
   );
-  const { items: events, errors: eventsErrors } = Event.useList({ limit: Event.maxLimit });
+  const namespace = useNamespaces();
+  const { items: events, errors: eventsErrors } = Event.useList({
+    limit: Event.maxLimit,
+    namespace,
+  });
 
   const warningActionFilterFunc = (event: Event, search?: string) => {
     if (!filterFunc(event, search)) {


### PR DESCRIPTION
## Summary

Use selected namespaces to fetch events in the Cluster Overview page
Fixes #3578

## Steps to Test

1. Go to the cluster overview page
2. Select a namespace in the dropdown
3. Check network requests in devtools and confirm that the events API call is made with the selected namespace
