### PR TITLE
backend: HeadlampServer: Move router initialization codes to createHeadlampHandler

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -453,6 +453,11 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 		r = baseRoute.PathPrefix(config.BaseURL).Subrouter()
 	}
 
+	if config.Telemetry != nil && config.Metrics != nil {
+		r.Use(telemetry.TracingMiddleware("headlamp-server"))
+		r.Use(config.Metrics.RequestCounterMiddleware)
+	}
+
 	fmt.Println("*** Headlamp Server ***")
 	fmt.Println("  API Routers:")
 
@@ -1138,13 +1143,6 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	config.Telemetry = tel
 	config.Metrics = metrics
 	config.telemetryHandler = telemetry.NewRequestHandler(tel, metrics)
-
-	router := mux.NewRouter()
-
-	if config.Telemetry != nil && config.Metrics != nil {
-		router.Use(telemetry.TracingMiddleware("headlamp-server"))
-		router.Use(config.Metrics.RequestCounterMiddleware)
-	}
 
 	// Copy static files as squashFS is read-only (AppImage)
 	if config.StaticDir != "" {


### PR DESCRIPTION
## Summary
Remove the dead code, and move router  use middle logic into createHeadlampHandler function


## Related Issue
Fixes #3708

