### PR TITLE
Fix missing PKCE arg in Helm

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -290,6 +290,9 @@ spec:
             # Check if callbackURL is non empty either from env or oidc.config
             - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"
             {{- end }}
+            {{- if or (eq ($oidc.usePKCE | toString) "true") (eq $usePKCE "true") }}
+            - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
+            {{- end }}
             {{- if or (ne $oidc.validatorClientID "") (ne $validatorClientID "") }}
             # Check if validatorClientID is non empty either from env or oidc.config
             - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"


### PR DESCRIPTION
This PR addresses issues reported in #4136 :

1. Helm chart PKCE arg omission
Ensure `-oidc-use-pkce=$(OIDC_USE_PKCE)` is rendered in both branches (when ExternalSecret is enabled or not). Previously, some paths did not include the arg although PKCE was enabled.

```
# values.yaml
config:
  oidc:
    secret:
      create: false
    externalSecret:
      enabled: true
      name: headlamp

env:
- name: OIDC_CALLBACK_URL
  value: https://headlamp-dev.example.com/oidc-callback
- name: OIDC_USE_PKCE
  value: 'true'
```

# Changes

- Helm: add `-oidc-use-pkce=$(OIDC_USE_PKCE)` in the `else` branch as well.

# Rationale
- PKCE should be consistently enabled when configured.

# Testing
- Verified Helm renders -oidc-use-pkce in both ExternalSecret paths.

# Related
- Fixes #4136 .