### PR TITLE
Docs: Fix broken link to architecture from Plugins page

### DIFF
--- a/docs/development/plugins/index.md
+++ b/docs/development/plugins/index.md
@@ -22,25 +22,32 @@ Headlamp plugins can transform your Kubernetes experience by:
 
 New to plugin development? Follow our step-by-step guide:
 
-### 🏗️ [Plugin Architecture](./architecture.md)
+### 🏗️ [Plugin Architecture](../architecture.md)
+
 Understand how plugins work, where they're loaded from, and how they integrate with Headlamp.
 
 ### 📚 [Getting Started With Plugin Development](./getting-started.md)
+
 Complete tutorial from installation to your first working plugin, with practical examples and troubleshooting tips.
 
 ### 🛠️ [Building & Shipping Plugins](./building.md)
+
 Learn the development workflow, production builds, and deployment strategies.
 
 ### 📖 [Common Patterns](./common-patterns.md)
+
 Ready-to-use examples for typical plugin scenarios like dashboards, resource extensions, and external integrations.
 
 ### 🎯 [Plugin Functionality Reference](./functionality/index.md)
+
 Comprehensive API documentation covering all available plugin capabilities.
 
 ### 🚀 [Publishing Plugins](./publishing.md)
+
 Share your plugins with the community through Artifact Hub.
 
 ### 🌍 [Internationalization](./i18n.md)
+
 Add support for multiple languages and locales
 
 ## Ready to Start?


### PR DESCRIPTION
## Summary

This PR fixes an issue on the website currently where accessing the 'architecture' link from the plugins docs page would lead it to a broken link.

## Related Issue

Fixes https://github.com/kubernetes-sigs/headlamp/issues/3864

## Changes

- Fixed broken link for architecture under the plugins docs

## Steps to Test

1. Nav to `/docs/latest/development/plugins/`
2. Click on the `Plugin Architecture` link
3. Note that this should take you to the architecture docs and not a "page not found" error

