### PR TITLE
charts: Add ability to specify priorityClassName

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -387,6 +387,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       {{- if or .Values.pluginsManager.enabled .Values.volumes }}
       volumes:
         {{- if .Values.pluginsManager.enabled }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -263,6 +263,9 @@ tolerations: []
 # -- Affinity settings for pod assignment
 affinity: {}
 
+# -- Pod priority class
+priorityClassName: ""
+
 # Plugin Manager Sidecar Container Configuration
 pluginsManager:
   # -- Enable plugin manager


### PR DESCRIPTION
## Summary

This PR adds the ability to specify a priorityClass for the headlamp deployment.
