### PR TITLE
backend: HeadlampConfig: Remove the unnecessary  assignment in for loop

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2040,8 +2040,6 @@ func (c *HeadlampConfig) updateCustomContextToCache(config *api.Config, clusterN
 	}
 
 	for _, context := range contexts {
-		context := context
-
 		// Remove the old context from the store
 		if err := c.KubeConfigStore.RemoveContext(clusterName); err != nil {
 			logger.Log(logger.LevelError, nil, err, "Removing context from the store")


### PR DESCRIPTION
## Summary

Remove the unnecessary assignment in for loop since we use over 1.24 go version, there is no need to assign a new variable any more
