### PR TITLE
frontend: Export functions for plugin Project overrides

### DIFF
--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -45,6 +45,7 @@ import Registry, {
   registerClusterChooser,
   registerClusterProviderDialog,
   registerClusterProviderMenuItem,
+  registerCustomCreateProject,
   registerDetailsViewHeaderAction,
   registerDetailsViewHeaderActionsProcessor,
   registerDetailsViewSection,
@@ -53,6 +54,8 @@ import Registry, {
   registerKubeObjectGlance,
   registerMapSource,
   registerPluginSettings,
+  registerProjectDetailsTab,
+  registerProjectOverviewSection,
   registerResourceTableColumnsProcessor,
   registerRoute,
   registerRouteFilter,
@@ -101,6 +104,9 @@ export {
   registerUIPanel,
   registerAppTheme,
   registerKubeObjectGlance,
+  registerCustomCreateProject,
+  registerProjectDetailsTab,
+  registerProjectOverviewSection,
 };
 
 export type {


### PR DESCRIPTION
## Summary

This PR adds the needed plugin exports so the type checker doesn't complain when plugins use it.

## Steps to Test

1. Check that VScode complains about the unknown imports in the Project example plugin 
2. Check that in this branch it works
