### PR TITLE
Accessibility [FastPass]: Fix ARIA label and tab navigation for notifications menu

### DIFF
--- a/frontend/src/components/App/Notifications/List/List.tsx
+++ b/frontend/src/components/App/Notifications/List/List.tsx
@@ -100,8 +100,8 @@ export default function NotificationList() {
 
     return (
       <>
-        <IconButton size="medium">
-          <Icon icon="mdi:dots-vertical" onClick={handleClick} />
+        <IconButton aria-label={t('translation|Menu')} size="medium" onClick={handleClick}>
+          <Icon icon="mdi:dots-vertical" />
         </IconButton>
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
           <MenuItem onClick={markAllAsRead} disabled={!hasUnseenNotifications}>

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "Mit dem Cluster ist etwas schief gelaufen {{ cluster }}",
   "Choose another cluster": "Wählen Sie einen anderen Cluster",
   "Skip to main content": "Zum Hauptinhalt springen",
+  "Menu": "",
   "Mark all as read": "Alle als gelesen markieren",
   "Clear all": "Alle löschen",
   "Notifications": "Nachrichten",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "Something went wrong with cluster {{ cluster }}",
   "Choose another cluster": "Choose another cluster",
   "Skip to main content": "Skip to main content",
+  "Menu": "Menu",
   "Mark all as read": "Mark all as read",
   "Clear all": "Clear all",
   "Notifications": "Notifications",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "Algo ha fallado en el cluster {{ cluster }}",
   "Choose another cluster": "Elegir un otro cluster",
   "Skip to main content": "Avanzar hacia el contenido principal",
+  "Menu": "",
   "Mark all as read": "Marcar todo como leído",
   "Clear all": "Eliminar todas",
   "Notifications": "Notificaciones",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "Quelque chose s'est mal passé avec le cluster {{ cluster }}",
   "Choose another cluster": "Choisir un autre cluster",
   "Skip to main content": "Aller au contenu principal",
+  "Menu": "",
   "Mark all as read": "Marquer toutes les notifications comme lues",
   "Clear all": "Tout effacer",
   "Notifications": "Notifications",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "क्लस्टर {{ cluster }} के साथ कुछ गलत हुआ",
   "Choose another cluster": "दूसरा क्लस्टर चुनें",
   "Skip to main content": "मुख्य सामग्री पर जाएँ",
+  "Menu": "",
   "Mark all as read": "सभी को पढ़ा हुआ चिह्नित करें",
   "Clear all": "सभी साफ करें",
   "Notifications": "सूचनाएँ",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "Qualcosa è andato storto con il cluster {{ cluster }}",
   "Choose another cluster": "Scegli un altro cluster",
   "Skip to main content": "Salta al contenuto principale",
+  "Menu": "",
   "Mark all as read": "Segna tutto come letto",
   "Clear all": "Pulisci tutto",
   "Notifications": "Notifiche",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "クラスター {{ cluster }} で問題が発生しました",
   "Choose another cluster": "別のクラスターを選択",
   "Skip to main content": "メインコンテンツへスキップ",
+  "Menu": "",
   "Mark all as read": "すべて既読にする",
   "Clear all": "すべてクリア",
   "Notifications": "通知",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "{{ cluster }} 클러스터에서 문제가 발생했습니다.",
   "Choose another cluster": "다른 클러스터 선택",
   "Skip to main content": "주요 콘텐츠로 건너뛰기",
+  "Menu": "",
   "Mark all as read": "모두 읽은 것으로 표시",
   "Clear all": "모두 삭제",
   "Notifications": "알림",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "Algo falhou com o cluster {{ cluster }}",
   "Choose another cluster": "Escolha outro cluster",
   "Skip to main content": "Saltar para o contúdo principal",
+  "Menu": "",
   "Mark all as read": "Marcar tudo como lido",
   "Clear all": "Limpar todas",
   "Notifications": "Notificações",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "{{ cluster }} க்ளஸ்டரில் ஏதோ பிழை நேர்ந்தது",
   "Choose another cluster": "மற்றொரு க்ளஸ்டரைத் தேர்ந்தெடுக்கவும்",
   "Skip to main content": "முக்கிய உள்ளடக்கத்திற்கு செல்",
+  "Menu": "",
   "Mark all as read": "அனைத்தையும் படித்ததாகக் குறி",
   "Clear all": "அனைத்தையும் அழி",
   "Notifications": "அறிவிப்புகள்",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "叢集 {{ cluster }} 出現問題",
   "Choose another cluster": "選擇其他叢集",
   "Skip to main content": "跳至主要內容",
+  "Menu": "",
   "Mark all as read": "全部標記為已讀",
   "Clear all": "全部清除",
   "Notifications": "通知",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -69,6 +69,7 @@
   "Something went wrong with cluster {{ cluster }}": "集群 {{ cluster }} 出现问题",
   "Choose another cluster": "选择其他集群",
   "Skip to main content": "跳至主要內容",
+  "Menu": "",
   "Mark all as read": "全部标记为已读",
   "Clear all": "全部清除",
   "Notifications": "通知",


### PR DESCRIPTION
This PR fixes the FastPass check for the notifications menu button when on the notifications page. 

Added a translated string for screen readers for the menu icon button, it should now read out "Notifcations menu"

I also included a change that moves the on click so that tab navigation works as intended. (Before you could not tab then press enter to open the menu, now you can.)

## FastPass issues

<img width="1919" height="304" alt="image" src="https://github.com/user-attachments/assets/7e6accc2-1974-4676-bd52-e45ababd612e" />

<img width="1621" height="776" alt="image" src="https://github.com/user-attachments/assets/0b1e65a7-9d57-4795-8b08-092e9d26e372" />
