### PR TITLE
feat(editor): fix bug in save & apply logic

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -480,6 +480,42 @@ export default function EditorDialog(props: EditorDialogProps) {
                   </FormGroup>
                 </Grid>
               </Grid>
+              <Box display="flex" gap={2} pb={2}>
+                <Button variant="outlined" component="label">
+                  Upload YAML
+                  <input
+                    type="file"
+                    accept=".yaml,.yml"
+                    hidden
+                    onChange={async e => {
+                      const file = e.target.files?.[0];
+                      if (file) {
+                        const text = await file.text();
+                        setCode({ code: text, format: 'yaml' });
+                        setError('');
+                      }
+                    }}
+                  />
+                </Button>
+                <Button
+                  variant="outlined"
+                  onClick={async () => {
+                    const url = prompt('Enter URL to load YAML from:');
+                    if (url) {
+                      try {
+                        const res = await fetch(url);
+                        const text = await res.text();
+                        setCode({ code: text, format: 'yaml' });
+                        setError('');
+                      } catch (err) {
+                        setError(`Failed to fetch YAML: ${(err as Error).message}`);
+                      }
+                    }
+                  }}
+                >
+                  Load from URL
+                </Button>
+              </Box>
             </Box>
             {isReadOnly() ? (
               makeEditor()


### PR DESCRIPTION
## Summary

This PR  proicdes the option to add yaml file from local or from url also 
## Related Issue

Fixes #3488 

## Changes 

- Added two buttons:

     1. Upload YAML – lets you choose a .yaml file from your system and loads it into the editor.

     2. Load from URL – lets you paste a link to a YAML file, fetches it, and shows it in the editor.




## Steps to Test

1. Open the YAML editor in the app

2. click on create button

3. Click on load or uplaod yaml

4. file is openend like yaml is loaded save and apply



## Screenshots (if applicable)



https://github.com/user-attachments/assets/df1cd9f6-9b0e-47d6-b491-47b5cb34a8d9


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
