### PR TITLE
frontend: headlamp-plugin: Bump react-markdown to 10.1.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,7 +73,7 @@
         "react-dropzone": "^14.2.9",
         "react-hotkeys-hook": "^4.5.1",
         "react-i18next": "^15.0.2",
-        "react-markdown": "^9.0.1",
+        "react-markdown": "^10.1.0",
         "react-redux": "^9.1.2",
         "react-router": "^5.3.0",
         "react-router-dom": "^5.3.0",
@@ -12715,11 +12715,12 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-markdown": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz",
-      "integrity": "sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "dependencies": {
         "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "hast-util-to-jsx-runtime": "^2.0.0",
         "html-url-attributes": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,7 @@
     "react-dropzone": "^14.2.9",
     "react-hotkeys-hook": "^4.5.1",
     "react-i18next": "^15.0.2",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^10.1.0",
     "react-redux": "^9.1.2",
     "react-router": "^5.3.0",
     "react-router-dom": "^5.3.0",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -89,7 +89,7 @@
         "react-dropzone": "^14.2.9",
         "react-hotkeys-hook": "^4.5.1",
         "react-i18next": "^15.0.2",
-        "react-markdown": "^9.0.1",
+        "react-markdown": "^10.1.0",
         "react-redux": "^9.1.2",
         "react-router": "^5.3.0",
         "react-router-dom": "^5.3.0",
@@ -12858,10 +12858,9 @@
       "license": "MIT"
     },
     "node_modules/react-markdown": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
-      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
-      "license": "MIT",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -94,7 +94,7 @@
     "react-dropzone": "^14.2.9",
     "react-hotkeys-hook": "^4.5.1",
     "react-i18next": "^15.0.2",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^10.1.0",
     "react-redux": "^9.1.2",
     "react-router": "^5.3.0",
     "react-router-dom": "^5.3.0",


### PR DESCRIPTION
This change bumps react-markdown to v10.1.0 to allow img tags to render in the release notes.

Fixes: #4022 

### Testing
- [x] Open Headlamp and navigate to `DevTools -> Application -> Local Storage -> http://localhost:3000`
- [x] Change the `app-version` value to something else (e.g. `0.0.0`)
- [x] Restart the app and ensure that screenshots render in the release notes

<img width="877" height="400" alt="image" src="https://github.com/user-attachments/assets/84f9ab7b-8f20-4f37-8eec-848cb3080a5a" />