### PR TITLE
Add support for i18n in plugins

### DIFF
--- a/docs/development/plugins/i18n.md
+++ b/docs/development/plugins/i18n.md
@@ -1,0 +1,40 @@
+---
+title: Plugin Internationalization
+sidebar_label: i18n
+sidebar_position: 6.1
+---
+
+# Internationalization (i18n) for plugins
+
+Headlamp plugins can include translations. Use the `headlamp-plugin` CLI to set up i18n, extract translatable strings, and add locales.
+
+Minimal steps:
+
+- Add an npm script to run the extractor (if missing):
+
+  ```json
+  "scripts": {
+  "i18n": "headlamp-plugin i18n"
+  }
+  ```
+
+- Then you can start adding new translations by running the i18n script
+  with a language code. For example:
+
+  ```bash
+  npm run i18n -- es
+  ```
+
+- The command above will:
+
+  1. Create a new i18n section to the package.json of the plugin:
+
+    ```json
+    "headlamp": {
+        "i18n": ["es"]
+    }
+    ```
+
+  2. Create the translation file for that locale in `locales/es/translation.json`. This is the file you will need to translate.
+
+- To update the locales after a string addition or change, run `npm run i18n`.

--- a/docs/development/plugins/index.md
+++ b/docs/development/plugins/index.md
@@ -40,6 +40,9 @@ Comprehensive API documentation covering all available plugin capabilities.
 ### 🚀 [Publishing Plugins](./publishing.md)
 Share your plugins with the community through Artifact Hub.
 
+### 🌍 [Internationalization](./i18n.md)
+Add support for multiple languages and locales
+
 ## Ready to Start?
 
 👉 **New to plugins?** Start with our [Getting Started Guide](./getting-started.md)

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -494,4 +494,5 @@
   "registerSidebarEntryFilter": [Function],
   "registerUIPanel": [Function],
   "runCommand": [Function],
+  "useTranslation": [Function],
 }

