### PR TITLE
frontend: Fix height for DocsViewer

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -480,15 +480,7 @@ export default function EditorDialog(props: EditorDialogProps) {
               {
                 label: t('translation|Documentation'),
                 component: (
-                  <Box
-                    p={2}
-                    sx={{
-                      overflowY: 'auto',
-                      overflowX: 'hidden',
-                    }}
-                    maxHeight={600}
-                    height={600}
-                  >
+                  <Box sx={{ height: '100%', overflowY: 'auto' }}>
                     <DocsViewer docSpecs={docSpecs} />
                   </Box>
                 ),

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -203,7 +203,7 @@
             role="tabpanel"
           >
             <div
-              class="MuiBox-root css-94bk7g"
+              class="MuiBox-root css-u718rw"
             >
               <div
                 class="MuiBox-root css-19midj6"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -239,7 +239,7 @@
             role="tabpanel"
           >
             <div
-              class="MuiBox-root css-94bk7g"
+              class="MuiBox-root css-u718rw"
             >
               <div
                 class="MuiBox-root css-19midj6"


### PR DESCRIPTION
Removed hardcoded height that was causing issues on smaller screens

Fixes #3551 

### How to test

1. Open documentation in the EditorDialog on a screen will small height <~700-800px
2. Open details and scroll down
3. Everything should be visible and within the screen

See original issue for more details
