### PR TITLE
backend: auth: Extract RefreshAndCacheNewToken from headlamp.go

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -21,7 +21,6 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -631,7 +630,7 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 			return
 		}
 
-		ctx = configureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
+		ctx = auth.ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
 
 		if config.oidcValidatorIdpIssuerURL != "" {
 			ctx = oidc.InsecureIssuerURLContext(ctx, config.oidcValidatorIdpIssuerURL)
@@ -805,47 +804,12 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 	return r
 }
 
-// configureTLSContext configures TLS settings for the HTTP client in the context.
-// If skipTLSVerify is true, TLS verification will be skipped.
-// If caCert is provided, it will be added to the certificate pool for TLS verification.
-func configureTLSContext(ctx context.Context, skipTLSVerify *bool, caCert *string) context.Context {
-	if skipTLSVerify != nil && *skipTLSVerify {
-		tlsSkipTransport := &http.Transport{
-			// the gosec linter is disabled here because we are explicitly requesting to skip TLS verification.
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		}
-		ctx = oidc.ClientContext(ctx, &http.Client{Transport: tlsSkipTransport})
-	}
-
-	if caCert != nil {
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM([]byte(*caCert)) {
-			// Log error but continue with original context
-			logger.Log(logger.LevelError, nil,
-				errors.New("failed to append ca cert to pool"), "couldn't add custom cert to context")
-			return ctx
-		}
-
-		// the gosec linter is disabled because gosec promotes using a minVersion of TLS 1.2 or higher.
-		// since we are using a custom CA cert configured by the user, we are not forcing a minVersion.
-		customTransport := &http.Transport{
-			TLSClientConfig: &tls.Config{ //nolint:gosec
-				RootCAs: caCertPool,
-			},
-		}
-
-		ctx = oidc.ClientContext(ctx, &http.Client{Transport: customTransport})
-	}
-
-	return ctx
-}
-
 func refreshAndCacheNewToken(oidcAuthConfig *kubeconfig.OidcConfig,
 	cache cache.Cache[interface{}],
 	tokenType, token, issuerURL string,
 ) (*oauth2.Token, error) {
 	ctx := context.Background()
-	ctx = configureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
+	ctx = auth.ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
 
 	// get provider
 	provider, err := oidc.NewProvider(ctx, issuerURL)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -1288,68 +1287,6 @@ func TestProcessTokenProtocol(t *testing.T) {
 			assert.Equal(t, tt.expectedAuthHeader, req.Header.Get("Authorization"))
 		})
 	}
