### PR TITLE
Dockerfile: Fix incorrect digest so they are not amd64, but are top level multi-arch digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go build -o ./headlamp-server ./cmd/
 
-FROM --platform=${BUILDPLATFORM} node:22@sha256:6fe286835c595e53cdafc4889e9eff903dd3008a3050c1675809148d8e0df805 AS frontend-build
+FROM --platform=${BUILDPLATFORM} node:22@sha256:dcf06103a9d4087e3244a51697adbbb85331dcb7161dbe994ca1cd07dd32e2a5 AS frontend-build
 
 # We need .git and app/ in order to get the version and git version for the frontend/.env file
 # that's generated when building the frontend.

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,5 +1,5 @@
 # Build the plugin
-FROM node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52 as builder
+FROM node:22@sha256:dcf06103a9d4087e3244a51697adbbb85331dcb7161dbe994ca1cd07dd32e2a5 as builder
 
 # Set the working directory
 WORKDIR /headlamp-plugins


### PR DESCRIPTION
The x64 digests were used accidentally for these rather than the multi arch top level ones. Which caused an issue with (at least) docker on arm64 machine when the latest image was pulled. I don't know if this issue affects containerd or kubernetes.

- **Dockerfile: Fix for alpine 3.22.2 correct digest**
- **Dockerfile: Fix for golang:1.24.10 correct digest**
- **Dockerfile: Dockerfile.plugins: Fix node:22 digests**

fixes #4155 
- https://github.com/kubernetes-sigs/headlamp/issues/4155

There's a test in a separate PR, so we can see it fails here:
- https://github.com/kubernetes-sigs/headlamp/pull/4159
