### PR TITLE
Fixed Searchbar overlaps vertical scroll 

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -427,6 +427,7 @@ export function SearchPopover(props: SearchPopoverProps) {
           right: 15,
           padding: '4px 8px',
           zIndex: theme.zIndex.modal,
+          marginRight: '7px',
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',


### PR DESCRIPTION
## Summary

Fixed Search-bar that overlaps vertical scroll in pod logs. 

## Related Issue

Fixes #3018

## Changes

before : 
<img width="2255" height="822" alt="Screenshot 2025-07-31 001350" src="https://github.com/user-attachments/assets/07af8c8e-365c-4039-85d2-1a6097053e7d" />

after : 
<img width="2236" height="1081" alt="Screenshot 2025-07-31 001329" src="https://github.com/user-attachments/assets/86a18b4e-549f-4db6-bf91-b3b5a2ef4163" />

## Steps to reproduce the bug:

Go to pod logs and open search-bar
