### PR TITLE
frontend: headlamp-plugins: Add yaml 2.7.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -87,7 +87,8 @@
         "vite": "^6.4.1",
         "vite-plugin-node-polyfills": "^0.23.0",
         "vite-plugin-static-copy": "^3.1.2",
-        "vite-plugin-svgr": "^4.3.0"
+        "vite-plugin-svgr": "^4.3.0",
+        "yaml": "^2.7.0"
       },
       "devDependencies": {
         "@rsbuild/core": "^1.4.15",
@@ -16149,7 +16150,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,7 +88,8 @@
     "vite": "^6.4.1",
     "vite-plugin-node-polyfills": "^0.23.0",
     "vite-plugin-static-copy": "^3.1.2",
-    "vite-plugin-svgr": "^4.3.0"
+    "vite-plugin-svgr": "^4.3.0",
+    "yaml": "^2.7.0"
   },
   "overrides": {
     "axe-core": "npm:dry-uninstall",

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -111,6 +111,7 @@
         "vite-plugin-static-copy": "^3.1.2",
         "vite-plugin-svgr": "^4.3.0",
         "vitest": "^3.0.5",
+        "yaml": "^2.7.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -16604,17 +16605,15 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14.6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -116,6 +116,7 @@
     "vite-plugin-static-copy": "^3.1.2",
     "vite-plugin-svgr": "^4.3.0",
     "vitest": "^3.0.5",
+    "yaml": "^2.7.0",
     "yargs": "^17.7.2"
   },
   "overrides": {


### PR DESCRIPTION
This is used by Resource.tsx where it imports 'yaml'. 

On some systems it shows this is missing. It is a dependency of js-yaml but we add it directly, so it is always available at the top level node_modules/yaml.