### PR TITLE
backend: auth: Extract IsTokenAboutToExpire from headlamp.go

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -32,7 +32,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -930,23 +929,6 @@ func TestGetOidcCallbackURL(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestIsTokenAboutToExpire(t *testing.T) {
-	// Token that expires in 4 minutes
-	header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-	originalPayload := "eyJleHAiOjE2MTIzNjE2MDB9"
-	signature := ".7vl9iBWGDQdXUTbEsqFHiHoaNWxKn4UwLhO9QDhXrpM"
-
-	token := header + originalPayload + signature
-	result := isTokenAboutToExpire(token)
-	assert.True(t, result)
-
-	modifiedPayload := strings.Replace(originalPayload, "J", "-", 1)
-
-	token = header + modifiedPayload + signature
-	result = isTokenAboutToExpire(token)
-	assert.False(t, result, "Expected to return false when payload decoding fails due to URL-safe characters")
 }
 
 func TestOIDCTokenRefreshMiddleware(t *testing.T) {


### PR DESCRIPTION
This change extracts the IsTokenAboutToExpire from headlamp.go into the auth package.

Part of:
- #3482

### Updates
- Simplify splitting token into parts
- Add more comprehensive tests for token expiry window and invalid inputs

### Testing
```shell
cd backend
go test -v ./pkg/auth -run TestIsTokenAboutToExpire
```