### PR TITLE
frontend: Fix fetchConfig to return a proper value

### DIFF
--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -172,6 +172,8 @@ const fetchConfig = (dispatch: Dispatch<UnknownAction>) => {
     if (config?.isDynamicClusterEnabled) {
       fetchStatelessClusterKubeConfigs(dispatch);
     }
+
+    return configToStore;
   });
 };
 


### PR DESCRIPTION
## Summary
This PR fixes a React Query error by ensuring the fetchConfig function returns a value. The issue was causing "Query data cannot be undefined. Please make sure to return a value other than undefined from your query function. Affected query key: ["cluster-fetch"] " errors in the browser console for the "cluster-fetch" query.

##  Related Issue

  Fixes the "Query data cannot be undefined" console error for the cluster-fetch query key.

## Changes

  - Updated fetchConfig function in Layout.tsx:176 to return configToStore from the Promise chain
  - Fixed useQuery implementation to properly receive data from the query function

## Steps to Test

  1. Start the frontend application
  2. Open browser developer console
  3. Navigate through the application, particularly pages that trigger cluster configuration fetching
  4. Verify that the "Query data cannot be undefined. Please make sure to return a value other than undefined from your query function. Affected query key: ["cluster-fetch"]" error no longer appears in the console
  5. Confirm that cluster configuration loading still works as expected

##  Screenshots (if applicable)

  N/A - This is a console error fix

## Notes for the Reviewer

  - This is a critical fix for React Query usage - the query function must return a value to prevent runtime errors
  - The fix ensures backward compatibility while resolving the undefined data issue
  - No functional changes to the cluster configuration logic, only ensuring proper return value for React Query
