### PR TITLE
backend: config: Add oidc-callback-url flag

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -73,6 +73,7 @@ type HeadlampConfig struct {
 	oidcValidatorClientID     string
 	oidcClientSecret          string
 	oidcIdpIssuerURL          string
+	oidcCallbackURL           string
 	oidcValidatorIdpIssuerURL string
 	oidcUseAccessToken        bool
 	cache                     cache.Cache[interface{}]
@@ -230,6 +231,12 @@ func baseURLReplace(staticDir string, baseURL string) {
 }
 
 func getOidcCallbackURL(r *http.Request, config *HeadlampConfig) string {
+	// If callback URL is configured, use it
+	if config.oidcCallbackURL != "" {
+		return config.oidcCallbackURL
+	}
+
+	// Otherwise, generate callback URL dynamically
 	urlScheme := r.URL.Scheme
 	if urlScheme == "" {
 		// check proxy headers first

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -67,6 +67,7 @@ func main() {
 		oidcValidatorClientID:     conf.OidcValidatorClientID,
 		oidcClientSecret:          conf.OidcClientSecret,
 		oidcIdpIssuerURL:          conf.OidcIdpIssuerURL,
+		oidcCallbackURL:           conf.OidcCallbackURL,
 		oidcValidatorIdpIssuerURL: conf.OidcValidatorIdpIssuerURL,
 		oidcScopes:                strings.Split(conf.OidcScopes, ","),
 		oidcUseAccessToken:        conf.OidcUseAccessToken,

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	OidcValidatorClientID     string `koanf:"oidc-validator-client-id"`
 	OidcClientSecret          string `koanf:"oidc-client-secret"`
 	OidcIdpIssuerURL          string `koanf:"oidc-idp-issuer-url"`
+	OidcCallbackURL           string `koanf:"oidc-callback-url"`
 	OidcValidatorIdpIssuerURL string `koanf:"oidc-validator-idp-issuer-url"`
 	OidcScopes                string `koanf:"oidc-scopes"`
 	OidcUseAccessToken        bool   `koanf:"oidc-use-access-token"`
@@ -256,6 +257,7 @@ func flagset() *flag.FlagSet {
 	f.String("oidc-client-secret", "", "ClientSecret for OIDC")
 	f.String("oidc-validator-client-id", "", "Override ClientID for OIDC during validation")
 	f.String("oidc-idp-issuer-url", "", "Identity provider issuer URL for OIDC")
+	f.String("oidc-callback-url", "", "Callback URL for OIDC")
 	f.String("oidc-validator-idp-issuer-url", "", "Override Identity provider issuer URL for OIDC during validation")
 	f.String("oidc-scopes", "profile,email",
 		"A comma separated list of scopes needed from the OIDC provider")

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -5,6 +5,7 @@
 {{- $clientSecret := "" }}
 {{- $issuerURL := "" }}
 {{- $scopes := "" }}
+{{- $callbackURL := "" }}
 {{- $validatorClientID := "" }}
 {{- $validatorIssuerURL := "" }}
 {{- $useAccessToken := "" }}
@@ -23,6 +24,9 @@
   {{- end }}
   {{- if eq .name "OIDC_SCOPES" }}
     {{- $scopes = .value }}
+  {{- end }}
+  {{- if eq .name "OIDC_CALLBACK_URL" }}
+    {{- $callbackURL = .value }}
   {{- end }}
   {{- if eq .name "OIDC_VALIDATOR_CLIENT_ID" }}
     {{- $validatorClientID = .value }}
@@ -118,6 +122,13 @@ spec:
                   name: {{ $oidc.secret.name }}
                   key: scopes
             {{- end }}
+            {{- if $oidc.callbackURL }}
+            - name: OIDC_CALLBACK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $oidc.secret.name }}
+                  key: callbackURL
+            {{- end }}
             {{- if $oidc.validatorClientID }}
             - name: OIDC_VALIDATOR_CLIENT_ID
               valueFrom:
@@ -155,6 +166,10 @@ spec:
             {{- if $oidc.scopes }}
             - name: OIDC_SCOPES
               value: {{ $oidc.scopes }}
+            {{- end }}
+            {{- if $oidc.callbackURL }}
+            - name: OIDC_CALLBACK_URL
+              value: {{ $oidc.callbackURL }}
             {{- end }}
             {{- if $oidc.validatorClientID }}
             - name: OIDC_VALIDATOR_CLIENT_ID
@@ -202,6 +217,10 @@ spec:
             # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
             {{- end }}
+            {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
+            # Check if callbackURL is non empty either from env or oidc.config
+            - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"
+            {{- end }}
             {{- if or (ne $oidc.validatorClientID "") (ne $validatorClientID "") }}
             # Check if validatorClientID is non empty either from env or oidc.config
             - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
@@ -219,6 +238,10 @@ spec:
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
+            # Check if callbackURL is non empty either from env or oidc.config
+            - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"
+            {{- end }}
             {{- if or (ne $oidc.validatorClientID "") (ne $validatorClientID "") }}
             # Check if validatorClientID is non empty either from env or oidc.config
             - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"

--- a/charts/headlamp/templates/secret.yaml
+++ b/charts/headlamp/templates/secret.yaml
@@ -18,6 +18,9 @@ data:
 {{- with .scopes }}
   scopes: {{ . | b64enc | quote }}
 {{- end }}
+{{- with .callbackURL }}
+  callbackURL: {{ . | b64enc | quote }}
+{{- end }}
 {{- with .validatorClientID }}
   validatorClientID: {{ . | b64enc | quote }}
 {{- end }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -66,6 +66,8 @@ config:
     issuerURL: ""
     # -- OIDC scopes to be used
     scopes: ""
+    # -- OIDC callback URL
+    callbackURL: ""
 
     # -- OIDC client to be used during token validation
     validatorClientID: ""


### PR DESCRIPTION
## Summary

When Headlamp is deployed in-cluster and configured for authentication with Dex, the authentication flow fails. We are trying to log in with LDAP using Dex. The root cause of this issue appears to be that Headlamp is not redirecting to the correct callback URL during the OIDC authentication process with Dex.

## Related Issue

Fixes #2625  

## Changes

- Added OIDC Callback URL

## Steps to Test

1. Install with helm provide callback url 
2. Install dex
3. Add dex with callback url
4. Try to login with dex

## Screenshots (if applicable)


## Notes for the Reviewer

