### PR TITLE
frontend: project: Add cluster links to project status

### DIFF
--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -28,6 +28,7 @@ import { useTypedSelector } from '../../redux/hooks';
 import { ProjectDefinition, ProjectDetailsTab } from '../../redux/projectsSlice';
 import { Activity } from '../activity/Activity';
 import { ButtonStyle, EditButton, EditorDialog, Loader, StatusLabel } from '../common';
+import Link from '../common/Link';
 import ResourceTable from '../common/Resource/ResourceTable';
 import SectionBox from '../common/SectionBox';
 import { GraphFilter } from '../resourceMap/graph/graphFiltering';
@@ -181,6 +182,20 @@ function ProjectOverview({
                     )}
                   </Box>
                 )}
+              </Box>
+            </Box>
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                {project.clusters.length === 1
+                  ? t('translation|Cluster')
+                  : t('translation|Clusters')}
+              </Typography>
+              <Box display="flex" flexWrap="wrap" gap={1} sx={{ mt: 0.5 }}>
+                {project.clusters.map(cluster => (
+                  <Link key={cluster} routeName="cluster" params={{ cluster }}>
+                    {cluster}
+                  </Link>
+                ))}
               </Box>
             </Box>
           </CardContent>


### PR DESCRIPTION
This change displays the relevant clusters at the bottom the project details status card with links that navigate to the cluster overview pages.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/4011, follow-up from https://github.com/kubernetes-sigs/headlamp/pull/4012

### Testing
- [x] Navigate to a project in Headlamp
- [x] Note that the associated clusters are displayed with clickable links

<img width="522" height="576" alt="image" src="https://github.com/user-attachments/assets/31f51bba-6e16-4f6a-8220-cfc8d65d68a4" />