### PR TITLE
app: Fix url decoding for external links handling

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1500,7 +1500,8 @@ function startElecron() {
     if a library is trying to open a url other than app url in electron take it
     to the default browser
     */
-    mainWindow.webContents.on('will-navigate', (event, url) => {
+    mainWindow.webContents.on('will-navigate', (event, encodedUrl) => {
+      const url = decodeURI(encodedUrl);
       if (url.startsWith(startUrl)) {
         return;
       }


### PR DESCRIPTION
## Summary

When clicking Reload Now after installing a plugin on Windows, the system's browser is opened on the index.html file.

## Steps to Test

1. Open Headlamp desktop on Windows
2. Go to the plugin catalog and install a plugin, then click Reload Now in the notification -> An index.html is mistakenly opened in the system's browser
