### PR TITLE
charts: fix loadBalancerSourceRanges formatting

### DIFF
--- a/charts/headlamp/templates/service.yaml
+++ b/charts/headlamp/templates/service.yaml
@@ -18,7 +18,7 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{ if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges))) }}
-  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges | toYaml | nindent 2 }}
   {{ end }}
   {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}


### PR DESCRIPTION
This fixes the loadBalancerSourceRanges format after helm templating.

## Summary

This PR fixes a chart bug by modifying how the variable `loadBalancerSourceRanges` is interpreted in the service chart.



Before:
```
helm template headlamp ./charts/headlamp -f test-values.yaml | grep SourceRanges
  loadBalancerSourceRanges: [1.2.3.4/12 5.6.7.8/12]
```

After:
```
helm template headlamp ./charts/headlamp -f test-values.yaml | grep -A 2 SourceRanges
  loadBalancerSourceRanges:
  - 1.2.3.4/12
  - 5.6.7.8/12
```

## Related Issue

N/A

## Changes

- Updated service template of the helm chart

## Steps to Test

1. Create a file `test-values.yaml`:
```yaml
service:
  type: LoadBalancer
  loadBalancerSourceRanges:
    - 1.2.3.4/12
    - 5.6.7.8/12
```
2. Run `helm template headlamp . -f test-values.yaml | grep -A2 SourceRanges`
3. You should see:
```
  loadBalancerSourceRanges:
  - 1.2.3.4/12
  - 5.6.7.8/12
```
and not:
```
  loadBalancerSourceRanges: [1.2.3.4/12 5.6.7.8/12]
```

## Screenshots (if applicable)
N/A

## Notes for the Reviewer
N/A