### PR TITLE
frontend: components: Fix isDrawerMode fetch when state not there

### DIFF
--- a/frontend/src/components/App/Settings/DrawerModeSettings.tsx
+++ b/frontend/src/components/App/Settings/DrawerModeSettings.tsx
@@ -143,7 +143,7 @@ const OptionButton = ({
 export default function DrawerModeSettings() {
   const dispatch = useDispatch();
 
-  const isDrawerEnabled = useTypedSelector(state => state.drawerMode.isDetailDrawerEnabled);
+  const isDrawerEnabled = useTypedSelector(state => state?.drawerMode?.isDetailDrawerEnabled);
 
   return (
     <Box sx={{ display: 'flex' }}>

--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -142,7 +142,7 @@ function PureLink(
 }
 
 export default function Link(props: React.PropsWithChildren<LinkProps | LinkObjectProps>) {
-  const drawerEnabled = useTypedSelector(state => state.drawerMode.isDetailDrawerEnabled);
+  const drawerEnabled = useTypedSelector(state => state?.drawerMode?.isDetailDrawerEnabled);
 
   const { tooltip, ...propsRest } = props as LinkObjectProps;
 

--- a/frontend/src/components/common/Resource/DetailsDrawer.tsx
+++ b/frontend/src/components/common/Resource/DetailsDrawer.tsx
@@ -30,7 +30,7 @@ export default function DetailsDrawer() {
   const dispatch = useDispatch();
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-  const isDetailDrawerEnabled = useTypedSelector(state => state.drawerMode.isDetailDrawerEnabled);
+  const isDetailDrawerEnabled = useTypedSelector(state => state?.drawerMode?.isDetailDrawerEnabled);
 
   function closeDrawer() {
     dispatch(setSelectedResource(undefined));

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -172,7 +172,7 @@ export function GlobalSearchContent({
   const [query, setQuery] = useState(defaultValue ?? '');
   const clusters = useClustersConf() ?? {};
   const selectedClusters = useSelectedClusters();
-  const drawerEnabled = useTypedSelector(state => state.drawerMode.isDetailDrawerEnabled);
+  const drawerEnabled = useTypedSelector(state => state?.drawerMode?.isDetailDrawerEnabled);
 
   const [recent, bump] = useRecent('search-recent-items');
 


### PR DESCRIPTION
There are common components that require this state that maybe should
not depend on it being set.

For testing individual components that do not even use the drawer
functionality we make it so these components do not fail when
the state is not set.
