### PR TITLE
frontend: ResourceSearch: Fix alert contrast issue for dark themes

### DIFF
--- a/frontend/src/components/advancedSearch/ResourceSearch.tsx
+++ b/frontend/src/components/advancedSearch/ResourceSearch.tsx
@@ -247,7 +247,12 @@ export function ResourceSearch({
       </Box>
 
       {deferredResults.items.length > maxResults && (
-        <Alert severity="warning">
+        <Alert
+          severity="warning"
+          sx={{
+            color: theme.palette.text.primary,
+          }}
+        >
           {t('Found {{0}} results. Showing first {{1}}', {
             0: deferredResults.items.length,
             1: maxResults,


### PR DESCRIPTION
## Summary

This PR fixes the issue where the text for alert message for the search were not readable on darker themes

## Related Issue

Related to issue https://github.com/kubernetes-sigs/headlamp/issues/3746

## Changes

- Added contrast text via theme.palette to the alert component

## Screenshots (if applicable)

### before
<img width="1112" height="199" alt="image" src="https://github.com/user-attachments/assets/10d9fdae-0363-402a-9023-688ef88d73bd" />
<img width="1122" height="196" alt="image" src="https://github.com/user-attachments/assets/c83d7f3c-8801-477d-9b28-1dc65f940d23" />


### after
<img width="1117" height="200" alt="image" src="https://github.com/user-attachments/assets/41e76309-53ce-4e27-95b8-f899dc4533b6" />
<img width="1113" height="199" alt="image" src="https://github.com/user-attachments/assets/ea360900-c1d9-4a92-874b-65bf3a818ac1" />

