### PR TITLE
frontend: ClusterTable: Add registerClusterStatus

### DIFF
--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -471,6 +471,7 @@
   "registerClusterChooser": [Function],
   "registerClusterProviderDialog": [Function],
   "registerClusterProviderMenuItem": [Function],
+  "registerClusterStatus": [Function],
   "registerCustomCreateProject": [Function],
   "registerDetailsViewHeaderAction": [Function],
   "registerDetailsViewHeaderActionsProcessor": [Function],

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -62,9 +62,11 @@ import {
 } from '../redux/clusterActionSlice';
 import {
   addAddClusterProvider,
+  addClusterStatus,
   addDialog,
   addMenuItem,
   ClusterProviderInfo,
+  ClusterStatusComponent,
   DialogComponent,
   MenuItemComponent,
 } from '../redux/clusterProviderSlice';
@@ -868,6 +870,28 @@ export function registerKindIcon(kind: string, definition: IconDefinition) {
  */
 export function registerClusterProviderMenuItem(item: MenuItemComponent) {
   store.dispatch(addMenuItem(item));
+}
+
+/**
+ * Register a new cluster status component.
+ *
+ * @param item - The component to add to the cluster status.
+ * Item is a function/component and its props are cluster and error.
+ *
+ * @example
+ * ```tsx
+ * import { registerClusterStatus } from '@kinvolk/headlamp-plugin/lib';
+ * import { ClusterStatus } from './ClusterStatus';
+ * registerClusterStatus(({ cluster, error }) => {
+ *   if (!isElectron() || !isMinikube(cluster)) {
+ *     return null;
+ *   }
+ *   return <ClusterStatus cluster={cluster} error={error} />;
+ * });
+ * ```
+ */
+export function registerClusterStatus(item: ClusterStatusComponent) {
+  store.dispatch(addClusterStatus(item));
 }
 
 /**

--- a/frontend/src/redux/clusterProviderSlice.ts
+++ b/frontend/src/redux/clusterProviderSlice.ts
@@ -15,6 +15,7 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { ApiError } from '../lib/k8s/apiProxy';
 
 export interface DialogProps {
   cluster: any;
@@ -28,8 +29,14 @@ export interface MenuItemProps {
   setOpenConfirmDialog: (value: string) => void;
 }
 
+export interface ClusterStatusProps {
+  cluster: any;
+  error: ApiError | null | undefined;
+}
+
 export type DialogComponent = (props: DialogProps) => React.ReactElement | null;
 export type MenuItemComponent = (props: MenuItemProps) => React.ReactElement | null;
+export type ClusterStatusComponent = (props: ClusterStatusProps) => React.ReactElement | null;
 
 /**
  * Information about a cluster provider, that is shown on the add cluster page.
@@ -52,12 +59,15 @@ export interface ClusterProviderSliceState {
   menuItems: MenuItemComponent[];
   /** Cluster providers for the Add Cluster page. */
   clusterProviders: ClusterProviderInfo[];
+  /** Cluster statuses for the Home page. */
+  clusterStatuses: ClusterStatusComponent[];
 }
 
 export const initialState: ClusterProviderSliceState = {
   menuItems: [],
   dialogs: [],
   clusterProviders: [],
+  clusterStatuses: [],
 };
 
 const clusterProviderSlice = createSlice({
@@ -73,9 +83,13 @@ const clusterProviderSlice = createSlice({
     addAddClusterProvider(state, action: PayloadAction<ClusterProviderInfo>) {
       state.clusterProviders.push(action.payload);
     },
+    addClusterStatus(state, action: PayloadAction<ClusterStatusComponent>) {
+      state.clusterStatuses.push(action.payload);
+    },
   },
 });
 
-export const { addDialog, addMenuItem, addAddClusterProvider } = clusterProviderSlice.actions;
+export const { addDialog, addMenuItem, addAddClusterProvider, addClusterStatus } =
+  clusterProviderSlice.actions;
 
 export default clusterProviderSlice.reducer;


### PR DESCRIPTION
This allows overriding cluster status on the Home table.

### How to test

install the minikube pre release plugin and see some stop/start buttons on the home page