-}
-
-// TestConfigureTLSContext_NoConfig tests when both skipTLSVerify and caCert are not set.
-func TestConfigureTLSContext_NoConfig(t *testing.T) {
-	baseCtx := context.Background()
-	resultCtx := configureTLSContext(baseCtx, nil, nil)
-
-	// Context should remain unchanged when no TLS configuration is provided
-	assert.Equal(t, baseCtx, resultCtx, "Context should remain unchanged when no TLS configuration is provided")
-}
-
-/*
-TestConfigureTLSContext_SkipTLS tests when skipTLSVerify is set to true.
-The OIDC library would use this context to make requests
-We can't directly extract the client, but we can verify the behavior
-by checking that the context was modified (indicating TLS config was applied).
-*/
-func TestConfigureTLSContext_SkipTLS(t *testing.T) {
-	// Create a test server that requires TLS
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("TLS connection successful"))
-		require.NoError(t, err)
-	}))
-	defer server.Close()
-
-	baseCtx := context.Background()
-	skipTLSVerify := true
-	resultCtx := configureTLSContext(baseCtx, &skipTLSVerify, nil)
-
-	// Context should be modified when skipTLSVerify is true
-	assert.NotEqual(t, baseCtx, resultCtx, "Context should be modified when skipTLSVerify is true")
-
-	// Test that the configured context can make TLS requests with skip verification
-	// This verifies that the TLS configuration was actually applied
-	_, err := http.NewRequestWithContext(resultCtx, "GET", server.URL, nil)
-	require.NoError(t, err)
-}
-
-// TestConfigureTLSContext_CACert tests when caCert is provided.
-func TestConfigureTLSContext_CACert(t *testing.T) {
-	// Read the pre-generated CA certificate from testdata
-	caCertBytes, err := os.ReadFile("headlamp_testdata/ca.crt")
-	require.NoError(t, err)
-
-	// Test the configureTLSContext function with the CA certificate
-	baseCtx := context.Background()
-	caCert := string(caCertBytes)
-	resultCtx := configureTLSContext(baseCtx, nil, &caCert)
-
-	// Context should be modified when caCert is provided
-	assert.NotEqual(t, baseCtx, resultCtx, "Context should be modified when caCert is provided")
-
-	// Verify that the CA certificate was parsed correctly by checking if it's valid PEM
-	block, _ := pem.Decode([]byte(caCert))
-	assert.NotNil(t, block, "CA certificate should be valid PEM format")
-	assert.Equal(t, "CERTIFICATE", block.Type, "CA certificate should be of type CERTIFICATE")
-
-	// Parse the CA certificate to verify it's valid
-	caCertParsed, err := x509.ParseCertificate(block.Bytes)
-	require.NoError(t, err)
-	assert.True(t, caCertParsed.IsCA, "Generated certificate should be a CA certificate")
 }
 
 // newFakeK8sServer create a mock k8s server for testing purpose,

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -18,11 +18,14 @@ package auth_test
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -30,6 +33,8 @@ import (
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
 
@@ -682,4 +687,64 @@ func TestGetNewToken_CacheUpdateErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConfigureTLSContext_NoConfig tests when both skipTLSVerify and caCert are not set.
+func TestConfigureTLSContext_NoConfig(t *testing.T) {
+	baseCtx := context.Background()
+	resultCtx := auth.ConfigureTLSContext(baseCtx, nil, nil)
+
+	// Context should remain unchanged when no TLS configuration is provided
+	assert.Equal(t, baseCtx, resultCtx, "Context should remain unchanged when no TLS configuration is provided")
+}
+
+// TestConfigureTLSContext_SkipTLS tests when skipTLSVerify is set to true.
+// The OIDC library would use this context to make requests
+// We can't directly extract the client, but we can verify the behavior
+// by checking that the context was modified (indicating TLS config was applied).
+func TestConfigureTLSContext_SkipTLS(t *testing.T) {
+	// Create a test server that requires TLS
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("TLS connection successful"))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	baseCtx := context.Background()
+	skipTLSVerify := true
+	resultCtx := auth.ConfigureTLSContext(baseCtx, &skipTLSVerify, nil)
+
+	// Context should be modified when skipTLSVerify is true
+	assert.NotEqual(t, baseCtx, resultCtx, "Context should be modified when skipTLSVerify is true")
+
+	// Test that the configured context can make TLS requests with skip verification
+	// This verifies that the TLS configuration was actually applied
+	_, err := http.NewRequestWithContext(resultCtx, "GET", server.URL, nil)
+	require.NoError(t, err)
+}
+
+// TestConfigureTLSContext_CACert tests when caCert is provided.
+func TestConfigureTLSContext_CACert(t *testing.T) {
+	// Read the pre-generated CA certificate from testdata
+	caCertBytes, err := os.ReadFile("../../cmd/headlamp_testdata/ca.crt")
+	require.NoError(t, err)
+
+	// Test the configureTLSContext function with the CA certificate
+	baseCtx := context.Background()
+	caCert := string(caCertBytes)
+	resultCtx := auth.ConfigureTLSContext(baseCtx, nil, &caCert)
+
+	// Context should be modified when caCert is provided
+	assert.NotEqual(t, baseCtx, resultCtx, "Context should be modified when caCert is provided")
+
+	// Verify that the CA certificate was parsed correctly by checking if it's valid PEM
+	block, _ := pem.Decode([]byte(caCert))
+	assert.NotNil(t, block, "CA certificate should be valid PEM format")
+	assert.Equal(t, "CERTIFICATE", block.Type, "CA certificate should be of type CERTIFICATE")
+
+	// Parse the CA certificate to verify it's valid
+	caCertParsed, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	assert.True(t, caCertParsed.IsCA, "Generated certificate should be a CA certificate")
 }


### PR DESCRIPTION
This change extracts the RefreshAndCacheNewToken function from headlamp.go into the auth package.

Part of:
- #3482

### Updates
- Update comment for `ConfigureTLSContext`
- Add `context.Context` parameter to `RefreshAndCacheNewToken`
- Use %w instead of %v in fmt.Errorf to allow error unwrapping
- Add comprehensive tests in `auth_test.go`

### Testing
```shell
cd backend
go test -v ./pkg/auth -run RefreshAndCacheNewToken
```