### PR TITLE
backend: embed: open Headlamp in default browser

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -28,6 +28,7 @@ require (
 )
 
 require (
+	github.com/cli/browser v1.3.0
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jmespath/go-jmespath v0.4.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -64,6 +64,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnTiM80=
 github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
+github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
+github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -159,6 +159,16 @@ func TestParseErrors(t *testing.T) {
 			args:          []string{"go run ./cmd", "--base-url=testingthis"},
 			errorContains: "base-url",
 		},
+		{
+			name:          "no_browser_without_embed",
+			args:          []string{"go run ./cmd", "--no-browser"},
+			errorContains: "no-browser cannot be used when running without embedded frontend",
+		},
+		{
+			name:          "no_browser_in_cluster",
+			args:          []string{"go run ./cmd", "--no-browser", "--in-cluster"},
+			errorContains: "no-browser cannot be used in in-cluster mode",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Open Headlamp (localhost:4466) in the default
browser when the binary is built with the 'embed'
tag. This default behaviour can be disabled by
using the -no-browser flag.

## Related Issue

Fixes #ISSUE_NUMBER  

## Changes

- Added/Updated [component/file/logic]
- Fixed [bug/issue/typo]
- Refactored [code/module] for clarity/performance

## Steps to Test

1. Build the backend embedded binary by running 
> make backend-embed
2. Run the binary 
> ./backend/headlamp-server
The binary should start the backend server and open locahost:4466 in the default browser
3. Run the binary with the `--no-browser` flag
> ./backend/headlamp-server --no-browser
The binary should just start the backend server