### PR TITLE
plugins: Bump vite-plugin-static-copy to 2.3.2

### DIFF
--- a/plugins/examples/app-menus/package-lock.json
+++ b/plugins/examples/app-menus/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/change-logo/package-lock.json
+++ b/plugins/examples/change-logo/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/cluster-chooser/package-lock.json
+++ b/plugins/examples/cluster-chooser/package-lock.json
@@ -16422,11 +16422,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/custom-theme/package-lock.json
+++ b/plugins/examples/custom-theme/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/customizing-map/package-lock.json
+++ b/plugins/examples/customizing-map/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/details-view/package-lock.json
+++ b/plugins/examples/details-view/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/dynamic-clusters/package-lock.json
+++ b/plugins/examples/dynamic-clusters/package-lock.json
@@ -16422,11 +16422,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/headlamp-events/package-lock.json
+++ b/plugins/examples/headlamp-events/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/pod-counter/package-lock.json
+++ b/plugins/examples/pod-counter/package-lock.json
@@ -16422,11 +16422,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/projects/package-lock.json
+++ b/plugins/examples/projects/package-lock.json
@@ -16427,11 +16427,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/resource-charts/package-lock.json
+++ b/plugins/examples/resource-charts/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/sidebar/package-lock.json
+++ b/plugins/examples/sidebar/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/tables/package-lock.json
+++ b/plugins/examples/tables/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/examples/ui-panels/package-lock.json
+++ b/plugins/examples/ui-panels/package-lock.json
@@ -16421,11 +16421,10 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -117,7 +117,7 @@
         "vite": "^6.3.5",
         "vite-plugin-css-injected-by-js": "^3.5.1",
         "vite-plugin-node-polyfills": "^0.23.0",
-        "vite-plugin-static-copy": "^2.2.0",
+        "vite-plugin-static-copy": "^2.3.2",
         "vite-plugin-svgr": "^4.3.0",
         "vitest": "^3.0.5",
         "vitest-canvas-mock": "^0.3.3",
@@ -19139,10 +19139,9 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz",
-      "integrity": "sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==",
-      "license": "MIT",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
       "dependencies": {
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -121,7 +121,7 @@
     "vite": "^6.3.5",
     "vite-plugin-css-injected-by-js": "^3.5.1",
     "vite-plugin-node-polyfills": "^0.23.0",
-    "vite-plugin-static-copy": "^2.2.0",
+    "vite-plugin-static-copy": "^2.3.2",
     "vite-plugin-svgr": "^4.3.0",
     "vitest": "^3.0.5",
     "vitest-canvas-mock": "^0.3.3",


### PR DESCRIPTION
This change updates the vite-plugin-static-copy dependency in the headlamp-plugin and plugins examples to the desired 2.3.2 version.