### PR TITLE
docs: Separate OIDC scopes by comma

### DIFF
--- a/docs/installation/in-cluster/azure-entra-id/index.md
+++ b/docs/installation/in-cluster/azure-entra-id/index.md
@@ -141,13 +141,15 @@ config:
     clientID: "<Your Application (client) ID>"
     clientSecret: "<Your Application (client) Secret>"
     issuerURL: "https://login.microsoftonline.com/<Your Directory (tenant) ID>/v2.0"
-    scopes: "6dae42f8-4368-4678-94ff-3960e28e3630/user.read openid email profile"
+    scopes: "6dae42f8-4368-4678-94ff-3960e28e3630/user.read,openid,email,profile"
     validatorClientID: "6dae42f8-4368-4678-94ff-3960e28e3630"
     validatorIssuerURL: "https://sts.windows.net/<Your Directory (tenant) ID>/"
     useAccessToken: true
 ```
 
 Replace `<Your Application (client) ID>`,`<Your Application (client) Secret>`, and `<Your Directory (tenant) ID>`, with your specific Azure Entra ID app registration details obtained in the steps above.
+
+> Note: The `scopes` string must be comma separated so each scope is passed individually to the OIDC provider.
 
 4. Save the `values.yaml` file and Install Headlamp using helm with the following commands:
 

--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -96,7 +96,7 @@ For quick reference if you are already familiar with setting up Entra ID,
 - Set `-oidc-client-id` to your Azure App Registration's clientID
 - Set `-oidc-client-secret` to your Azure App Registration's clientSecret
 - Set `-oidc-idp-issuer-url` to `https://login.microsoftonline.com/<Your Azure Directory (tenant) ID>/v2.0`
-- Set `-oidc-scopes` to `6dae42f8-4368-4678-94ff-3960e28e3630/user.read openid email profile`
+- Set `-oidc-scopes` to `6dae42f8-4368-4678-94ff-3960e28e3630/user.read,openid,email,profile`
 - Set `--oidc-validator-idp-issuer-url` to `https://sts.windows.net/<Your Directory (tenant) ID>/`
 - Set `-oidc-validator-client-id` to `6dae42f8-4368-4678-94ff-3960e28e3630`
 - Set `-oidc-use-access-token=true`


### PR DESCRIPTION
These changes separate the scopes in the OIDC docs by commas rather than spaces.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/4081