### PR TITLE
frontend: EditorDialog: Remove redirect from cancel action

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -346,7 +346,6 @@ export default function EditorDialog(props: EditorDialogProps) {
           errorMessage: t('translation|Failed to apply {{ newItemName }}.', {
             newItemName: resourceNames.join(','),
           }),
-          cancelUrl: location.pathname,
         })
       );
 


### PR DESCRIPTION
EditorDialogs are now rendered inside Activites and we don't need to redirect anywhere when cancelling
And also cancelUrl was incorrect which would cause a bug in electron app

## Steps to Test

1. Click "Create" button at the bottom of the sidebar
2. Paste some resource
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-configmap
  namespace: default
data:
  key1: value1
  key2: value2
```
4. Click Apply
5. Then click Cancel in the toast notification
6. It should just cancel without redirect

