### PR TITLE
frontend: Display deployment node selector in UI

### DIFF
--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -132,6 +132,14 @@ export default function WorkloadDetails<T extends WorkloadClass>(props: Workload
             ),
           },
           {
+            name: t('Node Selector'),
+            value: item.spec?.template?.spec?.nodeSelector && (
+              <MetadataDictGrid
+                dict={item.spec.template.spec.nodeSelector as { [key: string]: string }}
+              />
+            ),
+          },
+          {
             name: t('Replicas'),
             value: renderReplicas(item),
             hide: !showReplicas(item),


### PR DESCRIPTION
This change adds the node selector for deployments in the details page.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/4177

### Testing
- [x] Open a deployment and note the node selector field

<img width="788" height="514" alt="image" src="https://github.com/user-attachments/assets/aad40548-9472-4b36-922f-91f3960542cb" />