### PR TITLE
Accessibility [FastPass]: Fix contrast for labels for dark mode

### DIFF
--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -112,7 +112,7 @@ export const StatusLabel = forwardRef<HTMLSpanElement, StatusLabelProps>((props,
   } else {
     params = {
       backgroundColor: alpha(baseColor, 0.2),
-      color: base[400],
+      color: base[200],
       borderColor: alpha(base[400], 0.5),
     };
   }


### PR DESCRIPTION
Similar to https://github.com/kubernetes-sigs/headlamp/pull/3687

This PR fixes the FastPass check failures for the label comp when we use dark mode. I have set the texts to be a few shades lighter so that it contrasts better in dark mode, the lights out mode does not have this same issue.


## FastPass issues

<img width="1508" height="546" alt="image" src="https://github.com/user-attachments/assets/bb1291ae-2efe-4641-8a1c-672339591a7e" />


<img width="1630" height="611" alt="image" src="https://github.com/user-attachments/assets/08997c0a-9e3d-4a26-bf14-66422841447b" />
