### PR TITLE
frontend: k8s: Remove references to makeKubeObject

### DIFF
--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -19,7 +19,6 @@ import { getCluster } from '../cluster';
 import { KubeMetadata } from './KubeMetadata';
 export {
   KubeObject,
-  makeKubeObject,
   type KubeObjectClass,
   type KubeObjectInterface,
   type ApiListOptions,

--- a/frontend/src/lib/k8s/clusterRole.ts
+++ b/frontend/src/lib/k8s/clusterRole.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { makeKubeObject } from './KubeObject';
+import { KubeObject } from './KubeObject';
 import { KubeRole } from './role';
 
-class ClusterRole extends makeKubeObject<KubeRole>() {
+class ClusterRole extends KubeObject<KubeRole> {
   static kind = 'ClusterRole';
   static apiName = 'clusterroles';
   static apiVersion = 'rbac.authorization.k8s.io/v1';

--- a/frontend/src/lib/k8s/clusterRoleBinding.ts
+++ b/frontend/src/lib/k8s/clusterRoleBinding.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { makeKubeObject } from './KubeObject';
+import { KubeObject } from './KubeObject';
 import { KubeRoleBinding } from './roleBinding';
 
-class ClusterRoleBinding extends makeKubeObject<KubeRoleBinding>() {
+class ClusterRoleBinding extends KubeObject<KubeRoleBinding> {
   static kind = 'ClusterRoleBinding';
   static apiName = 'clusterrolebindings';
   static apiVersion = 'rbac.authorization.k8s.io/v1';

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -298,7 +298,6 @@
       "HEADLAMP_ALLOWED_NAMESPACES": "headlamp.allowed-namespaces",
       "KubeObject": [Function],
       "getAllowedNamespaces": [Function],
-      "makeKubeObject": [Function],
     },
     "clusterRole": {
       "default": [Function],


### PR DESCRIPTION
This change removes references to the deprecated `makeKubeObject()` function and replaces them with `KubeObject`.

### Testing
- [X] Open Headlamp and try to create a `ClusterRole` or `ClusterRoleBinding`
- [X] Ensure that they are successfully created with no errors