### PR TITLE
frontend: Table: Prevent dialog checkbox clicks from triggering table row selection

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -438,7 +438,8 @@ export default function Table<RowItem extends Record<string, any>>({
     const shouldHandle =
       !!target &&
       !!target.closest('input[type="checkbox"]') &&
-      !target.closest('.MuiSwitch-root, [role="switch"]');
+      !target.closest('.MuiSwitch-root, [role="switch"]') &&
+      !target.closest('[role="dialog"]');
 
     if (!shouldHandle) {
       return;


### PR DESCRIPTION
## Summary

This PR fixes a bug where clicking checkboxes inside dialog ("Force Delete" checkbox) incorrectly triggers table row selection instead of toggling the dialog's checkbox.

## Related Issue

Fixes #3980 

## Changes

- Updated `frontend/src/components/common/Table/Table.tsx`

## Steps to Test

1. Navigate to any resource list view (e.g., Workloads → Deployments)
2. Click the three-dot menu (actions) on any resource row
3. Click 'Delete'
4. In the "Delete item" confirmation dialog, click the "Force Delete" checkbox
5. Only the Force Delete checkbox should toggle

## Screenshots (if applicable)
**Before**

https://github.com/user-attachments/assets/ad8ebdf1-aa8a-4974-a468-08fea5da0299

**After**

https://github.com/user-attachments/assets/7d75b1ee-99ae-4918-8c8c-0424de3dae89


## Notes for the Reviewer
