### PR TITLE
frontend: lib/k8s: Fixing some circular imports

### DIFF
--- a/frontend/src/lib/k8s/KubeMetadata.ts
+++ b/frontend/src/lib/k8s/KubeMetadata.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { KubeManagedFieldsEntry, KubeOwnerReference, StringDict } from './cluster';
+import type { KubeManagedFieldsEntry, KubeOwnerReference, StringDict } from './cluster';
 
 /**
  * KubeMetadata contains the metadata that is common to all Kubernetes objects.

--- a/frontend/src/lib/k8s/api/v1/apply.ts
+++ b/frontend/src/lib/k8s/api/v1/apply.ts
@@ -16,8 +16,8 @@
 
 import _ from 'lodash';
 import { getCluster } from '../../../cluster';
-import { KubeObjectInterface } from '../../KubeObject';
-import { ApiError } from '../v2/ApiError';
+import type { KubeObjectInterface } from '../../KubeObject';
+import type { ApiError } from '../v2/ApiError';
 import { getClusterDefaultNamespace } from './clusterApi';
 import { resourceDefToApiFactory } from './factories';
 

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -17,12 +17,13 @@
 import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
 import { loadClusterSettings } from '../../../../helpers/clusterSettings';
 import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
-import { ConfigState } from '../../../../redux/configSlice';
+import type { ConfigState } from '../../../../redux/configSlice';
 import store from '../../../../redux/stores/store';
 import { deleteClusterKubeconfig, storeStatelessClusterKubeconfig } from '../../../../stateless';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getCluster, getSelectedClusters } from '../../../cluster';
-import { ClusterRequest, clusterRequest, post, request } from './clusterRequests';
+import type { ClusterRequest } from './clusterRequests';
+import { clusterRequest, post, request } from './clusterRequests';
 import { JSON_HEADERS } from './constants';
 
 /**

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -24,11 +24,11 @@ import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfi
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { logout } from '../../../auth';
 import { getCluster } from '../../../cluster';
-import { KubeObjectInterface } from '../../KubeObject';
-import { ApiError } from '../v2/ApiError';
+import type { KubeObjectInterface } from '../../KubeObject';
+import type { ApiError } from '../v2/ApiError';
 import { BASE_HTTP_URL, CLUSTERS_PREFIX, DEFAULT_TIMEOUT, JSON_HEADERS } from './constants';
 import { asQuery, combinePath } from './formatUrl';
-import { QueryParameters } from './queryParameters';
+import type { QueryParameters } from './queryParameters';
 
 /**
  * Options for the request.

--- a/frontend/src/lib/k8s/api/v1/factories.ts
+++ b/frontend/src/lib/k8s/api/v1/factories.ts
@@ -17,22 +17,18 @@
 // @todo: repeatStreamFunc could be improved for performance by remembering when a URL
 //       is 404 and not trying it again... and again.
 
-import { OpPatch } from 'json-patch';
+import type { OpPatch } from 'json-patch';
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { getCluster } from '../../../cluster';
-import { KubeObjectInterface } from '../../KubeObject';
-import { ApiError } from '../v2/ApiError';
+import type { KubeObjectInterface } from '../../KubeObject';
+import type { ApiError } from '../v2/ApiError';
 import { clusterRequest, patch, post, put, remove } from './clusterRequests';
-import { DeleteParameters } from './deleteParameters';
+import type { DeleteParameters } from './deleteParameters';
 import { asQuery, getApiRoot } from './formatUrl';
-import { QueryParameters } from './queryParameters';
-import { apiScaleFactory, ScaleApi } from './scaleApi';
-import {
-  StreamErrCb,
-  streamResult,
-  StreamResultsCb,
-  streamResultsForCluster,
-} from './streamingApi';
+import type { QueryParameters } from './queryParameters';
+import { apiScaleFactory, type ScaleApi } from './scaleApi';
+import type { StreamErrCb, StreamResultsCb } from './streamingApi';
+import { streamResult, streamResultsForCluster } from './streamingApi';
 
 export type CancelFunction = () => void;
 export type SingleApiFactoryArguments = [group: string, version: string, resource: string];

--- a/frontend/src/lib/k8s/api/v1/formatUrl.ts
+++ b/frontend/src/lib/k8s/api/v1/formatUrl.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { omit } from 'lodash';
-import { QueryParameters } from './queryParameters';
+import omit from 'lodash/omit';
+import type { QueryParameters } from './queryParameters';
 
 export function buildUrl(urlOrParts: string | string[], queryParams?: QueryParameters): string {
   const url = Array.isArray(urlOrParts) ? urlOrParts.filter(Boolean).join('/') : urlOrParts;

--- a/frontend/src/lib/k8s/api/v1/metricsApi.ts
+++ b/frontend/src/lib/k8s/api/v1/metricsApi.ts
@@ -16,8 +16,8 @@
 
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { getCluster } from '../../../cluster';
-import { KubeMetrics } from '../../cluster';
-import { ApiError } from '../v2/ApiError';
+import type { KubeMetrics } from '../../cluster';
+import type { ApiError } from '../v2/ApiError';
 import { clusterRequest } from './clusterRequests';
 
 /**

--- a/frontend/src/lib/k8s/api/v1/scaleApi.ts
+++ b/frontend/src/lib/k8s/api/v1/scaleApi.ts
@@ -15,7 +15,7 @@
  */
 
 import { getCluster } from '../../../cluster';
