### PR TITLE
frontend:feat:set Toggle default to false of Timestamps

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -61,7 +61,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
   const { item, onClose, open, ...other } = props;
   const [container, setContainer] = React.useState(getDefaultContainer());
   const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
-  const [showTimestamps, setShowTimestamps] = React.useState<boolean>(true);
+  const [showTimestamps, setShowTimestamps] = React.useState<boolean>(false);
   const [follow, setFollow] = React.useState<boolean>(true);
   const [prettifyLogs, setPrettifyLogs] = React.useState<boolean>(false);
   const [formatJsonValues, setFormatJsonValues] = React.useState<boolean>(false);


### PR DESCRIPTION

## Summary

This PR implements a feature where the toggle is now correctly defaulted to false on initial render. This aligns with the expected behavior in the issue.

## Related Issue

Fixes #3572 

## Changes

- Updated default toggle state in [pod/Details.tsx]

## Steps to Test

1. Navigate to frontend/src/Components/pod/Details.tsx
2. Observe the behaviour of timestamps ToggleState which is default to false now .

## Screenshots (if applicable)
[Screencast from 2025-07-08 01-18-34.webm](https://github.com/user-attachments/assets/ae297d05-f4e3-4e80-92ca-591d7d80245d)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]