### PR TITLE
frontend: pod logs: fix JSON prettify for entries with timestamp prefix

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -106,7 +106,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
         xtermRef.current?.write(
           displayLogs
             .slice(current.lastLineShown + 1)
-            .join('')
+            .join('\n')
             .replaceAll('\n', '\r\n')
         );
       }

--- a/frontend/src/components/pod/jsonHandling.ts
+++ b/frontend/src/components/pod/jsonHandling.ts
@@ -18,19 +18,26 @@ export const ANSI_BLUE = '\x1b[34m';
 export const ANSI_GREEN = '\x1b[32m';
 export const ANSI_RESET = '\x1b[0m';
 
-/**
- * Colorizes a JSON log entry with ANSI color codes for better readability.
- * @param logEntry - The log entry to colorize
- * @returns The colorized log entry string
- */
+function stripTimestampPrefix(line: string): string {
+  const timestampRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*/;
+  return line.replace(timestampRegex, '').trim();
+}
+
 export function colorizePrettifiedLog(logEntry: string): string {
+  const cleaned = stripTimestampPrefix(logEntry);
+
   try {
-    return logEntry
-      .replace(/"([^"]+)":/g, `${ANSI_BLUE}"$1"${ANSI_RESET}:`) // Color JSON keys
-      .replace(/: "([^"]+)"/g, `: ${ANSI_GREEN}"$1"${ANSI_RESET}`) // Color string values
-      .replace(/: (-?\d*\.?\d+)/g, `: ${ANSI_GREEN}$1${ANSI_RESET}`) // Color numeric values (integers and floats)
-      .replace(/: (true|false|null)/g, `: ${ANSI_GREEN}$1${ANSI_RESET}`); // Color boolean/null
-  } catch {
+    const parsed = JSON.parse(cleaned);
+    const pretty = JSON.stringify(parsed, null, 2);
+
+    return (
+      pretty
+        .replace(/"([^"]+)":/g, `${ANSI_BLUE}"$1"${ANSI_RESET}:`) // Keys
+        .replace(/: "([^"]*)"/g, `: ${ANSI_GREEN}"$1"${ANSI_RESET}`) // String values
+        .replace(/: (-?\d+(?:\.\d+)?)/g, `: ${ANSI_GREEN}$1${ANSI_RESET}`) // Numbers
+        .replace(/: (true|false|null)/g, `: ${ANSI_GREEN}$1${ANSI_RESET}`) + '\n' // Booleans/null with newline
+    );
+  } catch (e) {
     return logEntry;
   }
 }


### PR DESCRIPTION
## Summary

This Pr fixes inconsistent behavior of the Prettify toggle in the Pod logs view by improving how log lines with leading ISO 8601 timestamps are handled. Previously, these timestamps caused JSON parsing failures, preventing some log entries from being prettified.

## Related Issue

Fixes #3421  

## Changes

- Added stripTimestampPrefix() to remove ISO 8601 timestamps (for ex- 2025-07-08T19:23:09.294667423Z) before attempting to parse log lines as JSON.
- Used JSON.parse() followed by JSON.stringify() with indentation to improve JSON readability.
- Applied ANSI color codes:
  - JSON keys are colored blue.
- Ensured logs are joined using \n for consistent formatting.
- Fallback to original log line if JSON parsing fails to prevent any rendering issues.

## Steps to Test

1. Navigate to Workloads and then Pods 
2. Click the pod and open the Logs view.
3. Enable the Prettify toggle.
4. Observe that logs containing leading timestamps are now correctly prettified and colorized.
5. Confirm that malformed logs or non-JSON lines still appear without breaking the log viewer.
