### PR TITLE
backend: Fix baseURL handling in embedded spa handler

### DIFF
--- a/backend/pkg/spa/embeddedSPAHandler_test.go
+++ b/backend/pkg/spa/embeddedSPAHandler_test.go
@@ -18,49 +18,89 @@ func createTestFS(files map[string]*fstest.MapFile) fs.FS {
 	return fstest.MapFS(files)
 }
 
+// getTestHTML returns the test HTML content used across tests.
+func getTestHTML() string {
+	return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Headlamp</title>
+    <script>
+        // handles both webpack and rspack build systems
+        __baseUrl__ = './<%= BASE_URL %>'.replace('%BASE_' + 'URL%', '').replace('<' + '%= BASE_URL %>', '');
+        // the syntax of the following line is special - it will be matched and replaced by the server
+        // if a base URL is set by the server
+        headlampBaseUrl = __baseUrl__;
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`
+}
+
 func TestEmbeddedSpaHandler(t *testing.T) {
+	testHTML := getTestHTML()
+
 	t.Run("check_headlampBaseUrl_is_set_to_baseURL", func(t *testing.T) {
-		handler := spa.NewEmbeddedHandler(createTestFS(map[string]*fstest.MapFile{
-			"static/index.html": {Data: []byte("headlampBaseUrl = './';")},
-		}), "index.html", "/headlamp")
-
-		req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/index.html", nil)
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "headlampBaseUrl = '/headlamp';", rr.Body.String())
+		testHeadlampBaseURLWithBaseURL(t, testHTML)
 	})
 
 	t.Run("check_empty_path_returns_index.html", func(t *testing.T) {
-		handler := spa.NewEmbeddedHandler(createTestFS(map[string]*fstest.MapFile{
-			"static/index.html": {Data: []byte("headlampBaseUrl = './';")},
-		}), "index.html", "/")
-
-		req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/", nil)
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "headlampBaseUrl = './';", rr.Body.String())
+		testEmptyPathReturnsIndex(t, testHTML)
 	})
 
 	t.Run("file_not_found", func(t *testing.T) {
-		handler := spa.NewEmbeddedHandler(createTestFS(map[string]*fstest.MapFile{
-			"static/index.html": {Data: []byte("headlampBaseUrl = './';")},
-		}), "index.html", "/headlamp")
-
-		req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/not-found.html", nil)
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, "headlampBaseUrl = './';", rr.Body.String())
+		testFileNotFound(t, testHTML)
 	})
+}
+
+func testHeadlampBaseURLWithBaseURL(t *testing.T, testHTML string) {
+	handler := spa.NewEmbeddedHandler(createTestFS(map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(testHTML)},
+	}), "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/index.html", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// Check that the __baseUrl__ assignment was replaced
+	assert.Contains(t, rr.Body.String(), "__baseUrl__ = '/headlamp';")
+	assert.Contains(t, rr.Body.String(), "headlampBaseUrl = __baseUrl__;")
+}
+
+func testEmptyPathReturnsIndex(t *testing.T, testHTML string) {
+	handler := spa.NewEmbeddedHandler(createTestFS(map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(testHTML)},
+	}), "index.html", "/")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// When baseURL is "/", the replacement should happen and __baseUrl__ should be set to "/"
+	assert.Contains(t, rr.Body.String(), "__baseUrl__ = '/';")
+	assert.Contains(t, rr.Body.String(), "headlampBaseUrl = __baseUrl__;")
+}
+
+func testFileNotFound(t *testing.T, testHTML string) {
+	handler := spa.NewEmbeddedHandler(createTestFS(map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(testHTML)},
+	}), "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/not-found.html", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// Check that the __baseUrl__ assignment was replaced in fallback case
+	assert.Contains(t, rr.Body.String(), "__baseUrl__ = '/headlamp';")
+	assert.Contains(t, rr.Body.String(), "headlampBaseUrl = __baseUrl__;")
 }


### PR DESCRIPTION
## Summary

this patch updates the logic for replacing
the baseUrl in index.html file when the
basePath is configured in embedded spa
handler

## Steps to Test

1. run  `make backend-embed`
2. once the binary is built, run the following command and navigate to [localhost:4466/api/headlamp/](http://localhost:4466/api/headlamp/)
> ./backend/headlamp-server --base-url="/api/headlamp" --enable-dynamic-cluster