-import { KubeMetadata } from '../../KubeMetadata';
+import type { KubeMetadata } from '../../KubeMetadata';
 import { clusterRequest, patch, put } from './clusterRequests';
 
 export interface ScaleApi {

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -18,12 +18,12 @@ import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { getCluster } from '../../../cluster';
-import { KubeObjectInterface } from '../../KubeObject';
-import { ApiError } from '../v2/ApiError';
+import type { KubeObjectInterface } from '../../KubeObject';
+import type { ApiError } from '../v2/ApiError';
 import { clusterRequest } from './clusterRequests';
 import { BASE_HTTP_URL, CLUSTERS_PREFIX } from './constants';
 import { asQuery, combinePath } from './formatUrl';
-import { QueryParameters } from './queryParameters';
+import type { QueryParameters } from './queryParameters';
 
 export type StreamUpdate<T = any> = {
   type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'ERROR';

--- a/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
+++ b/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiResource } from './ApiResource';
+import type { ApiResource } from './ApiResource';
 import { clusterFetch } from './fetch';
 
 /**

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-import { QueryObserverOptions, useQueries, useQueryClient } from '@tanstack/react-query';
+import type { QueryObserverOptions } from '@tanstack/react-query';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { KubeObject, KubeObjectClass } from '../../KubeObject';
-import { QueryParameters } from '../v1/queryParameters';
+import type { KubeObject, KubeObjectClass } from '../../KubeObject';
+import type { QueryParameters } from '../v1/queryParameters';
 import { ApiError } from './ApiError';
 import { clusterFetch } from './fetch';
-import { QueryListResponse, useEndpoints } from './hooks';
-import { KubeList, KubeListUpdateEvent } from './KubeList';
+import type { QueryListResponse } from './hooks';
+import { useEndpoints } from './hooks';
+import type { KubeListUpdateEvent } from './KubeList';
+import { KubeList } from './KubeList';
 import { KubeObjectEndpoint } from './KubeObjectEndpoint';
 import { makeUrl } from './makeUrl';
 import { BASE_WS_URL, useWebSockets, WebSocketManager } from './webSocket';


### PR DESCRIPTION
Using import type in the lib/k8s folder. Only v1 and v2 folders done for now.

Why use import type?

-  No runtime code, removed from compiled JavaScript, so zero bundle impact
-  Clear intent, signals you’re importing types only, not values
-  Avoids circular dependencies, safer when working across interdependent modules
-  Faster builds, helps TypeScript and bundlers optimize
-  Cleaner output, keeps runtime imports minimal and focused

