### PR TITLE
frontend: TopBar: backend: auth: Add me-user-info-url config

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -93,6 +93,8 @@ type HeadlampConfig struct {
 	meEmailPaths string
 	// meGroupsPaths lists the JMESPath expressions tried for the groups in /clusters/{cluster}/me.
 	meGroupsPaths string
+	// MeUserInfoURL is the URL to fetch additional user info for the /me endpoint. /oauth2/userinfo
+	MeUserInfoURL string
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -494,6 +496,7 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 			UsernamePaths: config.meUsernamePaths,
 			EmailPaths:    config.meEmailPaths,
 			GroupsPaths:   config.meGroupsPaths,
+			UserInfoURL:   config.MeUserInfoURL,
 		}),
 	).Methods("GET")
 

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -101,11 +101,13 @@ var ParseWithEnvTests = []struct {
 			"HEADLAMP_CONFIG_ME_USERNAME_PATH": "user.name",
 			"HEADLAMP_CONFIG_ME_EMAIL_PATH":    "user.email",
 			"HEADLAMP_CONFIG_ME_GROUPS_PATH":   "user.groups",
+			"HEADLAMP_CONFIG_ME_USER_INFO_URL": "/oauth2/userinfo",
 		},
 		verify: func(t *testing.T, conf *config.Config) {
 			assert.Equal(t, "user.name", conf.MeUsernamePath)
 			assert.Equal(t, "user.email", conf.MeEmailPath)
 			assert.Equal(t, "user.groups", conf.MeGroupsPath)
+			assert.Equal(t, "/oauth2/userinfo", conf.MeUserInfoURL)
 		},
 	},
 	{

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -90,6 +90,7 @@ $ helm install my-headlamp headlamp/headlamp \
 | config.oidc.secret.name | string | `"oidc"` | Name of the OIDC secret |
 | config.oidc.externalSecret.enabled | bool | `false` | Enable using external secret for OIDC |
 | config.oidc.externalSecret.name | string | `""` | Name of external OIDC secret |
+| config.oidc.meUserInfoURL | string | `""` | URL to fetch additional user info for the /me endpoint. For oauth2proxy /oauth2/userinfo can be used. |
 
 There are three ways to configure OIDC:
 

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -10,6 +10,7 @@
 {{- $validatorIssuerURL := "" }}
 {{- $usePKCE := "" }}
 {{- $useAccessToken := "" }}
+{{- $meUserInfoURL := "" }}
 
 # This block of code is used to extract the values from the env.
 # This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
@@ -40,6 +41,9 @@
   {{- end }}
   {{- if eq .name "OIDC_USE_PKCE" }}
     {{- $usePKCE = .value | toString }}
+  {{- end }}
+  {{- if eq .name "ME_USER_INFO_URL" }}
+    {{- $meUserInfoURL = .value | toString }}
   {{- end }}
 {{- end }}
 
@@ -170,6 +174,13 @@ spec:
                   name: {{ $oidc.secret.name }}
                   key: usePKCE
             {{- end }}
+            {{- if $oidc.meUserInfoURL }}
+            - name: ME_USER_INFO_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $oidc.secret.name }}
+                  key: meUserInfoURL
+            {{- end }}
             {{- else }}
             {{- if $oidc.clientID }}
             - name: OIDC_CLIENT_ID
@@ -206,6 +217,10 @@ spec:
             {{- if $oidc.usePKCE }}
             - name: OIDC_USE_PKCE
               value: {{ $oidc.usePKCE }}
+            {{- end }}
+            {{- if $oidc.meUserInfoURL }}
+            - name: ME_USER_INFO_URL
+              value: {{ $oidc.meUserInfoURL }}
             {{- end }}
             {{- end }}
             {{- if .Values.env }}
@@ -263,6 +278,9 @@ spec:
             {{- if or (eq ($oidc.usePKCE | toString) "true") (eq $usePKCE "true") }}
             - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
             {{- end }}
