### PR TITLE
Accessibility [FastPass]: Fix contrast for cluster error message text on all themes

### DIFF
--- a/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
+++ b/frontend/src/components/cluster/ClusterGroupErrorMessage.tsx
@@ -18,6 +18,7 @@ import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import { useTheme } from '@mui/material/styles';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelectedClusters } from '../../lib/k8s';
@@ -39,6 +40,7 @@ export function ClusterGroupErrorMessage({ errors }: ClusterGroupErrorMessagePro
 }
 
 function ErrorMessage({ error }: { error: ApiError }) {
+  const theme = useTheme();
   const { t } = useTranslation();
   const showClusterName = useSelectedClusters().length > 1;
   const [showMessage, setShowMessage] = useState(false);
@@ -73,7 +75,14 @@ function ErrorMessage({ error }: { error: ApiError }) {
         </Button>
       }
     >
-      <AlertTitle sx={{ mb: showMessage ? undefined : 0 }}>{title}</AlertTitle>
+      <AlertTitle
+        sx={{
+          mb: showMessage ? undefined : 0,
+          color: theme.palette.text.primary,
+        }}
+      >
+        {title}
+      </AlertTitle>
       {showMessage && (
         <>
           {showClusterName ? <Box>Cluster: {error.cluster}</Box> : null}

--- a/frontend/src/components/cluster/__snapshots__/ClusterGroupErrorMessage.WithClusterErrors.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterGroupErrorMessage.WithClusterErrors.stories.storyshot
@@ -23,7 +23,7 @@
         class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
       >
         <div
-          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-m946el-MuiTypography-root-MuiAlertTitle-root"
+          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1mny8mx-MuiTypography-root-MuiAlertTitle-root"
         >
           Failed to load resources
         </div>
@@ -66,7 +66,7 @@
         class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
       >
         <div
-          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-m946el-MuiTypography-root-MuiAlertTitle-root"
+          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1mny8mx-MuiTypography-root-MuiAlertTitle-root"
         >
           Failed to load resources
         </div>

--- a/frontend/src/components/cluster/__snapshots__/ClusterGroupErrorMessage.WithMutipleErrorsPerCluster.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterGroupErrorMessage.WithMutipleErrorsPerCluster.stories.storyshot
@@ -23,7 +23,7 @@
         class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
       >
         <div
-          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-m946el-MuiTypography-root-MuiAlertTitle-root"
+          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1mny8mx-MuiTypography-root-MuiAlertTitle-root"
         >
           Failed to load resources
         </div>
@@ -66,7 +66,7 @@
         class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
       >
         <div
-          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-m946el-MuiTypography-root-MuiAlertTitle-root"
+          class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1mny8mx-MuiTypography-root-MuiAlertTitle-root"
         >
           Failed to load resources
         </div>


### PR DESCRIPTION
This PR aims to fix the issues found via FastPass for the cluster error message text not readable across all themes.

Mainly fixes the texts not being able to read easily on dark modes of headlamp, not an issue on light based modes.

## FastPass issues

<img width="1194" height="668" alt="image" src="https://github.com/user-attachments/assets/896b2e3f-c3d3-40d1-a4ba-a845afbfc300" />

<img width="1627" height="517" alt="image" src="https://github.com/user-attachments/assets/2678c5df-3c81-43f0-84e9-82b812cef2ac" />

---

### Before
<img width="1909" height="829" alt="image" src="https://github.com/user-attachments/assets/72265e97-3065-47bb-a11e-7e62c98efebb" />

### After
<img width="1914" height="836" alt="image" src="https://github.com/user-attachments/assets/087b7fee-b88a-418f-ac1f-529b9b92308a" />
