### PR TITLE
fix the kind at cr creation template

### DIFF
--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -488,7 +488,7 @@
                     class="MuiBox-root css-ldp2l3"
                   >
                     <button
-                      aria-label="Create mycustomresource"
+                      aria-label="Create MyCustomResource"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -39,7 +39,7 @@
               class="MuiBox-root css-ldp2l3"
             >
               <button
-                aria-label="Create mycustomresource"
+                aria-label="Create MyCustomResource"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"
                 tabindex="0"

--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -128,6 +128,7 @@ class CustomResourceDefinition extends KubeObject<KubeCRD> {
       singularName: this.spec.names.singular,
       pluralName: this.spec.names.plural,
       customResourceDefinition: this,
+      kind: this.spec.names.kind,
     });
   }
 
@@ -141,6 +142,7 @@ export interface CRClassArgs {
     group: string;
     version: string;
   }[];
+  kind: string;
   pluralName: string;
   singularName: string;
   isNamespaced: boolean;
@@ -181,7 +183,7 @@ export function makeCustomResourceClass(
 
   const apiFunc = !!objArgs.isNamespaced ? apiFactoryWithNamespace : apiFactory;
   return class CRClass extends KubeObject<any> {
-    static kind = objArgs.singleName;
+    static kind = crClassArgs.kind;
     static apiName = crClassArgs.pluralName;
     static apiVersion = apiInfoArgs.map(([group, version]) =>
       group ? `${group}/${version}` : version


### PR DESCRIPTION
## Summary

This PR fixes an issue with the auto-generated `kind` field in the Custom Resource (CR) creation template.

## Related Issue

Fixes #3591

## Changes

* Previously, the `kind` value in the generated CR template was being set using the `singular` field from the CRD.
* This behavior has been corrected to use the actual `kind` defined in the CRD.

## Steps to Test

1. Create a CustomResourceDefinition (CRD) where the `kind` and `singular` fields are different.
2. Open the CR creation form for that CRD.
3. Verify that the `kind` value in the YAML template uses the `kind` field from the CRD, not the `singular` one.

## Screenshots

**Before:**

```yaml
apiVersion: school.com/v1
kind: student  # Incorrect: used the 'singular' field
metadata:
  name: ''
```

**After:**

```yaml
apiVersion: school.com/v1
kind: Student  # Correct: uses the actual 'kind' field
metadata:
  name: ''
```