--- a/frontend/src/plugin/pluginI18n.ts
+++ b/frontend/src/plugin/pluginI18n.ts
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import i18next, { createInstance, i18n, TFunction, TOptions } from 'i18next';
+import { useEffect, useState } from 'react';
+import { useTranslation as useReactI18nTranslation } from 'react-i18next';
+import { getAppUrl } from '../helpers/getAppUrl';
+
+export interface PluginTranslations {
+  [locale: string]: {
+    [key: string]: string;
+  };
+}
+
+export interface PluginI18nInfo {
+  name: string;
+  translations: PluginTranslations;
+}
+
+export interface UseTranslationResult {
+  /** Translation function */
+  t: TFunction;
+  /** i18next instance for the plugin */
+  i18n: i18n | null;
+  /** Whether translations are ready */
+  ready: boolean;
+}
+
+export interface PluginPackageInfo {
+  name: string;
+  headlamp?: {
+    i18n?: string[]; // Array of supported locales
+  };
+  [key: string]: unknown;
+}
+
+// Store for plugin i18n instances and their paths
+const pluginI18nInstances: { [pluginName: string]: i18n } = {};
+const pluginPaths: { [pluginName: string]: string } = {};
+const pluginSupportedLocales: { [pluginName: string]: string[] } = {};
+
+/**
+ * Load translations for a plugin from its directory
+ * Always looks in the same directory as package.json: {pluginPath}/locales/{locale}/translation.json
+ */
+async function loadPluginTranslations(
+  pluginPath: string,
+  locale: string
+): Promise<Record<string, string>> {
+  try {
+    const response = await fetch(`${getAppUrl()}${pluginPath}/locales/${locale}/translation.json`);
+    if (response.ok) {
+      return response.json();
+    }
+  } catch (error) {
+    // Translation file doesn't exist for this locale
+  }
+
+  return {};
+}
+
+/**
+ * Create or get an i18next instance for a plugin
+ * Uses hard defaults: namespace = plugin name, loads from plugin path
+ */
+async function getPluginI18nInstance(
+  pluginName: string,
+  pluginPath: string,
+  supportedLocales?: string[]
+): Promise<i18n> {
+  if (pluginI18nInstances[pluginName]) {
+    return pluginI18nInstances[pluginName];
+  }
+
+  const instance = createInstance();
+
+  // Use supported locales from package.json or fall back to common locales
+  const locales = supportedLocales || ['en', 'es', 'fr', 'de', 'pt', 'it', 'zh', 'ko', 'ja'];
+  const resources: Record<string, Record<string, Record<string, string>>> = {};
+
+  // Load translations for each locale that exists
+  for (const locale of locales) {
+    const translations = await loadPluginTranslations(pluginPath, locale);
+    if (Object.keys(translations).length > 0) {
+      resources[locale] = {
+        [pluginName]: translations,
+      };
+    }
+  }
+
+  // If English is not in the supported locales but is the fallback language,
+  // provide an empty English resource to prevent warnings when no English
+  // translation file exists. This allows plugins to use their default strings
+  // (which may already be in English) without requiring explicit English translations.
+  const hasEnglishTranslations = resources['en'] !== undefined;
+  const supportsEnglish = supportedLocales?.includes('en') ?? true;
+
+  if (!hasEnglishTranslations && !supportsEnglish) {
+    // Provide empty English translations to prevent i18next warnings
+    // This allows the plugin to fall back to its original string keys
+    resources['en'] = {
+      [pluginName]: {},
+    };
+  }
+
+  await instance.init({
+    lng: i18next.language || 'en',
+    fallbackLng: 'en',
+    defaultNS: pluginName,
+    ns: [pluginName],
+    resources,
+    interpolation: {
+      escapeValue: false,
+    },
+    // Disable debug warnings for plugins that don't explicitly support English
+    // This prevents warnings about missing English translations when plugins
+    // may already have English strings as their default content
+    debug: false,
+    // Always return the key if no translation is found, which works well
+    // for plugins that already have English strings as their keys/content
+    returnEmptyString: false,
+    // Don't save missing keys to avoid console noise
+    saveMissing: false,
+  });
+
+  pluginI18nInstances[pluginName] = instance;
+  return instance;
+}
+
+/**
+ * Register translations for a plugin programmatically
+ * @deprecated This function is deprecated. Use automatic translation file detection instead.
+ * Just place translation files in locales/{language}/translation.json and use useTranslation().
+ */
+export function registerPluginTranslations(pluginName: string, translations: PluginTranslations) {
+  console.warn(
+    `registerPluginTranslations is deprecated. Plugin ${pluginName} should use automatic translation loading instead.`
+  );
+
+  const instance = createInstance();
+  const namespace = pluginName;
+
+  instance.init({
+    lng: i18next.language || 'en',
+    fallbackLng: 'en',
+    defaultNS: namespace,
+    ns: [namespace],
+    resources: Object.keys(translations).reduce((acc, locale) => {
+      acc[locale] = {
+        [namespace]: translations[locale],
+      };
+      return acc;
+    }, {} as Record<string, Record<string, Record<string, string>>>),
+    interpolation: {
+      escapeValue: false,
+    },
+    debug: false,
+    returnEmptyString: false,
+    saveMissing: false,
+  });
+
+  pluginI18nInstances[pluginName] = instance;
+}
+
+/**
+ * Hook to use translations in a plugin
+ * Automatically detects the plugin name from the build-time injected constants
+ * @param pluginNameParam Plugin name (automatically injected by build system)
+ */
+export function useTranslation(pluginNameParam?: string): UseTranslationResult {
+  const [ready, setReady] = useState(false);
+  const [instance, setInstance] = useState<i18n | null>(null);
+  const [pluginName] = useState(() => {
+    if (pluginNameParam) {
+      return pluginNameParam;
+    }
+
+    // If no plugin name is provided, it means the build system transformation didn't work
+    console.error(
+      'useTranslation: No plugin name provided. This usually means the build system transformation failed.'
+    );
+    return null;
+  });
+  const { i18n: mainI18n } = useReactI18nTranslation();
+
+  // Initialize plugin translations when plugin name is available
+  useEffect(() => {
+    async function initializeTranslations() {
+      if (!pluginName) {
+        console.error('useTranslation: No plugin name available. Plugin i18n will not work.');
+        setReady(true);
+        return;
+      }
+
+      try {
+        const currentPluginName = pluginName;
+
+        // Try to resolve the plugin path. Use the module-level pluginPaths mapping.
+        let pluginPath = pluginPaths[currentPluginName];
+
+        // As a last resort, try deriving a path from the package name by
+        // stripping the scope (if any) to match common directory setups.
+        if (!pluginPath && currentPluginName) {
+          const unscoped = currentPluginName.includes('/')
+            ? currentPluginName.split('/').slice(-1)[0]
+            : currentPluginName;
+          // Common plugin path shape is "/plugins/<name>"
+          const derived = `/plugins/${unscoped}`;
+          // We don't have a server filesystem check here; try to use the
+          // derived path optimistically. It will fail later when fetching
+          // translations, but gives us a chance to proceed.
+          pluginPath = derived;
+        }
+
+        if (!pluginPath) {
+          console.warn(
+            `No plugin path found for ${currentPluginName}. i18n initialization skipped.`
+          );
+          setReady(true);
+          return;
+        }
+
+        // Initialize plugin i18n instance
+        const supportedLocales = pluginSupportedLocales[currentPluginName];
+        const pluginInstance = await getPluginI18nInstance(
+          currentPluginName,
+          pluginPath,
+          supportedLocales
+        );
+        setInstance(pluginInstance);
+        setReady(true);
+      } catch (error) {
+        console.error(`Failed to initialize translations for plugin ${pluginName}:`, error);
+        setReady(true); // Set ready to true even on error to prevent hanging
+      }
+    }
+
+    initializeTranslations();
+  }, [pluginName]);
+
+  // Sync language changes from main i18n
+  useEffect(() => {
+    if (instance && mainI18n?.language !== instance.language) {
+      instance.changeLanguage(mainI18n.language);
+    }
+  }, [mainI18n?.language, instance]);
+
+  // Translation function
+  const t = (key: string, options?: TOptions) => {
+    // Avoid flashing the raw key in the UI before plugin translations are ready.
+    // While the plugin i18n instance is initializing (ready === false)
+    // return an empty string to avoid briefly showing the key.
+    if (!ready) {
+      return '';
+    }
+
+    // If initialization completed but we don't have an instance (for
+    // example the plugin has no translations or initialization failed),
+    // return the original key so the UI still shows a reasonable value.
+    if (!instance || !pluginName) {
+      return key;
+    }
+
+    return instance.t(key, options);
+  };
+
+  return {
+    t: t as TFunction,
+    i18n: instance,
+    ready,
+  };
+}
+
+/**
+ * Get all registered plugin translations info
+ */
+export function getPluginTranslationsInfo(): PluginI18nInfo[] {
+  return [];
+}
+
+/**
+ * Change language for all plugin instances
+ */
+export function changePluginLanguage(language: string) {
+  Object.values(pluginI18nInstances).forEach(instance => {
+    instance.changeLanguage(language);
+  });
+}
+
+/**
+ * Check if a locale is supported by a plugin
+ */
+export function isLocaleSupported(pluginName: string, locale: string): boolean {
+  const supportedLocales = pluginSupportedLocales[pluginName];
+  return Array.isArray(supportedLocales) && supportedLocales.includes(locale);
+}
+
+/**
+ * Get the list of supported locales for a plugin
+ */
+export function getSupportedLocales(pluginName: string): string[] {
+  return pluginSupportedLocales[pluginName] || [];
+}
+
+/**
+ * Initialize plugin i18n - simplified approach using package.json configuration
+ * This is called automatically during plugin loading
+ */
+export async function initializePluginI18n(
+  pluginName: string,
+  packageInfo: PluginPackageInfo,
+  pluginPath: string
+) {
+  // Store the plugin path for later use by useTranslation hook
+  pluginPaths[pluginName] = pluginPath;
+
+  // Detect duplicate pluginPath mappings: if another plugin name already
+  // points to the same path, warn because translations may be loaded from
+  // the wrong folder and cause cross-plugin leaks.
+  const duplicates = Object.keys(pluginPaths).filter(
+    name => name !== pluginName && pluginPaths[name] === pluginPath
+  );
+  if (duplicates.length > 0) {
+    console.warn(
+      `Plugin path collision: ${pluginName} and ${duplicates.join(
+        ', '
+      )} map to the same path ${pluginPath}`
+    );
+  }
+
+  // Check if plugin has i18n enabled in package.json (array of supported locales)
+  const i18nConfig = packageInfo.headlamp?.i18n;
+  let supportedLocales: string[] = [];
+  let i18nEnabled = false;
+
+  if (Array.isArray(i18nConfig)) {
+    // Array of supported locales
+    supportedLocales = i18nConfig;
+    i18nEnabled = supportedLocales.length > 0;
+  }
+
+  if (i18nEnabled) {
+    // Store supported locales for later use
+    pluginSupportedLocales[pluginName] = supportedLocales;
+    console.log(
+      `Initializing i18n for plugin ${pluginName} (supported locales: ${supportedLocales.join(
+        ', '
+      )})`
+    );
+    try {
+      await getPluginI18nInstance(pluginName, pluginPath, supportedLocales);
+    } catch (error) {
+      console.error(`Failed to initialize i18n for plugin ${pluginName}:`, error);
+    }
+  } else {
+    console.log(`Plugin ${pluginName} does not have i18n enabled in package.json`);
+  }
+}

