### PR TITLE
feat: plugins: Implement automated dev-plugins workflow

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headlamp",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "headlamp",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "dependencies": {
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headlamp",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Easy-to-use and extensible Kubernetes web UI",
   "main": "electron/main.js",
   "homepage": "https://github.com/kubernetes-sigs/headlamp/#readme",

--- a/app/windows/chocolatey/headlamp.nuspec
+++ b/app/windows/chocolatey/headlamp.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>headlamp</id>
-    <version>0.33.0</version>
+    <version>0.34.0</version>
     <packageSourceUrl>https://github.com/kubernetes-sigs/headlamp/tree/main/app/windows/chocolatey</packageSourceUrl>
     <title>Headlamp</title>
     <authors>Kinvolk</authors>

--- a/app/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/app/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$headlampVersion = '0.33.0'
+$headlampVersion = '0.34.0'
 $url = "https://github.com/kubernetes-sigs/headlamp/releases/download/v${headlampVersion}/Headlamp-${headlampVersion}-win-x64.exe"
-$checksum = 'a438191fcb08b82afcc4c5cb203808b341a8117dcd21d921d94f5f01bba19980'
+$checksum = 'ce4d0a5c7566ed6c97042b6e3245b91e5a3d8e8169b669a88d4d9386db7650b3'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1524,8 +1524,6 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 	}
 
 	for _, context := range contexts {
-		context := context
-
 		if context.Error != "" {
 			clusters = append(clusters, Cluster{
 				Name:  context.Name,
@@ -1580,8 +1578,6 @@ func parseCustomNameClusters(contexts []kubeconfig.Context) ([]Cluster, []error)
 	var setupErrors []error
 
 	for _, context := range contexts {
-		context := context
-
 		info := context.KubeContext.Extensions["headlamp_info"]
 		if info != nil {
 			// Convert the runtime.Unknown object to a byte slice
@@ -2042,8 +2038,6 @@ func (c *HeadlampConfig) updateCustomContextToCache(config *api.Config, clusterN
 	}
 
 	for _, context := range contexts {
-		context := context
-
 		// Remove the old context from the store
 		if err := c.KubeConfigStore.RemoveContext(clusterName); err != nil {
 			logger.Log(logger.LevelError, nil, err, "Removing context from the store")

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -290,6 +290,16 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 
 	r.PathPrefix("/plugins/").Handler(pluginHandler)
 
+	// Serve dev-plugins
+	devPluginDir := filepath.Join(filepath.Dir(config.PluginDir), "dev-plugins")
+	if _, err := os.Stat(devPluginDir); err == nil {
+		devPluginHandler := http.StripPrefix(config.BaseURL+"/dev-plugins/", http.FileServer(http.Dir(devPluginDir)))
+		if !config.UseInCluster {
+			devPluginHandler = serveWithNoCacheHeader(devPluginHandler)
+		}
+		r.PathPrefix("/dev-plugins/").Handler(devPluginHandler)
+	}
+
 	if config.StaticPluginDir != "" {
 		staticPluginsHandler := http.StripPrefix(config.BaseURL+"/static-plugins/",
 			http.FileServer(http.Dir(config.StaticPluginDir)))

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -248,7 +248,6 @@ func TestDynamicClusters(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -117,8 +117,6 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 	}
 
 	for _, context := range contexts {
-		context := context
-
 		info := context.KubeContext.Extensions["headlamp_info"]
 		if info != nil {
 			customObj, err := MarshalCustomObject(info, context.Name)

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -71,7 +71,6 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()
@@ -127,7 +126,6 @@ func TestStatelessClusterApiRequest(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()

--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -63,7 +63,6 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 		index.AddRepo(name, indexFile, true)
 
 		for _, chart := range index.All() {
-			chart := chart
 			if filter != "" {
 				if strings.Contains(strings.ToLower(chart.Name), strings.ToLower(filter)) {
 					chartInfos = append(chartInfos, chartInfo{

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -215,8 +215,6 @@ func listRepositories(settings *cli.EnvSettings) ([]repositoryInfo, error) {
 	repositories := make([]repositoryInfo, 0, len(repoFile.Repositories))
 
 	for _, repo := range repoFile.Repositories {
-		repo := repo
-
 		repositories = append(repositories, repositoryInfo{
 			Name: repo.Name,
 			URL:  repo.URL,

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -64,7 +64,6 @@ func checkRepoExists(t *testing.T, helmHandler *helm.Handler, repoName string) b
 	require.NoError(t, err)
 
 	for _, repo := range listRepoResponse.Repositories {
-		repo := repo
 		if repo.Name == repoName {
 			return true
 		}
@@ -186,7 +185,6 @@ func TestUpdateRepo(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, repo := range listRepoResponse.Repositories {
-			repo := repo
 			if repo.Name == "headlamp_test_repo" {
 				assert.Equal(t, "https://kubernetes-sigs-update-url.github.io/headlamp/", repo.URL)
 			}

--- a/backend/pkg/kubeconfig/watcher.go
+++ b/backend/pkg/kubeconfig/watcher.go
@@ -68,8 +68,6 @@ func LoadAndWatchFiles(kubeConfigStore ContextStore, paths string, source int, i
 
 func addFilesToWatcher(watcher *fsnotify.Watcher, paths []string) {
 	for _, path := range paths {
-		path := path
-
 		// if path is relative, make it absolute
 		if !filepath.IsAbs(path) {
 			absPath, err := filepath.Abs(path)

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -70,7 +70,6 @@ func TestLog(t *testing.T) {
 
 	// Call the Log function
 	for _, test := range tests {
-		test := test // Assign test to a local variable
 		t.Run(test.name, func(t *testing.T) {
 			logger.Log(test.level, test.str, test.err, test.msg)
 

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -497,7 +497,6 @@ func TestDelete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.pluginName, func(t *testing.T) {
 			err := plugins.Delete(tt.pluginDir, tt.pluginName)
 			if tt.expectErr {

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -46,7 +46,6 @@ func TestPortforwardKeyGenerator(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		testname := tt.name
 		t.Run(testname, func(t *testing.T) {
 			key := portforwardKeyGenerator(tt.p)

--- a/frontend/src/components/App/Settings/ClusterSelector.stories.tsx
+++ b/frontend/src/components/App/Settings/ClusterSelector.stories.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { configureStore } from '@reduxjs/toolkit';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import ClusterSelector, { ClusterSelectorProps } from './ClusterSelector';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    navbar: {
+      background: '#fff',
+    },
+  },
+});
+
+const getMockState = () => ({
+  plugins: { loaded: true },
+  theme: {
+    name: 'light',
+    logo: null,
+    palette: {
+      navbar: {
+        background: '#fff',
+      },
+    },
+  },
+});
+
+export default {
+  title: 'Components/ClusterSelector',
+  component: ClusterSelector,
+} as Meta<typeof ClusterSelector>;
+
+const Template: StoryFn<ClusterSelectorProps> = args => {
+  const store = configureStore({
+    reducer: (state = getMockState()) => state,
+    preloadedState: getMockState(),
+  });
+
+  return (
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <ClusterSelector {...args} />
+      </ThemeProvider>
+    </Provider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  currentCluster: 'dev',
+  clusters: ['dev', 'staging', 'prod'],
+};

--- a/frontend/src/components/App/Settings/ClusterSelector.tsx
+++ b/frontend/src/components/App/Settings/ClusterSelector.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+
+export interface ClusterSelectorProps {
+  currentCluster?: string;
+  clusters: string[];
+}
+
+const ClusterSelector: React.FC<ClusterSelectorProps> = ({ currentCluster = '', clusters }) => {
+  const history = useHistory();
+  const { t } = useTranslation('glossary');
+
+  return (
+    <FormControl variant="outlined" margin="normal" size="small" sx={{ minWidth: 250 }}>
+      <InputLabel id="settings--cluster-selector">{t('glossary|Cluster')}</InputLabel>
+      <Select
+        labelId="settings--cluster-selector"
+        value={currentCluster}
+        onChange={event => {
+          history.replace(`/settings/cluster?c=${event.target.value}`);
+        }}
+        label={t('glossary|Cluster')}
+        autoWidth
+        aria-label={t('glossary|Cluster selector')}
+      >
+        {clusters.map(clusterName => (
+          <MenuItem key={clusterName} value={clusterName}>
+            {clusterName}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default ClusterSelector;

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -17,11 +17,7 @@
 import { Icon, InlineIcon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import FormControl from '@mui/material/FormControl';
 import IconButton from '@mui/material/IconButton';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -46,6 +42,7 @@ import Link from '../../common/Link';
 import Loader from '../../common/Loader';
 import NameValueTable from '../../common/NameValueTable';
 import SectionBox from '../../common/SectionBox';
+import ClusterSelector from './ClusterSelector';
 import NodeShellSettings from './NodeShellSettings';
 import { isValidNamespaceFormat } from './util';
 
@@ -59,39 +56,6 @@ function isValidClusterNameFormat(name: string) {
   // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
   const regex = new RegExp('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$');
   return regex.test(name);
-}
-
-interface ClusterSelectorProps {
-  currentCluster?: string;
-  clusters: string[];
-}
-
-function ClusterSelector(props: ClusterSelectorProps) {
-  const { currentCluster = '', clusters } = props;
-  const history = useHistory();
-  const { t } = useTranslation('glossary');
-
-  return (
-    <FormControl variant="outlined" margin="normal" size="small" sx={{ minWidth: 250 }}>
-      <InputLabel id="settings--cluster-selector">{t('glossary|Cluster')}</InputLabel>
-      <Select
-        labelId="settings--cluster-selector"
-        value={currentCluster}
-        onChange={event => {
-          history.replace(`/settings/cluster?c=${event.target.value}`);
-        }}
-        label={t('glossary|Cluster')}
-        autoWidth
-        aria-label={t('glossary|Cluster selector')}
-      >
-        {clusters.map(clusterName => (
-          <MenuItem key={clusterName} value={clusterName}>
-            {clusterName}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  );
 }
 
 export default function SettingsCluster() {
@@ -360,7 +324,7 @@ export default function SettingsCluster() {
               }
             )}
           </Typography>
-          <ClusterSelector clusters={clusters} />
+          <ClusterSelector currentCluster={cluster} clusters={clusters} />
         </SectionBox>
       </>
     );

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.Default.stories.storyshot
@@ -1,0 +1,61 @@
+<body>
+  <div>
+    <div
+      class="MuiFormControl-root MuiFormControl-marginNormal css-1gtduw2-MuiFormControl-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="true"
+        id="settings--cluster-selector"
+      >
+        Cluster
+      </label>
+      <div
+        aria-label="Cluster selector"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+      >
+        <div
+          aria-controls=":mock-test-id:"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="settings--cluster-selector"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jedpe8-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          role="combobox"
+          tabindex="0"
+        >
+          dev
+        </div>
+        <input
+          aria-hidden="true"
+          aria-invalid="false"
+          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          tabindex="-1"
+          value="dev"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          data-testid="ArrowDropDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+        <fieldset
+          aria-hidden="true"
+          class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="css-14lo706"
+          >
+            <span>
+              Cluster
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterSelector.storyshots.test.tsx.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ClusterSelector > matches snapshot 1`] = `
+<div>
+  <div
+    class="MuiFormControl-root MuiFormControl-marginNormal css-1gtduw2-MuiFormControl-root"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      data-shrink="true"
+      id="settings--cluster-selector"
+    >
+      glossary|Cluster
+    </label>
+    <div
+      aria-label="glossary|Cluster selector"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+    >
+      <div
+        aria-controls=":r0:"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="settings--cluster-selector"
+        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jedpe8-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+        role="combobox"
+        tabindex="0"
+      >
+        dev
+      </div>
+      <input
+        aria-hidden="true"
+        aria-invalid="false"
+        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+        tabindex="-1"
+        value="dev"
+      />
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+        data-testid="ArrowDropDownIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10l5 5 5-5z"
+        />
+      </svg>
+      <fieldset
+        aria-hidden="true"
+        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+      >
+        <legend
+          class="css-14lo706"
+        >
+          <span>
+            glossary|Cluster
+          </span>
+        </legend>
+      </fieldset>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
@@ -81,7 +81,7 @@
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-14f1a7d-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
-                  aria-describedby=":r18:-helper-text"
+                  aria-describedby=":r19:-helper-text"
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
@@ -127,7 +127,7 @@
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-8secpz-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
-                  aria-describedby=":r19:-helper-text"
+                  aria-describedby=":r1a:-helper-text"
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"

--- a/frontend/src/components/common/Tooltip/TooltipIcon.tsx
+++ b/frontend/src/components/common/Tooltip/TooltipIcon.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import TooltipLight from './TooltipLight';
 
 export interface TooltipIconProps {
-  children: string;
+  children: string | React.ReactNode;
   /** A materialui/core icon. */
   icon?: IconProps['icon'];
 }

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -1124,12 +1124,28 @@
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lm23yi-MuiTableCell-root"
               >
-                16.32 m
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <span
+                    style="white-space: nowrap;"
+                  >
+                    16.32 m
+                  </span>
+                </div>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-rrz0sj-MuiTableCell-root"
               >
-                46.4 Mi
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <span
+                    style="white-space: nowrap;"
+                  >
+                    46.4 Mi
+                  </span>
+                </div>
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-fe8q5p-MuiTableCell-root"

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Anhängen",
   "Restarts": "Neustarts",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (vor {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nominierte Node",
   "Readiness Gates": "Bereitschaftstore",
   "Pod Disruption Budget": "Budget für Pod Disruption",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Attach",
   "Restarts": "Restarts",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} ago)",
+  "Request": "Request",
+  "Limit": "Limit",
   "Nominated Node": "Nominated Node",
   "Readiness Gates": "Readiness Gates",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Adjuntar",
   "Restarts": "Reinicios",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (hace {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nodo Nominado",
   "Readiness Gates": "Readiness Gates",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Attacher",
   "Restarts": "Redémarrages",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (il y a {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nœud nommé",
   "Readiness Gates": "Portes de disponibilité",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "अटैच",
   "Restarts": "रीस्टार्ट",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} पहले)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "नामांकित नोड",
   "Readiness Gates": "रेडीनेस गेट्स",
   "Pod Disruption Budget": "Pod डिसरप्शन बजट",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Collega",
   "Restarts": "Riavvii",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} fa)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Nodo Nominato",
   "Readiness Gates": "Readiness Gate",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "アタッチ",
   "Restarts": "再起動",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 前)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "指名ノード",
   "Readiness Gates": "準備ゲート",
   "Pod Disruption Budget": "ポッド中断バジェット",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "연결",
   "Restarts": "재시작",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 전)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "할당된 노드",
   "Readiness Gates": "준비 상태 게이트",
   "Pod Disruption Budget": "파드 중단 예산",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "Anexar",
   "Restarts": "Reinícios",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} (há {{ abbrevTime }})",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "Node Nomeado",
   "Readiness Gates": "Portais de Prontidão",
   "Pod Disruption Budget": "Pod Disruption Budget",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "இணை",
   "Restarts": "மறுதொடக்கம்",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} முன்பு)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "நாமினேடட் நோட்",
   "Readiness Gates": "ரெடினெஸ் கேட்ஸ்",
   "Pod Disruption Budget": "பாட் டிஸ்ரப்ஷன் பட்ஜெட்",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "附加",
   "Restarts": "重啟",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 前)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "提名節點",
   "Readiness Gates": "就緒閘道",
   "Pod Disruption Budget": "Pod 中斷預算",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -160,6 +160,8 @@
   "Attach": "附加",
   "Restarts": "重启",
   "{{ restarts }} ({{ abbrevTime }} ago)": "{{ restarts }} ({{ abbrevTime }} 前)",
+  "Request": "",
+  "Limit": "",
   "Nominated Node": "提名节点",
   "Readiness Gates": "就绪网关",
   "Pod Disruption Budget": "Pod 中断预算",

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -82,6 +82,14 @@ export type PluginInfo = {
    */
   isCompatible?: boolean;
 
+  /**
+   * pluginType indicates the source type of the plugin.
+   * 'dev' for development plugins from dev-plugins directory
+   * 'catalog' for plugins from the plugin catalog (plugins directory)
+   * 'static' for static plugins
+   */
+  pluginType?: 'dev' | 'catalog' | 'static';
+
   version?: string; // unused by PluginSettings
   author?: string; // unused by PluginSettings
   /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
         target: 'http://localhost:4466',
         changeOrigin: true,
       },
+      '/dev-plugins': {
+        target: 'http://localhost:4466',
+        changeOrigin: true,
+      },
     },
     cors: true,
   },

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -407,7 +407,7 @@ async function start() {
     const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
 
     // All plugins started with npm run start go to dev-plugins directory
-    await checkIfDevPlugin(packageName, configDir);
+    await checkIfDevPlugin(packageName);
     const targetDir = 'dev-plugins';
 
     console.log(`Installing plugin to ${targetDir}/ directory (development priority)`);
@@ -434,7 +434,7 @@ async function start() {
    * Check if this plugin should be treated as a development plugin
    * All plugins started with npm run start will be placed in dev-plugins directory
    */
-  async function checkIfDevPlugin(pluginName, configDir) {
+  async function checkIfDevPlugin(pluginName) {
     try {
       console.log(`✓ Plugin "${pluginName}" - using dev-plugins directory for development`);
       return true;


### PR DESCRIPTION
## Summary

This PR adds the plugins into a new dev-plugins folder, if ran by npm start , else the normal plugins folder is used for catalog and shipped plugins. 

## Related Issue

Fixes #3628


## Changes

- This is the part1 PR to fix the issue. 
- Segregate the plugins loading in the priority of shipped<catalog< dev
- Shows the 3 types of plugins in the table format in the plugins page.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/660fed13-c6cd-4811-acd6-6de1614770b3


<img width="1283" height="429" alt="Screenshot 2025-07-30 at 12 16 42 PM" src="https://github.com/user-attachments/assets/9cff6a6e-b16c-4700-ac8c-1853dfb6dc66" />

