### PR TITLE
Makefile: package.json: tools: .github: Add verify-image-digests

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -33,6 +33,8 @@ jobs:
     - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
         node-version: 20.x
+    - name: Verify container image digests
+      run: npm run image:verify-image-digests
     - name: Start Cluster 1
       uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.0.0
       with:

--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,12 @@ image:
 	Dockerfile \
 	.
 
+.PHONY: image-verify-digests
+
+image-verify-digests:
+	@echo "Verifying Docker image digests..."
+	@npm run image:verify-image-digests
+
 .PHONY: build-plugins-container
 build-plugins-container:
 	$(DOCKER_CMD) $(DOCKER_BUILDX_CMD) build \

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "start:backend": "npm run backend:build && npm run backend:start",
     "start:frontend": "npm run frontend:start",
     "plugins:test": "cd plugins/headlamp-plugin && npm install && ./test-headlamp-plugin.js && ./test-plugins-examples.sh && cd ../pluginctl/src && npm install && node ./plugin-management.e2e.js && cd .. && npx jest src/multi-plugin-management.test.js && npx jest src/plugin-management.test.js && npm run test",
-    "image:build": "sh -c 'docker buildx build --pull --platform=local -t ghcr.io/headlamp-k8s/headlamp:$(git describe --tags --always --dirty) -f Dockerfile .'"
+    "image:build": "sh -c 'docker buildx build --pull --platform=local -t ghcr.io/headlamp-k8s/headlamp:$(git describe --tags --always --dirty) -f Dockerfile .'",
+    "image:verify-image-digests": "node tools/verify-image-digests.js"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"