--- a/plugins/headlamp-plugin/config/i18next-parser.config.js
+++ b/plugins/headlamp-plugin/config/i18next-parser.config.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Get the current working directory (where the plugin is)
+const pluginDir = process.cwd();
+const directoryPath = path.join(pluginDir, './locales');
+
+// Read configured locales from package.json
+let configuredLocales = [];
+const packageJsonPath = path.join(pluginDir, 'package.json');
+if (fs.existsSync(packageJsonPath)) {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    if (Array.isArray(packageJson.headlamp?.i18n)) {
+      configuredLocales = packageJson.headlamp.i18n;
+    }
+  } catch (error) {
+    console.warn('Failed to read package.json for i18n configuration:', error.message);
+  }
+}
+
+// Fall back to scanning existing locale directories if no configuration found
+const currentLocales = [];
+if (fs.existsSync(directoryPath)) {
+  fs.readdirSync(directoryPath).forEach(file => currentLocales.push(file));
+}
+
+// Use configured locales first, then existing directories, then fallback to 'en'
+const localesToUse =
+  configuredLocales.length > 0
+    ? configuredLocales
+    : currentLocales.length > 0
+    ? currentLocales
+    : ['en'];
+
+module.exports = {
+  lexers: {
+    default: ['JsxLexer'],
+  },
+  namespaceSeparator: '|',
+  keySeparator: false,
+  output: path.join(directoryPath, './$LOCALE/$NAMESPACE.json'),
+  locales: localesToUse,
+  contextSeparator: '//context:',
+  defaultValue: (locale, _namespace, key) => {
+    // The English catalog has "SomeKey": "SomeKey" so we stop warnings about
+    // missing values.
+    if (locale === 'en') {
+      const contextSepIdx = key.indexOf('//context:');
+      if (contextSepIdx >= 0) {
+        return key.substring(0, contextSepIdx);
+      }
+      return key;
+    }
+    return '';
+  },
+};

