### PR TITLE
frontend: Projects: Add ability to register custom delete button for projects

### DIFF
--- a/frontend/src/components/project/ProjectDeleteButton.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.tsx
@@ -24,19 +24,16 @@ import { ProjectDeleteDialog } from './ProjectDeleteDialog';
 
 interface ProjectDeleteButtonProps {
   project: ProjectDefinition;
-  namespaces: Namespace[];
   buttonStyle?: ButtonStyle;
 }
 
-export function ProjectDeleteButton({
-  project,
-  namespaces,
-  buttonStyle,
-}: ProjectDeleteButtonProps) {
+export function ProjectDeleteButton({ project, buttonStyle }: ProjectDeleteButtonProps) {
   const { t } = useTranslation();
   const [openDialog, setOpenDialog] = useState(false);
+  const [namespaces] = Namespace.useList({ clusters: project.clusters });
 
-  const projectNamespaces = namespaces.filter(ns => project.namespaces.includes(ns.metadata.name));
+  const projectNamespaces =
+    namespaces?.filter(ns => project.namespaces.includes(ns.metadata.name)) ?? [];
 
   // Don't show the button if there are no namespaces for this project
   if (projectNamespaces.length === 0) {

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -486,6 +486,7 @@
   "registerMapSource": [Function],
   "registerOverviewChartsProcessor": [Function],
   "registerPluginSettings": [Function],
+  "registerProjectDeleteButton": [Function],
   "registerProjectDetailsTab": [Function],
   "registerProjectOverviewSection": [Function],
   "registerResourceTableColumnsProcessor": [Function],

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -96,8 +96,10 @@ import {
   addDetailsTab,
   addOverviewSection,
   CustomCreateProject,
+  ProjectDeleteButton,
   ProjectDetailsTab,
   ProjectOverviewSection,
+  setProjectDeleteButton,
 } from '../redux/projectsSlice';
 import { setRoute, setRouteFilter } from '../redux/routesSlice';
 import store from '../redux/stores/store';
@@ -1108,6 +1110,16 @@ export function registerProjectDetailsTab(projectDetailsTab: ProjectDetailsTab) 
  */
 export function registerProjectOverviewSection(projectOverviewSection: ProjectOverviewSection) {
   store.dispatch(addOverviewSection(projectOverviewSection));
+}
+
+/**
+ * Override default project delete button
+ *
+ * @param projectDeleteButton.component - React component for custom delete button
+ * @param projectDeleteButton.isEnabled - Optional function to determine if button is enabled
+ */
+export function registerProjectDeleteButton(projectDeleteButton: ProjectDeleteButton) {
+  store.dispatch(setProjectDeleteButton(projectDeleteButton));
 }
 
 export {

--- a/frontend/src/redux/projectsSlice.ts
+++ b/frontend/src/redux/projectsSlice.ts
@@ -17,6 +17,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import type { ReactNode } from 'react';
+import type { ButtonStyle } from '../components/common/ActionButton/ActionButton';
 import type { KubeObject } from '../lib/k8s/KubeObject';
 
 export interface ProjectDefinition {
@@ -54,10 +55,16 @@ export interface ProjectDetailsTab {
   component?: (props: { project: ProjectDefinition; projectResources: KubeObject[] }) => ReactNode;
 }
 
+export interface ProjectDeleteButton {
+  isEnabled?: (params: { project: ProjectDefinition }) => Promise<boolean>;
+  component: (props: { project: ProjectDefinition; buttonStyle?: ButtonStyle }) => ReactNode;
+}
+
 export interface ProjectsState {
   customCreateProject: Record<string, CustomCreateProject>;
   overviewSections: Record<string, ProjectOverviewSection>;
   detailsTabs: Record<string, ProjectDetailsTab>;
+  projectDeleteButton?: ProjectDeleteButton;
 }
 
 const initialState: ProjectsState = {
@@ -84,9 +91,15 @@ const projectsSlice = createSlice({
     addOverviewSection(state, action: PayloadAction<ProjectOverviewSection>) {
       state.overviewSections[action.payload.id] = action.payload;
     },
+
+    /** Override default delete button */
+    setProjectDeleteButton(state, action: PayloadAction<ProjectDeleteButton>) {
+      state.projectDeleteButton = action.payload;
+    },
   },
 });
 
-export const { addCustomCreateProject, addDetailsTab, addOverviewSection } = projectsSlice.actions;
+export const { addCustomCreateProject, addDetailsTab, addOverviewSection, setProjectDeleteButton } =
+  projectsSlice.actions;
 
 export default projectsSlice.reducer;

--- a/plugins/examples/projects/src/index.tsx
+++ b/plugins/examples/projects/src/index.tsx
@@ -17,6 +17,7 @@
 import {
   ApiProxy,
   registerCustomCreateProject,
+  registerProjectDeleteButton,
   registerProjectDetailsTab,
   registerProjectOverviewSection,
 } from '@kinvolk/headlamp-plugin/lib';
@@ -142,4 +143,16 @@ registerProjectDetailsTab({
 registerProjectOverviewSection({
   id: 'resource-usage',
   component: ({ project }) => <div>Custom resource usage for project {project.name}</div>,
+});
+
+registerProjectDeleteButton({
+  component: ({ project }) => (
+    <button
+      onClick={() => {
+        console.log('Custom delete action');
+      }}
+    >
+      Delete {project.id}
+    </button>
+  ),
 });


### PR DESCRIPTION
Adds `registerProjectDeleteButton` function available to plugins

```tsx
// delete button that is only enabled for certain projects
registerProjectDeleteButton({
  isEnabled: async ({ project }) => project.clusters.length > 1,
  component: ({ project }) => (
    <button
      onClick={() => {
        console.log('Custom delete action');
      }}
    >
      Delete {project.id}
    </button>
  ),
});
```