--- a/tools/verify-image-digests.js
+++ b/tools/verify-image-digests.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+const usage = `
+Usage: node tools/verify-image-digests.js [--help]
+
+Checks Dockerfile and Dockerfile.plugins for FROM or ARG lines pinned with @sha256,
+and verifies that the digest matches the top-level multi-arch manifest list
+digest from 'docker buildx imagetools inspect'. This prevents accidentally
+pinning an x64-only digest, which would break builds for other architectures
+such as arm64.
+`;
+
+const files = ["Dockerfile", "Dockerfile.plugins"];
+
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+if (process.argv.includes("--help")) {
+  console.log(usage);
+  process.exit(0);
+}
+
+/**
+ * Extract image references with digests from a Dockerfile.
+ * 
+ * @param {string} filePath - Path to the Dockerfile.
+ * @returns {Array<{ line: string, ref: string, lineNumber: number }>} 
+ *   Array of objects, each containing:
+ *     - line: The full matched line from the Dockerfile.
+ *     - ref: The image reference with digest (e.g., "nginx:1.25@sha256:...").
+ *     - lineNumber: The 1-based line number in the file where the match was found.
+ */
+function extractImages(filePath) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const results = [];
+
+  // Match FROM lines (with optional --platform and optional AS)
+  const fromRegex = /FROM\s+(?:--platform=\$\{[^\}]+\}\s+)?([^\s@]+(?::[^\s@]+)?@sha256:[a-f0-9]{64})/gi;
+  for (const m of content.matchAll(fromRegex)) {
+    results.push({
+      line: m[0],
+      ref: m[1],
+      lineNumber: content.substring(0, m.index).split("\n").length
+    });
+  }
+
+  // Match ARG assignments with digest
+  const argRegex = /ARG\s+[A-Z0-9_]+\s*=\s*([^\s@]+(?::[^\s@]+)?@sha256:[a-f0-9]{64})/gi;
+  for (const m of content.matchAll(argRegex)) {
+    results.push({
+      line: m[0],
+      ref: m[1],
+      lineNumber: content.substring(0, m.index).split("\n").length
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Gets the top-level multi-arch manifest digest for a given image tag.
+ * 
+ * @param {string} imageTag - The image tag (e.g., "nginx:1.25").
+ * @returns {string} The top-level digest (sha256:...)
+ */
+function getTopLevelDigest(imageTag) {
+  const output = execSync(`docker buildx imagetools inspect ${imageTag}`, { encoding: "utf-8" });
+  const digestLine = output.split("\n").find(line => line.includes("Digest:"));
+  return digestLine.split(": ")[1].trim();
+}
+
+/**
+ * Checks a Dockerfile for image digest correctness.
+ *
+ * For each image reference pinned with a digest, verifies that the digest
+ * matches the top-level multi-arch manifest digest from
+ * 'docker buildx imagetools inspect'. If a mismatch is found, an error
+ * object is added to the errors array.
+ *
+ * @param {string} filePath
+ *   Path to the Dockerfile to check.
+ * @param {Array<{
+ *   file: string,
+ *   line: string,
+ *   lineNumber: number,
+ *   image: string,
+ *   pinned: string,
+ *   correct: string
+ * }>} errors
+ *   Array to collect error objects for any mismatched digests.
+ */
+function checkFile(filePath, errors, oks) {
+  const images = extractImages(filePath);
+
+  for (const { line, ref, lineNumber } of images) {
+    const [imageTag, expectedDigest] = ref.split("@");
+    console.log(`Verifying ${filePath}@${lineNumber}: ${imageTag}@${expectedDigest}`);
+    const topDigest = getTopLevelDigest(imageTag);
+
+    if (expectedDigest === topDigest) {
+      oks.push(`OK: ${line}`);
+    } else {
+      errors.push({
+        file: filePath,
+        line,
+        lineNumber,
+        image: imageTag,
+        pinned: expectedDigest,
+        correct: topDigest,
+      });
+    }
+  }
+}
+
+function main() {
+  let errors = [];
+  let oks = [];
+  for (const file of files) {
+    if (fs.existsSync(file)) {
+      checkFile(file, errors, oks);
+    } else {
+      console.warn(`Skipping ${file}, not found`);
+    }
+  }
+
+  if (errors.length > 0) {
+    // Tell the user what to do to fix the errors
+    console.error("\nDigest check failed. Some digests are not top level digests but are arch specific ones:\n");
+    for (const e of errors) {
+      console.error(`Incorrect ${e.file}@${e.lineNumber}: ${e.line}`);
+      console.error(`Suggested fix ${e.file}@${e.lineNumber}\n  ${e.image}@${e.correct}\n`);
+    }
+    process.exit(1);
+  } else {
+    for (const ok of oks) {
+      console.log(ok);
+    }
+    console.log("All digests are correct top level digests and not arch specific digests.");
+  }
+}
+
+main();


### PR DESCRIPTION
This checks the image digests in Dockerfile and Dockerfile.plugins are top level ones and not arch specific ones. If arch specific ones are used it can break other architecture images. eg. if amd64 digest is used arm64 images will be broken (at least for docker in some situations).

Tests this in CI.

Here is a CI check (build container) that failed (because it found problematic digests) https://github.com/kubernetes-sigs/headlamp/actions/runs/19334844807/job/55306879357?pr=4159#step:4:15 The issues it found are fixed in:
- https://github.com/kubernetes-sigs/headlamp/pull/4157

- [x] ~~That should be merged first before this PR.~~ merged now.

---

Example output when it finds errors. Note it tells people how to fix it.

```shell
npm run image:verify-image-digests

Verifying Dockerfile@7: golang:1.24.10@sha256:34a51d74cf36b4c6250200f6fa63c214bb18a196710fc3e815b89556a41f43c6
Verifying Dockerfile@31: node:22@sha256:6fe286835c595e53cdafc4889e9eff903dd3008a3050c1675809148d8e0df805
Verifying Dockerfile@3: alpine:3.22.2@sha256:85f2b723e106c34644cd5851d7e81ee87da98ac54672b29947c052a45d31dc2f
Verifying Dockerfile.plugins@2: node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52
Verifying Dockerfile.plugins@28: alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f

Digest check failed. Some digests are not top level digests but are arch specific ones:

Incorrect Dockerfile@7: FROM --platform=${BUILDPLATFORM} golang:1.24.10@sha256:34a51d74cf36b4c6250200f6fa63c214bb18a196710fc3e815b89556a41f43c6
Suggested fix Dockerfile@7
  golang:1.24.10@sha256:83d7392cb47ac13ce7ffce0dcbede5658087baf4dd79436831221153793791d5

Incorrect Dockerfile@31: FROM --platform=${BUILDPLATFORM} node:22@sha256:6fe286835c595e53cdafc4889e9eff903dd3008a3050c1675809148d8e0df805
Suggested fix Dockerfile@31
  node:22@sha256:dcf06103a9d4087e3244a51697adbbb85331dcb7161dbe994ca1cd07dd32e2a5

Incorrect Dockerfile@3: ARG IMAGE_BASE=alpine:3.22.2@sha256:85f2b723e106c34644cd5851d7e81ee87da98ac54672b29947c052a45d31dc2f
Suggested fix Dockerfile@3
  alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412

Incorrect Dockerfile.plugins@2: FROM node:22.9.0@sha256:69e667a79aa41ec0db50bc452a60e705ca16f35285eaf037ebe627a65a5cdf52
Suggested fix Dockerfile.plugins@2
  node:22.9.0@sha256:8398ea18b8b72817c84af283f72daed9629af2958c4f618fe6db4f453c5c9328
```

Example output when it finds everything is ok.
```
npm run image:verify-image-digests
Verifying Dockerfile@7: golang:1.24.10@sha256:83d7392cb47ac13ce7ffce0dcbede5658087baf4dd79436831221153793791d5
Verifying Dockerfile@31: node:22@sha256:dcf06103a9d4087e3244a51697adbbb85331dcb7161dbe994ca1cd07dd32e2a5
Verifying Dockerfile@3: alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
Verifying Dockerfile.plugins@2: node:22@sha256:dcf06103a9d4087e3244a51697adbbb85331dcb7161dbe994ca1cd07dd32e2a5
Verifying Dockerfile.plugins@28: alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
OK: FROM --platform=${BUILDPLATFORM} golang:1.24.10@sha256:83d7392cb47ac13ce7ffce0dcbede5658087baf4dd79436831221153793791d5
OK: FROM --platform=${BUILDPLATFORM} node:22@sha256:dcf06103a9d4087e3244a51697adbbb85331dcb7161dbe994ca1cd07dd32e2a5
OK: ARG IMAGE_BASE=alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
OK: FROM node:22@sha256:dcf06103a9d4087e3244a51697adbbb85331dcb7161dbe994ca1cd07dd32e2a5
OK: FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
All digests are correct top level digests and not arch specific digests.
```

Related to this issue:
- https://github.com/kubernetes-sigs/headlamp/issues/4155