### PR TITLE
app: Fix glob pattern on windows for setup-plugins.js

### DIFF
--- a/app/scripts/setup-plugins.js
+++ b/app/scripts/setup-plugins.js
@@ -38,7 +38,7 @@ async function extractArchive(
         }
 
         // Move the plugins contents to the plugins folder
-        const mainLocationExpr = path.join(tmpFolder, '*', 'main.js');
+        const mainLocationExpr = path.join(tmpFolder, '*', 'main.js').replace(/\\/g, '/');
         const mainLocations = glob.sync(mainLocationExpr);
         const mainLocation = mainLocations[0];
         if (mainLocation && fs.existsSync(mainLocation)) {

--- a/app/scripts/setup-plugins.js
+++ b/app/scripts/setup-plugins.js
@@ -37,6 +37,8 @@ async function extractArchive(
           fs.mkdirSync(pluginFolder);
         }
 
+        console.log('Copying plugin to ', pluginFolder);
+
         // Move the plugins contents to the plugins folder
         const mainLocationExpr = path.join(tmpFolder, '*', 'main.js').replace(/\\/g, '/');
         const mainLocations = glob.sync(mainLocationExpr);
@@ -48,12 +50,11 @@ async function extractArchive(
             path.join(packageJsonLocation, 'package.json'),
             path.join(pluginFolder, 'package.json')
           );
-          resolve();
-          return;
+          console.log('Copied plugin from ', packageJsonLocation, ' to ', pluginFolder);
         }
-
         // Compatibility with legacy tarball structure
-        if (fs.existsSync(path.join(tmpFolder, 'package', 'dist'))) {
+        else if (fs.existsSync(path.join(tmpFolder, 'package', 'dist'))) {
+          console.log('Found plugin with a legacy tarball structure');
           // Move the plugins contents to the plugins folder
           fs.copyFileSync(
             path.join(tmpFolder, 'package', 'dist', 'main.js'),
@@ -63,7 +64,15 @@ async function extractArchive(
             path.join(tmpFolder, 'package', 'package.json'),
             path.join(pluginFolder, 'package.json')
           );
+        } else {
+          console.error('Failed to find plugin content within tarball');
+          console.error({
+            archivePath,
+            unarchivedPath: tmpFolder,
+          });
+          reject();
         }
+
         resolve();
       });
   });


### PR DESCRIPTION
This fixes a bug that is only happening on windows
setup-plugin.js fails to copy plugins because glob dependency was bumped from @7 to @11 
in version 8 they had a breaking change which treats all backslashes \ as an escape char which breaks path resolution on windows

## Changes

- Replace \ with / in glob pattern
- Add more logging

## Steps to Test

0. (windows only)
1. rm -rf .plugins
2. cd app && node ./scripts/setup-plugins.js
3. Make sure .plugins folder has plugins with main.js and package.json in each
