### PR TITLE
charts: Fix for security-context missing namespaces and env rendering

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -294,8 +294,10 @@ spec:
         - name: headlamp-plugin
           image: {{ .Values.pluginsManager.baseImage }}
           command: ["/bin/sh", "-c"]
+          {{- if .Values.pluginsManager.env }}
           env:
             {{- toYaml .Values.pluginsManager.env | nindent 12 }}
+          {{- end }}
           args:
             - |
               echo "Installing headlamp-plugin globally..."

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: oidc
+  namespace: default
 type: Opaque
 data:
 ---
@@ -24,6 +26,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: headlamp-plugin-config
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -58,6 +61,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp
@@ -84,6 +88,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
+  namespace: default
   labels:
     helm.sh/chart: headlamp-0.35.0
     app.kubernetes.io/name: headlamp


### PR DESCRIPTION
This is so CI charts job is working again.

`make helm-template-test`

