### PR TITLE
app,frontend: Allow open the About dialog from the menu item

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -957,8 +957,7 @@ function getDefaultAppMenu(): AppMenu[] {
         },
         {
           label: i18n.t('About'),
-          id: 'original-about',
-          url: 'https://github.com/kubernetes-sigs/headlamp',
+          id: 'original-about-help',
         },
       ],
     },
@@ -1052,7 +1051,12 @@ function menusToTemplate(mainWindow: BrowserWindow | null, menusFromPlugins: App
       return;
     }
 
-    if (!!url) {
+    // Handle the "About" menu item from the Help menu specially
+    if (appMenu.id === 'original-about-help') {
+      menu.click = () => {
+        mainWindow?.webContents.send('open-about-dialog');
+      };
+    } else if (!!url) {
       menu.click = async () => {
         // Open external links in the external browser.
         if (!!mainWindow && !url.startsWith('http')) {

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -47,6 +47,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'plugin-manager',
       'backend-token',
       'plugin-permission-secrets',
+      'open-about-dialog',
     ];
     if (validChannels.includes(channel)) {
       // Deliberately strip event as it includes `sender`

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -22,6 +22,8 @@ import { getBaseUrl } from '../../helpers/getBaseUrl';
 import { setBackendToken } from '../../helpers/getHeadlampAPIHeaders';
 import { isElectron } from '../../helpers/isElectron';
 import Plugins from '../../plugin/Plugins';
+import store from '../../redux/stores/store';
+import { uiSlice } from '../../redux/uiSlice';
 import ReleaseNotes from '../common/ReleaseNotes/ReleaseNotes';
 import { MonacoEditorLoaderInitializer } from '../monaco/MonacoEditorLoaderInitializer';
 import Layout from './Layout';
@@ -30,6 +32,11 @@ import { PreviousRouteProvider } from './RouteSwitcher';
 window.desktopApi?.send('request-backend-token');
 window.desktopApi?.receive('backend-token', (token: string) => {
   setBackendToken(token);
+});
+
+// Listen for the open-about-dialog event from the Electron app menu
+window.desktopApi?.receive('open-about-dialog', () => {
+  store.dispatch(uiSlice.actions.setVersionDialogOpen(true));
 });
 
 /**


### PR DESCRIPTION
## Summary

When the Help > About menu is clicked, it opens headlamp's github repo. It should instead open the About dialog in the app.
