### PR TITLE
frontend:fix the edit and view yml editor close button to close that activity

### DIFF
--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -125,9 +125,8 @@ export default function EditButton(props: EditButtonProps) {
         description={t('translation|Edit')}
         buttonStyle={buttonStyle}
         onClick={() => {
-          const id = 'edit-' + item.metadata.uid;
           Activity.launch({
-            id: id,
+            id: activityId,
             title: t('translation|Edit') + ': ' + item.metadata.name,
             icon: <Icon icon="mdi:pencil" />,
             cluster: item.cluster,
@@ -136,7 +135,7 @@ export default function EditButton(props: EditButtonProps) {
                 noDialog
                 item={item.getEditableObject()}
                 open
-                onClose={() => Activity.close(id)}
+                onClose={() => Activity.close(activityId)}
                 onSave={handleSave}
                 allowToHideManagedFields
                 errorMessage={errorMessage}

--- a/frontend/src/components/common/Resource/ViewButton.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.tsx
@@ -32,10 +32,11 @@ export interface ViewButtonProps {
 
 function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
   const { t } = useTranslation();
+  const activityId = 'yaml-' + item.metadata.uid;
 
   const launchActivity = () => {
     Activity.launch({
-      id: 'yaml-' + item.metadata.uid,
+      id: activityId,
       title: item.metadata.name,
       cluster: item.cluster,
       icon: <Icon icon="mdi:eye" />,
@@ -46,7 +47,7 @@ function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
           item={item.jsonData}
           open
           allowToHideManagedFields
-          onClose={() => {}}
+          onClose={() => Activity.close(activityId)}
           onSave={null}
         />
       ),


### PR DESCRIPTION
## Summary
This PR fixes the close button in the editor component to close the activity with the close button ..

## Related Issue

Fixes #3654 

## Changes

- Change both the button components in the close function to close the activity with the close button

## Steps to Test

1. Select any resource and tap on the View YAML/edit button.
2. And try to close with the close button 



# note 
- The edit button issue was already resolved by someone else before I pulled the latest changes. However, this PR fixes the view button functionality.
- For the edit functionality, I used the already initialized activityId instead of reinitializing id.