### PR TITLE
frontend:fix the overflow taints node table

### DIFF
--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -875,7 +875,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16qg0bt-MuiTableCell-root"
                 >
                   <div
-                    class="MuiBox-root css-am63uh"
+                    class="MuiBox-root css-15e19qo"
                   />
                 </td>
                 <td
@@ -1003,7 +1003,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16qg0bt-MuiTableCell-root"
                 >
                   <div
-                    class="MuiBox-root css-am63uh"
+                    class="MuiBox-root css-15e19qo"
                   />
                 </td>
                 <td

--- a/frontend/src/components/node/utils.tsx
+++ b/frontend/src/components/node/utils.tsx
@@ -26,8 +26,10 @@ const WrappingBox = styled(Box)(({ theme }) => ({
   display: 'flex',
   justifyContent: 'left',
   flexWrap: 'wrap',
+  overflow: 'hidden',
   '& > *': {
-    margin: theme.spacing(0.5),
+    marginRight: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
   },
 }));
 


### PR DESCRIPTION
## Summary

This PR fixes the overflow issue for taints at the node table .

## Related Issue

Fixes #3634   

## Changes

- updates the taint chip css 

## Steps to Test

1. Navigate to nodes under the cluster tab 
2.  and notice the taint field at the table 

## Screenshots (if applicable)
# before

<img width="1418" height="568" alt="Image" src="https://github.com/user-attachments/assets/c9312442-1d8c-4fcb-b731-46ece9899c30" />

# after 
<img width="1158" height="446" alt="image" src="https://github.com/user-attachments/assets/be808104-67d2-4289-9c19-932b585c7e05" />



## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
