### PR TITLE
Accessibility [FastPass]: Fix FastPass ARIA checks for cluster page in settings

### DIFF
--- a/frontend/src/components/App/Settings/NodeShellSettings.tsx
+++ b/frontend/src/components/App/Settings/NodeShellSettings.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Icon } from '@iconify/react';
+import { Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
@@ -49,6 +50,8 @@ export default function NodeShellSettings(props: SettingsProps) {
   const [userNamespace, setUserNamespace] = useState('');
   const [userImage, setUserImage] = useState('');
   const [userIsEnabled, setUserIsEnabled] = useState<boolean | null>(null);
+
+  const nodeShellLabelID = 'node-shell-enabled-label';
 
   useEffect(() => {
     setClusterSettings(!!cluster ? loadClusterSettings(cluster || '') : null);
@@ -178,9 +181,10 @@ export default function NodeShellSettings(props: SettingsProps) {
       <NameValueTable
         rows={[
           {
-            name: 'Enable Node Shell',
+            name: <Typography id={nodeShellLabelID}>Enable Node Shell</Typography>,
             value: (
               <Switch
+                inputProps={{ 'aria-labelledby': nodeShellLabelID }}
                 checked={userIsEnabled ?? true}
                 onChange={e => {
                   const newEnabled = e.target.checked;

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -407,6 +407,9 @@ export default function SettingsCluster() {
     );
   }
 
+  const defaultNamespaceLabelID = 'default-namespace-label';
+  const allowedNamespaceLabelID = 'allowed-namespace-label';
+
   return (
     <>
       <SectionBox title={t('translation|Cluster Settings')} backLink>
@@ -488,6 +491,7 @@ export default function SettingsCluster() {
           rows={[
             {
               name: t('translation|Default namespace'),
+              nameID: defaultNamespaceLabelID,
               value: (
                 <TextField
                   onChange={event => {
@@ -496,6 +500,7 @@ export default function SettingsCluster() {
                     setUserDefaultNamespace(value);
                   }}
                   value={userDefaultNamespace}
+                  aria-labelledby={defaultNamespaceLabelID}
                   placeholder={defaultNamespace}
                   error={!isValidDefaultNamespace}
                   helperText={
@@ -523,7 +528,11 @@ export default function SettingsCluster() {
               ),
             },
             {
-              name: t('translation|Allowed namespaces'),
+              name: (
+                <Typography id={allowedNamespaceLabelID}>
+                  {t('translation|Allowed namespaces')}
+                </Typography>
+              ),
               value: (
                 <>
                   <TextField
@@ -581,7 +590,6 @@ export default function SettingsCluster() {
                       },
                       marginTop: theme.spacing(1),
                     }}
-                    aria-label={t('translation|Allowed namespaces')}
                   >
                     {((clusterSettings || {}).allowedNamespaces || []).map(namespace => (
                       <Chip

--- a/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
@@ -32,7 +32,12 @@
           <dt
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
           >
-            Enable Node Shell
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              id="node-shell-enabled-label"
+            >
+              Enable Node Shell
+            </p>
           </dt>
           <dd
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
@@ -44,6 +49,7 @@
                 class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-1emuodk-MuiButtonBase-root-MuiSwitch-switchBase"
               >
                 <input
+                  aria-labelledby="node-shell-enabled-label"
                   checked=""
                   class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
                   type="checkbox"


### PR DESCRIPTION
## Summary

This PR fixes accessibility related issues for the settings page, mainly just the issues found by FastPass on the "Cluster' tab. 

These changes are part of a larger accessibility compliance goal from ADO.

Issues are found using FastPass automated checks, feel free to download the tool and doublecheck if interested.


## Changes

These aria labels are now added to the settings view

- Add aria labelled by for 'Allowed Namespace' name label and input
- Add aria labelled for 'Enable Node Shell'

## Notes
related to issue https://github.com/kubernetes-sigs/headlamp/pull/3542

## FastPass fixes

### Issue for `Allowed namespaces`

<img width="1916" height="832" alt="image" src="https://github.com/user-attachments/assets/6ca01f76-2759-40ed-bb6e-eaa8065f14e8" />

<img width="1623" height="424" alt="image" src="https://github.com/user-attachments/assets/5b10069a-7631-41c6-b018-1c1e3101fc4d" />


### Issue for `Enable Node Shell`

<img width="1916" height="833" alt="image" src="https://github.com/user-attachments/assets/0e26ccb3-d1dd-4702-9d8c-29aceb68ae37" />

<img width="1627" height="539" alt="image" src="https://github.com/user-attachments/assets/a0b5b7b7-d2d1-46da-8134-219eb69640d1" />


