### PR TITLE
ci: Fix credentials for nightly build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_IMAGES }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1


### PR DESCRIPTION
Uses automatically generated GITHUB_TOKEN secret for the workflow. Tested with a manual trigger [here](https://github.com/sniok/headlamp-o/actions/runs/16138765486). 