### PR TITLE
backend: caching: refactored PR for cache implementation 

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1431,14 +1431,8 @@ func (c *HeadlampConfig) handleError(w http.ResponseWriter, ctx context.Context,
 	http.Error(w, err.Error(), status)
 }
 
-// handleClusterAPI handles cluster API requests. It is responsible for
-// all the requests made to /clusters/{clusterName}/{api:.*} endpoint.
-// It parses the request and creates a proxy request to the cluster.
-// That proxy is saved in the cache with the context key.
-func handleClusterAPI(c *HeadlampConfig, router *mux.Router) { //nolint:funlen
-	router.HandleFunc("/clusters/{clusterName}/set-token", c.handleSetToken).Methods("POST")
-
-	router.PathPrefix("/clusters/{clusterName}/{api:.*}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ctx := r.Context()
 
@@ -1513,6 +1507,21 @@ func handleClusterAPI(c *HeadlampConfig, router *mux.Router) { //nolint:funlen
 			c.telemetryHandler.RecordEvent(span, "Cluster API request completed")
 		}
 	})
+}
+
+// handleClusterAPI handles cluster API requests. It is responsible for
+// all the requests made to /clusters/{clusterName}/{api:.*} endpoint.
+// It parses the request and creates a proxy request to the cluster.
+// That proxy is saved in the cache with the context key.
+func handleClusterAPI(c *HeadlampConfig, router *mux.Router) {
+	router.HandleFunc("/clusters/{clusterName}/set-token", c.handleSetToken).Methods("POST")
+
+	handler := clusterRequestHandler(c)
+	if c.CacheEnabled {
+		handler = CacheMiddleWare(c)(handler)
+	}
+
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(handler)
 }
 
 func recordRequestCompletion(c *HeadlampConfig, ctx context.Context,

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -25,11 +25,13 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1402,4 +1404,271 @@ func TestConfigureTLSContext_CACert(t *testing.T) {
 	caCertParsed, err := x509.ParseCertificate(block.Bytes)
 	require.NoError(t, err)
 	assert.True(t, caCertParsed.IsCA, "Generated certificate should be a CA certificate")
+}
+
+// newFakeK8sServer create a mock k8s server for testing purpose,
+// this would help to test Caching Machanism without making request
+// to the k8s server.
+func newFakeK8sServer(authAllowed bool) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			status := fmt.Sprintf(`{"status":{"allowed":%v}}`, authAllowed)
+			_, _ = w.Write([]byte(status))
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if authAllowed {
+			_, _ = w.Write([]byte(`{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`))
+		} else {
+			_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","metadata":{"resourceVersion":""},` +
+				`"message":"resource is forbidden: User \"system:serviceaccount:default:test\" cannot get resource ` +
+				`\"resource\" in API group \"\" at the cluster scope","reason":"Forbidden","details":{"kind":"resource"},` +
+				`"code":403}`))
+		}
+	}))
+}
+
+// newHeadlampConfig create mock HeadlampConfig for testing CacheMiddleware
+// mechanism without creating actual HeadlampConfig.
+func newHeadlampConfig(fakeK8s *httptest.Server, testName string) *HeadlampConfig {
+	store := kubeconfig.NewContextStore()
+
+	err := store.AddContext(&kubeconfig.Context{
+		ClusterID: fmt.Sprintf("./home/user/kube/config+test-cluster-%s", testName),
+		Name:      "test",
+		Cluster:   &api.Cluster{Server: fakeK8s.URL},
+		AuthInfo:  &api.AuthInfo{Token: "test-token"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return &HeadlampConfig{
+		HeadlampCFG: &headlampconfig.HeadlampCFG{
+			KubeConfigStore: store,
+			CacheEnabled:    true,
+		},
+		telemetryHandler: &telemetry.RequestHandler{},
+		cache:            cache.New[interface{}](),
+	}
+}
+
+// stringResponse converts the response from the request into
+// string value for comparing results.
+func stringResponse(resp *http.Response) (string, error) {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	bodyString := string(bodyBytes)
+
+	return bodyString, nil
+}
+
+// httpRequestWithContext create request by providing context, url and method, and return
+// http.Response and error.
+func httpRequestWithContext(ctx context.Context, url string, method string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.DefaultClient.Do(req)
+}
+
+const istrue = true
+
+// TestCacheMiddleware_CacheHitAndCacheMiss test whether the k8s is storing into the cache
+// and returns the data if the data is present in the cache.
+func TestCacheMiddleware_CacheHitAndCacheMiss(t *testing.T) {
+	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != strconv.FormatBool(istrue) {
+		t.Skip("skipping integration test")
+	}
+
+	fakeK8s := newFakeK8sServer(true)
+	defer fakeK8s.Close()
+
+	c := newHeadlampConfig(fakeK8s, t.Name())
+
+	ctx := context.Background()
+
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use the incoming request's context
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, fakeK8s.URL+r.URL.Path, nil)
+		if err != nil {
+			http.Error(w, "failed to create request", http.StatusInternalServerError)
+			return
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, "proxy error", http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+
+		_, err = io.Copy(w, resp.Body)
+		assert.NoError(t, err)
+	})
+
+	// 4. Wrap the proxy handler with the CacheMiddleWare
+	router := mux.NewRouter()
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
+		CacheMiddleWare(c)(proxyHandler))
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	expectedResponse := `{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`
+
+	resp1, err := httpRequestWithContext(ctx, ts.URL+"/clusters/test/api/v1/resource", "GET")
+	assert.NoError(t, err)
+
+	defer resp1.Body.Close()
+
+	resp2, err := httpRequestWithContext(ctx, ts.URL+"/clusters/test/api/v1/resource", "GET")
+	assert.NoError(t, err)
+
+	defer resp2.Body.Close()
+
+	resp1String, err := stringResponse(resp1)
+	assert.NoError(t, err)
+	resp2String, err := stringResponse(resp2)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedResponse, resp1String)
+	assert.Equal(t, "", resp1.Header.Get("X-HEADLAMP-CACHE")) // response is from k8s server, hence X-HEADLAMP-CACHE: ""
+	assert.Equal(t, http.StatusOK, resp1.StatusCode)
+	assert.Equal(t, expectedResponse, resp2String)
+	assert.Equal(t, "true", resp2.Header.Get("X-HEADLAMP-CACHE")) // response is from cache, hence X-HEADLAMP-CACHE: true
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+// TestCacheMiddleware_AuthErrorResponse test if the user is not authorized
+// to access a resource, CacheMiddleware should return AuthErrorResponse to
+// the client without going to k8 server.
+func TestCacheMiddleware_AuthErrorResponse(t *testing.T) {
+	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != strconv.FormatBool(istrue) {
+		t.Skip("skipping integration test")
+	}
+
+	fakeK8s := newFakeK8sServer(false)
+	defer fakeK8s.Close()
+
+	c := newHeadlampConfig(fakeK8s, t.Name())
+
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use the incoming request's context
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, fakeK8s.URL+r.URL.Path, nil)
+		if err != nil {
+			http.Error(w, "failed to create request", http.StatusInternalServerError)
+			return
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, "proxy error", http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+
+		_, err = io.Copy(w, resp.Body)
+		assert.NoError(t, err)
+	})
+
+	router := mux.NewRouter()
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
+		CacheMiddleWare(c)(proxyHandler))
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	ctx := context.Background()
+
+	expectedResponse := `{"kind":"Status","apiVersion":"v1","metadata":{"resourceVersion":""},` +
+		`"message":"resource is forbidden: User \"system:serviceaccount:default:test\" cannot get resource ` +
+		`\"resource\" in API group \"\" at the cluster scope","reason":"Forbidden","details":{"kind":"resource"},` +
+		`"code":403}`
+
+	resp1, err := httpRequestWithContext(ctx, ts.URL+"/clusters/test/api/v1/resource", "GET")
+	assert.NoError(t, err)
+
+	defer resp1.Body.Close()
+
+	resp1String, err := stringResponse(resp1)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, resp1String) // expected authErroResponse to the client.
+	assert.Equal(t, "true", resp1.Header.Get("X-HEADLAMP-CACHE"))
+	assert.Equal(t, http.StatusForbidden, resp1.StatusCode)
+}
+
+// TestCacheMiddlware_CacheInvalidation test if the request is modifying
+// it should delete the keys, making new fresh request to k8s server and store
+// into the cache if the request is same it should return response from the client.
+func TestCacheMiddleware_CacheInvalidation(t *testing.T) {
+	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != strconv.FormatBool(istrue) {
+		t.Skip("skipping integration test")
+	}
+
+	fakeK8s := newFakeK8sServer(true)
+	defer fakeK8s.Close()
+
+	c := newHeadlampConfig(fakeK8s, t.Name())
+
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use the incoming request's context
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, fakeK8s.URL+r.URL.Path, nil)
+		if err != nil {
+			http.Error(w, "failed to create request", http.StatusInternalServerError)
+			return
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, "proxy error", http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+
+		_, err = io.Copy(w, resp.Body)
+		assert.NoError(t, err)
+	})
+
+	router := mux.NewRouter()
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
+		CacheMiddleWare(c)(proxyHandler))
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	ctx := context.Background()
+
+	expectedResponse := `{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`
+
+	resp, err := httpRequestWithContext(ctx, ts.URL+"/clusters/test/api/v1/resource", "POST")
+	assert.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, "", resp.Header.Get("X-HEADLAMP-CACHE"))
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp1, err := httpRequestWithContext(ctx, ts.URL+"/clusters/test/api/v1/resource", "GET")
+	assert.NoError(t, err)
+
+	defer resp1.Body.Close()
+
+	resp1String, err := stringResponse(resp1)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, resp1String)
+	assert.Equal(t, "true", resp1.Header.Get("X-HEADLAMP-CACHE"))
+	assert.Equal(t, http.StatusOK, resp1.StatusCode)
 }

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -17,16 +17,26 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"os"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/plugins"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
+
+var k8scache = cache.New[string]()
 
 func main() {
 	if len(os.Args) == 2 && os.Args[1] == "list-plugins" {
@@ -55,6 +65,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 			KubeConfigPath:        conf.KubeConfigPath,
 			SkippedKubeContexts:   conf.SkippedKubeContexts,
 			ListenAddr:            conf.ListenAddr,
+			CacheEnabled:          conf.CacheEnabled,
 			Port:                  conf.Port,
 			DevMode:               conf.DevMode,
 			StaticDir:             conf.StaticDir,
@@ -102,6 +113,93 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 	}
 
 	return headlampConfig
+}
+
+// GetContextKeyAndContext returns Kcontext , ContextKey for using these in CacheMiddleWare function.
+// It also return span and ctx that will help while using handleError function.
+func GetContextKeyAndKContext(w http.ResponseWriter,
+	r *http.Request, c *HeadlampConfig) (context.Context,
+	trace.Span, string, *kubeconfig.Context, error,
+) {
+	ctx := r.Context()
+	ctx, span := telemetry.CreateSpan(ctx, r, "cluster-api", "handleClusterAPI",
+		attribute.String("cluster", mux.Vars(r)["clusterName"]),
+	)
+
+	contextKey, err := c.getContextKeyForRequest(r)
+	if err != nil {
+		c.handleError(w, ctx, span, err, "failed to get context Key:", http.StatusBadRequest)
+		return nil, nil, "", nil, err
+	}
+
+	kContext, err := c.KubeConfigStore.GetContext(contextKey)
+	if err != nil {
+		c.handleError(w, ctx, span, err, "failed to get context", http.StatusNotFound)
+		return nil, nil, "", nil, err
+	}
+
+	return ctx, span, contextKey, kContext, nil
+}
+
+// CacheMiddleWare is Middleware for Caching purpose. It involves generating key for a request,
+// authorizing user , store resource data in cache and returns data if key is present.
+func CacheMiddleWare(c *HeadlampConfig) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if k8cache.SkipWebSocket(r, next, w) {
+				return
+			}
+
+			ctx, span, contextKey, kContext, err := GetContextKeyAndKContext(w, r, c)
+			if err != nil {
+				return
+			}
+
+			if err := k8cache.HandleNonGETCacheInvalidation(k8scache, w, r, next, contextKey); err != nil {
+				c.handleError(w, ctx, span, err, "error while invalidating keys", http.StatusInternalServerError)
+				return
+			}
+
+			rcw := k8cache.NewResponseCapture(w)
+
+			key, err := k8cache.GenerateKey(r.URL, contextKey)
+			if err != nil {
+				c.handleError(w, ctx, span, err, "failed to generate key ", http.StatusBadRequest)
+				return
+			}
+
+			isAllowed, authErr := k8cache.IsAllowed(kContext, r)
+			if authErr != nil {
+				k8cache.ServeFromCacheOrForwardToK8s(k8scache, isAllowed, next, key, w, r, rcw)
+
+				return
+			} else if !isAllowed && k8cache.IsAuthBypassURL(r.URL.Path) {
+				_ = k8cache.ReturnAuthErrorResponse(w, r, contextKey)
+
+				return
+			}
+
+			served, err := k8cache.LoadFromCache(k8scache, isAllowed, key, w, r)
+			if err != nil {
+				c.handleError(w, ctx, span, errors.New(kContext.Error), "failed to load from cache", http.StatusServiceUnavailable)
+			}
+
+			if served {
+				c.telemetryHandler.RecordEvent(span, "Served from cache")
+				return
+			}
+
+			k8cache.CheckForChanges(k8scache, contextKey, *kContext)
+
+			next.ServeHTTP(rcw, r)
+
+			err = k8cache.StoreK8sResponseInCache(k8scache, r.URL, rcw, r, key)
+			if err != nil {
+				c.handleError(w, ctx, span, errors.New(kContext.Error), "error while storing into cache", http.StatusBadRequest)
+				return
+			}
+		})
+	}
 }
 
 func runListPlugins() {

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	InCluster                 bool   `koanf:"in-cluster"`
 	DevMode                   bool   `koanf:"dev"`
 	InsecureSsl               bool   `koanf:"insecure-ssl"`
+	CacheEnabled              bool   `koanf:"cache-enabled"`
 	EnableHelm                bool   `koanf:"enable-helm"`
 	EnableDynamicClusters     bool   `koanf:"enable-dynamic-clusters"`
 	ListenAddr                string `koanf:"listen-addr"`
@@ -261,6 +262,7 @@ func flagset() *flag.FlagSet {
 
 	f.Bool("in-cluster", false, "Set when running from a k8s cluster")
 	f.Bool("dev", false, "Allow connections from other origins")
+	f.Bool("cache-enabled", false, "K8s cache in backend")
 	f.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
 	f.Bool("enable-dynamic-clusters", false, "Enable dynamic clusters, which stores stateless clusters in the frontend.")
 	// Note: When running in-cluster and if not explicitly set, this flag defaults to false.

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -8,6 +8,7 @@ import (
 type HeadlampCFG struct {
 	UseInCluster          bool
 	ListenAddr            string
+	CacheEnabled          bool
 	DevMode               bool
 	Insecure              bool
 	EnableHelm            bool

--- a/backend/pkg/k8cache/authErrResp.go
+++ b/backend/pkg/k8cache/authErrResp.go
@@ -1,0 +1,85 @@
+package k8cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Details provides information about a specific resource kind.
+type Details struct {
+	Kind string `json:"kind"` // The resource Kind ie, Pods, Nodes etc.
+}
+
+// Metadata holds core data about a resource, such as its version.
+type Metadata struct {
+	ResourceVersion string `json:"resourceVersion"`
+}
+
+// AuthErrResponse is the Unauthorized Error message that can be used
+// for sending 403 or Unauthorized error when the user is not allowed
+// to access resources.
+type AuthErrResponse struct {
+	Kind       string   `json:"kind"`       // The Kubernetes resource kind.
+	APIVersion string   `json:"apiVersion"` // APIVersion is version for the resource.
+	MetaData   Metadata `json:"metadata"`   // Metadata for the resource.
+	Message    string   `json:"message"`    // A human-readable error message.
+	Reason     string   `json:"reason"`     // Reason for the error.
+	Details    Details  `json:"details"`    // Details about the resource kind.
+	Code       int      `json:"code"`       // The HTTP status code, typically 403.
+}
+
+// IsAuthBypassURL returns true if the given URL path should be checked for authorization errors,
+// excluding known public or health-check endpoints.
+func IsAuthBypassURL(urlPath string) bool {
+	return !strings.Contains(urlPath, "/version") &&
+		!strings.Contains(urlPath, "/healthz") &&
+		!strings.Contains(urlPath, "/selfsubjectrulesreviews") &&
+		!strings.Contains(urlPath, "/selfsubjectaccessreviews")
+}
+
+// ReturnAuthErrorResponse return the AuthErrorResponse if the user is not Authorized
+// this will returns directly without asking to K8's Server.
+func ReturnAuthErrorResponse(w http.ResponseWriter, r *http.Request, contextKey string) error {
+	last, kubeVerb := GetKindAndVerb(r)
+
+	// AuthErrorResponse will be the actual message which will be
+	// further transformed into JSON body for sending to the client.
+	authErrorResponse := AuthErrResponse{
+		Kind:       "Status",
+		APIVersion: "v1",
+		MetaData:   Metadata{}, // In this case the Metadata will always be empty.
+		Message: fmt.Sprintf("%s is forbidden: User \"system:serviceaccount:default:%s\" cannot ", last, contextKey) +
+			fmt.Sprintf("%s resource \"%s\" in API group \"\" at the cluster scope", kubeVerb, last),
+		Reason: "Forbidden", // For this scenerio the reason should be forbidden.
+		Details: Details{
+			Kind: last,
+		},
+		Code: 403, // 403 is StatusCode for Forbidden user.
+	}
+
+	response, err := json.Marshal(authErrorResponse)
+	if err != nil {
+		return err
+	}
+
+	err = WriteResponseToClient(response, w) // returning the error message to client.
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteResponseToClient returns UnAuthorized error response when the user Unauthorized
+// This helps to prevent requests to make actual call to clusterAPI.
+func WriteResponseToClient(response []byte, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-HEADLAMP-CACHE", "true") // For debugging and testing purpose.
+	w.WriteHeader(http.StatusForbidden)
+
+	_, err := w.Write(response)
+
+	return err
+}

--- a/backend/pkg/k8cache/authErrResp_test.go
+++ b/backend/pkg/k8cache/authErrResp_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAuthBypassUR(t *testing.T) {
+	tests := []struct {
+		name     string
+		urlPath  string
+		expected bool
+	}{
+		{"No restricted paths", "/api/v1/resource", true},
+		{"Contains /version", "/version", false},
+		{"Contains /healthz", "/healthz", false},
+		{"Contains /selfsubjectrulesreviews", "/apis/selfsubjectrulesreviews", false},
+		{"Contains /selfsubjectaccessreviews", "/apis/selfsubjectaccessreviews", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := k8cache.IsAuthBypassURL(tt.urlPath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReturnAuthErrorResponse(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	req := httptest.NewRequest("GET", "/apis/v1/resource", nil)
+
+	err := k8cache.ReturnAuthErrorResponse(rr, req, "test-context")
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	var resp k8cache.AuthErrResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "Status", resp.Kind)
+	assert.Equal(t, "v1", resp.APIVersion)
+	assert.Equal(t, 403, resp.Code)
+	assert.Contains(t, resp.Message, "is forbidden:")
+	assert.Equal(t, "Forbidden", resp.Reason)
+}
+
+func TestWriteResponseToClient(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	responseBody := []byte(`{"error":"forbidden"}`)
+
+	err := k8cache.WriteResponseToClient(responseBody, recorder)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.Equal(t, "true", recorder.Header().Get("X-HEADLAMP-CACHE"))
+	assert.Equal(t, responseBody, recorder.Body.Bytes())
+}

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -1,0 +1,81 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package k8cache provides caching utilities for Kubernetes API responses.
+// It includes middleware for intercepting cluster API requests, generating
+// unique cache keys, storing and retrieving responses, and invalidating
+// entries when resources change. The package aims to reduce redundant
+// API calls, improve performance, and handle authorization gracefully
+// while maintaining consistency across multiple Kubernetes contexts.
+package k8cache
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+	"k8s.io/client-go/kubernetes"
+)
+
+type CachedClientSet struct {
+	clientset *kubernetes.Clientset
+	lastUsed  time.Time
+}
+
+var (
+	clientsetCache = make(map[string]*CachedClientSet)
+	mu             sync.Mutex
+)
+
+// GetClientSet return *kubernetes.ClientSet and error which further used for creating
+// SSAR requests to k8s server to authorize user. GetClientSet uses kubeconfig.Context and
+// authentication bearer token  which will help to create clientSet based on the user's
+// identity.
+func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, error) {
+	contextKey := strings.Split(k.ClusterID, "+")
+	if len(contextKey) < 2 {
+		return nil, fmt.Errorf("unexpected ClusterID format in getClientSet: %q", k.ClusterID)
+	}
+
+	cacheKey := fmt.Sprintf("%s-%s", contextKey[1], token)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if cs, found := clientsetCache[cacheKey]; found {
+		now := time.Now()
+
+		if now.Sub(cs.lastUsed) > 10*time.Minute { // If the clientset was expired then delete
+			// the existing clientset resulting only fresh clientset.
+			delete(clientsetCache, cacheKey)
+			logger.Log(logger.LevelInfo, nil, nil, "clientset "+cacheKey+" was deleted")
+		} else {
+			return cs.clientset, nil // If the clientset is not expired then return directly.
+		}
+	}
+
+	cs, err := k.ClientSetWithToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating clientset for key %s: %w", cacheKey, err)
+	}
+
+	clientsetCache[cacheKey] = &CachedClientSet{
+		clientset: cs,
+		lastUsed:  time.Now(),
+	}
+
+	return cs, nil
+}

--- a/backend/pkg/k8cache/authorization_test.go
+++ b/backend/pkg/k8cache/authorization_test.go
@@ -1,0 +1,106 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+type MockKubeConfig struct {
+	*kubeconfig.Context
+}
+
+func (k *MockKubeConfig) ClientSetWithToken(token string) (kubernetes.Interface, error) {
+	return fake.NewSimpleClientset(), nil
+}
+
+type MockClientConfig struct{}
+
+func (k *MockKubeConfig) ClientConfig() (clientcmd.ClientConfig, error) {
+	conf := api.Config{
+		Clusters: map[string]*api.Cluster{
+			k.KubeContext.Cluster: k.Cluster,
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			k.KubeContext.AuthInfo: k.AuthInfo,
+		},
+		Contexts: map[string]*api.Context{
+			k.Name: k.KubeContext,
+		},
+	}
+
+	return clientcmd.NewNonInteractiveClientConfig(conf, "kind-headlamp-admin", nil, nil), nil
+}
+
+func TestGetClientSet(t *testing.T) {
+	tests := []struct {
+		name          string
+		mockK         MockKubeConfig
+		token         string
+		clientSet     *kubernetes.Clientset
+		expectedError error
+	}{
+		{
+			name: "valid ClusterID returns cached clientset",
+			mockK: MockKubeConfig{
+				&kubeconfig.Context{
+					ClusterID:   "/home/user/.kubeconfig+kind-headlamp-admin",
+					Cluster:     &api.Cluster{Server: "https://example.com"},
+					AuthInfo:    &api.AuthInfo{Token: "abcdef"},
+					KubeContext: &api.Context{Cluster: "kind-headlamp-admin"},
+				},
+			},
+			token:         "token-1245",
+			expectedError: nil,
+		},
+		{
+			name: "return unexpected ClusterID format",
+			mockK: MockKubeConfig{
+				&kubeconfig.Context{
+					ClusterID:   "/home/user/.kubeconfig/kind-headlamp-admin",
+					Cluster:     &api.Cluster{Server: "https://example.com"},
+					AuthInfo:    &api.AuthInfo{Token: "abcdef"},
+					KubeContext: &api.Context{Cluster: "kind-headlamp-admin"},
+				},
+			},
+			token: "token-54321",
+			expectedError: fmt.Errorf("unexpected ClusterID format in getClientSet: " +
+				"\"/home/user/.kubeconfig/kind-headlamp-admin\""),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cs, err := k8cache.GetClientSet(tc.mockK.Context, tc.token)
+			if tc.clientSet != nil { // It is difficult to compare the expected clientset with
+				// the returned clientSet as it return nested-struct inside the clientset which
+				// returns only memory references. To check whether the clientset was correct or
+				// not we can check by checking whether there was an error, so if there was an
+				// error clientset will be empty.
+				assert.NotEmpty(t, cs)
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tc.expectedError, err)
+			}
+		})
+	}
+}

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -21,12 +21,24 @@ package k8cache
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	watchCache "k8s.io/client-go/tools/cache"
 )
 
 // DeleteKeys deletes keys from the cache if data is present
@@ -86,4 +98,166 @@ func SkipWebSocket(r *http.Request, next http.Handler, w http.ResponseWriter) bo
 	}
 
 	return false
+}
+
+// returnGVRList return gvrList which is group, version, resource which is all the supported resources
+// that are supported by the k8s server.
+func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
+	skipKinds := map[string]bool{
+		"Lease": true,
+		"Event": true,
+	}
+
+	var gvrList []schema.GroupVersionResource
+
+	for _, apiResource := range apiResourceLists {
+		for _, resource := range apiResource.APIResources {
+			if strings.Contains(resource.Name, "/") || skipKinds[resource.Kind] {
+				continue
+			}
+
+			if slices.Contains(resource.Verbs, "list") && slices.Contains(resource.Verbs, "watch") {
+				gv, err := schema.ParseGroupVersion(apiResource.GroupVersion)
+				if err != nil {
+					continue
+				}
+
+				gvrList = append(gvrList, schema.GroupVersionResource{
+					Group:    gv.Group,
+					Version:  gv.Version,
+					Resource: resource.Name,
+				})
+			}
+		}
+	}
+
+	return gvrList
+}
+
+// Corrected CheckForChanges.
+var (
+	watcherRegistry sync.Map
+	contextCancel   sync.Map
+)
+
+// CheckForChanges lets 1 go routine to run for a contextKey which prevents
+// running go routines for every requests which can become performance issue if
+// there are many resource and events are going on.
+func CheckForChanges(
+	k8scache cache.Cache[string],
+	contextKey string,
+	kContext kubeconfig.Context,
+) {
+	if _, loaded := watcherRegistry.Load(contextKey); loaded {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	contextCancel.Store(contextKey, cancel)
+
+	watcherRegistry.Store(contextKey, struct{}{})
+
+	go runWatcher(ctx, k8scache, contextKey, kContext)
+}
+
+// runWatcher is a long-lived goroutine that sets up and runs Kubernetes informers.
+// It watches for resource changes and invalidates corresponding cache entries.
+// This function will only exit when its context is cancelled.
+func runWatcher(
+	ctx context.Context,
+	k8scache cache.Cache[string],
+	contextKey string,
+	kContext kubeconfig.Context,
+) {
+	logger.Log(logger.LevelInfo, nil, nil, "running runWatcher for watching k8s resource: "+contextKey)
+
+	config, err := kContext.RESTConfig()
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "error getting REST config for context:")
+		return
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "error creating dynamic client for context: "+contextKey)
+		return
+	}
+
+	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(config)
+
+	apiResourceLists, err := discoveryClient.ServerPreferredResources()
+	if apiResourceLists == nil && err != nil {
+		logger.Log(logger.LevelError, nil, err, "error fetching resource list for context: "+contextKey)
+		return
+	}
+
+	gvrList := returnGVRList(apiResourceLists)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 0, "", nil)
+
+	RunInformerToWatch(gvrList, factory, contextKey, k8scache)
+
+	factory.Start(ctx.Done())
+
+	factory.WaitForCacheSync(ctx.Done())
+
+	<-ctx.Done()
+	logger.Log(logger.LevelInfo, nil, nil, "Watcher for context "+contextKey+" is shutting down...")
+}
+
+// runInformerToWatch watches changes such as Addition, Deletion and Updation of a resource
+// and if so capture the data into the key and store all unique keys, and return unique
+// keys which will be delete in runWatcher.
+func RunInformerToWatch(gvrList []schema.GroupVersionResource,
+	factory dynamicinformer.DynamicSharedInformerFactory,
+	contextKey string, k8scache cache.Cache[string],
+) {
+	for _, gvr := range gvrList {
+		informer := factory.ForResource(gvr).Informer()
+
+		if _, err := informer.AddEventHandler(watchCache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) { // resources which are added in the informers, like creation of a resource.
+				handleKeyGenerationAndDeletion(obj, gvr, contextKey, k8scache)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) { // resources which are updated
+				// or changed, like pods configurations was changed.
+				handleKeyGenerationAndDeletion(newObj, gvr, contextKey, k8scache)
+			},
+			DeleteFunc: func(obj interface{}) { // resources which are removed from the informers,
+				// deletion of pods or any other resources.
+				handleKeyGenerationAndDeletion(obj, gvr, contextKey, k8scache)
+			},
+		}); err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to add event handler for resource: "+gvr.Resource)
+			return
+		}
+	}
+}
+
+// handleKeyGeneration generation key by using gvr's value, which will be used further for deletion of key in cache
+// so if the key match it will delete the key from cache.
+func handleKeyGenerationAndDeletion(obj interface{}, gvr schema.GroupVersionResource,
+	contextKey string, k8scache cache.Cache[string],
+) {
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		logger.Log(logger.LevelError, nil, nil, "unexpected object type")
+		return
+	}
+
+	if time.Since(unstructuredObj.GetCreationTimestamp().Time) > time.Minute { // this will let only latest changes rather
+		//  than all the all the resource that are just added into informers, as it will
+		// cause unnecessary watching of resources that doesn't required to be watched.
+		return
+	}
+
+	namespace := unstructuredObj.GetNamespace()
+	key := fmt.Sprintf("%s+%s+%s+%s", gvr.Group, gvr.Resource, namespace, contextKey) // Generation key using gvr's value
+
+	logger.Log(logger.LevelInfo, nil, nil, key+" will going to be deleted from the cache")
+
+	if err := k8scache.Delete(context.Background(), key); err != nil { // key is deleting from the cache
+		logger.Log(logger.LevelError, nil, err, "error while deleting key")
+		return
+	}
 }

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -1,0 +1,89 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package k8cache provides caching utilities for Kubernetes API responses.
+// It includes middleware for intercepting cluster API requests, generating
+// unique cache keys, storing and retrieving responses, and invalidating
+// entries when resources change. The package aims to reduce redundant
+// API calls, improve performance, and handle authorization gracefully
+// while maintaining consistency across multiple Kubernetes contexts.
+package k8cache
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+// DeleteKeys deletes keys from the cache if data is present
+// in cache, this delete keys having namespace non-empty and
+// also empty namespace.
+func DeleteKeys(key string, k8scache cache.Cache[string]) {
+	_ = k8scache.Delete(context.Background(), key)
+	keyPart := strings.Split(key, "+")
+	keyPart[2] = ""
+	key = strings.Join(keyPart, "+")
+	_ = k8scache.Delete(context.Background(), key)
+}
+
+// handleNonGetInvalidation handle request which are modifying eg. POST/DELETE/PUT and delete keys if
+// the data is present in the cache, if present PURGE the keys from the cache and make a fresh new
+// request to k8s server and store into the cache, the cache has now latest changes.
+func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.ResponseWriter, r *http.Request,
+	next http.Handler, contextKey string,
+) error {
+	// Skip cache invalidation if this is a GET request or the path is not allowed for auth error handling.
+	if r.Method == http.MethodGet || !IsAuthBypassURL(r.URL.Path) {
+		return nil
+	}
+
+	key, _ := GenerateKey(r.URL, contextKey)
+	DeleteKeys(key, k8scache)
+
+	freshURL := *r.URL
+
+	freshReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, freshURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	freshReq.Header = r.Header.Clone()
+	next.ServeHTTP(w, r)
+
+	rr := httptest.NewRecorder()
+	freshRcw := NewResponseCapture(rr)
+	next.ServeHTTP(freshRcw, freshReq)
+
+	if err := StoreK8sResponseInCache(k8scache, freshReq.URL, freshRcw, freshReq, key); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SkipWebSocket skip all the websocket requests coming from the client/ frontend to ensure
+// real time data updation in the frontend.
+func SkipWebSocket(r *http.Request, next http.Handler, w http.ResponseWriter) bool {
+	if strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade") {
+		logger.Log(logger.LevelInfo, nil, nil, "skipping websocket url")
+		next.ServeHTTP(w, r)
+
+		return true
+	}
+
+	return false
+}

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteKeys(t *testing.T) {
+	tests := []struct {
+		name            string
+		beforemockCache *MockCache
+		key             string
+		aftermockCache  *MockCache
+	}{
+		{
+			name: "both keys with empty namespace and non-empty are present in cache",
+			beforemockCache: &MockCache{
+				store: map[string]string{
+					"+pods+default+test-context":            "value-1",
+					"apps+deployments+default+test-context": "value-2",
+					"+pods++test-context":                   "value-3",
+				},
+			},
+			key: "+pods+default+test-context",
+			aftermockCache: &MockCache{
+				store: map[string]string{
+					"apps+deployments+default+test-context": "value-2",
+				},
+			},
+		},
+		{
+			name: "only key with only empty namespace present in cache",
+			beforemockCache: &MockCache{
+				store: map[string]string{
+					"apps+deployments+default+test-context": "value-2", "+pods++test-context": "value-3",
+				},
+			},
+			key: "+pods+default+test-context",
+			aftermockCache: &MockCache{
+				store: map[string]string{
+					"apps+deployments+default+test-context": "value-2",
+				},
+			},
+		},
+		{
+			name: "only key with only non-empty namespace present in cache",
+			beforemockCache: &MockCache{
+				store: map[string]string{
+					"apps+deployments+default+test-context": "value-2",
+					"+pods+default+test-context":            "value-3",
+				},
+			},
+			key: "+pods+default+test-context",
+			aftermockCache: &MockCache{
+				store: map[string]string{
+					"apps+deployments+default+test-context": "value-2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCache := tc.beforemockCache
+			k8cache.DeleteKeys(tc.key, mockCache)
+			assert.Equal(t, tc.aftermockCache, mockCache)
+		})
+	}
+}
+
+func TestSkipWebSocket(t *testing.T) {
+	tests := []struct {
+		name           string
+		connectionHdr  string
+		expectedResult bool
+		expectHandler  bool
+	}{
+		{
+			name:           "Upgrade header present",
+			connectionHdr:  "Upgrade",
+			expectedResult: true,
+			expectHandler:  true,
+		},
+		{
+			name:           "No upgrade header",
+			connectionHdr:  "",
+			expectedResult: false,
+			expectHandler:  false,
+		},
+		{
+			name:           "Upgrade header with different case",
+			connectionHdr:  "uPgRaDe",
+			expectedResult: true,
+			expectHandler:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlerCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+			if tt.connectionHdr != "" {
+				req.Header.Set("Connection", tt.connectionHdr)
+			}
+
+			w := httptest.NewRecorder()
+
+			result := k8cache.SkipWebSocket(req, next, w)
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectHandler, handlerCalled)
+		})
+	}
+}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
@@ -112,4 +113,27 @@ func ExtractNamespace(rawURL string) (string, string) {
 	}
 
 	return namespace, kind
