### PR TITLE
charts/headlamp: Fix for pluginctl without global install

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -327,13 +327,15 @@ spec:
           {{- end }}
           args:
             - |
-              echo "Installing headlamp-plugin globally..."
-              npm install -g @headlamp-k8s/pluginctl@{{ .Values.pluginsManager.version }}
-              echo "Installed headlamp-plugin successfully."
               if [ -f "/config/plugin.yml" ]; then
                 echo "Installing plugins from config..."
                 cat /config/plugin.yml
-                pluginctl install --config /config/plugin.yml --folderName {{ .Values.config.pluginsDir }} --watch
+                # Use a writable cache directory
+                export NPM_CONFIG_CACHE=/tmp/npm-cache
+                # Use a writable config directory
+                export NPM_CONFIG_USERCONFIG=/tmp/npm-userconfig
+                mkdir -p /tmp/npm-cache /tmp/npm-userconfig
+                npx --yes @headlamp-k8s/pluginctl@{{ .Values.pluginsManager.version }} install --config /config/plugin.yml --folderName {{ .Values.config.pluginsDir }} --watch
               fi
           volumeMounts:
             - name: plugins-dir

--- a/charts/headlamp/templates/plugin-configmap.yaml
+++ b/charts/headlamp/templates/plugin-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pluginsManager.enabled }}
+{{- if .Values.pluginsManager.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,6 +7,5 @@ metadata:
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
 data:
-  plugin.yml: |
-    {{ .Values.pluginsManager.configContent | nindent 4 }}
+  plugin.yml: |{{ .Values.pluginsManager.configContent | nindent 4 }}
 {{- end }}

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -159,13 +159,15 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              echo "Installing headlamp-plugin globally..."
-              npm install -g @headlamp-k8s/pluginctl@1.0.0
-              echo "Installed headlamp-plugin successfully."
               if [ -f "/config/plugin.yml" ]; then
                 echo "Installing plugins from config..."
                 cat /config/plugin.yml
-                pluginctl install --config /config/plugin.yml --folderName /headlamp/plugins --watch
+                # Use a writable cache directory
+                export NPM_CONFIG_CACHE=/tmp/npm-cache
+                # Use a writable config directory
+                export NPM_CONFIG_USERCONFIG=/tmp/npm-userconfig
+                mkdir -p /tmp/npm-cache /tmp/npm-userconfig
+                npx --yes @headlamp-k8s/pluginctl@1.0.0 install --config /config/plugin.yml --folderName /headlamp/plugins --watch
               fi
           volumeMounts:
             - name: plugins-dir


### PR DESCRIPTION
Because there is no permission to do that now. So we run it without installing it.


For 
- https://github.com/kubernetes-sigs/headlamp/issues/3999



## Testing

1. Deploy Headlamp using Helm chart version 0.36.0

Enable plugin manager:

Put in values.yml

```yaml
pluginsManager:
  enabled: true
  configContent: |
    plugins:
      - name: flux
        source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_flux
        version: 0.5.0
```

Use the local chart instead of the one in the repo.
```shell
helm install my-headlamp charts/headlamp --namespace kube-system -f values.yml
```

3. Check pod status: `kubectl get pods -n headlamp`
4. Before you would see CrashLoopBackOff with 1/2 Ready, with this it will say something like `my-headlamp-58789b6df-8cpwn        2/2     Running   0          0m11s`.
5. Check logs: `kubectl logs <pod> -c headlamp-plugin` There should be a success message not a failure one.

