### PR TITLE
frontend: Dockerfile: Bump Node.js image version to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go build -o ./headlamp-server ./cmd/
 
-FROM --platform=${BUILDPLATFORM} node:18@sha256:d0bbfdbad0bff8253e6159dcbee42141db4fc309365d5b8bcfce46ed71569078 AS frontend-build
+FROM --platform=${BUILDPLATFORM} node:22@sha256:6fe286835c595e53cdafc4889e9eff903dd3008a3050c1675809148d8e0df805 AS frontend-build
 
 # We need .git and app/ in order to get the version and git version for the frontend/.env file
 # that's generated when building the frontend.


### PR DESCRIPTION
## Summary

This PR Bump the Node.js image version to 22 in Dockerfile,  Because the node version in frontend code is supposed ti >= 20.11.1

```json
  "engines": {
    "npm": ">=10.0.0",
    "node": ">=20.11.1"
  },
```