+}
+
+// GenerateKey function helps to generate a unique key based on the request from the client
+// The function accepts url( which includes all the information of request ) and contextID which
+// helps to differentiate in multiple contexts.
+func GenerateKey(url *url.URL, contextID string) (string, error) {
+	namespace, kind := ExtractNamespace(url.Path)
+
+	apiGroup, _, err := GetAPIGroup(url.Path)
+	if err != nil {
+		return "", err
+	}
+
+	k := CacheKey{
+		Kind:      kind,
+		Namespace: namespace,
+		Context:   contextID,
+	}
+
+	// Create a stable representation
+	raw := fmt.Sprintf("%s+%s+%s+%s", apiGroup, k.Kind, k.Namespace, k.Context)
+
+	return raw, nil
 }

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -148,3 +148,22 @@ func SetHeader(cacheData CachedResponseData, w http.ResponseWriter) {
 	w.Header().Set("X-HEADLAMP-CACHE", "true")
 	w.WriteHeader(cacheData.StatusCode)
 }
+
+const gzipEncoding = "gzip"
+
+// FilterHeaderForCache ensures that the cached headers accurately reflect the state of the
+// decompressed body that is being stored, and prevents client side decompression
+// issues serving from cache.
+func FilterHeaderForCache(responseHeaders http.Header, encoding string) http.Header {
+	cacheHeader := make(http.Header)
+
+	for idx, header := range responseHeaders {
+		if strings.EqualFold(idx, "Content-Encoding") && encoding == gzipEncoding {
+			continue
+		}
+
+		cacheHeader[idx] = append(cacheHeader[idx], header...)
+	}
+
+	return cacheHeader
+}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -137,3 +137,14 @@ func GenerateKey(url *url.URL, contextID string) (string, error) {
 
 	return raw, nil
 }
