### PR TITLE
frontend: PluginSettingsDetails: Move useDispatch outside delete handler

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
@@ -40,13 +40,13 @@ const PluginSettingsDetailsInitializer = (props: { plugin: PluginInfo }) => {
   const store = new ConfigStore(plugin.name);
   const pluginConf = store.useConfig();
   const config = pluginConf() as { [key: string]: any };
+  const dispatch = useDispatch();
 
   function handleSave(data: { [key: string]: any }) {
     store.set(data);
   }
 
   function handleDeleteConfirm() {
-    const dispatch = useDispatch();
     const name = plugin.name.split('/').splice(-1)[0];
     deletePlugin(name)
       .then(() => {


### PR DESCRIPTION
This change moves useDispatch outside of the delete handler in `PluginSettingsDetails` to fix a regression where plugins could not be deleted.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3793

### Testing
- [X] Navigate to a plugin in the plugin settings (maybe install one for testing in the Plugin Catalog)
- [X] Try to delete it
- [X] Refresh Headlamp and notice that the plugin has been deleted