### PR TITLE
charts: fix useAccessToken arg not set when using external secrets

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -298,6 +298,10 @@ spec:
             # Check if validatorIssuerURL is non empty either from env or oidc.config
             - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
             {{- end }}
+            {{- if or (eq ($oidc.useAccessToken | toString) "true") (eq $useAccessToken "true") }}
+            # Check if useAccessToken is non false either from env or oidc.config
+            - "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)"
+            {{- end }}
             {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
             - "-me-user-info-url=$(ME_USER_INFO_URL)"
             {{- end }}


### PR DESCRIPTION
## Summary

This PR fixes issue when using externalSecrets in Values.yaml, Helm Charts, useAccessToken has not affect, **in cluster** setup
## Related Issue

Fixes #3954

## Steps to Test
_testing if  "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)" is set when config.oidc.useAccessToken or config.env OIDC_USE_ACCESS_TOEKN is set to true_

1. use default Values.yaml file, set externalSecrets.enable to true and secrets.create to false
2. add config.oidc.useAccessToken: true
```yaml
config:
  inCluster: true
  baseURL: ""
  oidc:
    secret:
      create: false
    externalSecret:
      enabled: true
      name: "oidc"
    useAccessToken: true
```
3. run `helm --release-name headlamp template . >all.yaml`, and see if "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)" is set for containers args in headlamp deployment
4. remove config.oidc.useAccessToken, set OIDC_USE_ACCESS_TOKEN at env
```yaml
config:
  inCluster: true
  baseURL: ""
  oidc:
    secret:
      create: false
    externalSecret:
      enabled: true
      name: "oidc"
env:
  - name: OIDC_USE_ACCESS_TOKEN
    value: "true"
```
5. repeat step 3

## Screenshots (if applicable)
<img width="1290" height="1079" alt="image" src="https://github.com/user-attachments/assets/d1b0b288-e1bc-4253-b8bc-1fc5c5c3f848" />


## Notes for the Reviewer
