### PR TITLE
charts: add ability to specify podLabels

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -208,6 +208,7 @@ ingress:
 | tolerations | list | `[]` | Pod tolerations |
 | affinity | object | `{}` | Pod affinity settings |
 | podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
 | env | list | `[]` | Additional environment variables |
 
 Example resource configuration:

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
       {{- end }}
       labels:
         {{- include "headlamp.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -130,6 +130,9 @@ deploymentAnnotations: {}
 # -- Annotations to add to the pod
 podAnnotations: {}
 
+# -- Labels to add to the pod
+podLabels: {}
+
 # -- Headlamp pod's Security Context
 podSecurityContext:
   {}


### PR DESCRIPTION
## Summary

This PR adds the possibility to specify `podLabels`.

## Related Issue

Fixes #3475

## Changes

- Added ability to specify `podLabels`

## Steps to Test

1. Deploy with `podLabels` specified.
2. Verify that the labels on the Pod.

## Screenshots (if applicable)

No screenshots.

## Notes for the Reviewer

Nothing special to say.
