### PR TITLE
charts: namespaceOverride added

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -131,6 +131,7 @@ config:
 | imagePullSecrets | list | `[]` | Image pull secrets references |
 | nameOverride | string | `""` | Override the name of the chart |
 | fullnameOverride | string | `""` | Override the full name of the chart |
+| namespaceOverride | string | `""` | Override the deployment namespace; defaults to .Release.Namespace |
 | initContainers | list | `[]` | Init containers to run before main container |
 
 ### Security Configuration

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -6,19 +6,19 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "headlamp.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ include "headlamp.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "headlamp.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ include "headlamp.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "headlamp.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "headlamp.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ include "headlamp.namespace" . }} svc -w {{ include "headlamp.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ include "headlamp.namespace" . }} {{ include "headlamp.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "headlamp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  export POD_NAME=$(kubectl get pods --namespace {{ include "headlamp.namespace" . }} -l "app.kubernetes.io/name={{ include "headlamp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ include "headlamp.namespace" . }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  kubectl --namespace {{ include "headlamp.namespace" . }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
 {{- if .Values.clusterRoleBinding.create }}
   {{- if and ( ge .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "24" ) }}
@@ -26,7 +26,7 @@
   kubectl create token {{ include "headlamp.serviceAccountName" . }} --namespace {{.Release.Namespace}}
   {{- else }}
 2. Get the clusterrolebinding token using
-  export SECRET=$(kubectl get secrets --namespace {{ .Release.Namespace }} -o custom-columns=":metadata.name" | grep "{{ include "headlamp.fullname" . }}-token")
-  kubectl get secret $SECRET --namespace {{ .Release.Namespace }} --template=\{\{.data.token\}\} | base64 --decode
+  export SECRET=$(kubectl get secrets --namespace {{ include "headlamp.namespace" . }} -o custom-columns=":metadata.name" | grep "{{ include "headlamp.fullname" . }}-token")
+  kubectl get secret $SECRET --namespace {{ include "headlamp.namespace" . }} --template=\{\{.data.token\}\} | base64 --decode
   {{- end }}
 {{- end }}

--- a/charts/headlamp/templates/_helpers.tpl
+++ b/charts/headlamp/templates/_helpers.tpl
@@ -24,6 +24,30 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
+*/}}
+{{- define "headlamp.namespace" -}}
+  {{- with $.Values }}
+    {{- if .namespaceOverride }}
+      {{- .namespaceOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- with $.Release }}
+        {{- .Namespace | trunc 63 | trimSuffix "-" -}}
+      {{- else -}}
+        default
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- with $.Release }}
+      {{- .Namespace | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      default
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "headlamp.chart" -}}

--- a/charts/headlamp/templates/clusterrolebinding.yaml
+++ b/charts/headlamp/templates/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "headlamp.fullname" . }}-admin
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
   {{- with .Values.clusterRoleBinding.annotations }}
@@ -16,5 +17,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "headlamp.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "headlamp.namespace" . }}
 {{- end }}

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -43,6 +43,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "headlamp.fullname" . }}
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}

--- a/charts/headlamp/templates/ingress.yaml
+++ b/charts/headlamp/templates/ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}

--- a/charts/headlamp/templates/pdb.yaml
+++ b/charts/headlamp/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "headlamp.fullname" . }}
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
 spec:

--- a/charts/headlamp/templates/plugin-configmap.yaml
+++ b/charts/headlamp/templates/plugin-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "headlamp.fullname" . }}-plugin-config
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
 data:

--- a/charts/headlamp/templates/pvc.yaml
+++ b/charts/headlamp/templates/pvc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
   {{- with .Values.persistentVolumeClaim.annotations }}

--- a/charts/headlamp/templates/secret.yaml
+++ b/charts/headlamp/templates/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .secret.name }}
+  namespace: {{ include "headlamp.namespace" $ }}
 type: Opaque
 data:
 {{- with .clientID }}