+
+// SetHeader function help to serve response from cache to ensure the client
+// receives correct metadata about the response.
+func SetHeader(cacheData CachedResponseData, w http.ResponseWriter) {
+	for idx, header := range cacheData.Headers {
+		w.Header()[idx] = header
+	}
+
+	w.Header().Set("X-HEADLAMP-CACHE", "true")
+	w.WriteHeader(cacheData.StatusCode)
+}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -26,6 +26,8 @@ import (
 	"io"
 	"net/http"
 
+	"strings"
+
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 )
 
@@ -62,4 +64,25 @@ func GetResponseBody(bodyBytes []byte, encoding string) (string, error) {
 	}
 
 	return string(dcmpBody), nil
+}
+
+// GetAPIGroup parses the URL path and returns the apiGroup and version.
+func GetAPIGroup(path string) (apiGroup, version string, err error) {
+	parts := strings.Split(path, "/")
+
+	if len(parts) < 4 {
+		return "", "", fmt.Errorf("invalid url format")
+	}
+
+	if parts[3] == "api" {
+		// Core API group
+		apiGroup = ""
+		version = parts[4]
+	} else if parts[3] == "apis" {
+		// Named API group
+		apiGroup = parts[4]
+		version = parts[5]
+	}
+
+	return
 }

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -1,0 +1,65 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package k8cache provides caching utilities for Kubernetes API responses.
+// It includes middleware for intercepting cluster API requests, generating
+// unique cache keys, storing and retrieving responses, and invalidating
+// entries when resources change. The package aims to reduce redundant
+// API calls, improve performance, and handle authorization gracefully
+// while maintaining consistency across multiple Kubernetes contexts.
+package k8cache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+// CachedResponseData stores information such as StatusCode, Headers, and Body.
+// It helps cache responses efficiently and serve them from the cache.
+type CachedResponseData struct {
+	StatusCode int         `json:"statusCode"`
+	Headers    http.Header `json:"headers"`
+	Body       string      `json:"body"`
+}
+
+// GetResponseBody decompresses a gzip-encoded response body and returns it as a string.
+// If the encoding is not gzip, it returns the raw body as a string.
+func GetResponseBody(bodyBytes []byte, encoding string) (string, error) {
+	var dcmpBody []byte
+
+	if encoding == "gzip" {
+		reader, err := gzip.NewReader(bytes.NewReader(bodyBytes))
+		if err != nil {
+			return "", fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+
+		defer reader.Close()
+
+		decompressedBody, err := io.ReadAll(reader)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to decompress body")
+			return "", fmt.Errorf("failed to decompress body: %w", err)
+		}
+
+		dcmpBody = decompressedBody
+	} else {
+		dcmpBody = bodyBytes
+	}
+
+	return string(dcmpBody), nil
+}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
 	"strings"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
