### PR TITLE
github: fix issue template labels to match repository labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: kind/bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: kind/feature
 assignees: ''
 
 ---


### PR DESCRIPTION
## Summary

This PR updates the GitHub issue templates to use the correct labels that exist in the repository, enabling automatic label assignment when issues are created.

## Related Issue

Fixes #3966 

## Changes
Updated `.github/ISSUE_TEMPLATE/` files to align with the repository's label schema:
- `kind/bug` for bug reports
- `kind/feature` for feature requests

## Steps to Test

## Screenshots (if applicable)

## Notes for the Reviewer
