### PR TITLE
frontend: fix: correct CPU/Memory tooltip positioning in Nodes table

### DIFF
--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -20,6 +20,7 @@ import { useTheme } from '@mui/material/styles';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import React, { ReactNode } from 'react';
+import { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import {
   Bar,
@@ -197,6 +198,8 @@ export function PercentageBar(props: PercentageBarProps) {
 
   const { data, total = 100, tooltipFunc = null } = props;
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   function formatData() {
     const dataItems: { [name: string]: number } = {};
 
@@ -214,12 +217,17 @@ export function PercentageBar(props: PercentageBarProps) {
     theme.palette.mode === 'dark' ? theme.palette.primary.light : theme.palette.primary.main;
 
   return (
-    <StyledResponsiveContainer width="95%" height={20}>
+    <StyledResponsiveContainer width="95%" height={20} ref={containerRef}>
       <StyledBarChart layout="vertical" maxBarSize={5} data={[formatData()]}>
         {tooltipFunc && (
           <Tooltip
             content={props => (
-              <PaperTooltip rechartsProps={props} tooltipFunc={tooltipFunc} data={data} />
+              <PaperTooltip
+                rechartsProps={props}
+                tooltipFunc={tooltipFunc}
+                data={data}
+                containerRef={containerRef}
+              />
             )}
           />
         )}
@@ -247,16 +255,17 @@ interface PaperTooltipProps {
   rechartsProps?: any;
   tooltipFunc: (data: any) => ReactNode;
   data: any;
+  containerRef: React.RefObject<HTMLDivElement>;
 }
 
-function PaperTooltip({ rechartsProps, tooltipFunc, data }: PaperTooltipProps) {
+function PaperTooltip({ rechartsProps, tooltipFunc, data, containerRef }: PaperTooltipProps) {
   if (!rechartsProps || !rechartsProps.active || !rechartsProps.coordinate) return null;
 
-  const chartRect = document.querySelector('.recharts-wrapper')?.getBoundingClientRect();
+  const rect = containerRef.current?.getBoundingClientRect();
 
   const { x, y } = rechartsProps.coordinate;
-  const left = (chartRect?.left || 0) + x;
-  const top = (chartRect?.top || 0) + y;
+  const left = (rect?.left || 0) + x;
+  const top = (rect?.top ?? 0) + y - 5;
 
   return ReactDOM.createPortal(
     <Paper
@@ -268,6 +277,7 @@ function PaperTooltip({ rechartsProps, tooltipFunc, data }: PaperTooltipProps) {
         zIndex: 1500,
         pointerEvents: 'none',
         minWidth: 120,
+        transform: 'translate(-50%, -100%)',
       }}
     >
       <Box m={1}>{tooltipFunc(data)}</Box>


### PR DESCRIPTION
## Summary
This PR fixes a tooltip mispositioning bug in the Nodes table by calculating the tooltip position relative to the hovered CPU/Memory bar element.

## Related Issue
Fixes #3937

## Changes
Updated `frontend/src/components/common/Chart.tsx` to:
- Ensure correct tooltip rendering within the table
## Steps to Test

1. Ensure metrics-server is installed.
2. Open Headlamp → Nodes tab.
3. Hover over CPU/Memory usage bars on rows 1 and 2 → tooltips should align with the hovered row.
4. Hover over CPU/Memory usage bars on rows ≥ 3 → tooltips should align with the hovered row.

## Screenshots (if applicable)
***Before***
<img width="1681" height="1032" alt="image" src="https://github.com/user-attachments/assets/fd2432ac-959a-4661-a641-be99dcf261c7" />

<img width="1677" height="1039" alt="image" src="https://github.com/user-attachments/assets/e02419d3-f43d-49cb-9cbe-54bcaa25a94b" />

***After***
<img width="1683" height="1034" alt="image" src="https://github.com/user-attachments/assets/f3f2011d-90ec-4b34-80e4-da58a748aa64" />
<img width="1682" height="1040" alt="image" src="https://github.com/user-attachments/assets/4ca96806-ec13-497f-ae95-b5f05fdc61d6" />


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
