### PR TITLE
charts: allow templating on podLabels

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       labels:
         {{- include "headlamp.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
## Summary

This PR adds a feature that enables podLabels using chart template in values.yaml file

## Related Issue

#4164

## Changes

- Replace `toYaml` with `tpl (toYaml .) $` when rendering .Values.podLabels

## Steps to Test

1. put an normal label and templated label on .Values.podLabels
```yaml
podLabels:
  app.kubernetes.io/version: "{{.Chart.AppVersion}}"
  env: "PROD"
```
2. Generate template `helm --release-name headlamp template . >all.yaml`
3.  templated label should be rendered, and normal label should left untouched

## Screenshots (if applicable)
None

## Notes for the Reviewer
None
