### PR TITLE
frontend: Sidebar: Stop focus on collapsed items

### DIFF
--- a/frontend/src/components/Sidebar/ListItemLink.tsx
+++ b/frontend/src/components/Sidebar/ListItemLink.tsx
@@ -33,6 +33,7 @@ interface ListItemLinkProps {
   search?: string;
   name: string;
   subtitle?: string;
+  tabIndex?: number;
   icon?: IconProps['icon'];
   iconOnly?: boolean;
   hasParent?: boolean;

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -290,6 +290,9 @@ export const PureSidebar = memo(
 
     const adjustedDrawerWidth = largeSideBarOpen ? drawerWidth : closedWidth;
 
+    // Remove items from tab order when the sidebar is collapsed.
+    const tabIndex = largeSideBarOpen ? undefined : -1;
+
     /**
      * For closing the sidebar if temporaryDrawer on mobile.
      */
@@ -316,6 +319,7 @@ export const PureSidebar = memo(
           direction="column"
           justifyContent="space-between"
           wrap="nowrap"
+          aria-hidden={!largeSideBarOpen}
         >
           <Grid item>
             <List
@@ -328,6 +332,7 @@ export const PureSidebar = memo(
                   isSelected={item.isSelected}
                   fullWidth={largeSideBarOpen}
                   search={search}
+                  tabIndex={tabIndex}
                   {...item}
                 />
               ))}

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -57,6 +57,7 @@ const SidebarItem = memo((props: SidebarItemProps) => {
     icon,
     fullWidth = true,
     hide,
+    tabIndex,
     ...other
   } = props;
   const clusters = useSelectedClusters();
@@ -86,6 +87,7 @@ const SidebarItem = memo((props: SidebarItemProps) => {
         subtitle={subtitle}
         search={search}
         iconOnly={!fullWidth}
+        tabIndex={tabIndex}
         hasParent={hasParent}
         fullWidth={fullWidth}
         {...other}

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -11,6 +11,7 @@
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-r16dox-MuiPaper-root-MuiDrawer-paper"
         >
           <div
+            aria-hidden="true"
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
           >
             <div
@@ -26,7 +27,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Home"
@@ -45,7 +46,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/notifications"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Notifications"
@@ -64,7 +65,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/settings/general"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Settings"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
@@ -11,6 +11,7 @@
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-r16dox-MuiPaper-root-MuiDrawer-paper"
         >
           <div
+            aria-hidden="false"
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
           >
             <div

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -11,6 +11,7 @@
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-r16dox-MuiPaper-root-MuiDrawer-paper"
         >
           <div
+            aria-hidden="true"
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
           >
             <div
@@ -26,7 +27,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider css-kgfvfq-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Home"
@@ -45,7 +46,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Cluster"
@@ -154,7 +155,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Map"
@@ -173,7 +174,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Workloads"
@@ -374,7 +375,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Storage"
@@ -483,7 +484,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Network"
@@ -638,7 +639,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Gateway (beta)"
@@ -839,7 +840,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Security"
@@ -948,7 +949,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Configuration"
@@ -1264,7 +1265,7 @@
                     class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
-                    tabindex="0"
+                    tabindex="-1"
                   >
                     <div
                       aria-label="Custom Resources"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -11,6 +11,7 @@
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-r16dox-MuiPaper-root-MuiDrawer-paper"
         >
           <div
+            aria-hidden="false"
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
           >
             <div

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -11,6 +11,7 @@
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-r16dox-MuiPaper-root-MuiDrawer-paper"
         >
           <div
+            aria-hidden="false"
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
           >
             <div


### PR DESCRIPTION
This change fixes an a11y issue where sidebar items were still reachable using the Tab key even when the sidebar was visually closed.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3790, follow-up from https://github.com/kubernetes-sigs/headlamp/pull/3573

### Testing
- [X] Open Headlamp and collapse the sidebar
- [X] Spam the Tab key until you get through the main content
- [X] Notice how the sidebar items are skipped