### PR TITLE
github: Disable nightly build workflow on forks

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   push_to_registry:
+    if: ${{ github.repository == 'kubernetes-sigs/headlamp' }}
     name: Build and push nightly container image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This change disables the nightly build workflow on forked repos so that it only gets created on the main repo `(kubernetes-sigs/headlamp)`.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3913