### PR TITLE
frontend: Link: Pass custom resource definitions to Activities

### DIFF
--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -196,6 +196,7 @@ export default function Link(props: React.PropsWithChildren<LinkProps | LinkObje
                   },
                   cluster: selectedResource.cluster,
                 }}
+                customResourceDefinition={selectedResource.customResourceDefinition}
               />
             ),
             icon: <KubeIcon kind={selectedResource.kind} width="100%" height="100%" />,


### PR DESCRIPTION
Fixes #3704 

## Steps to Test

1. Go to custom resource instances
2. Click on name links
3. Details should render properly

