### PR TITLE
[helm] add optional PodDisruptionBudget

### DIFF
--- a/.github/workflows/helm-chart-template-test.yml
+++ b/.github/workflows/helm-chart-template-test.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -27,16 +27,15 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.7.0
-
-      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+          version: v3.18.4
+          
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: 3.7
+          python-version: '3.13' 
 
       - name: Run template testing script
         run: |
           export SHELL=/bin/bash
           make helm-template-test
-

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -231,6 +231,44 @@ env:
     value: "6443"
 ```
 
+### Pod Disruption Budget (PDB)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget resource |
+| podDisruptionBudget.minAvailable | integer \| string \| null | `0` | Minimum pods that must be available. Rendered only when set to a positive integer or a percentage string (e.g. `"1"` or `"50%"`). Schema default is 0, but the chart skips rendering `0`. |
+| podDisruptionBudget.maxUnavailable | integer \| string \| null | `null` | Maximum pods allowed to be unavailable. Accepts integer >= 0 or percentage string. Mutually exclusive with `minAvailable`; the template renders this field when set. |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string \| null | `null` | Eviction policy: `"IfHealthyBudget"` or `"AlwaysAllow"`. Emitted only on clusters running Kubernetes >= 1.27 and when explicitly set in values. |
+
+Note: Ensure `minAvailable` and `maxUnavailable` are not both set (use `null` to disable one). To include `minAvailable` in the rendered PDB, set a positive integer or percentage; the template omits a `0` value.
+
+Example, Require at least 1 pod available (ensure maxUnavailable is disabled):
+```yaml
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  maxUnavailable: null
+```
+
+Example, Allow up to 50% of pods to be unavailable:
+```yaml
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: "50%"
+  minAvailable: null
+```
+
+Example, Set unhealthyPodEvictionPolicy (requires Kubernetes >= 1.27):
+```yaml
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+  minAvailable: null
+  unhealthyPodEvictionPolicy: "IfHealthyBudget"
+```
+
+Ensure your replicaCount and maintenance procedures respect the configured PDB to avoid blocking intended operations.
+
 ## Contributing
 
 We welcome contributions to the Headlamp Helm chart! To contribute:

--- a/charts/headlamp/templates/pdb.yaml
+++ b/charts/headlamp/templates/pdb.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "headlamp.fullname" . }}
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- if (semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version) }}
+  {{- if hasKey .Values.podDisruptionBudget "unhealthyPodEvictionPolicy" }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "headlamp.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/headlamp/tests/expected_templates/pod-disruption.yaml
+++ b/charts/headlamp/tests/expected_templates/pod-disruption.yaml
@@ -1,0 +1,142 @@
+---
+# Source: headlamp/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: IfHealthyBudget
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.35.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-plugins-dir=/headlamp/plugins"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}

--- a/charts/headlamp/tests/test_cases/pod-disruption.yaml
+++ b/charts/headlamp/tests/test_cases/pod-disruption.yaml
@@ -1,0 +1,5 @@
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: IfHealthyBudget
+  minAvailable: null

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -429,6 +429,66 @@
         }
       }
     },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable PodDisruptionBudget. See: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/"
+        },
+        "minAvailable": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
+              "type": "string",
+              "pattern": "^([0-9]+%?|[0-9]*\\.[0-9]+%)$"
+            }
+          ],
+          "default": 0,
+          "description": "Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null`"
+        },
+        "maxUnavailable": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
+              "type": "string",
+              "pattern": "^([0-9]+%?|[0-9]*\\.[0-9]+%)$"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number/percentage of pods that may be made unavailable"
+        },
+        "unhealthyPodEvictionPolicy": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "IfHealthyBudget",
+                "AlwaysAllow"
+              ]
+            }
+          ],
+          "default": null,
+          "description": "How are unhealthy, but running, pods counted for eviction"
+        }
+      }
+    },
     "extraManifests": {
       "type": "array",
       "description": "Extra manifests to apply to the deployment",

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -262,6 +262,27 @@ pluginsManager:
   #     cpu: "1000m"
   #     memory: "4096Mi"
 
+podDisruptionBudget:
+  # -- enable PodDisruptionBudget
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  enabled: false
+  # @schema
+  # type: [null, integer, string]
+  # @schema
+  # -- Minimum number/percentage of pods that should remain scheduled.
+  # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
+  minAvailable: 0
+  # @schema
+  # type: [null, integer, string]
+  # @schema
+  # -- Maximum number/percentage of pods that may be made unavailable
+  maxUnavailable: null
+  # @schema
+  # type: [null, string]
+  # @schema
+  # -- How are unhealthy, but running, pods counted for eviction
+  unhealthyPodEvictionPolicy: null
+
 # -- Additional Kubernetes manifests to be deployed. Include the manifest as nested YAML.
 extraManifests: []
 # - |


### PR DESCRIPTION
## Summary

This PR adds an optional PodDisruptionBudget for the helm deplopyment

## Related Issue

Fixes #ISSUE_NUMBER  

## Changes

- Added optional PodDisruptionBudget for helm

## Steps to Test

1. render template as is
2. Set `.Values.podDisruptionBudget.enabled` to true
3. render again

## Screenshots (if applicable)


## Notes for the Reviewer

- This should leave the default install without a PDB
- With `enabled` it should setup a PDB that lets headlamp be offline during a disruption