### PR TITLE
Fixing hover styling on close button in activity bar

### DIFF
--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -948,6 +948,8 @@ export const ActivityBar = React.memo(function ({
           key={it.id}
           sx={theme => ({
             display: 'flex',
+            alignItems: 'center',
+            padding: '3px',
             height: '100%',
             position: 'relative',
             border: '1px solid',
@@ -958,6 +960,7 @@ export const ActivityBar = React.memo(function ({
         >
           <Button
             sx={{
+              height: '100%',
               padding: '0px 5px 0 10px',
               lineHeight: 1,
               whiteSpace: 'nowrap',
@@ -1008,7 +1011,7 @@ export const ActivityBar = React.memo(function ({
               e.stopPropagation();
               Activity.close(it.id);
             }}
-            sx={{ width: '42px', flexShrink: 0 }}
+            sx={{ width: '42px', height: '42px', flexShrink: 0 }}
             aria-label="Close"
           >
             <Icon icon="mdi:close" />


### PR DESCRIPTION
The over circle over the close icon was not proper circle
Before - 
<img width="167" height="50" alt="Screenshot 2025-07-31 at 6 06 18 PM" src="https://github.com/user-attachments/assets/c92857a0-050e-4350-8cce-29881c0ae834" />
<img width="171" height="51" alt="Screenshot 2025-07-31 at 6 06 28 PM" src="https://github.com/user-attachments/assets/5d440acf-9416-4bb2-85d3-2a2f916bb55e" />

Now - 
<img width="163" height="47" alt="Screenshot 2025-07-31 at 6 08 58 PM" src="https://github.com/user-attachments/assets/6659dbc6-3afb-4f9d-80eb-49d565aa0373" />
<img width="162" height="48" alt="Screenshot 2025-07-31 at 6 09 04 PM" src="https://github.com/user-attachments/assets/678115d5-a20f-4269-bf43-927397c7c70b" />
