### PR TITLE
backend: serviceproxy: Restrict requests to relative paths

### DIFF
--- a/backend/pkg/serviceproxy/connection.go
+++ b/backend/pkg/serviceproxy/connection.go
@@ -35,6 +35,10 @@ func (c *Connection) Get(requestURI string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid request uri: %w", err)
 	}
 
+	if rel.IsAbs() {
+		return nil, fmt.Errorf("request uri must be a relative path")
+	}
+
 	fullURL := base.ResolveReference(rel)
 
 	body, err := HTTPGet(context.Background(), fullURL.String())

--- a/backend/pkg/serviceproxy/connection_test.go
+++ b/backend/pkg/serviceproxy/connection_test.go
@@ -69,6 +69,13 @@ var getTests = []struct {
 		wantBody:   nil,
 		wantErr:    true,
 	},
+	{
+		name:       "absolute request URI rejected",
+		uri:        "http://example.com",
+		requestURI: "http://malicious.local",
+		wantBody:   nil,
+		wantErr:    true,
+	},
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
This change restricts service proxy requests to relative paths, preventing uncontrolled data from being used in network requests.

### Testing
```shell
cd backend
go test -v ./pkg/serviceproxy -run '^TestGet$'
```