### PR TITLE
Add revisionHistoryLimit, docs for existing secret key names

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -47,6 +47,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "headlamp.selectorLabels" . | nindent 6 }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -7,6 +7,11 @@
       "description": "Number of replicas to deploy",
       "minimum": 1
     },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "description": "Number of historical ReplicaSets to keep before pruning",
+      "minimum": 1
+    },
     "image": {
       "type": "object",
       "title": "Image",

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -4,6 +4,8 @@
 
 # -- Number of desired pods
 replicaCount: 1
+# -- Number of historical ReplicaSets to keep before pruning
+revisionHistoryLimit: 3
 
 image:
   # -- Container image registry
@@ -86,6 +88,14 @@ config:
     #     externalSecret:
     #       enabled: true
     #       name: oidc
+    # When using an existing secret for OIDC, the key names are different
+    # OIDC_CLIENT_ID: "<Your Application (client) ID>"
+    # OIDC_CLIENT_SECRET: "<Your Application (client) Secret>"
+    # OIDC_ISSUER_URL: "https://login.microsoftonline.com/<Your Directory (tenant) ID>/v2.0"
+    # OIDC_SCOPES: "6dae42f8-4368-4678-94ff-3960e28e3630/user.read openid email profile"
+    # OIDC_USE_ACCESS_TOKEN: "true"
+    # OIDC_VALIDATOR_CLIENT_ID: "6dae42f8-4368-4678-94ff-3960e28e3630"
+    # OIDC_VALIDATOR_ISSUER_URL: "https://sts.windows.net/<Your Directory (tenant) ID>/"
     externalSecret:
       enabled: false
       name: ""


### PR DESCRIPTION
## Summary

This PR adds `revisionHistoryLimit` and existing secret key values to the Helm chart

## Changes

- Added `revisionHistoryLimit` to the Deployment Helm chart template
- Added comments indicated the existing Secret key names the chart references

## Steps to Test

1. `helm lint .`
2. `helm template .`

## Screenshots
### Before:
<img width="2127" height="692" alt="image" src="https://github.com/user-attachments/assets/a060c4cb-2f36-4d48-bf89-1b97845330f9" />

### After:
<img width="2140" height="464" alt="image" src="https://github.com/user-attachments/assets/81ba925b-38ec-409a-a626-f0eeb91a0662" />
