### PR TITLE
frontend: ClusterSelector: Create a separate component for ClusterSel…

### DIFF
--- a/frontend/src/components/App/Settings/ClusterSelector.stories.tsx
+++ b/frontend/src/components/App/Settings/ClusterSelector.stories.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { configureStore } from '@reduxjs/toolkit';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import ClusterSelector, { ClusterSelectorProps } from './ClusterSelector';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    navbar: {
+      background: '#fff',
+    },
+  },
+});
+
+const getMockState = () => ({
+  plugins: { loaded: true },
+  theme: {
+    name: 'light',
+    logo: null,
+    palette: {
+      navbar: {
+        background: '#fff',
+      },
+    },
+  },
+});
+
+export default {
+  title: 'Components/ClusterSelector',
+  component: ClusterSelector,
+} as Meta<typeof ClusterSelector>;
+
+const Template: StoryFn<ClusterSelectorProps> = args => {
+  const store = configureStore({
+    reducer: (state = getMockState()) => state,
+    preloadedState: getMockState(),
+  });
+
+  return (
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <ClusterSelector {...args} />
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  currentCluster: 'dev',
+  clusters: ['dev', 'staging', 'prod'],
+};

--- a/frontend/src/components/App/Settings/ClusterSelector.tsx
+++ b/frontend/src/components/App/Settings/ClusterSelector.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+
+export interface ClusterSelectorProps {
+  currentCluster?: string;
+  clusters: string[];
+}
+
+const ClusterSelector: React.FC<ClusterSelectorProps> = ({ currentCluster = '', clusters }) => {
+  const history = useHistory();
+  const { t } = useTranslation('glossary');
+
+  return (
+    <FormControl variant="outlined" margin="normal" size="small" sx={{ minWidth: 250 }}>
+      <InputLabel id="settings--cluster-selector">{t('glossary|Cluster')}</InputLabel>
+      <Select
+        labelId="settings--cluster-selector"
+        value={currentCluster}
+        onChange={event => {
+          history.replace(`/settings/cluster?c=${event.target.value}`);
+        }}
+        label={t('glossary|Cluster')}
+        autoWidth
+        aria-label={t('glossary|Cluster selector')}
+      >
+        {clusters.map(clusterName => (
+          <MenuItem key={clusterName} value={clusterName}>
+            {clusterName}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default ClusterSelector;

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -17,11 +17,7 @@
 import { Icon, InlineIcon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import FormControl from '@mui/material/FormControl';
 import IconButton from '@mui/material/IconButton';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -46,6 +42,7 @@ import Link from '../../common/Link';
 import Loader from '../../common/Loader';
 import NameValueTable from '../../common/NameValueTable';
 import SectionBox from '../../common/SectionBox';
+import ClusterSelector from './ClusterSelector';
 import NodeShellSettings from './NodeShellSettings';
 import { isValidNamespaceFormat } from './util';
 
@@ -59,39 +56,6 @@ function isValidClusterNameFormat(name: string) {
   // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
   const regex = new RegExp('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$');
   return regex.test(name);
-}
-
-interface ClusterSelectorProps {
-  currentCluster?: string;
-  clusters: string[];
-}
-
-function ClusterSelector(props: ClusterSelectorProps) {
-  const { currentCluster = '', clusters } = props;
-  const history = useHistory();
-  const { t } = useTranslation('glossary');
-
-  return (
-    <FormControl variant="outlined" margin="normal" size="small" sx={{ minWidth: 250 }}>
-      <InputLabel id="settings--cluster-selector">{t('glossary|Cluster')}</InputLabel>
-      <Select
-        labelId="settings--cluster-selector"
-        value={currentCluster}
-        onChange={event => {
-          history.replace(`/settings/cluster?c=${event.target.value}`);
-        }}
-        label={t('glossary|Cluster')}
-        autoWidth
-        aria-label={t('glossary|Cluster selector')}
-      >
-        {clusters.map(clusterName => (
-          <MenuItem key={clusterName} value={clusterName}>
-            {clusterName}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  );
 }
 
 export default function SettingsCluster() {
@@ -360,7 +324,7 @@ export default function SettingsCluster() {
               }
             )}
           </Typography>
-          <ClusterSelector clusters={clusters} />
+          <ClusterSelector currentCluster={cluster} clusters={clusters} />
         </SectionBox>
       </>
     );

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.Default.stories.storyshot
@@ -1,0 +1,59 @@
+<div>
+  <div
+    class="MuiFormControl-root MuiFormControl-marginNormal css-1gtduw2-MuiFormControl-root"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      data-shrink="true"
+      id="settings--cluster-selector"
+    >
+      glossary|Cluster
+    </label>
+    <div
+      aria-label="glossary|Cluster selector"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+    >
+      <div
+        aria-controls=":r0:"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="settings--cluster-selector"
+        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jedpe8-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+        role="combobox"
+        tabindex="0"
+      >
+        cluster-a
+      </div>
+      <input
+        aria-hidden="true"
+        aria-invalid="false"
+        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+        tabindex="-1"
+        value="cluster-a"
+      />
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+        data-testid="ArrowDropDownIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+      <fieldset
+        aria-hidden="true"
+        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+      >
+        <legend
+          class="css-14lo706"
+        >
+          <span>
+            glossary|Cluster
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</div>

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.Default.stories.storyshot
@@ -1,59 +1,61 @@
-<div>
-  <div
-    class="MuiFormControl-root MuiFormControl-marginNormal css-1gtduw2-MuiFormControl-root"
-  >
-    <label
-      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
-      data-shrink="true"
-      id="settings--cluster-selector"
-    >
-      glossary|Cluster
-    </label>
+<body>
+  <div>
     <div
-      aria-label="glossary|Cluster selector"
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+      class="MuiFormControl-root MuiFormControl-marginNormal css-1gtduw2-MuiFormControl-root"
     >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="true"
+        id="settings--cluster-selector"
+      >
+        Cluster
+      </label>
       <div
-        aria-controls=":r0:"
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="settings--cluster-selector"
-        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jedpe8-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-        role="combobox"
-        tabindex="0"
+        aria-label="Cluster selector"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
       >
-        cluster-a
-      </div>
-      <input
-        aria-hidden="true"
-        aria-invalid="false"
-        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-        tabindex="-1"
-        value="cluster-a"
-      />
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
-        data-testid="ArrowDropDownIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M7 10l5 5 5-5z"
-        />
-      </svg>
-      <fieldset
-        aria-hidden="true"
-        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-      >
-        <legend
-          class="css-14lo706"
+        <div
+          aria-controls=":mock-test-id:"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="settings--cluster-selector"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jedpe8-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          role="combobox"
+          tabindex="0"
         >
-          <span>
-            glossary|Cluster
-          </span>
-        </legend>
-      </fieldset>
+          dev
+        </div>
+        <input
+          aria-hidden="true"
+          aria-invalid="false"
+          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          tabindex="-1"
+          value="dev"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          data-testid="ArrowDropDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+        <fieldset
+          aria-hidden="true"
+          class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="css-14lo706"
+          >
+            <span>
+              Cluster
+            </span>
+          </legend>
+        </fieldset>
+      </div>
     </div>
   </div>
-</div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ClusterSelector > matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiFormControl-root MuiFormControl-marginNormal css-1gtduw2-MuiFormControl-root"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      data-shrink="true"
+      id="settings--cluster-selector"
+    >
+      glossary|Cluster
+    </label>
+    <div
+      aria-label="glossary|Cluster selector"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+    >
+      <div
+        aria-controls=":r0:"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="settings--cluster-selector"
+        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jedpe8-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+        role="combobox"
+        tabindex="0"
+      >
+        dev
+      </div>
+      <input
+        aria-hidden="true"
+        aria-invalid="false"
+        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+        tabindex="-1"
+        value="dev"
+      />
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+        data-testid="ArrowDropDownIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+      <fieldset
+        aria-hidden="true"
+        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+      >
+        <legend
+          class="css-14lo706"
+        >
+          <span>
+            glossary|Cluster
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
@@ -61,3 +61,4 @@ exports[`ClusterSelector > matches snapshot 1`] = `
   </div>
 </div>
 `;
+

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
@@ -61,4 +61,3 @@ exports[`ClusterSelector > matches snapshot 1`] = `
   </div>
 </div>
 `;
-

--- a/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
@@ -75,7 +75,7 @@
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-14f1a7d-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
-                  aria-describedby=":r18:-helper-text"
+                  aria-describedby=":r19:-helper-text"
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
@@ -121,7 +121,7 @@
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-8secpz-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
-                  aria-describedby=":r19:-helper-text"
+                  aria-describedby=":r1a:-helper-text"
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"


### PR DESCRIPTION
## Summary

This PR adds/fixes [feature/bug] by [brief description of what the change does]. 

This PR tries to create a separate component for ClusterSelector and reuse it inside SettingsCluster. Why separate ClusterSelector into its own component?
Reusability:
We're already using <ClusterSelector /> in multiple places inside SettingsCluster.tsx. Extracting it will make it easier to reuse elsewhere in the app.

Currently, SettingsCluster.tsx is very large and handles a lot like cluster name update, namespace settings, UI rendering, etc. Pulling ClusterSelector out will keep the code clean and testable. Then creating a Storybook helps to see how ClusterSelector behaves.

## Related Issue

Fixes #ISSUE_NUMBER  There is no specific issue related to this PR. I've tried to separate the component and write its storybook and create snapshots

## Changes
- Refactored [code] for clarity/performance

<img width="1514" height="708" alt="Screenshot 2025-07-24 141258" src="https://github.com/user-attachments/assets/3ff33cda-dfde-4706-b639-215cab0085f0" />

<img width="1512" height="469" alt="Screenshot 2025-07-25 160104" src="https://github.com/user-attachments/assets/1382bf9f-a740-425b-a5ed-684b9a460eaa" />

<img width="1916" height="968" alt="Screenshot 2025-07-24 014139" src="https://github.com/user-attachments/assets/22f20c6b-5bfe-422e-bb45-d8812837819d" />


## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
