### PR TITLE
add air file for automatic reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 backend/headlamp-server
 backend/headlamp-server.exe
+backend/bin
 backend/tools
 backend/coverage.out
 app/electron/src/*

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,10 @@ else
 	@cmd /c "set HEADLAMP_BACKEND_TOKEN=headlamp&& set HEADLAMP_CONFIG_ENABLE_HELM=true&& set HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS=true&& backend\headlamp-server -dev -proxy-urls https://artifacthub.io/* -listen-addr=localhost"
 endif
 
+run-dev:
+	@echo "Starting Headlamp backend in dev mode with Air..."
+	cd backend && air
+
 run-backend-with-metrics:
 	@echo "**** Running backend with Prometheus metrics enabled ****"
 ifeq ($(UNIXSHELL),true)

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,0 +1,37 @@
+
+root = "."
+tmp_dir = "bin"
+
+[build]
+  cmd = "go build -o ./bin/headlamp-server ./cmd"
+  bin = "bin/headlamp-server"
+  full_bin = ""
+  include_ext = ["go"]
+  exclude_dir = [ "bin"]
+  include_dir = []
+  exclude_file = []
+  delay = 1000
+  stop_on_error = true
+  log = "air_errors.log"
+
+
+[log]
+  time = false
+
+[color]
+  main = "magenta"
+  watcher = "cyan"
+  build = "yellow"
+  runner = "green"
+
+[env]
+  HEADLAMP_BACKEND_TOKEN = "headlamp"
+  HEADLAMP_CONFIG_ENABLE_HELM = "true"
+  HEADLAMP_CONFIG_ENABLE_DYNAMIC_CLUSTERS = "true"
+
+[run]
+  args = ["-dev", "-proxy-urls", "https://artifacthub.io/*", "-listen-addr=localhost"]
+
+[misc]
+  clean_on_exit = true 
+


### PR DESCRIPTION
## Summary

This PR adds hot-reload support for the Headlamp backend using the [Air](https://github.com/cosmtrek/air) tool, which improves the developer experience by automatically rebuilding and restarting the server when Go files are changed.

## Related Issue

Fixes #3621

## Changes

- Added `.air.toml` configuration file for Air in the `backend/` directory
- Added `run-dev` target to `Makefile` for running the backend with hot reload


## Steps to Test

1. Navigate to the project root
2. Run `make run-dev`
3. Modify any `.go` file in the `backend/` folder
4. Observe that the backend automatically rebuilds and restarts with updated code

## Screenshots (if applicable)

<img width="421" height="194" alt="image" src="https://github.com/user-attachments/assets/9589ba09-9275-495f-ac90-295ed6d3fa50" />


## Notes for the Reviewer

- This is a development-only change and does not affect production behavior.
- it will create a bin folder to store the binary created by air file and it will automatically be deleted after termination