@@ -85,4 +84,32 @@ func GetAPIGroup(path string) (apiGroup, version string, err error) {
 	}
 
 	return
+}
+
+// ExtractNamespace extracts the namespace from the parameter from the given raw URL. This is used to make
+// cache key more specific to a particular namespace.
+func ExtractNamespace(rawURL string) (string, string) {
+	if idx := strings.Index(rawURL, "?"); idx != -1 {
+		rawURL = rawURL[:idx]
+	}
+
+	rawURL = strings.TrimSuffix(rawURL, "/")
+
+	var namespace, kind string
+
+	urls := strings.Split(rawURL, "/")
+	n := len(urls)
+
+	for i := 0; i < n-1; i++ {
+		if urls[i] == "namespaces" {
+			namespace = urls[i+1]
+			break
+		}
+	}
+
+	if len(urls) > 2 {
+		kind = urls[n-1]
+	}
+
+	return namespace, kind
 }

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -18,6 +18,7 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -150,6 +151,48 @@ func TestGetResponseBody(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedBody, body)
 			}
+		})
+	}
+}
+
+// TestGetAPIGroup tests whether the GetAPIGroup returning correct
+// apiGroup and version from the URL.
+func TestGetAPIGroup(t *testing.T) {
+	tests := []struct {
+		name             string
+		urlPath          string
+		expectedAPIGroup string
+		expectedVersion  string
+		expectedError    error
+	}{
+		{
+			name:             "return non-empty apiGroup and version",
+			urlPath:          "/clusters/kind-kind/apis/metrics.k8s.io/v1beta1/pods",
+			expectedAPIGroup: "metrics.k8s.io",
+			expectedVersion:  "v1beta1",
+			expectedError:    nil,
+		},
+		{
+			name:             "return empty apiGroup",
+			urlPath:          "/clusters/kind-kind/api/v1/pods",
+			expectedAPIGroup: "",
+			expectedVersion:  "v1",
+			expectedError:    nil,
+		},
+		{
+			name:             "invalid url format",
+			urlPath:          "/clusters/kind-kind",
+			expectedAPIGroup: "",
+			expectedVersion:  "",
+			expectedError:    fmt.Errorf("invalid url format"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			apiGroup, version, err := k8cache.GetAPIGroup(tc.urlPath)
+			assert.Equal(t, tc.expectedAPIGroup, apiGroup)
+			assert.Equal(t, tc.expectedError, err)
+			assert.Equal(t, tc.expectedVersion, version)
 		})
 	}
 }

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockCache is struct which help to mock caching for testing purpose.
+type MockCache struct {
+	mu    sync.RWMutex
+	store map[string]string
+	err   error
+}
+
+// NewMockCache Helps to initialize cache struct for tests.
+func NewMockCache() *MockCache {
+	return &MockCache{
+		store: make(map[string]string),
+	}
+}
+
+// Set mocks storing of value with its corresponding key string.
+func (m *MockCache) Set(ctx context.Context, key, value string) error {
+	if m.err != nil {
+		return m.err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.store[key] = value
+
+	return nil
+}
+
+// SetWithTTL Mocks storing of value with its corresponding key string with time-to-live.
+func (m *MockCache) SetWithTTL(ctx context.Context, key, value string, ttl time.Duration) error {
+	return m.Set(ctx, key, value)
+}
+
+// Delete Mocks deleting value with the help of key string.
+func (m *MockCache) Delete(ctx context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.store, key)
+
+	return nil
+}
+
+// Get Mocks retrieval of value with its corresponding key string.
+func (m *MockCache) Get(ctx context.Context, key string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	val, ok := m.store[key]
+
+	if !ok {
+		return "", errors.New("not found")
+	}
+
+	return val, nil
+}
+
+// GetAll Mocks retrieving all the values inside the cache.
+func (m *MockCache) GetAll(ctx context.Context, selectFunc cache.Matcher) (map[string]string, error) {
+	return nil, nil
+}
+
+// UpdateTTL Mocks updating of time-to-live with the help of its corresponding key string.
+func (m *MockCache) UpdateTTL(ctx context.Context, key string, ttl time.Duration) error {
+	return nil
+}
+
+// TestGetResponseBody checks that the response body is correctly decoded
+// based on the content encoding (e.g., gzip).
+func TestGetResponseBody(t *testing.T) {
+	tests := []struct {
+		name            string
+		bodyBytes       []byte
+		contentEncoding string
+		expectedBody    string
+		expectError     bool
+	}{
+		{
+			name: "valid gzip response",
+			bodyBytes: func() []byte {
+				var buf bytes.Buffer
+				gz := gzip.NewWriter(&buf)
+
+				_, _ = gz.Write([]byte("test-response"))
+				gz.Close()
+				return buf.Bytes()
+			}(),
+			contentEncoding: "gzip",
+			expectedBody:    "test-response",
+			expectError:     false,
+		},
+		{
+			name: "empty gzip response",
+			bodyBytes: func() []byte {
+				var buf bytes.Buffer
+				gz := gzip.NewWriter(&buf)
+				gz.Close()
+				return buf.Bytes()
+			}(),
+			contentEncoding: "gzip",
+			expectedBody:    "",
+			expectError:     false,
+		},
+		{
+			name:            "invalid gzip data - should return error",
+			bodyBytes:       []byte("not-gzip-data"),
+			contentEncoding: "gzip",
+			expectedBody:    "",
+			expectError:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := k8cache.GetResponseBody(tc.bodyBytes, tc.contentEncoding)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedBody, body)
+			}
+		})
+	}
+}

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -355,3 +355,35 @@ func TestSetHeader(t *testing.T) {
 		})
 	}
 }
