### PR TITLE
backend, charts: Enabled Helm support via --enable-helm flag

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -335,6 +335,7 @@ func flagset() *flag.FlagSet {
 	f.String("listen-addr", "", "Address to listen on; default is empty, which means listening to any address")
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")
+	f.Bool("enable-helm", false, "Enable Helm operations")
 
 	f.String("oidc-client-id", "", "ClientID for OIDC")
 	f.String("oidc-client-secret", "", "ClientSecret for OIDC")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -178,6 +178,13 @@ func TestParseFlags(t *testing.T) {
 				assert.Equal(t, filepath.Join(getTestDataPath(), "valid_ca.pem"), conf.OidcCAFile)
 			},
 		},
+		{
+			name: "enable_helm",
+			args: []string{"go run ./cmd", "--enable-helm"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, true, conf.EnableHelm)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -72,6 +72,7 @@ $ helm install my-headlamp headlamp/headlamp \
 | config.inCluster | bool | `true` | Run Headlamp in-cluster |
 | config.baseURL | string | `""` | Base URL path for Headlamp UI |
 | config.pluginsDir | string | `"/headlamp/plugins"` | Directory to load Headlamp plugins from |
+| config.enableHelm  | bool   | `false`               | Enable Helm operations like install, upgrade and uninstall of Helm charts |
 | config.extraArgs | array | `[]` | Additional arguments for Headlamp server |
 | config.tlsCertPath | string | `""` | Certificate for serving TLS |
 | config.tlsKeyPath | string | `""` | Key for serving TLS |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -202,6 +202,9 @@ spec:
             {{- if .Values.config.inCluster }}
             - "-in-cluster"
             {{- end }}
+            {{- with .Values.config.enableHelm}}
+            - "-enable-helm"
+            {{- end }}
             {{- if .Values.config.watchPlugins }}
             - "-watch-plugins-changes"
             {{- end }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -96,6 +96,7 @@ config:
       name: ""
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
+  enableHelm: false
   watchPlugins: false
   # tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
   # tlsKeyPath: "/headlamp-cert/headlamp-tls.key"


### PR DESCRIPTION
Made helm feature toggleable via values.yaml

## Summary

This PR made enable-helm flag toggleable via values.yaml

## Related Issue

https://github.com/headlamp-k8s/plugins/pull/304

## Changes

- Enabled Helm support via --enable-helm flag 
- Made Helm feature toggleable via values.yaml.
- Added config test for enableHelm flag.


## Steps to Test

1.  Install Headlamp with Helm support enabled
2. Test Helm integration in the UI