+            {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
+            - "-me-user-info-url=$(ME_USER_INFO_URL)"
+            {{- end }}
             {{- else }}
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
@@ -279,6 +297,9 @@ spec:
             {{- if or (ne $oidc.validatorIssuerURL "") (ne $validatorIssuerURL "") }}
             # Check if validatorIssuerURL is non empty either from env or oidc.config
             - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
+            {{- end }}
+            {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
+            - "-me-user-info-url=$(ME_USER_INFO_URL)"
             {{- end }}
             {{- end }}
             {{- with .Values.config.baseURL }}

--- a/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
@@ -1,0 +1,130 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.36.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+            - name: ME_USER_INFO_URL
+              value: /oauth2/userinfocustom1
+          args:
+            - "-in-cluster"
+            - "-plugins-dir=/headlamp/plugins"
+            # Check if externalSecret is disabled
+            - "-me-user-info-url=$(ME_USER_INFO_URL)"
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}

--- a/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
@@ -1,0 +1,133 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.36.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.36.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.36.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+            - name: ME_USER_INFO_URL
+              valueFrom:
+                secretKeyRef:
+                  name: oidc
+                  key: meUserInfoURL
+          args:
+            - "-in-cluster"
+            - "-plugins-dir=/headlamp/plugins"
+            # Check if externalSecret is disabled
+            - "-me-user-info-url=$(ME_USER_INFO_URL)"
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}

--- a/charts/headlamp/tests/test_cases/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/test_cases/me-user-info-url-directly.yaml
@@ -1,0 +1,3 @@
+env:
+  - name: ME_USER_INFO_URL
+    value: /oauth2/userinfocustom1

--- a/charts/headlamp/tests/test_cases/me-user-info-url.yaml
+++ b/charts/headlamp/tests/test_cases/me-user-info-url.yaml
@@ -1,0 +1,4 @@
+# -- Headlamp OIDC me user info URL test case
+config:
+  oidc:
+    meUserInfoURL: /oauth2/userinfocustom2

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -96,6 +96,11 @@ config:
     externalSecret:
       enabled: false
       name: ""
+
+    # -- URL to fetch additional user info for the /me endpoint.
+    # For oauth2proxy /oauth2/userinfo can be used. Empty and it will not be used.
+    meUserInfoURL: ""
+
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
   enableHelm: false

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -103,7 +103,37 @@ export default function TopBar({}: TopBarProps) {
           autoLogoutOnAuthError: false,
         });
 
-        return res ? { username: res.username, email: res.email } : null;
+        if (!res) {
+          return null;
+        }
+
+        if (!(typeof res.userInfoURL === 'string' && res.userInfoURL.length > 0)) {
+          return { username: res.username, email: res.email };
+        }
+
+        const ui: {
+          preferredUsername?: string;
+          email?: string;
+        } = await fetch(res.userInfoURL, {
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }).then(r => {
+          if (!r.ok) {
+            throw new Error(`Could not fetch user info from ${res.userInfoURL}`);
+          }
+          return r.json();
+        });
+
+        if (!ui || (!ui.preferredUsername && !ui.email)) {
+          return null;
+        }
+
+        return {
+          username: ui.preferredUsername,
+          email: ui.email,
+        };
       } catch {
         return null;
       }


### PR DESCRIPTION
This PR adds support for optionally fetching additional user information from an external endpoint (like oauth2proxy's userinfo endpoint) to populate the user info displayed in the TopBar.

- Frontend fetches additional user info from the meUserInfoURL if provided
- Adds a new meUserInfoURL configuration option across frontend, backend(`me-user-info-url`), and Helm charts
- Backend passes the userInfoURL to the frontend in the /me endpoint response
- Adds a `config.oidc.meUserInfoURL` string with a default of `""`  to be returned by the `/me` endpoint (which is then fetch()'d by the frontend/. For oauth2proxy `"/oauth2/userinfo"` can be used.
