### PR TITLE
Remove usage of execSync in scripts

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ChildProcessWithoutNullStreams, exec, execSync, spawn } from 'child_process';
+import { ChildProcessWithoutNullStreams, exec, execFileSync, spawn } from 'child_process';
 import { randomBytes } from 'crypto';
 import dotenv from 'dotenv';
 import {
@@ -132,7 +132,7 @@ const args = yargs(hideBin(process.argv))
     () => {
       try {
         const backendPath = path.join(process.resourcesPath, 'headlamp-server');
-        const stdout = execSync(`${backendPath} list-plugins`);
+        const stdout = execFileSync(backendPath, ['list-plugins']);
         process.stdout.write(stdout);
         process.exit(0);
       } catch (error) {
@@ -1383,7 +1383,7 @@ async function getHeadlampPIDsOnPort(port: number): Promise<number[] | null> {
 function killProcess(pid: number) {
   if (process.platform === 'win32') {
     // Otherwise on Windows the process will stick around.
-    execSync('taskkill /pid ' + pid + ' /T /F');
+    execFileSync('taskkill', ['/pid', String(pid), '/T', '/F']);
   } else {
     process.kill(pid, 'SIGHUP');
   }

--- a/tools/releaser/src/utils/git.ts
+++ b/tools/releaser/src/utils/git.ts
@@ -1,11 +1,13 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { isValidVersion } from './version.js';
 
 export function getRepoRoot(): string {
   try {
-    const gitRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+    const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf-8',
+    }).trim();
     return gitRoot;
   } catch (error) {
     console.error('Error: Not in a git repository');
@@ -39,8 +41,14 @@ export function commitVersionChange(version: string): void {
   const expectedTemplatesPath = path.join(repoRoot, 'charts', 'headlamp', 'tests', 'expected_templates');
 
   try {
-    execSync(`git add "${packageJsonPath}" "${packageLockJsonPath}" "${chartYamlPath}" "${expectedTemplatesPath}"`);
-    execSync(`git commit --signoff -m "releaser: bump version to ${version}"`);
+    execFileSync(
+      'git',
+      ['add', packageJsonPath, packageLockJsonPath, chartYamlPath, expectedTemplatesPath],
+      { stdio: 'inherit' }
+    );
+    execFileSync('git', ['commit', '--signoff', '-m', `releaser: bump version to ${version}`], {
+      stdio: 'inherit',
+    });
   } catch (error) {
     console.error('Error: Failed to commit version change');
     console.error(error);
@@ -55,7 +63,9 @@ export function createReleaseTag(version: string): void {
   }
 
   try {
-    execSync(`git tag -a v${version} -m "Release ${version}"`);
+    execFileSync('git', ['tag', '-a', `v${version}`, '-m', `Release ${version}`], {
+      stdio: 'inherit',
+    });
   } catch (error) {
     console.error(`Error: Failed to create tag v${version}`);
     console.error(error);
@@ -70,7 +80,7 @@ export function pushTag(version: string): void {
   }
 
   try {
-    execSync(`git push origin v${version}`);
+    execFileSync('git', ['push', 'origin', `v${version}`], { stdio: 'inherit' });
   } catch (error) {
     console.error(`Error: Failed to push tag v${version} to origin`);
     console.error(error);
@@ -80,7 +90,7 @@ export function pushTag(version: string): void {
 
 export function branchExists(branchName: string): boolean {
   try {
-    execSync(`git rev-parse --verify ${branchName}`, { stdio: 'ignore' });
+    execFileSync('git', ['rev-parse', '--verify', branchName], { stdio: 'ignore' });
     return true;
   } catch (error) {
     return false;
@@ -89,7 +99,7 @@ export function branchExists(branchName: string): boolean {
 
 export function createAndCheckoutBranch(branchName: string): void {
   try {
-    execSync(`git checkout -b ${branchName}`);
+    execFileSync('git', ['checkout', '-b', branchName], { stdio: 'inherit' });
   } catch (error) {
     console.error(`Error: Failed to create and checkout branch ${branchName}`);
     console.error(error);
@@ -99,7 +109,9 @@ export function createAndCheckoutBranch(branchName: string): void {
 
 export function getCurrentBranch(): string {
   try {
-    return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf-8',
+    }).trim();
   } catch (error) {
     console.error('Error: Failed to get current branch');
     console.error(error);

--- a/tools/releaser/src/utils/git.ts
+++ b/tools/releaser/src/utils/git.ts
@@ -1,10 +1,12 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 
 export function getRepoRoot(): string {
   try {
-    const gitRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+    const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf-8',
+    }).trim();
     return gitRoot;
   } catch (error) {
     console.error('Error: Not in a git repository');
@@ -31,8 +33,10 @@ export function commitVersionChange(version: string): void {
   const packageLockJsonPath = path.join(repoRoot, 'app', 'package-lock.json');
 
   try {
-    execSync(`git add "${packageJsonPath}" "${packageLockJsonPath}"`);
-    execSync(`git commit --signoff -m "app: Bump version to ${version}"`);
+    execFileSync('git', ['add', packageJsonPath, packageLockJsonPath], { stdio: 'inherit' });
+    execFileSync('git', ['commit', '--signoff', '-m', `app: Bump version to ${version}`], {
+      stdio: 'inherit',
+    });
   } catch (error) {
     console.error('Error: Failed to commit version change');
     console.error(error);
@@ -42,7 +46,9 @@ export function commitVersionChange(version: string): void {
 
 export function createReleaseTag(version: string): void {
   try {
-    execSync(`git tag -a v${version} -m "Release ${version}"`);
+    execFileSync('git', ['tag', '-a', `v${version}`, '-m', `Release ${version}`], {
+      stdio: 'inherit',
+    });
   } catch (error) {
     console.error(`Error: Failed to create tag v${version}`);
     console.error(error);
@@ -52,7 +58,7 @@ export function createReleaseTag(version: string): void {
 
 export function pushTag(version: string): void {
   try {
-    execSync(`git push origin v${version}`);
+    execFileSync('git', ['push', 'origin', `v${version}`], { stdio: 'inherit' });
   } catch (error) {
     console.error(`Error: Failed to push tag v${version} to origin`);
     console.error(error);
@@ -62,7 +68,7 @@ export function pushTag(version: string): void {
 
 export function branchExists(branchName: string): boolean {
   try {
-    execSync(`git rev-parse --verify ${branchName}`, { stdio: 'ignore' });
+    execFileSync('git', ['rev-parse', '--verify', branchName], { stdio: 'ignore' });
     return true;
   } catch (error) {
     return false;
@@ -71,7 +77,7 @@ export function branchExists(branchName: string): boolean {
 
 export function createAndCheckoutBranch(branchName: string): void {
   try {
-    execSync(`git checkout -b ${branchName}`);
+    execFileSync('git', ['checkout', '-b', branchName], { stdio: 'inherit' });
   } catch (error) {
     console.error(`Error: Failed to create and checkout branch ${branchName}`);
     console.error(error);
@@ -81,7 +87,9 @@ export function createAndCheckoutBranch(branchName: string): void {
 
 export function getCurrentBranch(): string {
   try {
-    return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf-8',
+    }).trim();
   } catch (error) {
     console.error('Error: Failed to get current branch');
     console.error(error);


### PR DESCRIPTION
These changes replace `execSync` with `execFileSync` in the two places where
dynamic values are interpolated into a shell command string.

- `app/electron/main.ts`: `list-plugins` built its command from `backendPath`,
  which comes from `process.resourcesPath`. An install path with a space or a
  shell metacharacter would break the command or run arbitrary shell.
- `tools/releaser/src/utils/git.ts`: `version` and `branchName` come from
  releaser CLI arguments, and `git add` interpolated filesystem paths.

Note: the `git` calls in the releaser now use `stdio: 'inherit'` where they
previously defaulted to `'pipe'`, so their output is visible.

