### PR TITLE
frontend: Notifications: Fix contrast for menu items on all themes

### DIFF
--- a/frontend/src/components/App/Notifications/List/List.tsx
+++ b/frontend/src/components/App/Notifications/List/List.tsx
@@ -104,11 +104,29 @@ export default function NotificationList() {
           <Icon icon="mdi:dots-vertical" />
         </IconButton>
         <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-          <MenuItem onClick={markAllAsRead} disabled={!hasUnseenNotifications}>
-            <Typography color={'primary'}>{t('translation|Mark all as read')}</Typography>
+          <MenuItem
+            sx={{
+              '&.Mui-disabled': {
+                opacity: 0.7,
+              },
+            }}
+            onClick={markAllAsRead}
+            disabled={!hasUnseenNotifications}
+          >
+            <Typography color={theme.palette.text.primary}>
+              {t('translation|Mark all as read')}
+            </Typography>
           </MenuItem>
-          <MenuItem onClick={clearAllNotifications} disabled={allNotificationsAreDeleted}>
-            <Typography color="primary">{t('translation|Clear all')}</Typography>
+          <MenuItem
+            sx={{
+              '&.Mui-disabled': {
+                opacity: 0.7,
+              },
+            }}
+            onClick={clearAllNotifications}
+            disabled={allNotificationsAreDeleted}
+          >
+            <Typography color={theme.palette.text.primary}>{t('translation|Clear all')}</Typography>
           </MenuItem>
         </Menu>
       </>


### PR DESCRIPTION
## Summary

This PR fixes the issue where the text for notification menu items were not readable on darker themes

## Related Issue

Related to issue https://github.com/kubernetes-sigs/headlamp/issues/3746

## Changes

- Added contrast text via theme.palette to all notification menu items
- Keeps buttons disabled when needed, just not readable

## Steps to Test

1. Navigate to notifications
2. Click on the menu button
3. Note that they are now contrast friendly

## Screenshots (if applicable)

## Before
<img width="231" height="156" alt="image" src="https://github.com/user-attachments/assets/6d3297e7-134d-444b-a700-08b16e470bbb" />
<img width="277" height="177" alt="image" src="https://github.com/user-attachments/assets/3455fee6-4a96-4a54-934c-a5a449abd32f" />
<img width="214" height="171" alt="image" src="https://github.com/user-attachments/assets/e1c606b4-1d96-4f50-9471-427e2c8659c4" />



## After

### disabled
<img width="245" height="175" alt="image" src="https://github.com/user-attachments/assets/e16ff208-c440-49b1-b845-7bd566d792b1" />
<img width="248" height="163" alt="image" src="https://github.com/user-attachments/assets/ea5df0cd-866f-4c88-bd85-8586c208ac74" />
<img width="228" height="158" alt="image" src="https://github.com/user-attachments/assets/c7c5209f-454e-4806-89c8-da88a4888249" />

### enabled
<img width="249" height="185" alt="image" src="https://github.com/user-attachments/assets/fdb5c55e-b8e6-47d8-b29f-c6ddfa0c1200" />
<img width="225" height="196" alt="image" src="https://github.com/user-attachments/assets/92bd6a07-2f1b-42f8-8645-4bf516138467" />
<img width="241" height="188" alt="image" src="https://github.com/user-attachments/assets/361c01c0-ae24-4ad4-bc02-ecb7472ac406" />

