### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -126,7 +126,7 @@ Headlamp consists of the following major components:
 
 The following components are in separate GitHub repos:
 - **Plugins**: Extensible modules that add custom functionality to the UI. The Headlamp team maintains their plugins in the [headlamp-k8s/plugins repo](https://github.com/headlamp-k8s/plugins). These include plugins for projects like Flux, Backstage and Inspektor Gadget.
-- **Headlamp Website**: Maintained in the [headlamp-k8s/website repo](https://github.com/headlamp-k8s/website). This contains things like the blog and the documentation. The website can be found at https://headlamp.dev/
+- **Headlamp Website**: Maintained in the [headlamp-k8s/headlamp-website repo](https://github.com/headlamp-k8s/headlamp-website). This contains things like the blog and the documentation. The website can be found at https://headlamp.dev/
 
 ### npm scripts entry point
 

--- a/docs/development/i18n/contributing.md
+++ b/docs/development/i18n/contributing.md
@@ -26,7 +26,7 @@ In Headlamp, namespaces are separated by a `|` character. E.g. `t('glossary|Pod'
 
 ## Context
 
-In order to better express context for a translation, we use the [i18next context](https://www.i18next.com/principles/context) feature. It is used like this:
+In order to better express context for a translation, we use the [i18next context](https://www.i18next.com/translation-function/context) feature. It is used like this:
 
 ```typescript
 return t("translation|Desired", { context: "pods" });

--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -90,7 +90,7 @@ Change the Cluster Chooser button in the top middle of the app bar with
 
 ![screenshot of the cluster chooser button](../images/cluster-chooser.png)
 
-- Example plugin: [How To Register Cluster Chooser button](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/clusterchooser)
+- Example plugin: [How To Register Cluster Chooser button](https://github.com/kubernetes-sigs/headlamp/tree/main/plugins/examples/cluster-chooser)
 - API reference: [registerClusterChooser](../../api/plugin/registry/functions/registerclusterchooser)
 
 ### Details View Header Action


### PR DESCRIPTION
This change fixes broken links identified in an audit of the website.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/4187