### PR TITLE
frontend: AppTheme: make font family configurable

### DIFF
--- a/frontend/src/lib/AppTheme.ts
+++ b/frontend/src/lib/AppTheme.ts
@@ -63,4 +63,6 @@ export interface AppTheme {
   radius?: number;
   /** Text style in buttons */
   buttonTextTransform?: 'uppercase' | 'none';
+  /** Font family of the app */
+  fontFamily?: string[];
 }

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -191,7 +191,7 @@ export function createMuiTheme(currentTheme: AppTheme) {
       },
     },
     typography: {
-      fontFamily: ['Overpass', 'sans-serif'].join(', '),
+      fontFamily: currentTheme.fontFamily?.join(', ') ?? ['Overpass', 'sans-serif'].join(', '),
       h1: {
         fontWeight: 700,
         fontSize: '1.87rem',


### PR DESCRIPTION
## Summary

This PR adds the ability to customise the font-family from a AppTheme

## Changes

- Updated AppTheme interface to include `fontFamily`

## Steps to Test

1. Start Headlamp
2. Register a new Theme with `fontFamily`
3. Navigate to Settings and Select the custom theme
4. Observe the font changes

## Screenshots (if applicable)

Theme registration:

```js
import './index.css'; // where the @font-face is defined

registerAppTheme({
  name: "My Custom Theme",
  base: "light",
  primary: "#ff0000",
  secondary: "#333",
  fontFamily: ["Asimovian"],
})
```

<img width="1374" height="616" alt="image" src="https://github.com/user-attachments/assets/482a608c-2c8f-4647-8831-21bd56ebcee4" />