### PR TITLE
fix: improve config parse tests with env and args variations

### DIFF
--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -9,109 +9,153 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:funlen
-func TestParse(t *testing.T) {
-	t.Run("no_args_no_env", func(t *testing.T) {
-		conf, err := config.Parse(nil)
-		require.NoError(t, err)
-		require.NotNil(t, conf)
+func TestParseBasic(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		verify func(*testing.T, *config.Config)
+	}{
+		{
+			name: "no_args_no_env",
+			args: []string{"go run ./cmd", "-in-cluster"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, false, conf.DevMode)
+				assert.Equal(t, "", conf.ListenAddr)
+				assert.Equal(t, uint(4466), conf.Port)  
+				assert.Equal(t, "profile,email", conf.OidcScopes)
+			},
+		},
+		{
+			name: "with_args",
+			args: []string{"go run ./cmd", "--port=3456", "-in-cluster", "--oidc-client-id=test", "--oidc-idp-issuer-url=https://example.com"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, uint(3456), conf.Port)
+			},
+		},
+	}
 
-		assert.Equal(t, false, conf.DevMode)
-		assert.Equal(t, "", conf.ListenAddr)
-		assert.Equal(t, uint(4466), conf.Port)
-		assert.Equal(t, "profile,email", conf.OidcScopes)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			require.NotNil(t, conf)
 
-	t.Run("with_args", func(t *testing.T) {
-		args := []string{
-			"go run ./cmd", "--port=3456",
-		}
-		conf, err := config.Parse(args)
-		require.NoError(t, err)
-		require.NotNil(t, conf)
+			tt.verify(t, conf)
+		})
+	}
+}
 
-		assert.Equal(t, uint(3456), conf.Port)
-	})
+func TestParseWithEnv(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		env    map[string]string
+		verify func(*testing.T, *config.Config)
+	}{
+		{
+			name: "from_env",
+			args: []string{"go run ./cmd", "-in-cluster"},
+			env: map[string]string{
+				"HEADLAMP_CONFIG_OIDC_CLIENT_SECRET": "superSecretBotsStayAwayPlease",
+			},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, "superSecretBotsStayAwayPlease", conf.OidcClientSecret)
+			},
+		},
+		{
+			name: "both_args_and_env",
+			args: []string{"go run ./cmd", "-in-cluster", "--port=9876"},
+			env: map[string]string{
+				"HEADLAMP_CONFIG_PORT": "1234",
+			},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.NotEqual(t, uint(1234), conf.Port)
+				assert.Equal(t, uint(9876), conf.Port)
+			},
+		},
+		{
+			name: "kubeconfig_from_default_env",
+			args: []string{"go run ./cmd"}, 
+			env: map[string]string{
+				"KUBECONFIG": "~/.kube/test_config.yaml",
+			},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, "~/.kube/test_config.yaml", conf.KubeConfigPath)
+			},
+		},
+		
+	}
 
-	t.Run("from_env", func(t *testing.T) {
-		os.Setenv("HEADLAMP_CONFIG_OIDC_CLIENT_SECRET", "superSecretBotsStayAwayPlease")
-		defer os.Unsetenv("HEADLAMP_CONFIG_OIDC_CLIENT_SECRET")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.env {
+				os.Setenv(key, value)
+			}
+			defer func(env map[string]string) {
+				for key := range env {
+					os.Unsetenv(key)
+				}
+			}(tt.env)
 
-		args := []string{
-			"go run ./cmd", "-in-cluster",
-		}
-		conf, err := config.Parse(args)
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			require.NotNil(t, conf)
 
-		require.NoError(t, err)
-		require.NotNil(t, conf)
+			tt.verify(t, conf)
+		})
+	}
+}
 
-		assert.Equal(t, "superSecretBotsStayAwayPlease", conf.OidcClientSecret)
-	})
+func TestParseErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		errorContains string
+	}{
+		{
+			name:          "oidc_settings_without_incluster",
+			args:          []string{"go run ./cmd", "--oidc-client-id=noClient"},
+			errorContains: "are only meant to be used in inCluster mode",
+		},
+		{
+			name:          "invalid_base_url",
+			args:          []string{"go run ./cmd", "--base-url=testingthis"},
+			errorContains: "base-url",
+		},
+	}
 
-	t.Run("both_args_and_env", func(t *testing.T) {
-		os.Setenv("HEADLAMP_CONFIG_PORT", "1234")
-		defer os.Unsetenv("HEADLAMP_CONFIG_PORT")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.Error(t, err)
+			require.Nil(t, conf)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+}
 
-		args := []string{
-			"go run ./cmd", "--port=9876",
-		}
-		conf, err := config.Parse(args)
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		verify func(*testing.T, *config.Config)
+	}{
+		{
+			name: "enable_dynamic_clusters",
+			args: []string{"go run ./cmd", "--enable-dynamic-clusters", "-in-cluster"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, true, conf.EnableDynamicClusters)
+			},
+		},
+	}
 
-		require.NoError(t, err)
-		require.NotNil(t, conf)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			require.NotNil(t, conf)
 
-		assert.NotEqual(t, uint(1234), conf.Port)
-		assert.Equal(t, uint(9876), conf.Port)
-	})
-
-	t.Run("oidc_settings_without_incluster", func(t *testing.T) {
-		args := []string{
-			"go run ./cmd", "-oidc-client-id=noClient",
-		}
-		conf, err := config.Parse(args)
-
-		require.Error(t, err)
-		require.Nil(t, conf)
-
-		assert.Contains(t, err.Error(), "are only meant to be used in inCluster mode")
-	})
-
-	t.Run("invalid_base_url", func(t *testing.T) {
-		args := []string{
-			"go run ./cmd", "--base-url=testingthis",
-		}
-		conf, err := config.Parse(args)
-
-		require.Error(t, err)
-		require.Nil(t, conf)
-
-		assert.Contains(t, err.Error(), "base-url")
-	})
-
-	t.Run("kubeconfig_from_default_env", func(t *testing.T) {
-		os.Setenv("KUBECONFIG", "~/.kube/test_config.yaml")
-		defer os.Unsetenv("KUBECONFIG")
-
-		args := []string{
-			"go run ./cmd",
-		}
-		conf, err := config.Parse(args)
-
-		require.NoError(t, err)
-		require.NotNil(t, conf)
-
-		assert.Equal(t, conf.KubeConfigPath, "~/.kube/test_config.yaml")
-	})
-
-	t.Run("enable_dynamic_clusters", func(t *testing.T) {
-		args := []string{
-			"go run ./cmd", "--enable-dynamic-clusters",
-		}
-		conf, err := config.Parse(args)
-
-		require.NoError(t, err)
-		require.NotNil(t, conf)
-
-		assert.Equal(t, true, conf.EnableDynamicClusters)
-	})
+			tt.verify(t, conf)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

This PR fixes test failures in the config package by improving the environment and argument parsing logic within the test cases.

## Related Issue

Fixes #3287

## Changes

- Updated test cases to include -in-cluster where required

- Added environment setup and teardown for reliable test behavior

- Adjusted test expectations for KUBECONFIG and OIDC-related flags

## Steps to Test

1. Run go test ./pkg/config

2. Ensure all tests pass without errors

3. Verify behavior with different env vars or args manually if needed

## Screenshots (if applicable)


![image](https://github.com/user-attachments/assets/99e4be96-6fa0-46e9-9038-0c44c64ef4af)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
