### PR TITLE
frontend: createRouteURL: Accept paths for route names

### DIFF
--- a/frontend/src/lib/router/createRouteURL.tsx
+++ b/frontend/src/lib/router/createRouteURL.tsx
@@ -76,6 +76,14 @@ export function createRouteURL(routeName: string, params: RouteURLProps = {}) {
   const route = matchingStoredRouteByName || matchingStoredRouteByPath || getRoute(routeName);
 
   if (!route) {
+    // Backward compatibility: some plugins call createRouteURL with a
+    // path template instead of a registered route name. This serves
+    // as a temporary fix to avoid breaking those plugins.
+    //
+    // @todo: Merge the plugin routes into the main store.
+    if (routeName.startsWith('/')) {
+      return generatePath(routeName, params);
+    }
     return '';
   }
 


### PR DESCRIPTION
This change adds backward compatibility for plugins calling `createRouteURL` with a path template instead of a registered route name. This serves as a temporary fix to avoid breaking those plugins.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3925

### Testing
- [X] Open `app-catalog` or `plugin-catalog`
- [X] Try to click on an app or a plugin to open the details page
- [X] Ensure that the app navigates to the details page as expected

### Future work
As this is temporary, in the future it would be best to merge the plugin routes into the main store.