### PR TITLE
frontend: Fix wrong apiVersion used when CRUDing a CustomResource

### DIFF
--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -103,6 +103,7 @@ class CustomResourceDefinition extends KubeObject<KubeCRD> {
       for (const versionItem of this.spec.versions) {
         if (!!versionItem.storage) {
           version = versionItem.name;
+          break;
         } else if (!version) {
           version = versionItem.name;
         }
@@ -190,6 +191,22 @@ export function makeCustomResourceClass(
     static isNamespaced = objArgs.isNamespaced;
     static apiEndpoint = apiFunc(...apiInfoArgs);
     static customResourceDefinition = crClassArgs.customResourceDefinition;
+
+    static getBaseObject(): Omit<KubeObjectInterface, 'metadata'> & {
+      metadata: Partial<import('./KubeMetadata').KubeMetadata>;
+    } {
+      // For custom resources, use the storage version from the CRD
+      const [group, version] = crClassArgs.customResourceDefinition.getMainAPIGroup();
+      const apiVersion = group ? `${group}/${version}` : version;
+
+      return {
+        apiVersion,
+        kind: this.kind,
+        metadata: {
+          name: '',
+        },
+      };
+    }
   };
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the "wrong apiVersion set on the editor" bug by actually checking the storage version of the CRD when getting the BaseObject.

## Related Issue

Fixes #4223 

## Changes

- Added/Updated [component/file/logic]
- Fixed [bug/issue/typo]
- Refactored [code/module] for clarity/performance

## Steps to Test
Prerequisites:
Having a CRD that have multiple versions installed on the cluster

Steps to reproduce the bug:
1. Go to the 'Custom Resources' page of that CRD
2. Click 'Create' to enter in the editor
3. See the `apiVersion` is correctly set to the actual storage version of the CRD

## Screenshots (if applicable)
The CRD versions:
<img width="340" height="350" alt="Image" src="https://github.com/user-attachments/assets/9ef0c8f3-5970-4e78-a28f-349f3644dadd" />

The `apiVersion` automatically set when creating the Custom Resource:
<img width="548" height="140" alt="image" src="https://github.com/user-attachments/assets/9429da84-f1fd-4f87-9a15-015f88831f01" />

