### PR TITLE
frontend: Add storybook stories for Layout component with various states

### DIFF
--- a/frontend/src/components/App/Layout.stories.tsx
+++ b/frontend/src/components/App/Layout.stories.tsx
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { delay, http, HttpResponse } from 'msw';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from '../../redux/stores/store';
+import { TestContext } from '../../test';
+import Layout from './Layout';
+
+export default {
+  title: 'App/Layout',
+  component: Layout,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The main layout component for Headlamp. It includes the top bar, sidebar, main content area, and handles cluster configuration and routing. This is the primary layout wrapper for the application.',
+      },
+    },
+    msw: {
+      handlers: [
+        // Mock cluster config
+        http.get('http://localhost:4466/config', () =>
+          HttpResponse.json({
+            clusters: {
+              minikube: {
+                name: 'minikube',
+                meta_data: { namespace: 'default' },
+              },
+              production: {
+                name: 'production',
+                meta_data: { namespace: 'default' },
+              },
+            },
+          })
+        ),
+        // Mock plugins
+        http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
+        // Mock cluster version
+        http.get('http://localhost:4466/version', () =>
+          HttpResponse.json({
+            major: '1',
+            minor: '28',
+            gitVersion: 'v1.28.0',
+          })
+        ),
+        // Mock events
+        http.get('http://localhost:4466/*/api/v1/events', () =>
+          HttpResponse.json({
+            kind: 'EventList',
+            items: [],
+          })
+        ),
+        // Mock namespaces
+        http.get('http://localhost:4466/*/api/v1/namespaces', () =>
+          HttpResponse.json({
+            kind: 'NamespaceList',
+            items: [
+              {
+                metadata: { name: 'default', uid: '1' },
+                spec: {},
+                status: { phase: 'Active' },
+              },
+            ],
+          })
+        ),
+        // Mock CRDs
+        http.get(
+          'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
+          () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+              metadata: {},
+            })
+        ),
+        http.get(
+          'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+          () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+              metadata: {},
+            })
+        ),
+      ],
+    },
+  },
+  decorators: [
+    Story => (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/']}>
+          <TestContext>
+            <Story />
+          </TestContext>
+        </MemoryRouter>
+      </Provider>
+    ),
+  ],
+} as Meta<typeof Layout>;
+
+const Template: StoryFn = () => <Layout />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  docs: {
+    description: {
+      story: 'The default layout with sidebar, topbar, and main content area.',
+    },
+  },
+};
+
+export const WithClusterRoute = Template.bind({});
+WithClusterRoute.decorators = [
+  Story => (
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/c/minikube/pods']}>
+        <TestContext routerMap={{ cluster: 'minikube' }}>
+          <Story />
+        </TestContext>
+      </MemoryRouter>
+    </Provider>
+  ),
+];
+WithClusterRoute.parameters = {
+  docs: {
+    description: {
+      story: 'Layout when viewing a specific cluster route (e.g., /c/minikube/pods).',
+    },
+  },
+};
+
+export const LoadingState = Template.bind({});
+LoadingState.parameters = {
+  docs: {
+    description: {
+      story: 'Layout showing loading state while fetching cluster configuration.',
+    },
+  },
+  storyshots: {
+    disable: true,
+  },
+  msw: {
+    handlers: [
+      // Delay config response to show loading for 5 seconds
+      http.get('http://localhost:4466/config', async () => {
+        await delay(5000);
+        return HttpResponse.json({
+          clusters: {
+            minikube: {
+              name: 'minikube',
+              meta_data: { namespace: 'default' },
+            },
+          },
+        });
+      }),
+      http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
+      http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+        HttpResponse.json({
+          kind: 'List',
+          items: [],
+          metadata: {},
+        })
+      ),
+      http.get(
+        'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+        () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: [],
+            metadata: {},
+          })
+      ),
+    ],
+  },
+};
+
+export const ErrorState = Template.bind({});
+ErrorState.parameters = {
+  docs: {
+    description: {
+      story: 'Layout showing error state when cluster configuration fails to load.',
+    },
+  },
+  msw: {
+    handlers: [
+      http.get('http://localhost:4466/config', () => HttpResponse.error()),
+      http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
+      http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+        HttpResponse.json({
+          kind: 'List',
+          items: [],
+          metadata: {},
+        })
+      ),
+      http.get(
+        'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+        () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: [],
+            metadata: {},
+          })
+      ),
+    ],
+  },
+};
+
+export const MultiCluster = Template.bind({});
+MultiCluster.decorators = [
+  Story => (
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/c/minikube+production/pods']}>
+        <TestContext routerMap={{ cluster: 'minikube+production' }}>
+          <Story />
+        </TestContext>
+      </MemoryRouter>
+    </Provider>
+  ),
+];
+MultiCluster.parameters = {
+  docs: {
+    description: {
+      story: 'Layout when viewing multiple clusters simultaneously.',
+    },
+  },
+  msw: {
+    handlers: [
+      http.get('http://localhost:4466/config', () =>
+        HttpResponse.json({
+          clusters: {
+            minikube: {
+              name: 'minikube',
+              meta_data: { namespace: 'default' },
+            },
+            production: {
+              name: 'production',
+              meta_data: { namespace: 'default' },
+            },
+            staging: {
+              name: 'staging',
+              meta_data: { namespace: 'default' },
+            },
+          },
+        })
+      ),
+      http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
+      http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+        HttpResponse.json({
+          kind: 'List',
+          items: [],
+          metadata: {},
+        })
+      ),
+      http.get(
+        'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+        () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: [],
+            metadata: {},
+          })
+      ),
+    ],
+  },
+};

