### PR TITLE
fix: update Go version to remediate vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG IMAGE_BASE=alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
 FROM ${IMAGE_BASE} as image-base
 
-FROM --platform=${BUILDPLATFORM} golang:1.24.5@sha256:2b1cbf278ce05a2a310a3d695ebb176420117a8cfcfcc4e5e68a1bef5f6354da as backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.24.4 as backend-build
 
 WORKDIR /headlamp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG IMAGE_BASE=alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
 FROM ${IMAGE_BASE} as image-base
 
-FROM --platform=${BUILDPLATFORM} golang:1.24.4 as backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.24.6@sha256:2c89c41fb9efc3807029b59af69645867cfe978d2b877d475be0d72f6c6ce6f6 as backend-build
 
 WORKDIR /headlamp
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,8 +1,6 @@
 module github.com/kubernetes-sigs/headlamp/backend
 
-go 1.24.4
-
-toolchain go1.24.4
+go 1.24.6
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,8 +1,8 @@
 module github.com/kubernetes-sigs/headlamp/backend
 
-go 1.24.0
+go 1.24.4
 
-toolchain go1.24.5
+toolchain go1.24.4
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
## Summary

This PR resolves critical/high vulnerabilities in image by updating Go version to 1.24.6.

## Changes

- Updated Dockerfile
- Updated backend/go.mod

## Steps to Test

1. `make backend-test`
