### PR TITLE
frontend and docs: Gateway: Add manifest and markdown files for local testing of Gateway implementation

### DIFF
--- a/docs/development/gateway.md
+++ b/docs/development/gateway.md
@@ -1,0 +1,72 @@
+# Gateway API Development Guide
+
+This guide documents the usage of Gateway API manifests for testing and development. These manifests are configured to work with the Envoy Gateway controller (`gateway.envoyproxy.io/gatewayclass-controller`), and are useful for validating Gateway API features like HTTP routing, gRPC, backend TLS, traffic policies, and cross-namespace permissions.
+
+## Manifest Files
+
+| File                                                                                         | Description                               |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| [`gatewayclass.yaml`](../../frontend/src/components/gateway/manifests/gatewayclass.yaml)     | Defines the GatewayClass used by Gateway. |
+| [`gateway.yaml`](../../frontend/src/components/gateway/manifests/gateway.yaml)               | Configures the Gateway resource.          |
+| [`httproute.yaml`](../../frontend/src/components/gateway/manifests/httproute.yaml)           | Configures HTTP route rules.              |
+| [`grpcroute.yaml`](../../frontend/src/components/gateway/manifests/grpcroute.yaml)           | Configures gRPC route rules.              |
+| [`referencegrant.yaml`](../../frontend/src/components/gateway/manifests/referencegrant.yaml) | Grants cross-namespace access.            |
+| [`backendtls.yaml`](../../frontend/src/components/gateway/manifests/backendtls.yaml)         | Configures TLS for backends.              |
+| [`backendtraffic.yaml`](../../frontend/src/components/gateway/manifests/backendtraffic.yaml) | Configures traffic policies to backends.  |
+
+> These files are located in:  
+> `frontend/src/components/gateway/manifests/`
+
+## How to Apply the Manifests
+
+### Apply Manifests One-by-One (in recommended order):
+
+```bash
+kubectl apply -f frontend/src/components/gateway/manifests/gatewayclass.yaml
+kubectl apply -f frontend/src/components/gateway/manifests/gateway.yaml
+kubectl apply -f frontend/src/components/gateway/manifests/referencegrant.yaml
+kubectl apply -f frontend/src/components/gateway/manifests/httproute.yaml
+kubectl apply -f frontend/src/components/gateway/manifests/grpcroute.yaml
+kubectl apply -f frontend/src/components/gateway/manifests/backendtls.yaml
+kubectl apply -f frontend/src/components/gateway/manifests/backendtraffic.yaml
+```
+
+### Alternative: Apply All Manifests at Once
+
+```bash
+kubectl apply -R -f frontend/src/components/gateway/manifests/
+```
+
+> This recursively applies all YAML files in the directory.
+
+## Verifying the Setup
+
+After applying the manifests, verify that the Gateway and Routes are accepted and functioning:
+
+```bash
+kubectl get gateway
+kubectl get gatewayclass
+kubectl get httproute
+kubectl get grpcroute
+kubectl describe gateway envoy-gateway
+kubectl get backendtlspolicies.gateway.networking.k8s.io
+kubectl get xbackendtrafficpolicies.gateway.networking.x-k8s.io
+```
+
+You can also inspect events or logs for the Envoy Gateway controller if routes are not becoming `Accepted`.
+
+## Testing Locally with Minikube
+
+Start a fresh Minikube cluster with a dedicated profile:
+
+```bash
+minikube start --profile=gateway-checkup
+```
+
+Install the Gateway API CRDs and the Envoy Gateway controller, then apply the manifests as shown above.
+
+## Resources
+
+- [Kubernetes Gateway API Docs](https://gateway-api.sigs.k8s.io/)
+- [Envoy Gateway Docs](https://gateway.envoyproxy.io/)
+- [Gateway API GitHub](https://github.com/kubernetes-sigs/gateway-api)

--- a/frontend/src/components/gateway/manifests/backendtls.yaml
+++ b/frontend/src/components/gateway/manifests/backendtls.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: secure-backend-policy
+  namespace: secure-app
+spec:
+  targetRefs:
+    - group: ''
+      kind: Service
+      name: secure-backend
+      sectionName: https
+  validation:
+    caCertificateRefs:
+      - group: ''
+        kind: ConfigMap
+        name: backend-ca
+    hostname: backend.secureapp.com

--- a/frontend/src/components/gateway/manifests/backendtraffic.yaml
+++ b/frontend/src/components/gateway/manifests/backendtraffic.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.x-k8s.io/v1alpha1
+kind: XBackendTrafficPolicy
+metadata:
+  name: httpbin-retry-policy
+  namespace: default
+spec:
+  retryConstraint:
+    budget:
+      interval: 10s
+      percent: 20
+    minRetryRate:
+      count: 5
+      interval: 10s
+  targetRefs:
+    - group: ''
+      kind: Service
+      name: httpbin

--- a/frontend/src/components/gateway/manifests/gateway.yaml
+++ b/frontend/src/components/gateway/manifests/gateway.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: envoy-gateway
+  namespace: default
+spec:
+  gatewayClassName: envoy-secure-gwclass
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/frontend/src/components/gateway/manifests/gatewayclass.yaml
+++ b/frontend/src/components/gateway/manifests/gatewayclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-secure-gwclass
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/frontend/src/components/gateway/manifests/grpcroute.yaml
+++ b/frontend/src/components/gateway/manifests/grpcroute.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GRPCRoute
+metadata:
+  name: grpc-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-gateway
+  rules:
+    - matches:
+        - method:
+            service: helloworld.Greeter
+            method: SayHello
+      backendRefs:
+        - name: grpc-backend
+          port: 50051

--- a/frontend/src/components/gateway/manifests/httproute.yaml
+++ b/frontend/src/components/gateway/manifests/httproute.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: basic-http-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend-service
+          port: 80

--- a/frontend/src/components/gateway/manifests/referencegrant.yaml
+++ b/frontend/src/components/gateway/manifests/referencegrant.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: cross-namespace-backend-access
+  namespace: backend-ns
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ''
+      kind: Service
+      name: backend-service


### PR DESCRIPTION
## Summary

This PR adds Gateway API manifests and related documentation for the
`gateway` module to enable local development and testing.

## Changes

- Added Gateway API manifests:
  - `gatewayclass.yaml`
  - `gateway.yaml`
  - `httproute.yaml`
  - `grpcroute.yaml`
  - `backendtls.yaml`
  - `backendtraffic.yaml`
  - `referencegrant.yaml`
- Added `gateway.md` documentation explaining usage and setup

## Steps to Test

1. Apply the manifests using `kubectl apply -f <file>`
2. Deploy the Envoy Gateway controller (if not already running)
3. Access your service through the defined routes and test traffic flow
4. Refer to `gateway.md` for detailed instructions and expected behavior

## Screenshots 

<details>
<summary> All applied manifest files along with their details are visible in Headlamp.</summary>

1. Gateway
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 47 43 PM" src="https://github.com/user-attachments/assets/af8bd400-0916-4ed9-8886-a9646b0530bf" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 49 42 PM" src="https://github.com/user-attachments/assets/ad6b0d83-2f87-4521-88f2-ae5d2b3bc005" />

2. Gateway class
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 49 58 PM" src="https://github.com/user-attachments/assets/8cbf5d1c-7228-4d3f-8d6a-deeca215cb12" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 50 09 PM" src="https://github.com/user-attachments/assets/fa264ad0-b219-4c74-ba73-c28d7daa40fe" />

3. Http Route
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 50 23 PM" src="https://github.com/user-attachments/assets/604955c2-6bb9-49f4-8f8d-4ba257557944" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 50 31 PM" src="https://github.com/user-attachments/assets/65d472ef-acab-4cb6-b124-5ac735f3ad9d" />

4. Grpc Route
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 50 51 PM" src="https://github.com/user-attachments/assets/9583e7f2-9d33-4d2f-9a3f-1a7951ad6fcb" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 50 59 PM" src="https://github.com/user-attachments/assets/ef21a187-7aff-4e33-a80d-f14e30c93c66" />

5. Reference Grants
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 51 13 PM" src="https://github.com/user-attachments/assets/90d52a18-f3ca-49a6-a809-3c8ffd5c8eea" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 51 25 PM" src="https://github.com/user-attachments/assets/fc3f9e84-f9fc-4f64-a392-2a30f6732589" />

6. Backend TLS Policy
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 51 42 PM" src="https://github.com/user-attachments/assets/7413346c-5e1f-4ca5-9759-5d3a14f9e998" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 51 50 PM" src="https://github.com/user-attachments/assets/1a7508f6-640b-4d71-a0be-5b5a735234aa" />

7. Backend Traffic Policy
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 52 05 PM" src="https://github.com/user-attachments/assets/c7481265-dd86-4292-90c9-bd1868b57571" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 52 14 PM" src="https://github.com/user-attachments/assets/c2c77f6d-0f6e-4b83-b13b-444fdd314682" />

8. Preview of formatted markdown file
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 53 57 PM" src="https://github.com/user-attachments/assets/1cfe5702-7061-452c-bad7-c26be0c6852b" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 54 11 PM" src="https://github.com/user-attachments/assets/0e43b14e-037e-4a0e-8837-3c469fa8bafc" />
<img width="1426" height="895" alt="Screenshot 2025-07-28 at 2 55 08 PM" src="https://github.com/user-attachments/assets/c3b4e10f-be26-4ecf-ab8c-aba978c8c039" />
</details>



## Notes for the Reviewer

- These manifests are tailored for testing with Envoy Gateway and may evolve
  as new Gateway API features are adopted.
- Please verify all resource kinds match the currently installed CRDs.
