### PR TITLE
frontend: Tooltip: eliminate micro jitter

### DIFF
--- a/frontend/src/components/common/Tooltip/TooltipLight.tsx
+++ b/frontend/src/components/common/Tooltip/TooltipLight.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import Fade from '@mui/material/Fade';
 import Tooltip, { TooltipProps } from '@mui/material/Tooltip';
 import { ReactElement, ReactNode } from 'react';
 
@@ -35,6 +36,8 @@ export default function TooltipLight(props: TooltipLightProps) {
     return (
       <Tooltip
         disableInteractive={disableInteractive}
+        TransitionComponent={Fade}
+        TransitionProps={{ timeout: 0 }}
         sx={theme => ({
           backgroundColor: theme.palette.background.default,
           color: theme.palette.resourceToolTip.color,
@@ -52,6 +55,8 @@ export default function TooltipLight(props: TooltipLightProps) {
   return (
     <Tooltip
       {...rest}
+      TransitionComponent={Fade}
+      TransitionProps={{ timeout: 0 }}
       // children prop in the mui Tooltip is defined as ReactElement which is not totally correct
       // string should be a valid child and is used a lot in this project
       // but it's not included in the ReactElement type

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -16,6 +16,7 @@
 
 import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
+import Fade from '@mui/material/Fade';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ApiError } from '../../lib/k8s/api/v2/ApiError';
@@ -60,7 +61,18 @@ export function makePodStatusLabel(pod: Pod, showContainerStatus: boolean = true
   const containerIndicators = containerStatuses.map((cs, index) => {
     const { color, tooltip } = getContainerDisplayStatus(cs);
     return (
-      <LightTooltip title={tooltip} key={index}>
+      <LightTooltip
+        title={tooltip}
+        key={index}
+        TransitionComponent={Fade}
+        TransitionProps={{ timeout: 0 }}
+        slotProps={{
+          popper: {
+            modifiers: [{ name: 'computeStyles', options: { gpuAcceleration: false } }],
+          },
+          tooltip: { sx: { maxWidth: 'none', willChange: 'opacity' } },
+        }}
+      >
         <Icon icon="mdi:circle" style={{ color }} width="1rem" height="1rem" />
       </LightTooltip>
     );
@@ -68,7 +80,18 @@ export function makePodStatusLabel(pod: Pod, showContainerStatus: boolean = true
 
   return (
     <Box display="flex" alignItems="center" gap={1}>
-      <LightTooltip title={tooltip} interactive>
+      <LightTooltip
+        title={tooltip}
+        interactive
+        TransitionComponent={Fade}
+        TransitionProps={{ timeout: 0 }}
+        slotProps={{
+          popper: {
+            modifiers: [{ name: 'computeStyles', options: { gpuAcceleration: false } }],
+          },
+          tooltip: { sx: { maxWidth: 'none', willChange: 'opacity' } },
+        }}
+      >
         <Box display="inline">
           <StatusLabel status={status}>
             {(status === 'warning' || status === 'error') && (


### PR DESCRIPTION
## Summary
This PR fixes tooltip micro jitter across the UI.

## Related Issue
N/A

## Changes

- Removed tooltip animation

## Steps to Test

1. Open the Pods page (and other pages with tooltips).
2. Hover over Status and container indicators repeatedly.

## Screenshots (if applicable)
**Before**

https://github.com/user-attachments/assets/e73459bc-6855-40f1-8315-61d33d03d0dc

**After**

https://github.com/user-attachments/assets/f326deb7-155c-4b75-bd8b-958e99bbb4da

## Notes for



 the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