--- a/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/NodeShellSettings.Default.stories.storyshot
@@ -81,7 +81,7 @@
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-14f1a7d-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
-                  aria-describedby=":r1r:-helper-text"
+                  aria-describedby=":mock-test-id:"
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"
@@ -127,7 +127,7 @@
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-8secpz-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
-                  aria-describedby=":r1s:-helper-text"
+                  aria-describedby=":mock-test-id:"
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   id=":mock-test-id:"

--- a/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
@@ -1,0 +1,113 @@
+<body>
+  <div>
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1561pfm-MuiTypography-root-MuiLink-root"
+      href="#main"
+    >
+      Skip to main content
+    </a>
+    <div
+      class="MuiBox-root css-12ub0xu"
+    >
+      <div
+        class="MuiBox-root css-1uqao6u"
+      >
+        <nav
+          aria-label="Appbar Tools"
+          class="MuiPaper-root MuiPaper-outlined MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-1sf61jf-MuiPaper-root-MuiAppBar-root"
+        >
+          <div
+            class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
+          >
+            <div
+              class="MuiBox-root css-19midj6"
+            />
+            <div
+              class="MuiBox-root css-p8ekiu"
+            >
+              <div
+                class="MuiBox-root css-xqhmuz"
+              >
+                <div
+                  class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                >
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                  >
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </div>
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-12yjm75-MuiInputBase-input-MuiOutlinedInput-input"
+                      id=":mock-test-id:"
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="MuiBox-root css-1rstwa7"
+                    >
+                      Press
+                      <div
+                        class="MuiBox-root css-1y54l5z"
+                      >
+                        /
+                      </div>
+                      to search
+                    </div>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ihdtdm"
+                      >
+                        <span
+                          class="notranslate"
+                        >
+                          ​
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            />
+          </div>
+        </nav>
+        <div
+          class="MuiBox-root css-1xd9zsj"
+        >
+          <main
+            class="css-afmxug"
+            id="main"
+          >
+            <div
+              class="MuiBox-root css-10klw3m"
+            >
+              <div
+                class="css-0"
+              />
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthXl css-15p3enc-MuiContainer-root"
+              />
+            </div>
+          </main>
+          <div
+            class="MuiBox-root css-11hh78l"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
@@ -1,0 +1,113 @@
+<body>
+  <div>
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1561pfm-MuiTypography-root-MuiLink-root"
+      href="#main"
+    >
+      Skip to main content
+    </a>
+    <div
+      class="MuiBox-root css-12ub0xu"
+    >
+      <div
+        class="MuiBox-root css-1uqao6u"
+      >
+        <nav
+          aria-label="Appbar Tools"
+          class="MuiPaper-root MuiPaper-outlined MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-1sf61jf-MuiPaper-root-MuiAppBar-root"
+        >
+          <div
+            class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
+          >
+            <div
+              class="MuiBox-root css-19midj6"
+            />
+            <div
+              class="MuiBox-root css-p8ekiu"
+            >
+              <div
+                class="MuiBox-root css-xqhmuz"
+              >
+                <div
+                  class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                >
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                  >
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </div>
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-12yjm75-MuiInputBase-input-MuiOutlinedInput-input"
+                      id=":mock-test-id:"
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="MuiBox-root css-1rstwa7"
+                    >
+                      Press
+                      <div
+                        class="MuiBox-root css-1y54l5z"
+                      >
+                        /
+                      </div>
+                      to search
+                    </div>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ihdtdm"
+                      >
+                        <span
+                          class="notranslate"
+                        >
+                          ​
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            />
+          </div>
+        </nav>
+        <div
+          class="MuiBox-root css-1xd9zsj"
+        >
+          <main
+            class="css-afmxug"
+            id="main"
+          >
+            <div
+              class="MuiBox-root css-10klw3m"
+            >
+              <div
+                class="css-0"
+              />
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthXl css-15p3enc-MuiContainer-root"
+              />
+            </div>
+          </main>
+          <div
+            class="MuiBox-root css-11hh78l"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
@@ -1,0 +1,113 @@
+<body>
+  <div>
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1561pfm-MuiTypography-root-MuiLink-root"
+      href="#main"
+    >
+      Skip to main content
+    </a>
+    <div
+      class="MuiBox-root css-12ub0xu"
+    >
+      <div
+        class="MuiBox-root css-1uqao6u"
+      >
+        <nav
+          aria-label="Appbar Tools"
+          class="MuiPaper-root MuiPaper-outlined MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-1sf61jf-MuiPaper-root-MuiAppBar-root"
+        >
+          <div
+            class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
+          >
+            <div
+              class="MuiBox-root css-19midj6"
+            />
+            <div
+              class="MuiBox-root css-p8ekiu"
+            >
+              <div
+                class="MuiBox-root css-xqhmuz"
+              >
+                <div
+                  class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                >
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                  >
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </div>
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-12yjm75-MuiInputBase-input-MuiOutlinedInput-input"
+                      id=":mock-test-id:"
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="MuiBox-root css-1rstwa7"
+                    >
+                      Press
+                      <div
+                        class="MuiBox-root css-1y54l5z"
+                      >
+                        /
+                      </div>
+                      to search
+                    </div>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ihdtdm"
+                      >
+                        <span
+                          class="notranslate"
+                        >
+                          ​
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            />
+          </div>
+        </nav>
+        <div
+          class="MuiBox-root css-1xd9zsj"
+        >
+          <main
+            class="css-afmxug"
+            id="main"
+          >
+            <div
+              class="MuiBox-root css-10klw3m"
+            >
+              <div
+                class="css-0"
+              />
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthXl css-15p3enc-MuiContainer-root"
+              />
+            </div>
+          </main>
+          <div
+            class="MuiBox-root css-11hh78l"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
@@ -1,0 +1,113 @@
+<body>
+  <div>
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1561pfm-MuiTypography-root-MuiLink-root"
+      href="#main"
+    >
+      Skip to main content
+    </a>
+    <div
+      class="MuiBox-root css-12ub0xu"
+    >
+      <div
+        class="MuiBox-root css-1uqao6u"
+      >
+        <nav
+          aria-label="Appbar Tools"
+          class="MuiPaper-root MuiPaper-outlined MuiAppBar-root MuiAppBar-colorPrimary MuiAppBar-positionStatic css-1sf61jf-MuiPaper-root-MuiAppBar-root"
+        >
+          <div
+            class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular css-1g5gxk7-MuiToolbar-root"
+          >
+            <div
+              class="MuiBox-root css-19midj6"
+            />
+            <div
+              class="MuiBox-root css-p8ekiu"
+            >
+              <div
+                class="MuiBox-root css-xqhmuz"
+              >
+                <div
+                  class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                >
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                  >
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </div>
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-12yjm75-MuiInputBase-input-MuiOutlinedInput-input"
+                      id=":mock-test-id:"
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="MuiBox-root css-1rstwa7"
+                    >
+                      Press
+                      <div
+                        class="MuiBox-root css-1y54l5z"
+                      >
+                        /
+                      </div>
+                      to search
+                    </div>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-ihdtdm"
+                      >
+                        <span
+                          class="notranslate"
+                        >
+                          ​
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            />
+          </div>
+        </nav>
+        <div
+          class="MuiBox-root css-1xd9zsj"
+        >
+          <main
+            class="css-afmxug"
+            id="main"
+          >
+            <div
+              class="MuiBox-root css-10klw3m"
+            >
+              <div
+                class="css-0"
+              />
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthXl css-15p3enc-MuiContainer-root"
+              />
+            </div>
+          </main>
+          <div
+            class="MuiBox-root css-11hh78l"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -89,7 +89,7 @@ window.matchMedia = () => ({
  * Recursively walks the tree and replaces any usage of useId
  */
 function replaceUseId(node: any) {
-  const attributesToReplace = ['id', 'for', 'aria-described', 'aria-labelledby', 'aria-controls'];
+  const attributesToReplace = ['id', 'for', 'aria-describedby', 'aria-labelledby', 'aria-controls'];
   if (node.nodeType === Node.ELEMENT_NODE) {
     for (const attr of node.attributes) {
       if (attributesToReplace.includes(attr.name)) {


### PR DESCRIPTION
## Summary

This PR adds comprehensive Storybook stories for the Layout component to improve documentation and testing coverage.

## Related Issue

Fixes #570 (part of "Components that need stories")

## Changes

- Added `frontend/src/components/App/Layout.stories.tsx` with 5 comprehensive stories
- Implemented MSW mocking for cluster configuration, plugins, and Kubernetes API endpoints
- Created stories for: Default, WithClusterRoute, LoadingState, ErrorState, and MultiCluster scenarios
- Used MSW's `delay()` utility for realistic loading state simulation

## Steps to Test

1. Run Storybook: `cd frontend && npm run storybook`
2. Navigate to **App → Layout** in the sidebar
3. Verify all 5 stories render correctly:
   - Default (basic layout)
   - WithClusterRoute (shows cluster-specific route)
   - LoadingState (shows loading for 5 seconds, then loads)
   - ErrorState (shows error handling)
   - MultiCluster (shows multi-cluster view)
4. Check that layout includes topbar, sidebar, and main content area in all stories

## Screenshots (if applicable)

_(Add Storybook screenshots showing the different Layout states)_

## Notes for the Reviewer

- This completes the Layout component entry in issue #570's checklist

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
