### PR TITLE
charts: Add default securityContext and make pluginsManager use global securityContext

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -81,7 +81,12 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- if .Values.securityContext }}
+              {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- else }}
+              {{- $defaultSC := dict "allowPrivilegeEscalation" false "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") "capabilities" (dict "drop" (list "ALL")) }}
+              {{- toYaml $defaultSC | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{ if or $oidc .Values.env }}
@@ -286,7 +291,6 @@ spec:
           {{- end }}
         {{- if .Values.pluginsManager.enabled }}
         - name: headlamp-plugin
-
           image: {{ .Values.pluginsManager.baseImage }}
           command: ["/bin/sh", "-c"]
           args:
@@ -306,6 +310,15 @@ spec:
               mountPath: /config
           resources:
             {{- toYaml .Values.pluginsManager.resources | nindent 12 }}
+          securityContext:
+            {{- if .Values.pluginsManager.securityContext }}
+              {{- toYaml .Values.pluginsManager.securityContext | nindent 12 }}
+            {{- else if $.Values.securityContext }}
+              {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- else }}
+              {{- $defaultSC := dict "allowPrivilegeEscalation" false "runAsNonRoot" true "seccompProfile" (dict "type" "RuntimeDefault") "capabilities" (dict "drop" (list "ALL")) }}
+              {{- toYaml $defaultSC | nindent 12 }}
+            {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -1,0 +1,185 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+type: Opaque
+data:
+---
+# Source: headlamp/templates/plugin-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-plugin-config
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  plugin.yml: |
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  labels:
+    helm.sh/chart: headlamp-0.35.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.35.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: headlamp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+            seccompProfile:
+              type: RuntimeDefault
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.35.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-plugins-dir=/headlamp/plugins"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}
+          volumeMounts:
+            - name: plugins-dir
+              mountPath: /headlamp/plugins
+        - name: headlamp-plugin
+          image: node:18-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Installing headlamp-plugin globally..."
+              npm install -g @headlamp-k8s/pluginctl@1.0.0
+              echo "Installed headlamp-plugin successfully."
+              if [ -f "/config/plugin.yml" ]; then
+                echo "Installing plugins from config..."
+                cat /config/plugin.yml
+                pluginctl install --config /config/plugin.yml --folderName /headlamp/plugins --watch
+              fi
+          volumeMounts:
+            - name: plugins-dir
+              mountPath: /headlamp/plugins
+            - name: plugin-config
+              mountPath: /config
+          resources:
+            null
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+      volumes:
+        - name: plugins-dir
+          emptyDir: {}
+        - name: plugin-config
+          configMap:
+            name: headlamp-plugin-config

--- a/charts/headlamp/tests/test_cases/security-context.yaml
+++ b/charts/headlamp/tests/test_cases/security-context.yaml
@@ -1,0 +1,31 @@
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 3000
+  fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
+
+# This config will be rendered into the container's securityContext.
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# Example override for the optional pluginsManager container securityContext
+pluginsManager:
+  enabled: true
+  baseImage: "node:18-alpine"
+  version: "1.0.0"
+  securityContext:
+    runAsUser: 1001
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -148,6 +148,15 @@ securityContext:
   privileged: false
   runAsUser: 100
   runAsGroup: 101
+# Uses these defaults if this is empty.
+#   allowPrivilegeEscalation: false
+#   runAsNonRoot: true
+#   seccompProfile:
+#     type: RuntimeDefault
+#   capabilities:
+#     drop:
+#       - ALL
+
 
 service:
   # -- Annotations to add to the service
@@ -261,6 +270,16 @@ pluginsManager:
   #   limits:
   #     cpu: "1000m"
   #     memory: "4096Mi"
+  # If omitted, the plugin manager will inherit the global securityContext
+  securityContext:
+    {}
+    # runAsUser: 1001
+    # runAsNonRoot: true
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # capabilities:
+    #   drop:
+    #     - ALL
 
 podDisruptionBudget:
   # -- enable PodDisruptionBudget


### PR DESCRIPTION
Also allow pluginsManager to specify its own securityContext.

In addition the default securityContext is a bit more strict than before.

Fixes #3867
- #3867


### More information

https://kubernetes.io/docs/concepts/security/pod-security-standards/


`allowPrivilegeEscalation: false`
Prevents the container from gaining more privileges than its parent process—helps block privilege escalation attacks.

`runAsNonRoot: true`
Ensures the container runs as a non-root user. Kubernetes will reject the pod if it tries to run as UID 0.

`seccompProfile.type: RuntimeDefault`
Applies the default Seccomp profile provided by the container runtime, which restricts system calls to a safe subset.

`capabilities.drop: [ "ALL" ]`
Removes all Linux capabilities from the container, minimizing its ability to perform privileged operations (like modifying kernel settings or networking).



## How to test?

- Deploy headlamp in-cluster using helm chart. `helm install my-headlamp ./charts/headlamp --namespace kube-system` and follow instructions to view in browser with token. Now test Headlamp is working.
- There's a test case included in the PR and expected output. Check it matches a valid structure here: https://kubernetes.io/docs/concepts/security/pod-security-standards/


Deploy headlamp with the chart and test case, then manually see if the output has the expected securityContext.
```shell
helm install my-headlamp ./charts/headlamp -f charts/headlamp/tests/test_cases/security-context.yaml --namespace kube-system
kubectl get deployment my-headlamp -o yaml
```
