### PR TITLE
headlamp-plugin/config/plugins-tsconfig.json: Enable checkJS

### DIFF
--- a/plugins/headlamp-plugin/config/plugins-tsconfig.json
+++ b/plugins/headlamp-plugin/config/plugins-tsconfig.json
@@ -7,6 +7,7 @@
     "baseUrl": "../../../../",
     "esModuleInterop": true,
     "allowJs": true,
+    "checkJs": true,
     "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals", "lodash"],
     "paths": {
       "@iconify/react": [


### PR DESCRIPTION
This makes hovering functions imported from places like
headlamp-plugin/lib to show the function definition and documentation.

For some reason without that it just says "import type" or so.

If you imported from places like lib/plugins/registry where the
declarations actually are it also works. It's just places that
import from somewhere and export.

The docs for checkJs say it enables checking js files, so it might
be related to that, because the compiled files inside of headlamp-plugin
are .js files and declarations.
Docs for checkJs https://www.typescriptlang.org/tsconfig/#checkJs


### How to test

Build and install the headlamp-plugin and then in a plugin import
a register function from headlamp-plugin/lib and then hover it to
see the types and docs.

Before it was just saying "import registerxyz".
