### PR TITLE
frontend: Fix createRouteURL not being able to lookup routes from redux

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,9 +29,12 @@ import i18n from './i18n/config';
 import { useElectronI18n } from './i18n/electronI18n';
 import ThemeProviderNexti18n from './i18n/ThemeProviderNexti18n';
 import { queryClient } from './lib/queryClient';
+import { setStore } from './lib/router/createRouteURL';
 import { createMuiTheme, getThemeName, usePrefersColorScheme } from './lib/themes';
 import { useTypedSelector } from './redux/hooks';
 import store from './redux/stores/store';
+
+setStore(store);
 
 function AppWithRedux(props: React.PropsWithChildren<{}>) {
   let themeName = useTypedSelector(state => state.theme.name);

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router';
 import { getCluster, getClusterPrefixedPath } from '../../lib/cluster';
+import { getRoute } from '../../lib/router';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { useTypedSelector } from '../../redux/hooks';
 import Tabs from '../common/Tabs';
@@ -132,7 +133,7 @@ export default function NavigationTabs() {
       return [null, null];
     }
 
-    if (createRouteURL(item.name)) {
+    if (getRoute(item.name)) {
       list.unshift(item);
     }
 
@@ -143,12 +144,13 @@ export default function NavigationTabs() {
     if (!subList) {
       return;
     }
+
     const index = findIndexNameInSubList(subList, sidebar.selected.item) ?? null;
     if (index === undefined || index === null || index === -1) {
       return;
     }
 
-    if (createRouteURL(navigationItem?.name ?? '') && index === 0) {
+    if (getRoute(navigationItem?.name ?? '') && index === 0) {
       setSecondLevelTabRoutes([]);
     } else if (
       subList[index] !== undefined &&
@@ -166,7 +168,7 @@ export default function NavigationTabs() {
       if (subList === undefined || subList === null) {
         return;
       }
-      if (createRouteURL(navigationItem?.name ?? '') && index === 0) {
+      if (getRoute(navigationItem?.name ?? '') && index === 0) {
         setSecondLevelTabRoutes([]);
       } else if (subList[index].subList !== undefined && subList[index].subList.length !== 0) {
         setSecondLevelTabRoutes(subList[index].subList);

--- a/frontend/src/lib/router/createRouteURL.tsx
+++ b/frontend/src/lib/router/createRouteURL.tsx
@@ -78,14 +78,6 @@ export function createRouteURL(routeName?: string, params: RouteURLProps = {}) {
   const route = matchingStoredRouteByName || matchingStoredRouteByPath || getRoute(routeName);
 
   if (!route) {
-    // Backward compatibility: some plugins call createRouteURL with a
-    // path template instead of a registered route name. This serves
-    // as a temporary fix to avoid breaking those plugins.
-    //
-    // @todo: Merge the plugin routes into the main store.
-    if (routeName.startsWith('/')) {
-      return generatePath(routeName, params);
-    }
     return '';
   }
 

--- a/frontend/src/lib/router/createRouteURL.tsx
+++ b/frontend/src/lib/router/createRouteURL.tsx
@@ -32,22 +32,17 @@ export interface RouteURLProps {
   [prop: string]: any;
 }
 
-var theStore: { store: AppStore | null } | undefined = { store: null };
+const storeRef: { current?: AppStore } = { current: undefined };
 
 function getStore() {
-  return theStore?.store ?? null;
+  return storeRef.current;
 }
 /**
  * This is so we can access the store from anywhere, but not import it directly.
  * @param newStore
  */
 export function setStore(newStore: AppStore) {
-  if (!theStore) {
-    // Initialize theStore if this module hasn't finished evaluating yet (avoids TDZ on circular imports)
-    theStore = { store: newStore };
-  } else {
-    theStore.store = newStore;
-  }
+  storeRef.current = newStore;
 }
 
 export function createRouteURL(routeName?: string, params: RouteURLProps = {}) {

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -117,7 +117,6 @@ import WorkloadDetails from '../../components/workload/Details';
 import WorkloadOverview from '../../components/workload/Overview';
 import { isElectron } from '../../helpers/isElectron';
 import LocaleSelect from '../../i18n/LocaleSelect/LocaleSelect';
-import store from '../../redux/stores/store';
 import { useCluster } from '..//k8s';
 import DaemonSet from '../k8s/daemonSet';
 import Deployment from '../k8s/deployment';
@@ -125,7 +124,7 @@ import Job from '../k8s/job';
 import ReplicaSet from '../k8s/replicaSet';
 import StatefulSet from '../k8s/statefulSet';
 import type { RouteURLProps } from './createRouteURL';
-import { createRouteURL, setStore } from './createRouteURL';
+import { createRouteURL } from './createRouteURL';
 import { getDefaultRoutes, setDefaultRoutes } from './getDefaultRoutes';
 import { getRoute } from './getRoute';
 import { getRoutePath } from './getRoutePath';
@@ -138,8 +137,6 @@ export { getDefaultRoutes, getRouteUseClusterURL, getRoutePath, getRoute, create
 const LazyGraphView = React.lazy(() =>
   import('../../components/resourceMap/GraphView').then(it => ({ default: it.GraphView }))
 );
-
-setStore(store);
 
 /** @private */
 const defaultRoutes: { [routeName: string]: Route } = {


### PR DESCRIPTION
This PR fixes getRouteURL to work with routes registered from plugins.
Currently getStore() returns null resulting in createRouteURL not being able to lookup any routes registered by plugins
I also had to fix NavigationTabs since it started crashing as soon as createRouteURL was fixed

## Steps to Test

1. Open headlamp app
2. Go to App Catalog
3. Click on helm charts

