### PR TITLE
frontend: AddCluster: Fix Add Local Cluster Provider link

### DIFF
--- a/frontend/src/components/App/CreateCluster/AddCluster.tsx
+++ b/frontend/src/components/App/CreateCluster/AddCluster.tsx
@@ -93,7 +93,9 @@ export default function AddCluster(props: DialogProps & { onChoice: () => void }
           {isElectron() && isPluginCatalogRegistered && addClusterProviders.length === 0 && (
             <Grid item xs={12}>
               <Button
-                onClick={() => history.push('/#/plugin-catalog/headlamp-plugins/headlamp_minikube')}
+                onClick={() => {
+                  window.location.href = '#/plugin-catalog/headlamp-plugins/headlamp_minikube';
+                }}
                 startIcon={<InlineIcon icon="mdi:plus-box-outline" />}
               >
                 {t('translation|Add Local Cluster Provider')}


### PR DESCRIPTION
Build the app.
- Click Add Cluster button bottom left in sidebar
- Click "Add Local Cluster Provider"
- You should be on minikube plugin detail page of plugin catalog
