### PR TITLE
frontend: EditButton: close actions menu on edit click

### DIFF
--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -125,6 +125,9 @@ export default function EditButton(props: EditButtonProps) {
         description={t('translation|Edit')}
         buttonStyle={buttonStyle}
         onClick={() => {
+          if (afterConfirm) {
+            afterConfirm();
+          }
           Activity.launch({
             id: activityId,
             title: t('translation|Edit') + ': ' + item.metadata.name,


### PR DESCRIPTION
## Summary

This PR fixes a bug where the Actions dropdown menu remains open after the "Edit" action is selected from a resource table. 
By modifying the shared EditButton component, this fix is applied to all tables that use it.

## Related Issue

Fixes #3956 

## Changes

Updated `frontend/src/components/common/Resource/EditButton.tsx` to ensure the menu-closing callback is triggered immediately upon clicking the Edit button.

## Steps to Test
1. Navigate to any resource list view with an "Actions" menu.
2. Click the kebab menu (three dots) in the "Actions" column for any row to open the dropdown.
3. Click on Edit.
4. Observe that the Actions dropdown menu closes as the YAML editor opens.

## Screenshots (if applicable)

## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
