### PR TITLE
frontend: Table: Enhance click handling for table rows

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -418,6 +418,17 @@ export default function Table<RowItem extends Record<string, any>>({
   // Handle shift+click range selection
   const handleRowClick = (e: React.MouseEvent, clickedIndex: number) => {
     if (!table || !table.getRowModel) return;
+    const target = e.target;
+    if (
+      !(target instanceof HTMLInputElement) ||
+      target.tagName !== 'INPUT' ||
+      target.type !== 'checkbox'
+    ) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+
     const rowModel = table.getRowModel();
     const rowIds = rowModel.rows.map(row => row.id);
 
@@ -560,7 +571,7 @@ const Row = memo(
     onRowClick?: (e: React.MouseEvent, rowIndex: number) => void;
     rowIndex: number;
   }) => (
-    <StyledRow data-selected={isSelected} onClick={e => onRowClick?.(e, rowIndex)}>
+    <StyledRow data-selected={isSelected} onClickCapture={e => onRowClick?.(e, rowIndex)}>
       {cells.map(cell => (
         <MemoCell
           cell={cell as MRT_Cell<Record<string, any>, unknown>}


### PR DESCRIPTION
This makes shift-selecting only work by clicking on checkbox instead of the whole row.
Also avoids selecting text by doing e.preventDefault


## Steps to Test

1. Go to any resource table
2. Select rows by clicking on checkboxes
3. Shift-select multiple rows
