### PR TITLE
.github: build-container: Only run verify image digests if some changed

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -33,7 +33,49 @@ jobs:
     - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
         node-version: 20.x
+    - name: Check if sha256 lines changed in this PR for verifying image digest changes
+      id: check-sha
+      if: github.event_name == 'pull_request'
+      run: |
+        set -euo pipefail
+
+        echo "Checking only Dockerfile and Dockerfile.plugins for sha256 changes"
+
+        # Prefer the base SHA from the PR event, which works for both forks and same-repo branches.
+        BASE_SHA="${{ github.event.pull_request.base.sha }}"
+        echo "Initial diff target from PR base SHA: $BASE_SHA"
+
+        # If the base SHA is not present in the local clone (e.g., shallow fetch), try fetching the base ref.
+        if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+          echo "Base SHA not found locally, trying to fetch base ref"
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          git fetch origin "$BASE_REF" --depth=5000 || git fetch origin "$BASE_REF" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/${BASE_REF}"; then
+            BASE_SHA="origin/${BASE_REF}"
+            echo "Using origin/${BASE_REF} as diff target"
+          else
+            echo "Warning: could not fetch base ref; falling back to PR base SHA (may fail if missing)"
+          fi
+        fi
+
+        # Try three-dot first; if there is no merge base (e.g., unrelated histories),
+        # fall back to a simple two-dot diff which doesn't require a merge base.
+        if git merge-base "$BASE_SHA" HEAD >/dev/null 2>&1; then
+          DIFF_RANGE="${BASE_SHA}...HEAD"
+        else
+          echo "No merge-base between $BASE_SHA and HEAD; using two-dot diff"
+          DIFF_RANGE="${BASE_SHA}..HEAD"
+        fi
+
+        if git diff -U0 "$DIFF_RANGE" -- Dockerfile Dockerfile.plugins | grep -E '^[+-].*sha256:' >/dev/null; then
+          echo "sha_changed=true"
+          echo "sha_changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "sha_changed=false"
+          echo "sha_changed=false" >> "$GITHUB_OUTPUT"
+        fi
     - name: Verify container image digests
+      if: github.event_name == 'pull_request' && steps.check-sha.outputs.sha_changed == 'true'
       run: npm run image:verify-image-digests
     - name: Start Cluster 1
       uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.0.0


### PR DESCRIPTION
This only checks the image digests if they are changed. Because these images can be updated quite often, which could cause quite a lot of churn. So we only check them when they are changed, which is when humans could make mistakes putting in the correct ones.

### Testing

- [x] Job for PR with NO digest changes. It does NOT run verify digests step. https://github.com/kubernetes-sigs/headlamp/actions/runs/19519731231/job/55880321808?pr=4181
- [x] Job for PR WITH digest changes. It DOES run verify digest step. https://github.com/kubernetes-sigs/headlamp/actions/runs/19519551817/job/55879781749?pr=4180