### PR TITLE
frontend: resourceMap: Display valid dates for events

### DIFF
--- a/frontend/src/components/resourceMap/KubeObjectGlance/KubeObjectGlance.tsx
+++ b/frontend/src/components/resourceMap/KubeObjectGlance/KubeObjectGlance.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { KubeObject } from '../../../lib/k8s/cluster';
 import Deployment from '../../../lib/k8s/deployment';
 import Endpoints from '../../../lib/k8s/endpoints';
-import Event from '../../../lib/k8s/event';
+import Event, { KubeEvent } from '../../../lib/k8s/event';
 import HPA from '../../../lib/k8s/hpa';
 import Pod from '../../../lib/k8s/pod';
 import ReplicaSet from '../../../lib/k8s/replicaSet';
@@ -41,7 +41,9 @@ export const KubeObjectGlance = memo(({ resource }: { resource: KubeObject }) =>
   const { t } = useTranslation();
   const [events, setEvents] = useState<Event[]>([]);
   useEffect(() => {
-    Event.objectEvents(resource).then(it => setEvents(it));
+    Event.objectEvents(resource).then(fetchedEvents =>
+      setEvents(fetchedEvents.map((event: KubeEvent) => new Event(event)))
+    );
   }, []);
 
   const kind = resource.kind;


### PR DESCRIPTION
This change fixes the "Invalid Date" on map events and displays them properly in the UI.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/4049

### Testing
- [x] Navigate to the Map in Headlamp and click on a resource with Events
- [x] Note that the proper dates are displayed with no errors