### PR TITLE
fix Monaco Editor with custom base url

### DIFF
--- a/frontend/src/components/monaco/MonacoEditorLoaderInitializer.tsx
+++ b/frontend/src/components/monaco/MonacoEditorLoaderInitializer.tsx
@@ -19,6 +19,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBaseUrl } from '../../helpers/getBaseUrl';
 import { isElectron } from '../../helpers/isElectron';
+import { makeUrl } from '../../lib/k8s/api/v2/makeUrl';
 
 /**
  * A React component which configures the monaco-editor loader to make sure
@@ -49,7 +50,7 @@ export function MonacoEditorLoaderInitializer({ children }: React.PropsWithChild
     // This needs to include the origin and not just a relative path because it is used as a fetch
     // from inside a web worker; which isn't allowed to fetch from relative paths.
     // The Vite configuration will copy the relevant source files into the served assets/vs/ folder
-    let url = `${window.location.origin}/${getBaseUrl()}assets/vs`;
+    let url = makeUrl([window.location.origin, getBaseUrl(), 'assets', 'vs']);
 
     // If electron in the built app, get the base url from window.location.href
     // eg window.location.href


### PR DESCRIPTION
## Summary

Sorry, I should have caught this issue the last version
* I added support for the Monaco Editor to work in offline mode in 0.35 https://github.com/kubernetes-sigs/headlamp/pull/3818
* In 0.35 using a custom baseURL was broken because of the rspack changes
* In 0.36 I fixed baseUrl support https://github.com/kubernetes-sigs/headlamp/pull/3883 but the fix didn't quite work for the offline Monaco Editor support.

Using the `makeUrl` function here handles the URL generation a bit better, adding missing slashes and removing duplicate slashes - this was the issue with the prior implementation.

## Changes

- Fixed the url generation to handle missing/extra slashes `/`

## Screenshots (if applicable)

Monaco editor working via webpack dev server with base url set
```sh
make run-backend
npm run start
```
<img width="1010" height="687" alt="image" src="https://github.com/user-attachments/assets/e70e3ea0-2b71-4b7a-b1d2-3667b53357fe" />


Monaco editor working via docker image with base url set
```sh
make -e DOCKER_IMAGE_VERSION=dan -e DOCKER_PLATFORM=linux/amd64 image; docker run -p 4466:4466/tcp -v '/Users/danielleone/.kube/config-in-docker:/home/headlamp/.kube/config' ghcr.io/headlamp-k8s/headlamp:dan -base-url=/headlamp
```
<img width="1022" height="682" alt="image" src="https://github.com/user-attachments/assets/6c0d2e97-2a54-488b-b174-0224940db8e2" />

Monaco editor working via docker image without base URL set
```sh
docker run -p 4466:4466/tcp -v '/Users/danielleone/.kube/config-in-docker:/home/headlamp/.kube/config' ghcr.io/headlamp-k8s/headlamp:dan
```
<img width="1012" height="1038" alt="image" src="https://github.com/user-attachments/assets/5252dc4e-69c3-44d7-90fa-e10803b8d984" />
