### PR TITLE
frontend: ClusterContextMenu: Fix menu to not show two deletes

### DIFF
--- a/frontend/src/components/App/Home/ClusterContextMenu.tsx
+++ b/frontend/src/components/App/Home/ClusterContextMenu.tsx
@@ -153,7 +153,8 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
         >
           <ListItemText>{t('translation|Settings')}</ListItemText>
         </MenuItem>
-        {helpers.isElectron() &&
+        {(!menuItems || menuItems.length === 0) &&
+          helpers.isElectron() &&
           (cluster.meta_data?.source === 'dynamic_cluster' ||
             cluster.meta_data?.source === 'kubeconfig') && (
             <MenuItem
@@ -165,7 +166,6 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
               <ListItemText>{t('translation|Delete')}</ListItemText>
             </MenuItem>
           )}
-
         {menuItems.map((Item, index) => {
           return (
             <Item


### PR DESCRIPTION
Do not show a delete if there are custom menu items.
Because they are responsible for adding delete.


Before (two deletes):

<img width="116" height="293" alt="Screenshot 2025-08-04 at 21 38 02" src="https://github.com/user-attachments/assets/77c5a74e-03b1-42a3-8820-66f25af2d91f" />


After:

<img width="126" height="245" alt="Screenshot 2025-08-04 at 21 36 17" src="https://github.com/user-attachments/assets/c9bb7980-a345-4f48-9662-771392cc7881" />

