### PR TITLE
frontend: resourceMap/GraphView: Fix ChipToggleButton to display Chinese text completely

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -404,7 +404,7 @@ function ChipToggleButton({
       icon={isActive ? <Icon icon="mdi:check" /> : undefined}
       onClick={onClick}
       sx={{
-        lineHeight: '1',
+        lineHeight: '2',
       }}
     />
   );

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.BasicExample.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.BasicExample.stories.storyshot
@@ -115,7 +115,7 @@
             class="MuiBox-root css-esugir"
           >
             <div
-              class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-qsy4j-MuiButtonBase-root-MuiChip-root"
+              class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
               role="button"
               tabindex="0"
             >
@@ -129,7 +129,7 @@
               />
             </div>
             <div
-              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-o4yg6p-MuiButtonBase-root-MuiChip-root"
+              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
               role="button"
               tabindex="0"
             >
@@ -143,7 +143,7 @@
               />
             </div>
             <div
-              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-o4yg6p-MuiButtonBase-root-MuiChip-root"
+              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
               role="button"
               tabindex="0"
             >
@@ -158,7 +158,7 @@
             </div>
           </div>
           <div
-            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-o4yg6p-MuiButtonBase-root-MuiChip-root"
+            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
             role="button"
             tabindex="0"
           >
@@ -172,7 +172,7 @@
             />
           </div>
           <div
-            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-o4yg6p-MuiButtonBase-root-MuiChip-root"
+            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
             role="button"
             tabindex="0"
           >


### PR DESCRIPTION
  ## Summary

  This PR fixes the ChipToggleButton display issue in GraphView component where Chinese text was being truncated by increasing the line height.


  ## Changes

  - Updated ChipToggleButton component in frontend/src/components/resourceMap/GraphView.tsx to increase lineHeight from '1' to '2'
  - This ensures Chinese characters and other non-Latin scripts display completely without truncation

  ## Steps to Test

  1. Navigate to the Resource Map view in Headlamp
  2. Switch the interface language to Chinese (中文)
  3. Check the ChipToggleButton components displaying "命名空间" (Namespace), "实例" (Instance), "节点" (Node), "状态：错误或警告" (Status: Error or Warning), and "全部展开" (Expand All)
  4. Verify that all Chinese text is fully visible without being cut off

 ## Screenshots (if applicable)

  Before: Chinese text was truncated in ChipToggleButton
<img width="1974" height="182" alt="image" src="https://github.com/user-attachments/assets/e85d6595-f44f-4775-b889-463c76057f0f" />
<img width="818" height="82" alt="image" src="https://github.com/user-attachments/assets/f4d23c20-2f42-4274-82be-6c90a50b1d97" />

  After: Chinese text displays completely with proper spacing
<img width="2288" height="298" alt="image" src="https://github.com/user-attachments/assets/bd456399-a85c-4eff-a064-d7e6882a2dd5" />
<img width="812" height="116" alt="image" src="https://github.com/user-attachments/assets/5d3bb2ba-4f5c-4cad-85d6-71bfb5a1301e" />


  ## Notes for the Reviewer

  - This is a minimal fix that only adjusts the line height to accommodate longer text in different languages
  - The change affects all ChipToggleButton instances in the GraphView component
  - Tested with Chinese translations but should benefit all languages with taller character heights