### PR TITLE
frontend: Fix portforwarding to a pod when not in a cluster

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -677,11 +677,20 @@ export function LivenessProbes(props: { liveness: KubeContainer['livenessProbe']
   );
 }
 
-export interface ContainerInfoProps {
+/** @deprecated Please use `ContainerInfoKubeObjectProps` for better type safety */
+export interface ContainerInfoLegacyProps {
   container: KubeContainer;
   resource: KubeObjectInterface | null;
   status?: Omit<KubePod['status']['KubeContainerStatus'], 'name'>;
 }
+
+export interface ContainerInfoKubeObjectProps {
+  container: KubeContainer;
+  resource: KubeObject | null;
+  status?: Omit<KubePod['status']['KubeContainerStatus'], 'name'>;
+}
+
+export type ContainerInfoProps = ContainerInfoKubeObjectProps | ContainerInfoLegacyProps;
 
 export function ContainerInfo(props: ContainerInfoProps) {
   const { container, status, resource } = props;

--- a/frontend/src/components/daemonset/Details.tsx
+++ b/frontend/src/components/daemonset/Details.tsx
@@ -125,7 +125,7 @@ export default function DaemonSetDetails(props: {
         },
         {
           id: 'headlamp.daemonset-containers',
-          section: <ContainersSection resource={item?.jsonData} />,
+          section: <ContainersSection resource={item} />,
         },
       ]}
     />

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -686,7 +686,7 @@ export default function PodDetails(props: PodDetailsProps) {
           },
           {
             id: 'headlamp.pod-containers',
-            section: <ContainersSection resource={item?.jsonData} />,
+            section: <ContainersSection resource={item} />,
           },
           {
             id: 'headlamp.pod-volumes',

--- a/frontend/src/components/statefulset/Details.tsx
+++ b/frontend/src/components/statefulset/Details.tsx
@@ -61,7 +61,7 @@ export default function StatefulSetDetails(props: {
           },
           {
             id: 'headlamp.statefulset-containers',
-            section: <ContainersSection resource={item?.jsonData} />,
+            section: <ContainersSection resource={item} />,
           },
         ]
       }

--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -150,7 +150,7 @@ export default function WorkloadDetails<T extends WorkloadClass>(props: Workload
           },
           {
             id: 'headlamp.workload-containers',
-            section: <ContainersSection resource={item?.jsonData} />,
+            section: <ContainersSection resource={item} />,
           },
         ]
       }


### PR DESCRIPTION
## Summary

When opening a pod, navigating to a different or to a no-cluster view, and attempting to portforwarding that pod, this action was failing because the cluster context was taken from whatever was in the URL at that moment and that was none. This patch fixes that by relying on the resource's cluster or the initial one.

## Related Issue

Fixes #3668 

## Steps to Test

Check the issue.