+
+// TestFilterToCache verifies that headers are correctly filtered before caching,
+// specifically removing Content-Encoding when the body is decompressed.
+func TestFilterToCache(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseHeader http.Header
+		encoding       string
+		expectedHeader http.Header
+	}{
+		{
+			name: "headers are valid",
+			responseHeader: http.Header{
+				"Content-Type":     {"application/json"},
+				"Content-Encoding": {"gzip"},
+				"X-Test":           {"test"},
+			},
+			encoding: "gzip",
+			expectedHeader: http.Header{
+				"Content-Type": {"application/json"},
+				"X-Test":       {"test"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			header := k8cache.FilterHeaderForCache(tc.responseHeader, tc.encoding)
+			assert.Equal(t, tc.expectedHeader, header)
+		})
+	}
+}

--- a/backend/pkg/k8cache/key.go
+++ b/backend/pkg/k8cache/key.go
@@ -1,0 +1,21 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package k8cache
+
+// Key struct used to store different values to make Key unique
+// for different requests.
+type CacheKey struct {
+	Kind      string // Kind is the string object which is the user is requesting
+	Namespace string // Namespace is string object which tells what Namespace is the user trying to access
+	Context   string // Context is the unique Id which helps to differentiate multi-context
+}

--- a/backend/pkg/k8cache/responseCapture.go
+++ b/backend/pkg/k8cache/responseCapture.go
@@ -46,3 +46,12 @@ func (r *ResponseCapture) Write(b []byte) (int, error) {
 
 	return r.ResponseWriter.Write(b)
 }
