### PR TITLE
frontend: Add missing onClose handlers for EditDialog activities

### DIFF
--- a/frontend/src/components/advancedSearch/ResourceSearch.tsx
+++ b/frontend/src/components/advancedSearch/ResourceSearch.tsx
@@ -306,13 +306,20 @@ function ViewYaml({ item }: { item: KubeObject }) {
         variant="contained"
         color="secondary"
         onClick={() => {
+          const id = 'view-yaml-' + item.metadata.uid;
           Activity.launch({
-            id: 'view-yaml-' + item.metadata.uid,
+            id,
             location: 'full',
             icon: <KubeIcon kind={item.kind} />,
             title: item.kind + ': ' + item.metadata.name,
             content: (
-              <EditorDialog noDialog open item={item.jsonData} onClose={() => {}} onSave={null} />
+              <EditorDialog
+                noDialog
+                open
+                item={item.jsonData}
+                onClose={() => Activity.close(id)}
+                onSave={null}
+              />
             ),
           });
         }}

--- a/frontend/src/components/common/Resource/CreateButton.tsx
+++ b/frontend/src/components/common/Resource/CreateButton.tsx
@@ -54,8 +54,9 @@ export default function CreateButton(props: CreateButtonProps) {
   }, [clusters]);
 
   const openActivity = () => {
+    const id = 'create-button';
     Activity.launch({
-      id: 'create-button',
+      id: id,
       title: t('translation|Create / Apply'),
       icon: <Icon icon="mdi:pencil" />,
       content: (
@@ -63,7 +64,7 @@ export default function CreateButton(props: CreateButtonProps) {
           item={itemRef.current}
           open
           noDialog
-          onClose={() => {}}
+          onClose={() => Activity.close(id)}
           setOpen={() => {}}
           saveLabel={t('translation|Apply')}
           errorMessage={errorMessage}

--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -125,8 +125,9 @@ export default function EditButton(props: EditButtonProps) {
         description={t('translation|Edit')}
         buttonStyle={buttonStyle}
         onClick={() => {
+          const id = 'edit-' + item.metadata.uid;
           Activity.launch({
-            id: 'edit-' + item.metadata.uid,
+            id: id,
             title: t('translation|Edit') + ': ' + item.metadata.name,
             icon: <Icon icon="mdi:pencil" />,
             cluster: item.cluster,
@@ -135,7 +136,7 @@ export default function EditButton(props: EditButtonProps) {
                 noDialog
                 item={item.getEditableObject()}
                 open
-                onClose={() => {}}
+                onClose={() => Activity.close(id)}
                 onSave={handleSave}
                 allowToHideManagedFields
                 errorMessage={errorMessage}


### PR DESCRIPTION
I missed a couple of onClose handlers.
Without `open` state and the Popup they were generally not needed but I forgot about the close button on the bottom right.

### How to test

Click "Create Resource" on the bottom left
Then close it using the close button on the bottom right