### PR TITLE
backend: auth: Include baseURL in Cookie Path

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -755,7 +755,7 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 			}
 
 			// Set auth cookie
-			auth.SetTokenCookie(w, r, string(decodedState), rawUserToken)
+			auth.SetTokenCookie(w, r, string(decodedState), rawUserToken, config.BaseURL)
 
 			redirectURL += fmt.Sprintf("auth?cluster=%1s", decodedState)
 			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
@@ -841,7 +841,7 @@ func (c *HeadlampConfig) refreshAndSetToken(oidcAuthConfig *kubeconfig.OidcConfi
 		}
 
 		// Set refreshed token in cookie
-		auth.SetTokenCookie(w, r, cluster, newTokenString)
+		auth.SetTokenCookie(w, r, cluster, newTokenString, c.BaseURL)
 
 		c.telemetryHandler.RecordEvent(span, "Token refreshed successfully")
 	}
@@ -2333,9 +2333,9 @@ func (c *HeadlampConfig) handleSetToken(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if req.Token == "" {
-		auth.ClearTokenCookie(w, r, cluster)
+		auth.ClearTokenCookie(w, r, cluster, c.BaseURL)
 	} else {
-		auth.SetTokenCookie(w, r, cluster, req.Token)
+		auth.SetTokenCookie(w, r, cluster, req.Token, c.BaseURL)
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/backend/pkg/auth/cookies_test.go
+++ b/backend/pkg/auth/cookies_test.go
@@ -117,13 +117,56 @@ func TestIsSecureContext(t *testing.T) {
 	}
 }
 
+func TestGetCookiePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		cluster  string
+		wantPath string
+	}{
+		{
+			name:     "empty base URL",
+			baseURL:  "",
+			cluster:  "test-cluster",
+			wantPath: "/clusters/test-cluster",
+		},
+		{
+			name:     "base URL without leading slash",
+			baseURL:  "headlamp",
+			cluster:  "test-cluster",
+			wantPath: "/headlamp/clusters/test-cluster",
+		},
+		{
+			name:     "base URL with leading slash",
+			baseURL:  "/headlamp",
+			cluster:  "test-cluster",
+			wantPath: "/headlamp/clusters/test-cluster",
+		},
+		{
+			name:     "base URL with trailing slash",
+			baseURL:  "/headlamp/",
+			cluster:  "test-cluster",
+			wantPath: "/headlamp/clusters/test-cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := auth.GetCookiePath(tt.baseURL, tt.cluster)
+			if got != tt.wantPath {
+				t.Errorf("getCookiePath() = %q, want %q", got, tt.wantPath)
+			}
+		})
+	}
+}
+
 func TestSetAndGetAuthCookie(t *testing.T) {
 	req := httptest.NewRequest("GET", localhost, nil)
 	req.Host = localhost
 	w := httptest.NewRecorder()
 
 	// Test setting a cookie
-	auth.SetTokenCookie(w, req, "test-cluster", "test-token")
+	auth.SetTokenCookie(w, req, "test-cluster", "test-token", "")
 
 	// Check if cookie was set
 	cookies := w.Result().Cookies()
@@ -170,7 +213,7 @@ func TestGetAuthCookieChunked(t *testing.T) {
 	longToken := strings.Repeat("a", 5000)
 
 	// Test setting a cookie
-	auth.SetTokenCookie(w, req, "test-cluster", longToken)
+	auth.SetTokenCookie(w, req, "test-cluster", longToken, "")
 
 	// Check if cookie was set
 	cookies := w.Result().Cookies()
@@ -209,7 +252,7 @@ func TestClearAuthCookie(t *testing.T) {
 	})
 
 	// Clear a cookie
-	auth.ClearTokenCookie(w, req, "test-cluster")
+	auth.ClearTokenCookie(w, req, "test-cluster", "")
 
 	// Check if cookie was set
 	cookies := w.Result().Cookies()
@@ -218,7 +261,7 @@ func TestClearAuthCookie(t *testing.T) {
 	}
 
 	// Test clearing the cookie
-	auth.ClearTokenCookie(w, req, "test-cluster")
+	auth.ClearTokenCookie(w, req, "test-cluster", "")
 
 	// Check if cookie was cleared
 	clearedCookies := w.Result().Cookies()


### PR DESCRIPTION
## Summary

This PR fixes a bug where the Cookie's `Path` attribute does not respect the `base url` option.

## Related Issue

Fixes #4014

## Changes

- Added `GetCookiePath` function for getting the path using the `baseURL`.
- Fixed the bug where the Cookie `Path` did not respect the `baseURL` option.

## Steps to Test

1. Start the backend with the `baseURL` option, e.g., run `/backend/headlamp-server -base-url=/headlamp -port=8081`.
2. Request the token setting endpoint (e.g., `/set-token`) using `curl`:

```
curl --request POST
--url http://localhost:8081/headlamp/clusters/main/set-token
--data '{"token": "XXXXX"}'
```

3.  Verify the `Set-Cookie` header in the response. The `Path` attribute should start with the configured `baseURL` (`/headlamp/clusters/main` in this example).

Expected result:

```
Set-Cookie: headlamp-auth-main.0=XXXXX; Path=/headlamp/clusters/main; Max-Age=86400; HttpOnly; SameSite=Strict
```

## Notes for the Reviewer

- I could not test this change with the OIDC authentication flow locally. As this change affects how the Cookie Path is set, please also verify that the OIDC login/logout flow works correctly when the base-url option is used.
