### PR TITLE
Fix plugin ambiguity

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -290,6 +290,16 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 
 	r.PathPrefix("/plugins/").Handler(pluginHandler)
 
+	// Serve dev-plugins
+	devPluginDir := filepath.Join(filepath.Dir(config.PluginDir), "dev-plugins")
+	if _, err := os.Stat(devPluginDir); err == nil {
+		devPluginHandler := http.StripPrefix(config.BaseURL+"/dev-plugins/", http.FileServer(http.Dir(devPluginDir)))
+		if !config.UseInCluster {
+			devPluginHandler = serveWithNoCacheHeader(devPluginHandler)
+		}
+		r.PathPrefix("/dev-plugins/").Handler(devPluginHandler)
+	}
+
 	if config.StaticPluginDir != "" {
 		staticPluginsHandler := http.StripPrefix(config.BaseURL+"/static-plugins/",
 			http.FileServer(http.Dir(config.StaticPluginDir)))

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -207,28 +207,29 @@ export function updateSettingsPackages(
 ): PluginInfo[] {
   if (backendPlugins.length === 0) return [];
 
-  const pluginsChanged =
-    backendPlugins.length !== settingsPlugins.length ||
-    backendPlugins.map(p => p.name + p.version).join('') !==
-      settingsPlugins.map(p => p.name + p.version).join('');
-
-  if (!pluginsChanged) {
-    return settingsPlugins;
-  }
-
+  // Always update settings with the latest plugin info (including pluginType)
+  // even if no plugins were added/removed
   return backendPlugins.map(plugin => {
     const index = settingsPlugins.findIndex(x => x.name === plugin.name);
     if (index === -1) {
       // It's a new one settings doesn't know about so we do not enable it by default
-      return {
+      const newPlugin = {
         ...plugin,
         isEnabled: true,
       };
+      console.log(
+        `updateSettingsPackages: New plugin ${plugin.name} with type: ${plugin.pluginType}`
+      );
+      return newPlugin;
     }
-    return {
+    const updatedPlugin = {
       ...settingsPlugins[index],
       ...plugin,
     };
+    console.log(
+      `updateSettingsPackages: Updated plugin ${plugin.name} with type: ${updatedPlugin.pluginType}`
+    );
+    return updatedPlugin;
   });
 }
 
@@ -345,15 +346,52 @@ export async function fetchAndExecutePlugins(
                 ' by running "headlamp-plugin extract" again.' +
                 ' Please use headlamp-plugin >= 0.8.0'
             );
+            // For missing package.json, determine type from path
+            let pluginType: 'dev' | 'catalog' | 'static' = 'static';
+            if (path.startsWith('dev-plugins/')) {
+              pluginType = 'dev';
+            } else if (path.startsWith('plugins/')) {
+              // All plugins in plugins/ directory are catalog plugins
+              pluginType = 'catalog';
+            } else if (path.startsWith('.plugins/') || path.startsWith('static-plugins/')) {
+              // Bundled/shipped plugins are static plugins
+              pluginType = 'static';
+            }
             return {
               name: path.split('/').slice(-1)[0],
               version: '0.0.0',
               author: 'unknown',
               description: '',
+              pluginType,
+              artifacthub: pluginType !== 'dev', // All plugins except dev plugins come from artifacthub
             };
           }
         }
-        return resp.json();
+        return resp.json().then((packageJson: any) => {
+          // Determine plugin type based on path structure
+          let pluginType: 'dev' | 'catalog' | 'static' = 'static';
+
+          if (path.startsWith('dev-plugins/')) {
+            pluginType = 'dev';
+          } else if (path.startsWith('plugins/')) {
+            // All plugins in the plugins/ directory are catalog plugins
+            pluginType = 'catalog';
+          } else if (path.startsWith('.plugins/') || path.startsWith('static-plugins/')) {
+            // Bundled/shipped plugins are static plugins
+            pluginType = 'static';
+          }
+
+          const pluginInfo = {
+            ...packageJson,
+            pluginType,
+            // Set artifacthub property - catalog and static plugins come from artifacthub
+            artifacthub: pluginType !== 'dev',
+          };
+          console.log(
+            `Plugin loaded: ${packageJson.name} with type: ${pluginType} (path: ${path})`
+          );
+          return pluginInfo;
+        });
       })
     )
   );
