### PR TITLE
backend: auth: Fetch user info from header

### DIFF
--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -302,8 +302,18 @@ func HandleMe(opts MeHandlerOptions) http.HandlerFunc {
 			return
 		}
 
-		token, err := GetTokenFromCookie(r, clusterName)
-		if err != nil || token == "" {
+		requestCluster, token := ParseClusterAndToken(r)
+
+		if requestCluster == "" {
+			requestCluster = clusterName
+		}
+
+		if requestCluster != clusterName {
+			writeMeJSON(w, http.StatusBadRequest, map[string]interface{}{"message": "cluster mismatch"})
+			return
+		}
+
+		if token == "" {
 			writeMeJSON(w, http.StatusUnauthorized, map[string]interface{}{"message": "unauthorized"})
 			return
 		}


### PR DESCRIPTION
This change swaps the `GetTokenFromCookie` call in the `HandleMe` function to `ParseClusterAndToken`, which allows us to fetch user info from a header with a fall back to the cookie.