### PR TITLE
detailsViewSectionSlice: HeaderActionFuncType: Fix return type to contain ReactNode

### DIFF
--- a/frontend/src/components/DetailsViewSection/detailsViewSectionSlice.ts
+++ b/frontend/src/components/DetailsViewSection/detailsViewSectionSlice.ts
@@ -38,7 +38,7 @@ export enum DefaultDetailsViewSection {
 type HeaderActionFuncType = (
   resource: KubeObject | null,
   sections: (DetailsViewSection | ReactNode)[]
-) => DetailsViewSection[];
+) => (DetailsViewSection | ReactNode)[];
 
 export type DetailsViewsSectionProcessor = {
   id: string;


### PR DESCRIPTION
Because the input sections can contain ReactNode, the output
should also contain ReactNode.
