### PR TITLE
gitignore: Add ignore for mac .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 .idea/
 plugins/headlamp-plugin/headlamp-myfancy/
 plugins/examples/*/dist/
+.DS_Store


### PR DESCRIPTION
MacOS Finder leaves these little .DS_Store presents wherever it's used.