+
+// NewResponseCapture initializes ResponseCapture with a http.ResponseWriter and empty bytes.Buffer for the body.
+func NewResponseCapture(w http.ResponseWriter) *ResponseCapture {
+	return &ResponseCapture{
+		ResponseWriter: w,
+		Body:           &bytes.Buffer{},
+		StatusCode:     http.StatusOK,
+	}
+}

--- a/backend/pkg/k8cache/responseCapture.go
+++ b/backend/pkg/k8cache/responseCapture.go
@@ -1,0 +1,48 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package k8cache provides caching utilities for Kubernetes API responses.
+// It includes middleware for intercepting cluster API requests, generating
+// unique cache keys, storing and retrieving responses, and invalidating
+// entries when resources change. The package aims to reduce redundant
+// API calls, improve performance, and handle authorization gracefully
+// while maintaining consistency across multiple Kubernetes contexts.
+package k8cache
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// ResponseCapture is a struct that will capture statusCode, Headers and Body
+// while the response is coming from the K8s clusters.
+type ResponseCapture struct {
+	http.ResponseWriter
+	StatusCode int
+	Body       *bytes.Buffer
+}
+
+// WriteHeader sets the status code and delegates to the underlying ResponseWriter.
+func (r *ResponseCapture) WriteHeader(code int) {
+	r.StatusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// Write stores the response body and writes it to the underlying ResponseWriter.
+func (r *ResponseCapture) Write(b []byte) (int, error) {
+	if _, err := r.Body.Write(b); err != nil {
+		return 0, err
+	}
+
+	return r.ResponseWriter.Write(b)
+}

--- a/backend/pkg/k8cache/responseCapture_test.go
+++ b/backend/pkg/k8cache/responseCapture_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+)
+
+// TestResponseCapture_WriteHeader tests that WriteHeader sets the status code and calls the underlying ResponseWriter.
+func TestResponseCapture_WriteHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	capture := &k8cache.ResponseCapture{
+		ResponseWriter: rec,
+		Body:           &bytes.Buffer{},
+	}
+
+	capture.WriteHeader(http.StatusTeapot)
+
+	if capture.StatusCode != http.StatusTeapot {
+		t.Errorf("expected StatusCode %d, got %d", http.StatusTeapot, capture.StatusCode)
+	}
+
+	if rec.Result().StatusCode != http.StatusTeapot {
+		t.Errorf("expected recorder StatusCode %d, got %d", http.StatusTeapot, rec.Result().StatusCode)
+	}
+}
+
+// TestResponseCapture_Integration tests integration with an HTTP handler.
+func TestResponseCapture_Integration(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+
+		if _, err := w.Write([]byte("integration test")); err != nil {
+			t.Errorf("unexpected error writing response: %v", err)
+		}
+	})
+
+	rec := httptest.NewRecorder()
+	capture := &k8cache.ResponseCapture{
+		ResponseWriter: rec,
+		Body:           &bytes.Buffer{},
+	}
+
+	handler.ServeHTTP(capture, httptest.NewRequest("GET", "/", nil))
+
+	if capture.StatusCode != http.StatusAccepted {
+		t.Errorf("expected StatusCode %d, got %d", http.StatusAccepted, capture.StatusCode)
+	}
+
+	if capture.Body.String() != "integration test" {
+		t.Errorf("expected body %q, got %q", "integration test", capture.Body.String())
+	}
+
+	if rec.Result().StatusCode != http.StatusAccepted {
+		t.Errorf("expected recorder StatusCode %d, got %d", http.StatusAccepted, rec.Result().StatusCode)
+	}
+
+	if rec.Body.String() != "integration test" {
+		t.Errorf("expected recorder body %q, got %q", "integration test", rec.Body.String())
+	}
+}
+
+type errorWriter struct {
+	http.ResponseWriter
+}
+
+func (e *errorWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("simulated write error")
+}
+
+func TestResponseCapture_Write_Error(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ew := &errorWriter{ResponseWriter: rec}
+
+	capture := &k8cache.ResponseCapture{
+		ResponseWriter: ew,
+		Body:           &bytes.Buffer{}, // still a *bytes.Buffer
+	}
+
+	n, err := capture.Write([]byte("fail"))
+	if err == nil {
+		t.Errorf("expected error from ResponseWriter.Write, got nil")
+	}
+
+	if n != 0 {
+		t.Errorf("expected written length 0, got %d", n)
+	}
+}
+
+// Update the existing TestResponseCapture_Write to ensure no error is returned.
+func TestResponseCapture_Write(t *testing.T) {
+	rec := httptest.NewRecorder()
+	capture := &k8cache.ResponseCapture{
+		ResponseWriter: rec,
+		Body:           &bytes.Buffer{},
+	}
+
+	data := []byte("hello world")
+
+	n, err := capture.Write(data)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if n != len(data) {
+		t.Errorf("expected written length %d, got %d", len(data), n)
+	}
+
+	if capture.Body.String() != "hello world" {
+		t.Errorf("expected body %q, got %q", "hello world", capture.Body.String())
+	}
+
+	if rec.Body.String() != "hello world" {
+		t.Errorf("expected recorder body %q, got %q", "hello world", rec.Body.String())
+	}
+}
+
+// TestResponseCapture_Write_BodySuccess tests that ResponseCapture.Write writes to
+// Body and ResponseWriter when Body.Write succeeds.
+func TestResponseCapture_Write_BodySuccess(t *testing.T) {
+	rec := httptest.NewRecorder()
+	buf := &bytes.Buffer{}
+	capture := &k8cache.ResponseCapture{
+		ResponseWriter: rec,
+		Body:           buf,
+	}
+
+	data := []byte("body success")
+
+	n, err := capture.Write(data)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if n != len(data) {
+		t.Errorf("expected written length %d, got %d", len(data), n)
+	}
+
+	if buf.String() != "body success" {
+		t.Errorf("expected body %q, got %q", "body success", buf.String())
+	}
+
+	if rec.Body.String() != "body success" {
+		t.Errorf("expected recorder body %q, got %q", "body success", rec.Body.String())
+	}
+}

