### PR TITLE
backend: fix responseWriter to support protocol switching

### DIFF
--- a/backend/pkg/telemetry/metrics.go
+++ b/backend/pkg/telemetry/metrics.go
@@ -1,6 +1,9 @@
 package telemetry
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 
 	"go.opentelemetry.io/otel"
@@ -177,4 +180,15 @@ func newResponseWriter(w http.ResponseWriter) *responseWriter {
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack implements the http.Hijacker interface to support WebSocket connections.
+// This method delegates to the underlying ResponseWriter's Hijacker implementation.
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("responseWriter does not implement http.Hijacker")
+	}
+
+	return hijacker.Hijack()
 }


### PR DESCRIPTION
Summary

  This PR fixes WebSocket connection errors by implementing http.Hijacker interface support in the telemetry responseWriter.

  Related Issue

  Fixes WebSocket protocol upgrade failures that were causing "can't switch protocols using non-Hijacker ResponseWriter type *telemetry.responseWriter" errors.

  Changes

  - Added http.Hijacker interface support to telemetry responseWriter - Implemented Hijack() method to support WebSocket protocol upgrades
  - Added necessary imports - Added bufio, fmt, and net packages for hijacking functionality
  - Delegated hijacking to underlying ResponseWriter - Properly forwards hijack requests to the wrapped ResponseWriter when supported

  Steps to Test

  1. Start the backend server with make backend && cd backend && ./headlamp-server -dev
  2. Navigate to any Kubernetes resource view that uses WebSocket connections (like Pods, Nodes, etc.)
  3. Check browser console - WebSocket connection errors should be resolved
  4. Verify WebSocket connections work properly for cluster API requests and real-time updates
  5. Confirm that telemetry metrics still function correctly

  Screenshots (if applicable)

  N/A

  Notes for the Reviewer

  - The WebSocket fix addresses the "can't switch protocols using non-Hijacker ResponseWriter" error by properly implementing the Hijacker interface in the telemetry middleware
  - This change maintains backward compatibility and doesn't affect existing functionality
  - The fix ensures that WebSocket connections can properly upgrade protocols while still collecting telemetry metrics