### PR TITLE
frontend: Improve empty state for the cluster list view

### DIFF
--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -22,10 +22,12 @@ import Typography from '@mui/material/Typography';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router-dom';
+import { isElectron } from '../../../helpers/isElectron';
 import { formatClusterPathParam } from '../../../lib/cluster';
 import { useClustersConf, useClustersVersion } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
 import { Cluster } from '../../../lib/k8s/cluster';
+import { createRouteURL } from '../../../lib/router/createRouteURL';
 import { getClusterPrefixedPath } from '../../../lib/util';
 import { useTypedSelector } from '../../../redux/hooks';
 import { Loader } from '../../common';
@@ -145,6 +147,42 @@ export default function ClusterTable({
     return <Loader title={t('Loading...')} />;
   }
 
+  const clustersList = Object.values(customNameClusters);
+  if (clustersList.length === 0) {
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        minHeight="400px"
+        textAlign="center"
+      >
+        <Icon
+          icon="mdi:hexagon-multiple-outline"
+          style={{ fontSize: 64, color: '#ccc', marginBottom: 16 }}
+        />
+        <Typography variant="h6" gutterBottom>
+          {t('No clusters found')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" paragraph>
+          {t('Add a cluster to get started.')}
+        </Typography>
+        {isElectron() && (
+          <Button
+            variant="contained"
+            startIcon={<Icon icon="mdi:plus" />}
+            onClick={() => {
+              history.push(createRouteURL('addCluster'));
+            }}
+          >
+            {t('Add Cluster')}
+          </Button>
+        )}
+      </Box>
+    );
+  }
+
   return (
     <Table
       columns={[
@@ -194,7 +232,7 @@ export default function ClusterTable({
           enableColumnFilter: false,
         },
       ]}
-      data={Object.values(customNameClusters)}
+      data={clustersList}
       enableRowSelection={
         MULTI_HOME_ENABLED
           ? row => {

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "",
   "Status": "Status",
   "Warnings": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "In-cluster",
   "View Clusters": "View Clusters",
   "Loading...": "Loading...",
+  "No clusters found": "No clusters found",
+  "Add a cluster to get started.": "Add a cluster to get started.",
   "Origin": "Origin",
   "Status": "Status",
   "Warnings": "Warnings",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "En-cluster",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "Origen",
   "Status": "Estado",
   "Warnings": "Avisos",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "",
   "Status": "Statut",
   "Warnings": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "क्लस्टर में",
   "View Clusters": "क्लस्टर देखें",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "उत्पत्ति",
   "Status": "स्थिति",
   "Warnings": "चेतावनियाँ",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "In-cluster",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "Origine",
   "Status": "Stato",
   "Warnings": "Avvertenze",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "クラスター内",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "元",
   "Status": "ステータス",
   "Warnings": "警告",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "클러스터 내부",
   "View Clusters": "클러스터 보기",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "출처",
   "Status": "상태",
   "Warnings": "경고",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "No cluster",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "Origem",
   "Status": "Estado",
   "Warnings": "Avisos",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "க்ளஸ்டருக்குள்",
   "View Clusters": "க்ளஸ்டர்களைப் பார்",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "மூலம்",
   "Status": "நிலை",
   "Warnings": "எச்சரிக்கைகள்",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "叢集內",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "來源",
   "Status": "狀態",
   "Warnings": "警告",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -61,6 +61,8 @@
   "In-cluster": "集群內",
   "View Clusters": "",
   "Loading...": "",
+  "No clusters found": "",
+  "Add a cluster to get started.": "",
   "Origin": "来源",
   "Status": "状态",
   "Warnings": "警告",


### PR DESCRIPTION
## Summary

When the cluster list is empty, Headlamp looks very empty and there is no clue on what to do.
This PR fixes that by adding a call to action (in app mode). When in-cluster, it just states there are no clusters (since one cannot add it).

## Steps to Test

1. Make a backup of your ~/.kube/config, remove it, and then open headlamp -> Realize how now there's a much better looking empty state for the cluster list view

## Screenshots (if applicable)

<img width="1843" height="919" alt="Screenshot showing the changes" src="https://github.com/user-attachments/assets/44d58d05-fcba-457c-879e-a39fcf167155" />

