### PR TITLE
frontend: resourceMap: Unify network icon with sidebar

### DIFF
--- a/frontend/src/components/resourceMap/sources/definitions/sources.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/sources.tsx
@@ -121,7 +121,14 @@ export function useGetAllSources(): GraphSource[] {
     {
       id: 'network',
       label: 'Network',
-      icon: <Icon icon="mdi:lan" width="100%" height="100%" color={getKindGroupColor('network')} />,
+      icon: (
+        <Icon
+          icon="mdi:folder-network-online"
+          width="100%"
+          height="100%"
+          color={getKindGroupColor('network')}
+        />
+      ),
       sources: [
         makeKubeSource(Service),
         makeKubeSource(Endpoints),


### PR DESCRIPTION
## Summary

This PR fixes an icon inconsistency for the "Network" section by updating the icon used in the resource map filter to match the one used in the sidebar.

## Related Issue

Fixes #3485

## Changes

- Updated the icon for the "Network" group in GraphSources.tsx

- Replaced mdi:lan with mdi:folder-network-online for visual consistency

## Steps to Test

1) Start Headlamp locally

2) Navigate to the Resource Map

3) Confirm that the Network icon in the sidebar and map filter now match visually



## Screenshot

![image](https://github.com/user-attachments/assets/a55ec8d2-7503-4763-8517-ee63b471e61b)
