### PR TITLE
frontend: Map: Add null check for ingress relation

### DIFF
--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -167,7 +167,7 @@ const endpointSlicesToServices = makeRelation(
 );
 
 const ingressToService = makeRelation(Ingress, Service, (ingress, service) =>
-  ingress.spec.rules?.find((rule: any) =>
+  ingress.spec?.rules?.find((rule: any) =>
     rule.http?.paths?.find((path: any) => service.metadata.name === path?.backend?.service?.name)
   )
 );


### PR DESCRIPTION
This PR adds an additional null check for spec field in ingress relation.
This should fix #4133 but I don't have a way to reproduce or validate this fix.

