### PR TITLE
app: docs: Note libgconf removal on Ubuntu

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -6,8 +6,12 @@
 
 Headlamp on WSL requires some packages installed (maybe it requires more) to run the app.
 
+Note: `libgconf-2-4` was removed starting with Ubuntu 24.04 and newer
+releases. If you are on an older release where it is still available you can
+install it as well, otherwise you can safely omit it.
+
 ```bash
-sudo apt install libgconf-2-4 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm1 libnss3 libasound2 firefox libgstreamer-plugins-bad1.0-0 libegl1 libnotify4 libopengl0 libwoff1 libharfbuzz-icu0 libgstreamer-gl1.0-0 libwebpdemux2 libenchant1c2a libsecret-1-0 libhyphen0 libevdev2 libgles2 gstreamer1.0-libav
+sudo apt install libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm1 libnss3 libasound2 firefox libgstreamer-plugins-bad1.0-0 libegl1 libnotify4 libopengl0 libwoff1 libharfbuzz-icu0 libgstreamer-gl1.0-0 libwebpdemux2 libenchant1c2a libsecret-1-0 libhyphen0 libevdev2 libgles2 gstreamer1.0-libav
 ```
 
 To get going with development run these:

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -116,8 +116,12 @@ which runs everything including the `backend`, `frontend` and `app` in parallel.
 
 Headlamp on WSL requires some packages installed (maybe it requires more) to run the app.
 
+Note: `libgconf-2-4` was removed starting with Ubuntu 24.04 and newer
+releases. If you are on an older release where it is still available you can
+install it as well, otherwise you can safely omit it.
+
 ```bash
-sudo apt install libgconf-2-4 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm1 libnss3 libasound2
+sudo apt install libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm1 libnss3 libasound2
 ```
 
 Some of these are also needed some of them only for the end to end tests.


### PR DESCRIPTION
This change adds notes to the docs about the removal of `libgconf-2-4` from newer releases of Ubuntu.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/3939