### PR TITLE
fix: add fallback for idpIssuerURL

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -876,12 +876,17 @@ func (c *HeadlampConfig) refreshAndSetToken(oidcAuthConfig *kubeconfig.OidcConfi
 		tokenType = "access_token"
 	}
 
+	idpIssuerURL := c.oidcIdpIssuerURL
+	if idpIssuerURL == "" {
+		idpIssuerURL = oidcAuthConfig.IdpIssuerURL
+	}
+
 	newToken, err := refreshAndCacheNewToken(
 		oidcAuthConfig,
 		cache,
 		tokenType,
 		token,
-		c.oidcIdpIssuerURL,
+		idpIssuerURL,
 	)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},


### PR DESCRIPTION
## Summary

This PR fixes empty idpIssuerURL by setting fallback for kubeconfig field.

## Related Issue

Fixes #3961

## Changes

- Added fallback for idpIssuerURL

## Steps to Test

1. Set your idpIssuerURL outside of global flag
2. After logging in, wait for token to expire

