### PR TITLE
backend: charts: Add Helm support via --enable-helm flag again

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -359,6 +359,7 @@ func flagset() *flag.FlagSet {
 	// TLS flags
 	f.String("tls-cert-path", "", "Certificate for serving TLS")
 	f.String("tls-key-path", "", "Key for serving TLS")
+	f.Bool("enable-helm", false, "Enable Helm operations")
 
 	return f
 }

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -178,6 +178,13 @@ func TestParseFlags(t *testing.T) {
 				assert.Equal(t, filepath.Join(getTestDataPath(), "valid_ca.pem"), conf.OidcCAFile)
 			},
 		},
+		{
+			name: "enable_helm",
+			args: []string{"go run ./cmd", "--enable-helm"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, true, conf.EnableHelm)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -72,6 +72,7 @@ $ helm install my-headlamp headlamp/headlamp \
 | config.inCluster   | bool   | `true`                | Run Headlamp in-cluster                                                   |
 | config.baseURL     | string | `""`                  | Base URL path for Headlamp UI                                             |
 | config.pluginsDir  | string | `"/headlamp/plugins"` | Directory to load Headlamp plugins from                                   |
+| config.enableHelm  | bool   | `false`               | Enable Helm operations like install, upgrade and uninstall of Helm charts |
 | config.extraArgs   | array  | `[]`                  | Additional arguments for Headlamp server                                  |
 | config.tlsCertPath | string | `""`                  | Certificate for serving TLS                                               |
 | config.tlsKeyPath  | string | `""`                  | Key for serving TLS                                                       |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -202,6 +202,9 @@ spec:
             {{- if .Values.config.inCluster }}
             - "-in-cluster"
             {{- end }}
+            {{- with .Values.config.enableHelm }}
+            - "-enable-helm"
+            {{- end }}
             {{- if .Values.config.watchPlugins }}
             - "-watch-plugins-changes"
             {{- end }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -96,6 +96,7 @@ config:
       name: ""
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
+  enableHelm: false
   watchPlugins: false
   # tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
   # tlsKeyPath: "/headlamp-cert/headlamp-tls.key"


### PR DESCRIPTION
Seems there was a merge issue, and this was removed accidentally.
