### PR TITLE
add -oidc-scopes parameter only if scopes are actually provided

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -285,7 +285,9 @@ spec:
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            {{- if or (ne $oidc.scopes "") (ne $scopes "") }}
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            {{- end }}
             {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
             # Check if callbackURL is non empty either from env or oidc.config
             - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"


### PR DESCRIPTION
This pull request introduces a conditional check to the Helm chart deployment template for Headlamp, ensuring that the OIDC scopes argument is only included when the relevant value is set. This improves the flexibility and correctness of the deployment configuration.

Enhancement to OIDC configuration:

* [`charts/headlamp/templates/deployment.yaml`](diffhunk://#diff-930e3d10431541186fdce080b0d63ffdd19741ba8b0453153588ed4331240b0dR288-R290): Added a conditional block so that the `-oidc-scopes=$(OIDC_SCOPES)` argument is only included if either `$oidc.scopes` or `$scopes` is not empty, preventing unnecessary or empty configuration arguments.## Summary

## Related Issue

Fixes #4220 
