### PR TITLE
frontend: ActionsNotifier: Fix contrast issue for all themes

### DIFF
--- a/frontend/src/components/common/ActionsNotifier.tsx
+++ b/frontend/src/components/common/ActionsNotifier.tsx
@@ -47,7 +47,11 @@ function PureActionsNotifier({ dispatch, clusterActions }: PureActionsNotifierPr
         {(clusterAction.buttons || []).map(({ label, actionToDispatch }, i) => (
           <Button
             key={i}
-            color="secondary"
+            sx={{
+              color: 'white',
+              textTransform: 'none',
+            }}
+            variant="text"
             size="small"
             onClick={() => {
               dispatch({ type: actionToDispatch });

--- a/frontend/src/components/common/__snapshots__/ActionsNotifier.Some.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ActionsNotifier.Some.stories.storyshot
@@ -30,7 +30,7 @@
                 class="go703367398"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorSecondary MuiButton-disableElevation css-ukjbk1-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1ceptvv-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >


### PR DESCRIPTION
## Summary

This PR fixes the issue where the text for the ActionsNotifier (like cancel) were not readable on darker themes. I have set the text to be white as all themes share the same black background.

## Related Issue

Related to issue https://github.com/kubernetes-sigs/headlamp/issues/3746

## Changes

- Added contrast text to be white on all ActionsNotifiers

## Steps to Test

1. Navigate to dashboard of any resource
2. Click on the create button and create a resource
3. Notice the Actions Notifier on the bottom left text is readable

## Screenshots
<img width="469" height="108" alt="image" src="https://github.com/user-attachments/assets/0302e3f1-633d-4ade-897c-3e72e6423919" />

### After
<img width="483" height="116" alt="image" src="https://github.com/user-attachments/assets/63e157be-9475-43af-a8e0-656adc895df7" />
