### PR TITLE
headlamp-plugin: Fix npm start to log where files are copied

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -432,6 +432,32 @@ async function start() {
         ],
       })
     );
+
+    viteConfig.plugins.push({
+      name: 'headlamp-log-files-copied-to-plugin-folder',
+      buildEnd: async () => {
+        const destDir = path.join(configDir, 'plugins', packageName);
+        if (!fs.existsSync(destDir)) {
+          console.log(`No files copied to "${destDir}" (directory does not exist).`);
+          return;
+        }
+        try {
+          const files = fs.readdirSync(destDir);
+          if (files.length === 0) {
+            console.log(`No files found in "${destDir}".`);
+            return;
+          }
+          files.forEach(file => {
+            const destPath = path.join(destDir, file);
+            const srcPath =
+              file === 'package.json' ? path.resolve('package.json') : path.resolve('dist', file);
+            console.log(`Copied "${srcPath}" -> "${destPath}"`);
+          });
+        } catch (err) {
+          console.error('Error logging copied files:', err);
+        }
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
The previous headlamp-plugin printed where files were copied.
It was added after a contrib fest spent telling people where files
were copied to. The next one didn't have this problem, but the
feature was lost after the vite port... and then people started
asking again.
