### PR TITLE
frontend: Add support for project header actions

### DIFF
--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -492,6 +492,7 @@
   "registerPluginSettings": [Function],
   "registerProjectDeleteButton": [Function],
   "registerProjectDetailsTab": [Function],
+  "registerProjectHeaderAction": [Function],
   "registerProjectOverviewSection": [Function],
   "registerResourceTableColumnsProcessor": [Function],
   "registerRoute": [Function],

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -94,10 +94,12 @@ import { addOverviewChartsProcessor, OverviewChartsProcessor } from '../redux/ov
 import {
   addCustomCreateProject,
   addDetailsTab,
+  addHeaderAction,
   addOverviewSection,
   CustomCreateProject,
   ProjectDeleteButton,
   ProjectDetailsTab,
+  ProjectHeaderAction,
   ProjectOverviewSection,
   setProjectDeleteButton,
 } from '../redux/projectsSlice';
@@ -1121,6 +1123,33 @@ export function registerProjectOverviewSection(projectOverviewSection: ProjectOv
  */
 export function registerProjectDeleteButton(projectDeleteButton: ProjectDeleteButton) {
   store.dispatch(setProjectDeleteButton(projectDeleteButton));
+}
+
+/**
+ * Register a new action button in the project details header.
+ *
+ * This allows plugins to add custom action buttons next to the delete button
+ * in the project details page header.
+ *
+ * @param projectHeaderAction - The action configuration to register
+ * @param projectHeaderAction.id - Unique identifier for the action
+ * @param projectHeaderAction.component - React component to render as the action button
+ * @param projectHeaderAction.isEnabled - Optional function to determine if action is displayed
+ *
+ * @example
+ * ```tsx
+ * registerProjectHeaderAction({
+ *   id: 'deploy-app',
+ *   component: ({ project }) => (
+ *     <Button onClick={() => navigate(`/deploy/${project.id}`)}>
+ *       Deploy App
+ *     </Button>
+ *   )
+ * });
+ * ```
+ */
+export function registerProjectHeaderAction(projectHeaderAction: ProjectHeaderAction) {
+  store.dispatch(addHeaderAction(projectHeaderAction));
 }
 
 export {

--- a/frontend/src/redux/projectsSlice.ts
+++ b/frontend/src/redux/projectsSlice.ts
@@ -62,17 +62,26 @@ export interface ProjectDeleteButton {
   component: (props: { project: ProjectDefinition; buttonStyle?: ButtonStyle }) => ReactNode;
 }
 
+export interface ProjectHeaderAction {
+  id: string;
+  component: (props: { project: ProjectDefinition }) => ReactNode;
+  /** Function to check if this action should be displayed in the given project. If not provided the action will be enabled. */
+  isEnabled?: ({ project }: { project: ProjectDefinition }) => Promise<boolean>;
+}
+
 export interface ProjectsState {
   customCreateProject: Record<string, CustomCreateProject>;
   overviewSections: Record<string, ProjectOverviewSection>;
   detailsTabs: Record<string, ProjectDetailsTab>;
   projectDeleteButton?: ProjectDeleteButton;
+  headerActions: Record<string, ProjectHeaderAction>;
 }
 
 const initialState: ProjectsState = {
   customCreateProject: {},
   detailsTabs: {},
   overviewSections: {},
+  headerActions: {},
 };
 
 const projectsSlice = createSlice({
@@ -98,10 +107,20 @@ const projectsSlice = createSlice({
     setProjectDeleteButton(state, action: PayloadAction<ProjectDeleteButton>) {
       state.projectDeleteButton = action.payload;
     },
+
+    /** Register additional action button for project header */
+    addHeaderAction(state, action: PayloadAction<ProjectHeaderAction>) {
+      state.headerActions[action.payload.id] = action.payload;
+    },
   },
 });
 
-export const { addCustomCreateProject, addDetailsTab, addOverviewSection, setProjectDeleteButton } =
-  projectsSlice.actions;
+export const {
+  addCustomCreateProject,
+  addDetailsTab,
+  addOverviewSection,
+  setProjectDeleteButton,
+  addHeaderAction,
+} = projectsSlice.actions;
 
 export default projectsSlice.reducer;

--- a/plugins/headlamp-plugin/src/index.ts
+++ b/plugins/headlamp-plugin/src/index.ts
@@ -68,6 +68,7 @@ import Registry, {
   registerPluginSettings,
   registerProjectDeleteButton,
   registerProjectDetailsTab,
+  registerProjectHeaderAction,
   registerProjectOverviewSection,
   registerResourceTableColumnsProcessor,
   registerRoute,
@@ -129,6 +130,7 @@ export {
   registerCustomCreateProject,
   registerProjectDetailsTab,
   registerProjectOverviewSection,
+  registerProjectHeaderAction,
   registerClusterStatus,
   registerProjectDeleteButton,
 };


### PR DESCRIPTION
## Summary

This PR adds ability for plugins to add custom header actions in project details


Change from aks-desktop
