### PR TITLE
frontend: Update failing EndpointSlice snapshot

### DIFF
--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -51,7 +51,19 @@
                 </h1>
                 <div
                   class="MuiBox-root css-ldp2l3"
-                />
+                >
+                  <button
+                    aria-label="Copy to clipboard"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
               </div>
             </div>
             <div


### PR DESCRIPTION
This change updates the failing EndpointSlice snapshot in the CI.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3931