### PR TITLE
backend: Remove unnecessary assignment in range for loop

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1524,8 +1524,6 @@ func (c *HeadlampConfig) getClusters() []Cluster {
 	}
 
 	for _, context := range contexts {
-		context := context
-
 		if context.Error != "" {
 			clusters = append(clusters, Cluster{
 				Name:  context.Name,
@@ -1580,8 +1578,6 @@ func parseCustomNameClusters(contexts []kubeconfig.Context) ([]Cluster, []error)
 	var setupErrors []error
 
 	for _, context := range contexts {
-		context := context
-
 		info := context.KubeContext.Extensions["headlamp_info"]
 		if info != nil {
 			// Convert the runtime.Unknown object to a byte slice
@@ -2042,8 +2038,6 @@ func (c *HeadlampConfig) updateCustomContextToCache(config *api.Config, clusterN
 	}
 
 	for _, context := range contexts {
-		context := context
-
 		// Remove the old context from the store
 		if err := c.KubeConfigStore.RemoveContext(clusterName); err != nil {
 			logger.Log(logger.LevelError, nil, err, "Removing context from the store")

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -248,7 +248,6 @@ func TestDynamicClusters(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -117,8 +117,6 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 	}
 
 	for _, context := range contexts {
-		context := context
-
 		info := context.KubeContext.Extensions["headlamp_info"]
 		if info != nil {
 			customObj, err := MarshalCustomObject(info, context.Name)

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -71,7 +71,6 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()
@@ -127,7 +126,6 @@ func TestStatelessClusterApiRequest(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()

--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -63,7 +63,6 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 		index.AddRepo(name, indexFile, true)
 
 		for _, chart := range index.All() {
-			chart := chart
 			if filter != "" {
 				if strings.Contains(strings.ToLower(chart.Name), strings.ToLower(filter)) {
 					chartInfos = append(chartInfos, chartInfo{

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -215,8 +215,6 @@ func listRepositories(settings *cli.EnvSettings) ([]repositoryInfo, error) {
 	repositories := make([]repositoryInfo, 0, len(repoFile.Repositories))
 
 	for _, repo := range repoFile.Repositories {
-		repo := repo
-
 		repositories = append(repositories, repositoryInfo{
 			Name: repo.Name,
 			URL:  repo.URL,

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -64,7 +64,6 @@ func checkRepoExists(t *testing.T, helmHandler *helm.Handler, repoName string) b
 	require.NoError(t, err)
 
 	for _, repo := range listRepoResponse.Repositories {
-		repo := repo
 		if repo.Name == repoName {
 			return true
 		}
@@ -186,7 +185,6 @@ func TestUpdateRepo(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, repo := range listRepoResponse.Repositories {
-			repo := repo
 			if repo.Name == "headlamp_test_repo" {
 				assert.Equal(t, "https://kubernetes-sigs-update-url.github.io/headlamp/", repo.URL)
 			}

--- a/backend/pkg/kubeconfig/watcher.go
+++ b/backend/pkg/kubeconfig/watcher.go
@@ -68,8 +68,6 @@ func LoadAndWatchFiles(kubeConfigStore ContextStore, paths string, source int, i
 
 func addFilesToWatcher(watcher *fsnotify.Watcher, paths []string) {
 	for _, path := range paths {
-		path := path
-
 		// if path is relative, make it absolute
 		if !filepath.IsAbs(path) {
 			absPath, err := filepath.Abs(path)

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -70,7 +70,6 @@ func TestLog(t *testing.T) {
 
 	// Call the Log function
 	for _, test := range tests {
-		test := test // Assign test to a local variable
 		t.Run(test.name, func(t *testing.T) {
 			logger.Log(test.level, test.str, test.err, test.msg)
 

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -497,7 +497,6 @@ func TestDelete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.pluginName, func(t *testing.T) {
 			err := plugins.Delete(tt.pluginDir, tt.pluginName)
 			if tt.expectErr {

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -46,7 +46,6 @@ func TestPortforwardKeyGenerator(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		testname := tt.name
 		t.Run(testname, func(t *testing.T) {
 			key := portforwardKeyGenerator(tt.p)


### PR DESCRIPTION
## Summary

Remove unnecessary assignment in range for loop, the return values of range for are already local values, dont have to do it again in the range for loop body 


