### PR TITLE
frontend: Table: Include filter value for memoization

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -456,6 +456,7 @@ export default function Table<RowItem extends Record<string, any>>({
                 sorting={header.column.getIsSorted()}
                 showColumnFilters={table.getState().showColumnFilters}
                 selected={table.getSelectedRowModel().flatRows.length}
+                filterValue={header.column.getFilterValue()}
               />
             ))}
           </StyledHeadRow>
@@ -487,6 +488,7 @@ const MemoHeadCell = memo(
     isFiltered: boolean;
     selected: number;
     showColumnFilters: boolean;
+    filterValue: any;
   }) => {
     return (
       <MRT_TableHeadCell
@@ -503,7 +505,8 @@ const MemoHeadCell = memo(
     a.sorting === b.sorting &&
     a.isFiltered === b.isFiltered &&
     a.showColumnFilters === b.showColumnFilters &&
-    (a.header.column.id === 'mrt-row-select' ? a.selected === b.selected : true)
+    (a.header.column.id === 'mrt-row-select' ? a.selected === b.selected : true) &&
+    a.filterValue === b.filterValue
 );
 
 const Row = memo(


### PR DESCRIPTION
This fixes weird behavior when typing anything in the column filter value.

Due to internal handling of the input (multiple sources of truth, sync and debouncing) we cannot efficiently render header cell and have rerender the whole component on each update to the filter value.

fixes #3552

## Steps to Test

1. Go to any table
2. Open column filter
3. Slowly type anything
4. Filter value should appear as you type without any dropped characters
