### PR TITLE
frontend: EditButton: Use JSON patch to prevent resource version conflicts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
         "fake-indexeddb": "^6.0.0",
+        "fast-json-patch": "^3.1.1",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
         "i18next": "^23.15.1",
@@ -7942,6 +7943,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.3",
     "fake-indexeddb": "^6.0.0",
+    "fast-json-patch": "^3.1.1",
     "fuse.js": "^7.0.0",
     "humanize-duration": "^3.27.2",
     "i18next": "^23.15.1",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
+        "fast-json-patch": "^3.1.1",
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "humanize-duration": "^3.27.2",
@@ -8060,6 +8061,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
       "license": "MIT"
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.3",
+    "fast-json-patch": "^3.1.1",
     "fs-extra": "^11.2.0",
     "fuse.js": "^7.0.0",
     "humanize-duration": "^3.27.2",

--- a/plugins/headlamp-plugin/template/package-lock.json
+++ b/plugins/headlamp-plugin/template/package-lock.json
@@ -1780,11 +1780,10 @@
       }
     },
     "node_modules/@kinvolk/headlamp-plugin": {
-      "version": "0.13.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0-alpha.10.tgz",
-      "integrity": "sha512-fBOvwA9OjMELLrJV5AN7UeNWLwKIGeeGcq99MNX3eKKZYvg5Fh6dJ80pLO1EtSwlTMNSHwv2q3Ljo4N7Cm1E6Q==",
+      "version": "0.13.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@kinvolk/headlamp-plugin/-/headlamp-plugin-0.13.0-alpha.11.tgz",
+      "integrity": "sha512-7HiZiiuJdiIcFLfrQafbWTdna4hnyPBfaHYiMXGYwXIpuYX4SMiEGuRw2KvV4I+81sanV91ekQel1YTL0SGXZQ==",
       "dev": true,
-      "license": "Apache 2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.0.3",
         "@emotion/react": "^11.11.1",
@@ -1866,7 +1865,7 @@
         "react-dropzone": "^14.2.9",
         "react-hotkeys-hook": "^4.5.1",
         "react-i18next": "^15.0.2",
-        "react-markdown": "^9.0.1",
+        "react-markdown": "^10.1.0",
         "react-redux": "^9.1.2",
         "react-router": "^5.3.0",
         "react-router-dom": "^5.3.0",
@@ -8159,11 +8158,10 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/axe-core": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
+      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
       "dev": true,
-      "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }
@@ -12364,7 +12362,6 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
       "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -13869,11 +13866,10 @@
       "license": "MIT"
     },
     "node_modules/react-markdown": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
-      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",


### PR DESCRIPTION
## Summary

This PR fixes 409 Conflict errors in the YAML editor. 
The editor now sends only the changed fields instead of the entire resource, significantly reducing conflicts on frequently updated resources like Nodes.

## Related Issue

Fixes #4097 

## Changes

### Before
The editor performed a full PUT request with the entire resource object:

```typescript
async function updateFunc(newItem: KubeObjectInterface) {
  // Simply sent the entire edited resource
  await item.update(newItem);  // Uses PUT request
}
```

**Problem:** If the resource's `resourceVersion` changed between opening the editor and saving (e.g., kubelet updating Node status), Kubernetes rejected the request with 409 Conflict.

### After
The editor now captures the original snapshot and sends only the diff:

```typescript
async function updateFunc(newItem: KubeObjectInterface) {
  // Calculate JSON Patch: diff between original and edited
  const patches = compare(originalResourceRef.current, newItem);
  
  // Send PATCH with json-patch format
  await patch(url, patches, true, {
    cluster: item._clusterName,
    headers: { 'Content-Type': 'application/json-patch+json' }
  });
}
```

**Benefit:** Only changed fields are sent, dramatically reducing conflict probability even when the resource is modified by other processes.

## Steps to Test

1. Navigate to a Node page
2. Click the Edit button to open the YAML editor
3. Make a small change (e.g., add a label or modify a taint)
4. Wait a few seconds (kubelet will update the Node status in the background)
5. Click "Save & Apply"
6. Verify the change is applied successfully without a 409 Conflict error

## Screenshots (if applicable)
### Before
<img width="1325" height="796" alt="image" src="https://github.com/user-attachments/assets/6ffac90c-86aa-4d00-a6fc-daf59309931f" />

### After
<img width="880" height="791" alt="image" src="https://github.com/user-attachments/assets/f6f560c3-86cb-4cd0-a618-f548989083e5" />


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
