### PR TITLE
frontend: Service: Expose NodePort/LoadbalancerPorts directly in service column

### DIFF
--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -54,8 +54,8 @@ export default function ServiceList() {
           id: 'ports',
           label: t('Ports'),
           gridTemplate: 'auto',
-          getValue: service => service.getPorts()?.join(', '),
-          render: service => <LabelListItem labels={service.getPorts() ?? []} />,
+          getValue: service => service.getFormattedPorts()?.join(', '),
+          render: service => <LabelListItem labels={service.getFormattedPorts() ?? []} />,
         },
         {
           id: 'selector',

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -851,11 +851,11 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ccolv7-MuiTableCell-root"
               >
                 <span
-                  aria-label="80"
+                  aria-label="80:8080/TCP"
                   class=""
                   data-mui-internal-clone-element="true"
                 >
-                  80
+                  80:8080/TCP
                 </span>
               </td>
               <td

--- a/frontend/src/lib/k8s/service.ts
+++ b/frontend/src/lib/k8s/service.ts
@@ -104,6 +104,15 @@ class Service extends KubeObject<KubeService> {
     return this.spec?.ports?.map(port => port.port);
   }
 
+  getFormattedPorts() {
+    return this.spec?.ports?.map(({ port, nodePort, targetPort, protocol }) => {
+      const isSamePort = targetPort && Number(targetPort) === port;
+      const secondary = nodePort ?? (targetPort && isSamePort ? undefined : targetPort);
+      const label = secondary ? `${port}:${secondary}` : `${port}`;
+      return protocol ? `${label}/${protocol}` : label;
+    });
+  }
+
   getSelector() {
     return Object.entries(this.spec?.selector || {}).map(([key, value]) => `${key}=${value}`);
   }


### PR DESCRIPTION
## Summary

This PR improves port visibility in the Service Overview by including nodePort and targetPort directly in the Ports column. 

## Related Issue

Fixes #3808 

## Changes

- Updated Service.getPorts() to display external ports in port:nodePort/Protocol or port:targetPort/Protocol format.

## Steps to Test

1. Navigate to Network > Services.
2. Check the Ports column for NodePort or LoadBalancer services; 
   -> it should show port:nodePort/Protocol.

## Screenshots (if applicable)
**Before**
<img width="2586" height="985" alt="Screenshot 2025-11-20 at 6 02 14 PM" src="https://github.com/user-attachments/assets/9d0c793f-5edc-4dab-a148-af0824f1e1e9" />

**After**
<img width="2559" height="894" alt="image" src="https://github.com/user-attachments/assets/d4e0c44e-ed92-474b-95f2-20f7be80d8d0" />


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
