### PR TITLE
frontend: deployments/List: Fix status color for labels

### DIFF
--- a/frontend/src/components/deployments/List.tsx
+++ b/frontend/src/components/deployments/List.tsx
@@ -49,6 +49,17 @@ export default function DeploymentsList() {
       return null;
     }
 
+    function renderStatus(c: any) {
+      const type = c.type?.toLowerCase();
+      const status = String(c.status)?.toLowerCase();
+
+      if (!type || !status) {
+        return '';
+      }
+
+      return status === 'true' ? 'success' : status === 'false' ? 'warning' : 'error';
+    }
+
     return conditions
       .sort((c1: any, c2: any) => {
         if (c1.type < c2.type) {
@@ -63,7 +74,7 @@ export default function DeploymentsList() {
         const { type, message } = condition;
         return (
           <Box display="inline-block">
-            <StatusLabel status="">
+            <StatusLabel status={renderStatus(condition)}>
               <span title={message} key={type}>
                 {type}
               </span>

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -852,7 +852,7 @@
                     class="MuiBox-root css-1baulvz"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
                     >
                       <span>
                         Progressing
@@ -991,7 +991,7 @@
                     class="MuiBox-root css-1baulvz"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
                     >
                       <span>
                         Available


### PR DESCRIPTION
## Summary

This PR fixes the missing color renders for the conditions status labels

## Related Issue

Fixes https://github.com/kubernetes-sigs/headlamp/issues/3764

## Changes

- Added logic to get the render status for each StatusLabel component
- Fixes colors not matching to current status

## Steps to Test

1. Navigate to Deployments tab under Workloads
2. Note the colors now appear correctly for conditions
3. Add example deployments if needed 

## Screenshots (if applicable)
### Before
<img width="1820" height="860" alt="image" src="https://github.com/user-attachments/assets/1be2a201-4b94-436a-b5b7-6ed47b7a95e3" />

### After
<img width="1823" height="868" alt="image" src="https://github.com/user-attachments/assets/a4fed0d9-6b0d-4e63-9506-c4fc52df8cae" />

