### PR TITLE
frontend: Activity: Fix exit overview mode when last activity is manually closed

### DIFF
--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -822,6 +822,11 @@ export const ActivitiesRenderer = React.memo(function ActivitiesRenderer() {
   const history = useTypedSelector(state => state.activity.history) as string[];
   const lastElement = history.at(-1);
   const [isOverview, setIsOverview] = useState(false);
+  useEffect(() => {
+    if (activities.length === 0 && isOverview) {
+      setIsOverview(false);
+    }
+  }, [activities, isOverview]);
 
   useHotkeys('Ctrl+ArrowDown', () => {
     setIsOverview(isOverview => !isOverview);


### PR DESCRIPTION
## Summary

This PR fixes a bug where the Overview mode remains active with a blurred background UI even after all activities are manually closed one by one. The update ensures that when the last activity is closed, the overview mode exits automatically, restoring the normal UI state.

## Related Issue

Fixes #3690 

## Changes

- Updated the ActivitiesRenderer component to include a useEffect hook:
- This ensures the overview mode deactivates automatically when the taskbar is empty.

## Steps to Test

1. Open multiple activities in Headlamp.
2. Enter Overview mode.
3. Close each activity manually using the X button on the tabs (not "Close All").
4. After the last activity is closed, the UI should no longer be blurred and overview mode should exit.

## Demo video (if applicable)

https://github.com/user-attachments/assets/89e31249-3009-4859-9bea-5df99d460748

