### PR TITLE
frontend: LogViewer: Prevent search overlapping scroll

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -427,6 +427,7 @@ export function SearchPopover(props: SearchPopoverProps) {
           right: 15,
           padding: '4px 8px',
           zIndex: theme.zIndex.modal,
+          marginRight: '7px',
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',


### PR DESCRIPTION
This change fixes an issue in Windows where the search bar in the log viewer overlaps with the scroll on the side.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3018, follow-up from [#3721 ](https://github.com/kubernetes-sigs/headlamp/pull/3721) by @greedy-wudpeckr

### Testing
- [X] Navigate to a pod in Headlamp and click on 'Show Logs'
- [X] Click on the search icon and note that the search bar does not overlap with scroll

<img width="2236" height="1081" alt="image" src="https://github.com/user-attachments/assets/9d85a399-3d0a-43d1-a6e6-cac03b50a85f" />