### PR TITLE
frontend: k8s: Handle new k8s feature native sidecars

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -403,6 +403,21 @@ export interface KubeContainer {
     };
   };
 
+  /**
+   * RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be
+   * set for init containers, and the only allowed value is "Always". For non-init containers or when this
+   * field is not specified, the restart behavior is defined by the Pod's restart policy and the container
+   * type. Setting the RestartPolicy as "Always" for the init container will have the following effect: this
+   * init container will be continually restarted on exit until all regular containers have terminated.
+   * Once all regular containers have completed, all init containers with restartPolicy "Always" will be
+   * shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar"
+   * container. Although this init container still starts in the init container sequence, it does not wait for
+   * the container to complete before proceeding to the next init container. Instead, the next init
+   * container starts immediately after this init container is started, or after any startupProbe has
+   * successfully completed.
+   */
+  restartPolicy?: string;
+
   // @todo:
   // securityContext SecurityContext	SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   // startupProbe Probe	StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -303,6 +303,19 @@ class Pod extends KubeObject<KubePod> {
     return lastRestartDate;
   }
 
+  private isRestartableInitContainer(spec?: KubeContainer): boolean {
+    return !!spec && (spec as any).restartPolicy === 'Always';
+  }
+
+  private isPodInitializedConditionTrue(status?: KubePod['status']): boolean {
+    for (const c of status?.conditions ?? []) {
+      if (c.type === 'Initialized' && c.status === 'True') {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private hasPodReadyCondition(conditions: any): boolean {
     for (const condition of conditions) {
       if (condition.type === 'Ready' && condition.Status === 'True') {
@@ -312,7 +325,7 @@ class Pod extends KubeObject<KubePod> {
     return false;
   }
 
-  // Implementation based on: https://github.com/kubernetes/kubernetes/blob/7b6293b6b6a5662fc37f440e839cf5da8b96e935/pkg/printers/internalversion/printers.go#L759
+  // Implementation based on: https://github.com/kubernetes/kubernetes/blob/67216cfdd980cdd0234866d66a9ffe2ba3d8fcc4/pkg/printers/internalversion/printers.go#L891
   getDetailedStatus(): PodDetailedStatus {
     // We cache this data to avoid going through all this logic when nothing has changed
     if (
@@ -331,12 +344,22 @@ class Pod extends KubeObject<KubePod> {
     }
 
     let restarts = 0;
-    const totalContainers = (this.spec.containers ?? []).length;
+    let restartableInitContainerRestarts = 0;
     let readyContainers = 0;
     let message = '';
     let lastRestartDate = new Date(0);
+    let lastRestartableInitContainerRestartDate = new Date(0);
 
     let reason = this.status.reason || this.status.phase;
+
+    const initContainers: Record<string, KubeContainer> = {};
+    let totalContainers = (this.spec.containers ?? []).length;
+    for (const ic of this.spec.initContainers ?? []) {
+      initContainers[ic.name] = ic;
+      if (this.isRestartableInitContainer(ic)) {
+        totalContainers++;
+      }
+    }
 
     let initializing = false;
     for (const i in this.status.initContainerStatuses ?? []) {
@@ -344,8 +367,34 @@ class Pod extends KubeObject<KubePod> {
       restarts += container.restartCount;
       lastRestartDate = this.getLastRestartDate(container, lastRestartDate);
 
+      if (container.lastState.terminated !== null) {
+        const terminatedDate = container.lastState.terminated?.finishedAt
+          ? new Date(container.lastState.terminated?.finishedAt)
+          : undefined;
+        if (!!terminatedDate && lastRestartDate < terminatedDate) {
+          lastRestartDate = terminatedDate;
+        }
+      }
+
+      if (this.isRestartableInitContainer(initContainers[container.name])) {
+        restartableInitContainerRestarts += container.restartCount;
+        if (container.lastState.terminated !== null) {
+          const terminatedDate = container.lastState.terminated?.finishedAt
+            ? new Date(container.lastState.terminated?.finishedAt)
+            : undefined;
+          if (!!terminatedDate && lastRestartableInitContainerRestartDate < terminatedDate) {
+            lastRestartableInitContainerRestartDate = terminatedDate;
+          }
+        }
+      }
+
       switch (true) {
         case container.state.terminated?.exitCode === 0:
+          continue;
+        case !!container.started && this.isRestartableInitContainer(initContainers[container.name]):
+          if (container.ready) {
+            readyContainers++;
+          }
           continue;
         case !!container.state.terminated:
           if (!container.state.terminated!.reason) {
@@ -373,8 +422,9 @@ class Pod extends KubeObject<KubePod> {
       break;
     }
 
-    if (!initializing) {
-      restarts = 0;
+    if (!initializing || this.isPodInitializedConditionTrue(this.status)) {
+      restarts = restartableInitContainerRestarts;
+      lastRestartDate = lastRestartableInitContainerRestartDate;
       let hasRunning = false;
       for (let i = (this.status?.containerStatuses?.length || 0) - 1; i >= 0; i--) {
         const container = this.status?.containerStatuses[i];


### PR DESCRIPTION
This change handles native sidecar containers, as enabled by default in Kubernetes v1.29. These sidecars are listed under `initContainers` with a special field `restartPolicy: Always` and remain running throughout the pod's lifetime.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/2483

### Testing
- [X] Create a deployment in Headlamp with a native sidecar (i.e. https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#sidecar-example)
- [X] Navigate to the newly created pod
- [X] Ensure that both containers are running and there are no errors

<img width="532" height="118" alt="image" src="https://github.com/user-attachments/assets/5e273916-db22-4c23-8a6c-69f4e979ad4a" />
<img width="363" height="169" alt="image" src="https://github.com/user-attachments/assets/dc2c008a-a96c-41e7-bfcc-92e44102b708" />
<img width="355" height="170" alt="image" src="https://github.com/user-attachments/assets/3202b94d-8359-4ecd-9f50-35b5883f210f" />