@@ -363,8 +401,18 @@ export async function fetchAndExecutePlugins(
   const permissionSecrets = await permissionSecretsPromise;
 
   const updatedSettingsPackages = updateSettingsPackages(packageInfos, settingsPackages);
+  console.log(
+    'updatedSettingsPackages:',
+    updatedSettingsPackages.map(p => ({ name: p.name, pluginType: p.pluginType }))
+  );
+
+  // Check if settings changed (new plugins added/removed) to decide whether to call onSettingsChange early
   const settingsChanged = packageInfos.length !== settingsPackages.length;
   if (settingsChanged) {
+    console.log(
+      'First onSettingsChange call with:',
+      updatedSettingsPackages.map(p => ({ name: p.name, pluginType: p.pluginType }))
+    );
     onSettingsChange(updatedSettingsPackages);
   }
 
@@ -391,6 +439,10 @@ export async function fetchAndExecutePlugins(
         isCompatible: !incompatiblePlugins[plugin.name],
       };
     }
+  );
+  console.log(
+    'Second onSettingsChange call with:',
+    packagesIncompatibleSet.map(p => ({ name: p.name, pluginType: p.pluginType }))
   );
   onSettingsChange(packagesIncompatibleSet);
 

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -82,6 +82,14 @@ export type PluginInfo = {
    */
   isCompatible?: boolean;
 
+  /**
+   * pluginType indicates the source type of the plugin.
+   * 'dev' for development plugins from dev-plugins directory
+   * 'catalog' for plugins from the plugin catalog (plugins directory)
+   * 'static' for static plugins
+   */
+  pluginType?: 'dev' | 'catalog' | 'static';
+
   version?: string; // unused by PluginSettings
   author?: string; // unused by PluginSettings
   /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
         target: 'http://localhost:4466',
         changeOrigin: true,
       },
+      '/dev-plugins': {
+        target: 'http://localhost:4466',
+        changeOrigin: true,
+      },
     },
     cors: true,
   },

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -407,7 +407,7 @@ async function start() {
     const configDir = fs.existsSync(paths.data) ? paths.data : paths.config;
 
     // All plugins started with npm run start go to dev-plugins directory
-    await checkIfDevPlugin(packageName, configDir);
+    await checkIfDevPlugin(packageName);
     const targetDir = 'dev-plugins';
 
     console.log(`Installing plugin to ${targetDir}/ directory (development priority)`);
@@ -434,7 +434,7 @@ async function start() {
    * Check if this plugin should be treated as a development plugin
    * All plugins started with npm run start will be placed in dev-plugins directory
    */
-  async function checkIfDevPlugin(pluginName, configDir) {
+  async function checkIfDevPlugin(pluginName) {
     try {
       console.log(`✓ Plugin "${pluginName}" - using dev-plugins directory for development`);
       return true;


### PR DESCRIPTION
## Summary

Fixes https://github.com/kubernetes-sigs/headlamp/issues/3628

Based on the PR https://github.com/kubernetes-sigs/headlamp/pull/3713

We need to make sure we also:
- [ ] Standardize how plugins' directories are named
  Right now their name comes from the package they decompress too. So a plugin can be called foo-bar and their package be called foo, and this may conflict with a plugin called foo with the same package name
- [ ] Return plugins by what installed origin type they are: dev, static, or catalog
  So in the UI we can show them accordingly, and also make sure we do not attempt to load the same plugin
- [ ] Migrate the `plugins` folder to be a `dev-plugins` folder

Test dev vs catalog:
1. Install the _flux_ plugin from the catalog;
2. Install/run the dev version of _flux_ -> both should be shown in the plugins list but only the dev version should be loaded

Test dev vs static:
1. Install/run the dev version of _prometheus_ -> both the static and the dev version should be shown in the plugins list but only the dev version should be loaded

Test static vs catalog:
1. Ship the _minikube_ plugin
2. If there's a more recent update for minikube from the Catalog, this should be shown as available; install it
3. Install the _minikube_ plugin from the catalog -> both should be shown in the plugins list but only the catalog version should be loaded