--- a/backend/pkg/k8cache/responseCapture_test.go
+++ b/backend/pkg/k8cache/responseCapture_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestResponseCapture_WriteHeader tests that WriteHeader sets the status code and calls the underlying ResponseWriter.
@@ -160,4 +161,20 @@ func TestResponseCapture_Write_BodySuccess(t *testing.T) {
 	if rec.Body.String() != "body success" {
 		t.Errorf("expected recorder body %q, got %q", "body success", rec.Body.String())
 	}
+}
+
+// TestNewResponseCapture verifies that responseCapture is initialized with
+// the original http.ResponseWriter and an empty buffer.
+func TestNewResponseCapture(t *testing.T) {
+	t.Run("initializes responseCapture with defaults", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		rc := k8cache.NewResponseCapture(recorder)
+
+		assert.NotNil(t, rc)
+		assert.Equal(t, http.StatusOK, rc.StatusCode)
+		assert.Equal(t, recorder, rc.ResponseWriter)
+		assert.NotNil(t, rc.Body)
+		assert.Equal(t, 0, rc.Body.Len())
+	})
 }


### PR DESCRIPTION
### Summary
This PR is the refactored and cleaner PR of #3499, which includes Caching functionalities like Storing, Serving and Authorization of the user to access a resources.

 ### How to Test
-  Currently in this setup, cache is by-default ``false``, so to test it you would need to put make it true by overriding the ``CacheEnabled = true``, this would enable the cache.

There are many scenerios here which you can test it out:-
1.  If you want to test whether it is showing the data that the user was authorized to access it or not ? you can do it by creating your service accounts and bind roles and add resource which you want to test it out.
2. For the scenerio where the ``user's permissions`` just revoked by admin so for that you can remove your added <resource>  and now reload the resource page you should see the change. 
3. If you want see the changes when you are making changes inside Headlamp, you can create resource through also, for seeing the changes you can see the changes by reloading the page.
4. For the scenerio where you want to check whether it is syncing with the ``external changing like kubectl`` then you create a resource like secrets (secrets here because it is easier to create secrets ). after creating you just reload the page you should see the created secret. 
```
kubectl create secret generic new-secret --from-literal=username=admin --from-literal= password='s3cr3t'
```
5. For the scenerio where there could be err while Authorizing the user's permission you can re-create the error for testing purpose, go to k8scace.go file and under `` func isAllowed()``
```
result, err := clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(
		context.TODO(),
		nil,
		metav1.CreateOptions{},
	)
```    
