### PR TITLE
frontend: Projects: Add isEnabled method to ProjectDetailsTab to allow conditional tab rendering

### DIFF
--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -1076,6 +1076,7 @@ export function registerCustomCreateProject(customCreateProject: CustomCreatePro
  * @param projectDetailsTab.label - Display label for the tab
  * @param projectDetailsTab.icon - Display icon for the tab
  * @param projectDetailsTab.component - React component to render in the tab content
+ * @param projectDetailsTab.isEnabled - Optional function to determine if tab is displayed
  *
  * @example
  * ```tsx

--- a/frontend/src/redux/projectsSlice.ts
+++ b/frontend/src/redux/projectsSlice.ts
@@ -53,6 +53,8 @@ export interface ProjectDetailsTab {
   label?: ReactNode;
   icon: string | ReactNode;
   component?: (props: { project: ProjectDefinition; projectResources: KubeObject[] }) => ReactNode;
+  /** Function to check if this tab be displayed in the given project. If not provided the Tab will be enabled. */
+  isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
 }
 
 export interface ProjectDeleteButton {

--- a/plugins/examples/projects/README.md
+++ b/plugins/examples/projects/README.md
@@ -24,6 +24,10 @@ Replaces the default "Access" tab with a completely custom implementation that s
 
 Shows how to remove default tabs by setting `component: undefined`.
 
+### 4. Conditional Tab
+
+Shows how to register a Tab that is only displayed for certain projects.
+
 ## Running the Example
 
 ```bash

--- a/plugins/examples/projects/src/index.tsx
+++ b/plugins/examples/projects/src/index.tsx
@@ -140,6 +140,20 @@ registerProjectDetailsTab({
 //   component: undefined,
 // });
 
+// Example of Tab that is only enabled for certain projects
+registerProjectDetailsTab({
+  id: 'special-tab',
+  label: 'Special tab',
+  icon: 'mdi:circle',
+  component: () => <div>Special tab content</div>,
+  isEnabled: async ({ project }) => {
+    // In this example tab will only be displayed for projects
+    // that have more than 1 cluster selected
+    // Note: This function is async so you can make network requests here
+    return project.clusters.length > 1;
+  },
+});
+
 registerProjectOverviewSection({
   id: 'resource-usage',
   component: ({ project }) => <div>Custom resource usage for project {project.name}</div>,


### PR DESCRIPTION
This PR adds a way for plugins to define a new tab in projects that is only rendered on certain projects.

It is implemented as an async `isEnabled` function 

```tsx
// Example of Tab that is only enabled for certain projects
registerProjectDetailsTab({
  id: 'special-tab',
  label: 'Special tab',
  icon: 'mdi:circle',
  component: () => <div>Special tab content</div>,
  isEnabled: async ({ project }) => {
    // In this example tab will only be displayed for projects
    // that have more than 1 cluster selected
    // Note: This function is async so you can make network requests here
    return project.clusters.length > 1;
  },
});
```