### PR TITLE
app: frontend: Fix function name typos

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1324,7 +1324,7 @@ function adjustZoom(delta: number) {
   setZoom(newZoom);
 }
 
-function startElecron() {
+function startElectron() {
   console.info('App starting...');
 
   let appVersion: string;
@@ -1812,6 +1812,6 @@ if (isHeadlessMode) {
   );
 } else {
   if (!isRunningScript) {
-    startElecron();
+    startElectron();
   }
 }

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -192,7 +192,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
    * Now handles plugins by both name and type to support multiple versions of the same plugin.
    * When enabling a plugin, it automatically disables other versions of the same plugin.
    */
-  function switchChangeHanlder(plug: { name: any; type?: string; isEnabled?: boolean }) {
+  function switchChangeHandler(plug: { name: any; type?: string; isEnabled?: boolean }) {
     const plugName = plug.name;
     const plugType = plug.type;
     const newEnabledState = !plug.isEnabled;
@@ -375,7 +375,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                   <EnableSwitch
                     aria-label={`Toggle ${plugin.name}`}
                     checked={isChecked}
-                    onChange={() => switchChangeHanlder(plugin)}
+                    onChange={() => switchChangeHandler(plugin)}
                     color="primary"
                     name={plugin.name}
                   />


### PR DESCRIPTION
This change fixes misspelled functions for clarity.

Fixes: https://github.com/kubernetes-sigs/headlamp/issues/4193