### PR TITLE
Revert "backend: HeadlampServer: Move router initialization codes to createHeadlampHandler"

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -453,11 +453,6 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 		r = baseRoute.PathPrefix(config.BaseURL).Subrouter()
 	}
 
-	if config.Telemetry != nil && config.Metrics != nil {
-		r.Use(telemetry.TracingMiddleware("headlamp-server"))
-		r.Use(config.Metrics.RequestCounterMiddleware)
-	}
-
 	fmt.Println("*** Headlamp Server ***")
 	fmt.Println("  API Routers:")
 
@@ -1165,6 +1160,13 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	config.Telemetry = tel
 	config.Metrics = metrics
 	config.telemetryHandler = telemetry.NewRequestHandler(tel, metrics)
+
+	router := mux.NewRouter()
+
+	if config.Telemetry != nil && config.Metrics != nil {
+		router.Use(telemetry.TracingMiddleware("headlamp-server"))
+		router.Use(config.Metrics.RequestCounterMiddleware)
+	}
 
 	// Copy static files as squashFS is read-only (AppImage)
 	if config.StaticDir != "" {


### PR DESCRIPTION
This reverts commit f4298cbe7094b37eaafab9827716aebebd454653.

For PR: 
- https://github.com/kubernetes-sigs/headlamp/pull/3727

This causes an error with websocket upgrades not working.

### How to test

make backend run-backend


- Check web dev console for websocket errors.
- Check backend logs for errors.
  - `2025/08/18 08:52:38 http: proxy error: can't switch protocols using non-Hijacker ResponseWriter type *telemetry.responseWriter`

