### PR TITLE
charts: add ability to specify automountServiceAccountToken in the spec of the pod

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -137,6 +137,7 @@ config:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| automountServiceAccountToken | bool | `true` | Mount Service Account token in pod |
 | serviceAccount.create | bool | `true` | Create service account |
 | serviceAccount.name | string | `""` | Service account name |
 | serviceAccount.annotations | object | `{}` | Service account annotations |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -64,6 +64,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "headlamp.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.initContainers }}

--- a/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
+++ b/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
@@ -81,6 +81,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -89,6 +89,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -89,6 +89,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -106,6 +106,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
+++ b/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
@@ -81,6 +81,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -93,6 +93,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -89,6 +89,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -81,6 +81,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -81,6 +81,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -81,6 +81,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -89,6 +89,7 @@ spec:
         app.kubernetes.io/instance: headlamp
     spec:
       serviceAccountName: headlamp
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -251,6 +251,10 @@
         "additionalProperties": false
       }
     },
+    "automountServiceAccountToken": {
+      "type": "boolean",
+      "description": "Mount Service Account token in pod"
+    },
     "serviceAccount": {
       "type": "object",
       "properties": {

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -102,6 +102,9 @@ config:
 #   - name: KUBERNETES_SERVICE_PORT
 #     value: "6443"
 
+# -- Mount Service Account token in pod
+automountServiceAccountToken: true
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Summary

This PR adds the feature to be able to specify `automountServiceAccountToken` in the spec of the pod.

For security purpose, in my cluster, the `automountServiceAccountToken: false` is set on all the service accounts (the `default` included). 

In the case of Headlamp, I need to mount this service account else I have the following error when I create the pod starts:

```
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":399,"time":"2025-08-11T14:08:59Z","message":"Creating Headlamp handler"}
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":400,"time":"2025-08-11T14:08:59Z","message":"Listen address: :4466"}
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":401,"time":"2025-08-11T14:08:59Z","message":"Kubeconfig path: "}
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":402,"time":"2025-08-11T14:08:59Z","message":"Static plugin dir: /headlamp/static-plugins"}
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":403,"time":"2025-08-11T14:08:59Z","message":"Plugins dir: /headlamp/plugins"}
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":404,"time":"2025-08-11T14:08:59Z","message":"Dynamic clusters support: false"}
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":405,"time":"2025-08-11T14:08:59Z","message":"Helm support: false"}
{"level":"info","source":"/headlamp/backend/cmd/headlamp.go","line":406,"time":"2025-08-11T14:08:59Z","message":"Proxy URLs: []"}
{"level":"error","source":"/headlamp/backend/cmd/headlamp.go","line":427,"error":"open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory","time":"2025-08-11T14:08:59Z","message":"Failed to get in-cluster context"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x2070c45]
```

## Related Issue

No related issue.

## Changes

- Added ability to specify `automountServiceAccountToken` in the spec of the pod (`true` by default because this is the default behaviour of Kubernetes)

## Steps to Test

1. Deploy with `automountServiceAccountToken: true`: the `default` service account should not be mounted in the pod.
2. Deploy with `automountServiceAccountToken: false`: the `default` service account should be mounted in the pod.

## Screenshots (if applicable)

No screenshots.

## Notes for the Reviewer

Nothing special to say.
