### PR TITLE
docs/oidc.md: Fix typo

### DIFF
--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -74,7 +74,7 @@ In the event your OIDC Provider issues `access_tokens` from a different Issuer U
 
 ### Use Access Tokens instead of ID Tokens
 
-Be default, headlamp leverages the `id_token` provided back from the OIDC Provider after authentication returned to the `/oidc-callback` endpoint. For some Identity Providers like Azure Entra ID, the `access_token` is what is used for authorization to Kubernetes clusters. To instruct headlamp to use the `access_token` instead of the `id_token`, the following flag can be used.
+By default, headlamp leverages the `id_token` provided back from the OIDC Provider after authentication returned to the `/oidc-callback` endpoint. For some Identity Providers like Azure Entra ID, the `access_token` is what is used for authorization to Kubernetes clusters. To instruct headlamp to use the `access_token` instead of the `id_token`, the following flag can be used.
 
 - `-oidc-use-access-token=true` or env var `HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN`
 


### PR DESCRIPTION
Fix typo: "Be default" -> "By default"

## Summary

This PR fixes typo in documentation.

## Related Issue

Fixes #ISSUE_NUMBER  

## Changes

- Fixed typo

## Steps to Test

1. [Step 1: e.g., Navigate to ...]
2. [Step 2: Click on ...]
3. [Step 3: Observe behavior or check logs/output]

## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