--- a/plugins/headlamp-plugin/config/vite-plugin-name-injection.mjs
+++ b/plugins/headlamp-plugin/config/vite-plugin-name-injection.mjs
@@ -1,0 +1,97 @@
+/**
+ * Vite plugin to inject plugin name and transform useTranslation imports
+ * Automatically injects plugin name into useTranslation calls
+ */
+import fs from 'fs';
+import path from 'path';
+
+export function pluginNameInjection() {
+  let pluginName = null;
+
+  return {
+    name: 'plugin-name-injection',
+
+    // Find plugin name during build start
+    buildStart() {
+      // Find the closest package.json to determine plugin name
+      let currentDir = process.cwd();
+
+      while (currentDir !== path.parse(currentDir).root) {
+        const packageJsonPath = path.join(currentDir, 'package.json');
+        if (fs.existsSync(packageJsonPath)) {
+          try {
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+            pluginName = packageJson.name;
+            console.log(`🎯 Plugin name detected: '${pluginName}'`);
+            break;
+          } catch (error) {
+            // Continue searching
+          }
+        }
+        currentDir = path.dirname(currentDir);
+      }
+    },
+
+    // Transform code to inject plugin name into useTranslation calls
+    transform(code, id) {
+      // Only transform TypeScript/JavaScript files that import useTranslation
+      if (!/\.(tsx?|jsx?)$/.test(id)) return null;
+      if (!code.includes('useTranslation')) return null;
+
+      // Determine plugin name: prefer the name found at buildStart, but if not
+      // available (for example when build CWD is different), walk up from the
+      // transformed file's path (`id`) and read the closest package.json.
+      let localPluginName = pluginName;
+      if (!localPluginName) {
+        let currentDir = path.dirname(id);
+        while (currentDir && currentDir !== path.dirname(currentDir)) {
+          const packageJsonPath = path.join(currentDir, 'package.json');
+          if (fs.existsSync(packageJsonPath)) {
+            try {
+              const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+              if (packageJson && packageJson.name) {
+                localPluginName = packageJson.name;
+                console.log(
+                  `🎯 Plugin name detected from '${path.relative(
+                    process.cwd(),
+                    id
+                  )}': '${localPluginName}'`
+                );
+                break;
+              }
+            } catch (error) {
+              // ignore and continue walking up
+            }
+          }
+          currentDir = path.dirname(currentDir);
+        }
+      }
+
+      if (!localPluginName) return null;
+
+      // Transform useTranslation/registerPluginSettings calls using the resolved name
+      let transformedCode = code;
+      let hasTransformations = false;
+
+      const nameLiteral = JSON.stringify(localPluginName);
+
+      // Transform useTranslation() calls without parameters
+      const useTranslationMatches = transformedCode.match(/\buseTranslation\(\s*\)/g);
+      if (useTranslationMatches) {
+        console.log(`🔄 Found ${useTranslationMatches.length} useTranslation() calls to transform`);
+        transformedCode = transformedCode.replace(
+          /\buseTranslation\(\s*\)/g,
+          `useTranslation(${nameLiteral})`
+        );
+        hasTransformations = true;
+      }
+
+      if (hasTransformations) {
+        console.log(`🔄 Transformed useTranslation() calls in ${path.relative(process.cwd(), id)}`);
+        return transformedCode;
+      }
+
+      return null;
+    },
+  };
+}