--- a/charts/headlamp/templates/service.yaml
+++ b/charts/headlamp/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "headlamp.fullname" . }}
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/headlamp/templates/serviceaccount.yaml
+++ b/charts/headlamp/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "headlamp.serviceAccountName" . }}
+  namespace: {{ include "headlamp.namespace" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
+++ b/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -36,6 +38,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -62,6 +65,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
+  namespace: default
 type: Opaque
 data:
 ---
@@ -24,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -44,6 +47,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -70,6 +74,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
+  namespace: default
 type: Opaque
 data:
 ---
@@ -41,6 +43,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -61,6 +64,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -87,6 +91,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
-  namespace: default
+  namespace: mynamespace2
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -17,16 +17,20 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
-  namespace: default
+  namespace: mynamespace2
 type: Opaque
 data:
+  clientID: "dGVzdENsaWVudElk"
+  clientSecret: "dGVzdENsaWVudFNlY3JldA=="
+  issuerURL: "dGVzdElzc3VlclVSTA=="
+  scopes: "dGVzdFNjb3Bl"
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
-  namespace: default
+  namespace: mynamespace2
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -40,14 +44,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: headlamp
-  namespace: default
+  namespace: mynamespace2
 ---
 # Source: headlamp/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
-  namespace: default
+  namespace: mynamespace2
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -74,7 +78,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
-  namespace: default
+  namespace: mynamespace2
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -108,11 +112,38 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: clientID
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: clientSecret
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: issuerURL
+            - name: OIDC_SCOPES
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: scopes
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
             # Check if externalSecret is disabled
-            - -insecure-ssl
+            # Check if clientID is non empty either from env or oidc.config
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            # Check if clientSecret is non empty either from env or oidc.config
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            # Check if issuerURL is non empty either from env or oidc.config
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            # Check if scopes are non empty either from env or oidc.config
+            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/namespace-override.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
-  namespace: default
+  namespace: mynamespace
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -17,7 +17,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
-  namespace: default
+  namespace: mynamespace
 type: Opaque
 data:
 ---
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
-  namespace: default
+  namespace: mynamespace
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -40,14 +40,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: headlamp
-  namespace: default
+  namespace: mynamespace
 ---
 # Source: headlamp/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
-  namespace: default
+  namespace: mynamespace
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -74,7 +74,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
-  namespace: default
+  namespace: mynamespace
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -112,7 +112,6 @@ spec:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"
             # Check if externalSecret is disabled
-            - -insecure-ssl
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
+++ b/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -36,6 +38,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -62,6 +65,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
+  namespace: default
 type: Opaque
 data:
   clientID: "dGVzdENsaWVudElk"
@@ -28,6 +30,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -48,6 +51,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -74,6 +78,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
+  namespace: default
 type: Opaque
 data:
 ---
@@ -24,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -44,6 +47,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -70,6 +74,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -36,6 +38,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -62,6 +65,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -36,6 +38,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -62,6 +65,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -36,6 +38,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -62,6 +65,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/pod-disruption.yaml
+++ b/charts/headlamp/tests/expected_templates/pod-disruption.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -23,6 +24,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -35,6 +37,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
+  namespace: default
 type: Opaque
 data:
 ---
@@ -43,6 +46,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -63,6 +67,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -89,6 +94,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
+  namespace: default
 type: Opaque
 data:
 ---
@@ -24,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -44,6 +47,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -70,6 +74,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp

--- a/charts/headlamp/tests/test_cases/namespace-override-oidc-create-secret.yaml
+++ b/charts/headlamp/tests/test_cases/namespace-override-oidc-create-secret.yaml
@@ -1,0 +1,18 @@
+namespaceOverride: "mynamespace2"
+
+# This is a test case for the oidc.secret.create field in the Headlamp deployment.
+# The oidc.secret.create field is a boolean that determines whether to create a secret for OIDC.
+# The oidc.secret.name field is a string that specifies the name of the OIDC secret.
+# The oidc.clientID field is a string that specifies the client ID for OIDC.
+# The oidc.clientSecret field is a string that specifies the client secret for OIDC.
+# The oidc.issuerURL field is a string that specifies the issuer URL for OIDC.
+# The oidc.scopes field is a string that specifies the scopes for OIDC.
+config:
+  oidc:
+    secret:
+      create: true
+      name: oidc
+    clientID: "testClientId"
+    clientSecret: "testClientSecret"
+    issuerURL: "testIssuerURL"
+    scopes: "testScope"

--- a/charts/headlamp/tests/test_cases/namespace-override.yaml
+++ b/charts/headlamp/tests/test_cases/namespace-override.yaml
@@ -1,0 +1,1 @@
+namespaceOverride: "mynamespace"

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -52,6 +52,10 @@
       "type": "string",
       "description": "Override the full name of the chart"
     },
+    "namespaceOverride": {
+      "type": "string",
+      "description": "Override the deployment namespace; defaults to .Release.Namespace"
+    },
     "initContainers": {
       "type": "array",
       "description": "Init containers",

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -22,6 +22,9 @@ nameOverride: ""
 # -- Overrides the full name of the chart
 fullnameOverride: ""
 
+# -- Override the deployment namespace; defaults to .Release.Namespace
+namespaceOverride: ""
+
 # -- An optional list of init containers to be run before the main containers.
 initContainers: []
 


### PR DESCRIPTION
## Summary

This PR adds feature: namespaceOverride support in HelmCharts.

## Related Issue

Fixes #3910  

## Changes

- namespaceOverride support in charts

## Steps to Test

1. Install using three variants
2. Check namespace placement of K8S objects
3. Smoke-test you're able accessing headlamp GUI

## Screenshots (if applicable)
N/A

## Notes for the Reviewer
Fixed also test chart templates.
Already tested variants:
a) no namespace definition (backward compatibility)
```
helm install headlamp ./headlamp-0.35.0.tgz
kubectl port-forward -n default svc/headlamp 7080:80 --address 0.0.0.0
...access GUI using generated token
helm uninstall headlamp

```

b) namespace definition using helm command (backward compatibility)
```
helm install headlamp ./headlamp-0.35.0.tgz --namespace kube-system
kubectl port-forward -n kube-system svc/headlamp 7080:80 --address 0.0.0.0
...access GUI using generated token
helm uninstall headlamp --namespace kube-system

```

c) namespace definition using namespaceOverride (new feature)
```
cat test3-values.yaml
namespaceOverride: "monitoring"

```


```
helm install headlamp ./headlamp-0.35.0.tgz --values test3-values.yaml
kubectl port-forward -n monitoring svc/headlamp 7080:80 --address 0.0.0.0
...access GUI using generated token
helm uninstall headlamp

```