### PR TITLE
CI: test: add in-cluster Headlamp e2e test

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -137,8 +137,12 @@ jobs:
     - name: Import images to kind
       run: |
         export SHELL=/bin/bash
+        # Load images into Cluster 1 (test)
         kind load docker-image ghcr.io/headlamp-k8s/headlamp-plugins-test:latest --name test
         kind load docker-image ghcr.io/headlamp-k8s/headlamp:latest --name test
+
+        # Load Headlamp image into Cluster 2 (test2) so it can run in-cluster tests there
+        kind load docker-image ghcr.io/headlamp-k8s/headlamp:latest --name test2
     - name: Test .plugins folder
       if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |
@@ -230,6 +234,70 @@ jobs:
           exit 1
         else
           echo "Playwright tests passed successfully"
+        fi
+    - name: Deploy Headlamp in in-cluster mode and run TS API tests
+      run: |
+        # Reuse Cluster 2 context for in-cluster tests
+        kubectl config use-context test2
+
+        # Setup service account and RBAC for Headlamp
+        kubectl create serviceaccount headlamp --namespace kube-system || true
+        kubectl create clusterrolebinding headlamp --serviceaccount=kube-system:headlamp --clusterrole=cluster-admin || true
+        kubectl get serviceaccount headlamp -n kube-system
+
+        # Deploy Headlamp with in-cluster mode
+        kubectl apply -f e2e-tests/kubernetes-headlamp-incluster-ci.yaml
+
+        echo "Waiting for headlamp deployment to be available (in-cluster)..."
+        kubectl wait deployment -n kube-system headlamp --for condition=Available=True --timeout=120s
+        kubectl get pods -n kube-system -l app.kubernetes.io/name=headlamp
+
+        echo "Checking headlamp pod status (in-cluster)..."
+        kubectl logs -n kube-system -l app.kubernetes.io/name=headlamp --tail=50 || true
+
+        # Start port-forward in background
+        echo "Starting port-forward to headlamp service (in-cluster)..."
+        kubectl port-forward -n kube-system service/headlamp 8080:80 &
+        PORT_FORWARD_PID=$!
+
+        # Wait for port-forward to be ready
+        sleep 5
+
+        # Verify port-forward is working
+        if ! kill -0 $PORT_FORWARD_PID 2>/dev/null; then
+          echo "❌ Port-forward failed to start for in-cluster test"
+          exit 1
+        fi
+
+        export HEADLAMP_TEST_URL="http://localhost:8080"
+        echo "In-cluster Headlamp URL: $HEADLAMP_TEST_URL"
+
+        # Get service account token for API checks
+        echo "Getting service account token for in-cluster test..."
+        export HEADLAMP_SA_TOKEN=$(kubectl create token headlamp --duration=1h -n kube-system)
+
+        if [ -z "$HEADLAMP_SA_TOKEN" ]; then
+          echo "❌ Failed to get service account token for in-cluster test"
+          kill $PORT_FORWARD_PID 2>/dev/null || true
+          exit 1
+        fi
+
+        echo "✅ Service account token obtained"
+        echo "Running in-cluster API Playwright tests..."
+
+        # Run the TypeScript in-cluster API tests
+        cd e2e-tests
+        npm ci
+        npx playwright install --with-deps
+        npx playwright test tests/incluster-api.spec.ts
+        EXIT_CODE=$?
+
+        # Cleanup port-forward
+        kill $PORT_FORWARD_PID 2>/dev/null || true
+
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "❌ In-cluster API tests failed with exit code $EXIT_CODE"
+          exit $EXIT_CODE
         fi
     # Clear disk space by removing unnecessary files, apt files and uninstall some playwright dependencies
     - name: Clear Disk Space

--- a/e2e-tests/kubernetes-headlamp-incluster-ci.yaml
+++ b/e2e-tests/kubernetes-headlamp-incluster-ci.yaml
@@ -1,0 +1,55 @@
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: kube-system
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 4466
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      containers:
+      - name: headlamp
+        securityContext:
+          privileged: false
+          runAsGroup: 101
+          runAsNonRoot: true
+          runAsUser: 100
+        image: "ghcr.io/headlamp-k8s/headlamp:latest"
+        imagePullPolicy: Never
+        args:
+        - "-in-cluster"
+        ports:
+        - name: http
+          containerPort: 4466
+          protocol: TCP
+      nodeSelector:
+        'kubernetes.io/os': linux
+

--- a/e2e-tests/tests/incluster-api.spec.ts
+++ b/e2e-tests/tests/incluster-api.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * In-cluster API integration tests.
+ *
+ * These tests assume:
+ * - Headlamp is running in-cluster mode and exposed locally via port-forward
+ *   at HEADLAMP_TEST_URL (e.g. http://localhost:8080)
+ * - A service account token with cluster-admin permissions is available in
+ *   HEADLAMP_SA_TOKEN
+ */
+
+import { expect, test } from '@playwright/test';
+
+const baseURL = process.env.HEADLAMP_TEST_URL || 'http://localhost:8080';
+const saToken = process.env.HEADLAMP_SA_TOKEN || '';
+
+// Only run these tests when explicitly configured (e.g. from CI in in-cluster job).
+// In all other environments, they are skipped so they don't interfere with normal e2e runs.
+const shouldRun = !!saToken;
+
+test.describe('Headlamp in-cluster API', () => {
+  test.skip(!shouldRun, 'HEADLAMP_SA_TOKEN is not set; skipping in-cluster API tests');
+
+  test('can list namespaces via /clusters/main/api/v1/namespaces', async ({ request }) => {
+    const response = await request.get('/clusters/main/api/v1/namespaces', {
+      headers: {
+        Authorization: `Bearer ${saToken}`,
+      },
+      baseURL,
+    });
+
+    expect(response.status(), 'expected 200 from namespaces API').toBe(200);
+
+    const body = await response.json();
+
+    // Basic sanity checks – structure may vary between clusters, so keep it loose
+    expect(body).toHaveProperty('items');
+    expect(Array.isArray(body.items)).toBe(true);
+  });
+
+  test('can list nodes via /clusters/main/api/v1/nodes', async ({ request }) => {
+    const response = await request.get('/clusters/main/api/v1/nodes', {
+      headers: {
+        Authorization: `Bearer ${saToken}`,
+      },
+      baseURL,
+    });
+
+    expect(response.status(), 'expected 200 from nodes API').toBe(200);
+
+    const body = await response.json();
+    expect(body).toHaveProperty('items');
+    expect(Array.isArray(body.items)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

this patch adds in-cluster e2e test case where
the built image is deployed to a cluster as
in-cluster deployment and it is tested by
creating a service account token.
