### PR TITLE
app: start.js: Fix start on windows with cmd

### DIFF
--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -16,6 +16,8 @@ let frontendCmd =
 if (process.platform !== 'win32') {
   // to prevent clearing the screen
   frontendCmd += ' | cat';
+} else {
+  frontendCmd = frontendCmd.replace(/\//g, '\\');
 }
 const frontendProcess = spawn(frontendCmd, [], {
   stdio: 'inherit',


### PR DESCRIPTION
The frontend command was failing to start.


### How to test
In cmd on windows (not gitbash):

`cd app && npm start`