--- a/plugins/headlamp-plugin/config/vite.config.mjs
+++ b/plugins/headlamp-plugin/config/vite.config.mjs
@@ -6,6 +6,7 @@ import svgr from 'vite-plugin-svgr';
 import { resolve } from 'path';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 import { fileURLToPath } from 'url';
+import { pluginNameInjection } from './vite-plugin-name-injection.mjs';
 
 const externalModules = {
   '@mui/material': 'pluginLib.MuiMaterial',
@@ -54,6 +55,7 @@ export default defineConfig({
     global: 'globalThis',
   },
   plugins: [
+    pluginNameInjection(),
     nodePolyfills({
       include: ['process', 'buffer', 'stream'],
     }),

--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -27,6 +27,7 @@ import * as Notification from './lib/notification';
 import * as Router from './lib/router';
 import * as Utils from './lib/util';
 import { Headlamp, Plugin } from './plugin/lib';
+import { getSupportedLocales, isLocaleSupported, useTranslation } from './plugin/pluginI18n';
 import { PluginSettingsDetailsProps } from './plugin/pluginsSlice';
 import Registry, {
   AppLogoProps,
@@ -101,6 +102,9 @@ export {
   registerUIPanel,
   registerAppTheme,
   registerKubeObjectGlance,
+  useTranslation,
+  isLocaleSupported,
+  getSupportedLocales,
 };
 
 export type {

--- a/plugins/headlamp-plugin/template/package.json
+++ b/plugins/headlamp-plugin/template/package.json
@@ -12,7 +12,8 @@
     "tsc": "headlamp-plugin tsc",
     "storybook": "headlamp-plugin storybook",
     "storybook-build": "headlamp-plugin storybook-build",
-    "test": "headlamp-plugin test"
+    "test": "headlamp-plugin test",
+    "i18n": "headlamp-plugin i18n"
   },
   "keywords": [
     "headlamp",

--- a/plugins/headlamp-plugin/template/src/index.tsx
+++ b/plugins/headlamp-plugin/template/src/index.tsx
@@ -18,8 +18,15 @@ import { registerAppBarAction } from '@kinvolk/headlamp-plugin/lib';
 
 // Below are some imports you may want to use.
 //   See README.md for links to plugin development documentation.
+// import { Headlamp, K8s, useTranslation } from '@kinvolk/headlamp-plugin/lib';
 // import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 // import { K8s } from '@kinvolk/headlamp-plugin/lib/K8s';
 // import { Typography } from '@mui/material';
 
 registerAppBarAction(<span>Hello</span>);
+
+// Example of using i18n (internationalization):
+// function MyComponent() {
+//   const { t } = useTranslation();
+//   return <div>{t('translation_key')}</div>;
+// }


### PR DESCRIPTION
## Summary

This PR adds the ability for plugins to use i18n.

fixes https://github.com/headlamp-k8s/plugins/issues/372

## Steps to Test

1. Go to the [pod-counter-with-i18n](https://github.com/kubernetes-sigs/headlamp/compare/main...headlamp-k8s:hl-shared:pod-counter-with-i18n) branch from the **hl-shared fork**
2. Go to headlamp-plugin; Run `npm i; npm run build; npm run pack`. This will create a _kinvolk-headlamp-plugin-0.13.0-alpha.3.tgz_ file
3. Go to the pod-counter example plugin; run `npm i; npm i -S ../../headlamp-plugin/kinvolk-headlamp-plugin-0.13.0-alp
ha.3.tgz ; npm run start`; Notice that it mentions the locales:
```bash
build started...
🎯 Plugin name detected: '@kinvolk/headlamp-pod-counter'
🎯 Plugin name detected: '@kinvolk/headlamp-pod-counter'
Checking if @kinvolk/headlamp-plugin is up to date...
🔄 Found 2 useTranslation() calls to transform
🔄 Transformed useTranslation() calls in src/index.tsx
transforming (1) src/index.tsxAuto-copying locales directory "/home/jrocha/headlamp/plugins/examples/pod-counter/locales" to "/home/jrocha/headlamp/plugins/examples/pod-counter/dist/locales"
Successfully copied extra dist files
✓ 2 modules transformed.
```
4. Refresh Headlamp just in case and go to a cluster, notice the English pod-counter message at the top bar
5. Change Headlamp's language to Portuguese and verify that the top bar message from the pod-counter is translated
<img width="458" height="68" alt="Screenshot of the message in portuguese" src="https://github.com/user-attachments/assets/6dcb71ed-5918-4247-91e9-2f5b1db2d504" />


## Notes for the Reviewer

We can update all the example plugins with translations once we have a new version of headlamp-plugin released.
