### PR TITLE
.github/build-container.yml: Cleanup disk space to avoid running out

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -51,20 +51,21 @@ jobs:
     - name: Try the cluster!
       run: kubectl get pods -A
     - name: Restore image-cache Folder
-      id: cache-image-restore
+      id: cache-image-restore2
       uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       with:
         path: ~/image-cache
         # cache the container image. All the paths this PR depends on except the e2e-tests folder for the key.
         key: ${{ runner.os }}-image-${{ hashFiles('backend/pkg/**', 'backend/cmd/**', 'backend/go.*', 'frontend/src/**', 'frontend/package.json', 'frontend/package-lock.json', 'Makefile', '.github/workflows/build-container.yml', 'Dockerfile', 'Dockerfile.plugins') }}
     - name: Restore Cached Docker Images
-      if: steps.cache-image-restore.outputs.cache-hit == 'true'
+      if: steps.cache-image-restore2.outputs.cache-hit == 'true'
       run: |
         export SHELL=/bin/bash
-        docker load -i ~/image-cache/headlamp-plugins-test.tar
-        docker load -i ~/image-cache/headlamp.tar
+        mkdir -p ~/image-cache
+        gzip -dc ~/image-cache/headlamp-plugins-test.tar.gz | docker load
+        gzip -dc ~/image-cache/headlamp.tar.gz | docker load
     - name: Make a .plugins folder for testing later
-      if: steps.cache-image-restore.outputs.cache-hit != 'true'
+      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |
         echo "Extract pod-counter plugin into .plugins folder, which will be copied into image later by 'make image'."
         cd plugins/examples/pod-counter
@@ -77,12 +78,12 @@ jobs:
         cd ../../
         ls -laR .plugins
     - name: Remove unnecessary files
-      if: steps.cache-image-restore.outputs.cache-hit != 'true'
+      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Build image
-      if: steps.cache-image-restore.outputs.cache-hit != 'true'
+      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |
         export SHELL=/bin/bash
         DOCKER_IMAGE_VERSION=latest make image
@@ -95,7 +96,7 @@ jobs:
         kind load docker-image ghcr.io/headlamp-k8s/headlamp-plugins-test:latest --name test
         kind load docker-image ghcr.io/headlamp-k8s/headlamp:latest --name test
     - name: Test .plugins folder
-      if: steps.cache-image-restore.outputs.cache-hit != 'true'
+      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |
         export SHELL=/bin/bash
         echo "----------------------------"
@@ -186,20 +187,30 @@ jobs:
         else
           echo "Playwright tests passed successfully"
         fi
+    # Clear disk space by removing unnecessary files, apt files and uninstall some playwright dependencies
+    - name: Clear Disk Space
+      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
+      run: |
+        export SHELL=/bin/bash
+        sudo rm -rf /var/lib/apt/lists/*
+        sudo apt-get remove -y libgbm-dev libxcb-dri3-0 libxcb-dri2-0 libxcb-xfixes0 libxcb-shape0 libxcb-shm0 libxcb-render0 libxcb-glx0 || true
+        sudo rm -rf e2e-tests/node_modules/
+        kind delete cluster --name test
+        kind delete cluster --name test2
     - name: Save Docker Images to Tar files in image-cache Folder
-      if: steps.cache-image-restore.outputs.cache-hit != 'true'
+      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |
         export SHELL=/bin/bash
         mkdir -p ~/image-cache
-        docker save -o ~/image-cache/headlamp-plugins-test.tar ghcr.io/headlamp-k8s/headlamp-plugins-test
-        docker save -o ~/image-cache/headlamp.tar ghcr.io/headlamp-k8s/headlamp
+        docker save ghcr.io/headlamp-k8s/headlamp-plugins-test | gzip -9 > ~/image-cache/headlamp-plugins-test.tar.gz
+        docker save ghcr.io/headlamp-k8s/headlamp | gzip -9 > ~/image-cache/headlamp.tar.gz
     - name: Cache image-cache Folder
-      if: steps.cache-image-restore.outputs.cache-hit != 'true'
+      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       id: cache-image-save
       uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
       with:
         path: ~/image-cache
-        key: ${{ steps.cache-image-restore.outputs.cache-primary-key }}
+        key: ${{ steps.cache-image-restore2.outputs.cache-primary-key }}
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: always()
       with:


### PR DESCRIPTION
Sometimes this job is running out of disk space.

- removed node_modules, apt packages, and deleted clusters before saving container images to cache
- compressed container images with gzip