### PR TITLE
frontend: AddCluster: Add link to minikube in plugin-catalog

### DIFF
--- a/frontend/src/components/App/CreateCluster/AddCluster.tsx
+++ b/frontend/src/components/App/CreateCluster/AddCluster.tsx
@@ -24,6 +24,7 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { isElectron } from '../../../helpers/isElectron';
 import { createRouteURL } from '../../../lib/router';
 import { ClusterProviderInfo } from '../../../redux/clusterProviderSlice';
 import { useTypedSelector } from '../../../redux/hooks';
@@ -55,10 +56,15 @@ export default function AddCluster(props: DialogProps & { onChoice: () => void }
   const { t } = useTranslation(['translation']);
   const history = useHistory();
   const addClusterProviders = useTypedSelector(state => state.clusterProvider.clusterProviders);
+  const customSidebarEntries = useTypedSelector(state => state.sidebar.entries);
 
   if (!open) {
     return null;
   }
+
+  const isPluginCatalogRegistered = Object.values(customSidebarEntries).some(
+    entry => entry.url === '/plugin-catalog'
+  );
 
   return (
     <PageGrid>
@@ -81,9 +87,17 @@ export default function AddCluster(props: DialogProps & { onChoice: () => void }
               </CardContent>
             </Card>
           </Grid>
-          {addClusterProviders.length > 0 && (
+          <Grid item xs={12}>
+            <Typography variant="h4">{t('translation|Providers')}</Typography>
+          </Grid>
+          {isElectron() && isPluginCatalogRegistered && addClusterProviders.length === 0 && (
             <Grid item xs={12}>
-              <Typography variant="h4">{t('translation|Providers')}</Typography>
+              <Button
+                onClick={() => history.push('/#/plugin-catalog/headlamp-plugins/headlamp_minikube')}
+                startIcon={<InlineIcon icon="mdi:plus-box-outline" />}
+              >
+                {t('translation|Add Local Cluster Provider')}
+              </Button>
             </Grid>
           )}
           {addClusterProviders.length > 0 && (

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "",
   "Load from KubeConfig": "Laden aus KubeConfig",
   "Providers": "",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "Proceed to select your preferred method for cluster creation and addition",
   "Load from KubeConfig": "Load from KubeConfig",
   "Providers": "Providers",
+  "Add Local Cluster Provider": "Add Local Cluster Provider",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "This action will remove cluster \"{{ clusterName }}\".",
   "This action cannot be undone! Do you want to proceed?": "This action cannot be undone! Do you want to proceed?",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "",
   "Load from KubeConfig": "Cargar desde KubeConfig",
   "Providers": "",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "",
   "Load from KubeConfig": "Charger à partir d'un KubeConfig",
   "Providers": "",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "क्लस्टर बनाने और जोड़ने के लिए अपनी पसंदीदा विधि चुनें",
   "Load from KubeConfig": "KubeConfig से लोड करें",
   "Providers": "प्रदाता",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "",
   "Load from KubeConfig": "Carica da KubeConfig",
   "Providers": "",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "希望するクラスターの作成や追加の方法を選択してください",
   "Load from KubeConfig": "KubeConfig から読み込む",
   "Providers": "プロバイダー",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "클러스터 생성 및 추가 방법을 선택하세요.",
   "Load from KubeConfig": "KubeConfig에서 불러오기",
   "Providers": "제공자",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "",
   "Load from KubeConfig": "Carregar a partir de um KubeConfig",
   "Providers": "",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "க்ளஸ்டர் உருவாக்கம் மற்றும் சேர்ப்பதற்கான உங்கள் விருப்பமான முறையைத் தேர்ந்தெடுக்க தொடரவும்",
   "Load from KubeConfig": "கியூப்கான்ஃபிக்கிலிருந்து ஏற்றுக",
   "Providers": "வழங்குநர்கள்",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "இந்த செயல் \"{{ source }}\" இலிருந்து \"{{ clusterName }}\" க்ளஸ்டரை நீக்கும்.",
   "This action will remove cluster \"{{ clusterName }}\".": "இந்த செயல் \"{{ clusterName }}\" க்ளஸ்டரை நீக்கும்.",
   "This action cannot be undone! Do you want to proceed?": "இந்த செயலை மீட்டெடுக்க முடியாது! நீங்கள் தொடர விரும்புகிறீர்களா?",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "",
   "Load from KubeConfig": "從 KubeConfig 讀取",
   "Providers": "",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -47,6 +47,7 @@
   "Proceed to select your preferred method for cluster creation and addition": "",
   "Load from KubeConfig": "从 KubeConfig 读取",
   "Providers": "",
+  "Add Local Cluster Provider": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",


### PR DESCRIPTION
If in electron, and no plugin is already installed... then we add
a link to the plugin-catalog.

This will allow Headlamp users to more easily add local clusters.
