### PR TITLE
frontend: NetworkPolicy: Add missing fields and subsection

### DIFF
--- a/frontend/src/components/networkpolicy/Details.tsx
+++ b/frontend/src/components/networkpolicy/Details.tsx
@@ -175,49 +175,55 @@ export function NetworkPolicyDetails(props: {
                     <Port key={index} port={port} />
                   )),
                 },
-                {
-                  name: t('translation|To'),
-                  value: '',
-                },
-                {
-                  name: t('ipBlock'),
-                  value: item.to?.map(to => {
-                    const { cidr, except = [] } = to.ipBlock || {};
-                    if (!cidr) {
-                      return <></>;
-                    }
-                    if (cidr && except.length === 0) {
-                      return <>{`cidr: ${cidr}`}</>;
-                    }
-                    return (
-                      <>{`cidr: ${cidr}, ${t('except: {{ cidrExceptions }}', {
-                        cidrExceptions: except.join(', '),
-                      })}`}</>
-                    );
-                  }),
-                },
-                {
-                  name: t('namespaceSelector'),
-                  value: item.to?.map(to => {
-                    if (!to.namespaceSelector) {
-                      return <></>;
-                    }
-                    const { matchLabels = {}, matchExpressions = [] } = to.namespaceSelector || {};
-                    return prepareMatchLabelsAndExpressions(matchLabels, matchExpressions);
-                  }),
-                },
-                {
-                  name: t('podSelector'),
-                  value: item.to?.map(to => {
-                    if (!to.podSelector) {
-                      return <></>;
-                    }
-                    const { matchLabels = {}, matchExpressions = [] } = to.podSelector || {};
-                    return prepareMatchLabelsAndExpressions(matchLabels, matchExpressions);
-                  }),
-                },
               ]}
             />
+            {item.to && item.to.length > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Typography sx={{ fontWeight: 600, mb: 1 }}>{t('translation|To')}</Typography>
+                <NameValueTable
+                  rows={[
+                    {
+                      name: t('ipBlock'),
+                      value: item.to?.map(to => {
+                        const { cidr, except = [] } = to.ipBlock || {};
+                        if (!cidr) {
+                          return <></>;
+                        }
+                        if (cidr && except.length === 0) {
+                          return <>{`cidr: ${cidr}`}</>;
+                        }
+                        return (
+                          <>{`cidr: ${cidr}, ${t('except: {{ cidrExceptions }}', {
+                            cidrExceptions: except.join(', '),
+                          })}`}</>
+                        );
+                      }),
+                    },
+                    {
+                      name: t('namespaceSelector'),
+                      value: item.to?.map(to => {
+                        if (!to.namespaceSelector) {
+                          return <></>;
+                        }
+                        const { matchLabels = {}, matchExpressions = [] } =
+                          to.namespaceSelector || {};
+                        return prepareMatchLabelsAndExpressions(matchLabels, matchExpressions);
+                      }),
+                    },
+                    {
+                      name: t('podSelector'),
+                      value: item.to?.map(to => {
+                        if (!to.podSelector) {
+                          return <></>;
+                        }
+                        const { matchLabels = {}, matchExpressions = [] } = to.podSelector || {};
+                        return prepareMatchLabelsAndExpressions(matchLabels, matchExpressions);
+                      }),
+                    },
+                  ]}
+                />
+              </Box>
+            )}
           </SectionBox>
         ))}
       </>


### PR DESCRIPTION
These changes display missing fields (`endPort`, egress `podSelector` and `namespaceSelector`) from the NetworkPolicy in the UI, and also changes the "to" field properly to a subsection.

Fixes https://github.com/kubernetes-sigs/headlamp/issues/4038, https://github.com/kubernetes-sigs/headlamp/issues/4040, https://github.com/kubernetes-sigs/headlamp/issues/4044

### Testing
- [x] Create a network policy in Headlamp with a defined `endPort` and egress `podSelector` and `namespaceSelector`

<img width="475" height="307" alt="image" src="https://github.com/user-attachments/assets/bcf08c07-cc70-4dce-a479-3543cb6dd86d" />
