### PR TITLE
backend: Dockerfile: Update alpine to 3.22.2 and golang to 1.24.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE_BASE=alpine:3.22.2@sha256:85f2b723e106c34644cd5851d7e81ee87da98ac54672
 FROM ${IMAGE_BASE} AS image-base
 
 
-FROM --platform=${BUILDPLATFORM} golang:1.24.6@sha256:2c89c41fb9efc3807029b59af69645867cfe978d2b877d475be0d72f6c6ce6f6 AS backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.24.10@sha256:34a51d74cf36b4c6250200f6fa63c214bb18a196710fc3e815b89556a41f43c6 AS backend-build
 
 WORKDIR /headlamp
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/headlamp/backend
 
-go 1.24.6
+go 1.24.10
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
- Dockerfile dep updates (alpine golang etc)
- go version updates

Fixes some [issues mentioned on artifact hub headlamp page](https://artifacthub.io/packages/helm/headlamp/headlamp?modal=security-report&image=ghcr.io%2Fheadlamp-k8s%2Fheadlamp%3Av0.37.0&target=ghcr.io%2Fheadlamp-k8s%2Fheadlamp%3Av0.37.0%20(alpine%203.20.6))

<img width="1042" height="568" alt="Screenshot 2025-11-11 at 11 13 37" src="https://github.com/user-attachments/assets/109a2f01-e29e-4951-83d4-26b72f493853" />


- The apps are already using 1.24.9 https://github.com/kubernetes-sigs/headlamp/actions/runs/19268267687/job/55089472130?pr=4147#step:4:12
- The containerd update was done in another PR recently.
- Alpine fixes include ssl fixes https://www.alpinelinux.org/posts/Alpine-3.19.9-3.20.8-3.21.5-3.22.2-released.html