### PR TITLE
chore(docs): brew `--no-quarantine` kludge to resolve bad sig/corrupt binary error

### DIFF
--- a/docs/installation/desktop/mac-installation.md
+++ b/docs/installation/desktop/mac-installation.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 Once you have the [Homebrew package manager](https://brew.sh/) itself installed, you can install the latest Headlamp release by running the following command:
 
 ```sh
-brew install --cask headlamp
+brew install --cask --no-quarantine headlamp
 ```
 
 ### Upgrading


### PR DESCRIPTION
## Summary

Adds `--no-quarantine` to the brew install command so that new users aren't confounded by corrupt binary errors (due to bad signature).

## Related Issue

#3655