### PR TITLE
.github/workflows/trigger-website-build: Fix only run on main merge

### DIFF
--- a/.github/workflows/trigger-website-build.yml
+++ b/.github/workflows/trigger-website-build.yml
@@ -3,6 +3,8 @@ name: Trigger Headlamp website update
 # See https://github.com/kubernetes-sigs/headlamp-website
 on:
   push:
+    branches:
+      - main
     paths:
       - 'docs/**'
   workflow_dispatch:


### PR DESCRIPTION
For forked PRs this would fail because the secret is not available
to them. Which is quite often now.

So we only run it when something is merged to main branch with
docs changes.
