### PR TITLE
frontend: Pod: Add tooltip for requests and limits

### DIFF
--- a/frontend/src/components/common/Tooltip/TooltipIcon.tsx
+++ b/frontend/src/components/common/Tooltip/TooltipIcon.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import TooltipLight from './TooltipLight';
 
 export interface TooltipIconProps {
-  children: string;
+  children: string | React.ReactNode;
   /** A materialui/core icon. */
   icon?: IconProps['icon'];
 }

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -1124,12 +1124,28 @@
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lm23yi-MuiTableCell-root"
               >
-                16.32 m
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <span
+                    style="white-space: nowrap;"
+                  >
+                    16.32 m
+                  </span>
+                </div>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-rrz0sj-MuiTableCell-root"
               >
-                46.4 Mi
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <span
+                    style="white-space: nowrap;"
+                  >
+                    46.4 Mi
+                  </span>
+                </div>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Anhängen",
   "Restarts": "Neustarts",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (vor {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nominierte Node",
   "Readiness Gates": "Bereitschaftstore",
   "Pod Disruption Budget": "Budget für Pod Disruption",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Attach",
   "Restarts": "Restarts",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} ago)",
+  "Request": "Request",
+  "Limit": "Limit",
   "Nominated Node": "Nominated Node",
   "Readiness Gates": "Readiness Gates",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Adjuntar",
   "Restarts": "Reinicios",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (hace {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nodo Nominado",
   "Readiness Gates": "Readiness Gates",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Attacher",
   "Restarts": "Redémarrages",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (il y a {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nœud nommé",
   "Readiness Gates": "Portes de disponibilité",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "अटैच",
   "Restarts": "रीस्टार्ट",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} पहले)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "नामांकित नोड",
   "Readiness Gates": "रेडीनेस गेट्स",
   "Pod Disruption Budget": "Pod डिसरप्शन बजट",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Collega",
   "Restarts": "Riavvii",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} fa)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nodo Nominato",
   "Readiness Gates": "Readiness Gate",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "アタッチ",
   "Restarts": "再起動",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 前)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "指名ノード",
   "Readiness Gates": "準備ゲート",
   "Pod Disruption Budget": "ポッド中断バジェット",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "연결",
   "Restarts": "재시작",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 전)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "할당된 노드",
   "Readiness Gates": "준비 상태 게이트",
   "Pod Disruption Budget": "파드 중단 예산",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Anexar",
   "Restarts": "Reinícios",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (há {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Node Nomeado",
   "Readiness Gates": "Portais de Prontidão",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "இணை",
   "Restarts": "மறுதொடக்கம்",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} முன்பு)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "நாமினேடட் நோட்",
   "Readiness Gates": "ரெடினெஸ் கேட்ஸ்",
   "Pod Disruption Budget": "பாட் டிஸ்ரப்ஷன் பட்ஜெட்",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "附加",
   "Restarts": "重啟",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 前)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "提名節點",
   "Readiness Gates": "就緒閘道",
   "Pod Disruption Budget": "Pod 中斷預算",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "附加",
   "Restarts": "重启",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 前)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "提名节点",
   "Readiness Gates": "就绪网关",
   "Pod Disruption Budget": "Pod 中断预算",


### PR DESCRIPTION
This change adds a tooltip to display requests and limits values for pods, if provided. This will improve resource tracking for individual pods in real time.

### Testing
- [X] Go to the "Pods" page in Headlamp
- [X] Navigate to a pod with resource requests and/or limits specified
- [X] Ensure that a tooltip displaying the values appears

<img width="576" height="513" alt="image" src="https://github.com/user-attachments/assets/322b43cd-2709-47df-b244-6ee35e21a17c" />