### PR TITLE
github: e2e-tests: Save screenshot if there is an a11y failure

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -206,3 +206,9 @@ jobs:
         name: e2e-tests-report
         path: e2e-tests/playwright-report/
         retention-days: 30
+    - name: Upload accessibility artifacts
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: a11y-artifacts
+        path: ${{ github.workspace }}/a11y-artifacts
+        retention-days: 30


### PR DESCRIPTION
This also dumps the html which can be useful for debugging.

- See e2e test CI
- Look in e2e test logs for dumped html (only if there is an a11y failure)
- Look for link in the logs to the saved screenshot artifact

