### PR TITLE
frontend: Table: Refactor handleRowClick for switches

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -414,10 +414,14 @@ export default function Table<RowItem extends Record<string, any>>({
   ]);
 
   const rows = useMRT_Rows(table);
+  const rowIds = useMemo(() => rows.map(r => r.id), [rows]);
 
   // Handle shift+click range selection
   const handleRowClick = (e: React.MouseEvent, clickedIndex: number) => {
-    if (!table || !table.getRowModel) return;
+    if (!table || !table.getRowModel) {
+      return;
+    }
+
     const target = e.target;
     if (
       !(target instanceof HTMLInputElement) ||
@@ -426,17 +430,15 @@ export default function Table<RowItem extends Record<string, any>>({
     ) {
       return;
     }
+
     e.preventDefault();
     e.stopPropagation();
-
-    const rowModel = table.getRowModel();
-    const rowIds = rowModel.rows.map(row => row.id);
 
     if (e.shiftKey && lastSelectedRowIndex !== null) {
       const start = Math.min(lastSelectedRowIndex, clickedIndex);
       const end = Math.max(lastSelectedRowIndex, clickedIndex);
-      const newSelected: Record<string, boolean> = {};
 
+      const newSelected: Record<string, boolean> = {};
       for (let i = start; i <= end; i++) {
         const rowId = rowIds[i];
         if (rowId) {
@@ -444,16 +446,10 @@ export default function Table<RowItem extends Record<string, any>>({
         }
       }
 
-      table.setRowSelection(prev => ({
-        ...prev,
-        ...newSelected,
-      }));
+      table.setRowSelection(prev => ({ ...prev, ...newSelected }));
     } else {
       const rowId = rowIds[clickedIndex];
-      table.setRowSelection(prev => ({
-        ...prev,
-        [rowId]: !prev[rowId],
-      }));
+      table.setRowSelection(prev => ({ ...prev, [rowId]: !prev[rowId] }));
       setLastSelectedRowIndex(clickedIndex);
     }
   };

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -422,12 +422,13 @@ export default function Table<RowItem extends Record<string, any>>({
       return;
     }
 
-    const target = e.target;
-    if (
-      !(target instanceof HTMLInputElement) ||
-      target.tagName !== 'INPUT' ||
-      target.type !== 'checkbox'
-    ) {
+    const target = e.target as HTMLElement | null;
+    const shouldHandle =
+      !!target &&
+      !!target.closest('input[type="checkbox"]') &&
+      !target.closest('.MuiSwitch-root, [role="switch"]');
+
+    if (!shouldHandle) {
       return;
     }
 


### PR DESCRIPTION
This change improves the handleRowClick function in the Table component and stops the Table from blocking the switch functionality and allowing for range selection when it is not applicable.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3773

### Testing
- [X] Go to a resource list page and ensure that shift+click selection works as expected from https://github.com/kubernetes-sigs/headlamp/pull/3672
- [X] Go to the plugin settings and ensure that the toggles to enable/disable are working

<img width="1363" height="804" alt="image" src="https://github.com/user-attachments/assets/009c7062-8634-447d-9bb2-02b91faf10db" />
