### PR TITLE
fix: update extraManifests example

### DIFF
--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -254,13 +254,15 @@ pluginsManager:
 
 # -- Additional Kubernetes manifests to be deployed. Include the manifest as nested YAML.
 extraManifests: []
-# - apiVersion: v1
+# - |
+#   apiVersion: v1
 #   kind: ConfigMap
 #   metadata:
 #     name: my-config
 #   data:
 #     key: value
-# - apiVersion: v1
+# - |
+#   apiVersion: v1
 #   kind: ConfigMap
 #   metadata:
 #     name: my-config-too


### PR DESCRIPTION
## Summary

extraManifests example was not working properly, it failed with this error

Error: values don't meet the specifications of the schema(s) in the following chart(s): headlamp:
- extraManifests.0: Invalid type. Expected: string, given: object

