### PR TITLE
backend: auth: Extract RefreshAndSetToken from headlamp.go

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -933,49 +933,6 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	return r
 }
 
-func (c *HeadlampConfig) refreshAndSetToken(oidcAuthConfig *kubeconfig.OidcConfig,
-	cache cache.Cache[interface{}], token string,
-	w http.ResponseWriter, r *http.Request, cluster string, span trace.Span, ctx context.Context,
-) {
-	// The token type to use
-	tokenType := "id_token"
-	if c.OidcUseAccessToken {
-		tokenType = "access_token"
-	}
-
-	idpIssuerURL := c.OidcIdpIssuerURL
-	if idpIssuerURL == "" {
-		idpIssuerURL = oidcAuthConfig.IdpIssuerURL
-	}
-
-	newToken, err := auth.RefreshAndCacheNewToken(
-		ctx,
-		oidcAuthConfig,
-		cache,
-		tokenType,
-		token,
-		idpIssuerURL,
-	)
-	if err != nil {
-		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
-			err, "failed to refresh token")
-		c.TelemetryHandler.RecordError(span, err, "Token refresh failed")
-		c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error", "token_refresh_failure"))
-	} else if newToken != nil {
-		var newTokenString string
-		if c.OidcUseAccessToken {
-			newTokenString = newToken.Extra("access_token").(string)
-		} else {
-			newTokenString = newToken.Extra("id_token").(string)
-		}
-
-		// Set refreshed token in cookie
-		auth.SetTokenCookie(w, r, cluster, newTokenString, c.BaseURL, c.SessionTTL)
-
-		c.TelemetryHandler.RecordEvent(span, "Token refreshed successfully")
-	}
-}
-
 // setTokenFromCookie attempts to get a token from the cookie and set it as Authorization header.
 func setTokenFromCookie(r *http.Request, clusterName string) {
 	tokenFromCookie, err := auth.GetTokenFromCookie(r, clusterName)
@@ -1062,6 +1019,9 @@ func (c *HeadlampConfig) handleOIDCAuthConfigError(err error, w http.ResponseWri
 	return false
 }
 
+// TODO: moving functions one at a time, this will be relocated
+//
+//nolint:funlen
 func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -1113,7 +1073,21 @@ func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Hand
 		}
 
 		// refresh and cache new token
-		c.refreshAndSetToken(oidcAuthConfig, c.Cache, token, w, r, cluster, span, ctx)
+		auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
+			Ctx:                ctx,
+			OIDCAuthConfig:     oidcAuthConfig,
+			Cache:              c.Cache,
+			Token:              token,
+			Cluster:            cluster,
+			Span:               span,
+			Writer:             w,
+			Request:            r,
+			TelemetryHandler:   c.TelemetryHandler,
+			OIDCUseAccessToken: c.OidcUseAccessToken,
+			OIDCIdpIssuerURL:   c.OidcIdpIssuerURL,
+			BaseURL:            c.BaseURL,
+			SessionTTL:         c.SessionTTL,
+		})
 
 		next.ServeHTTP(w, r)
 		c.TelemetryHandler.RecordDuration(ctx, start,

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -36,6 +36,9 @@ import (
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
 )
 
@@ -487,4 +490,64 @@ func marshalToString(val interface{}) (string, bool) {
 	}
 
 	return string(b), true
+}
+
+// RefreshAndSetTokenParams groups the inputs required to refresh a token and
+// update the Headlamp auth cookie.
+type RefreshAndSetTokenParams struct {
+	Ctx                context.Context
+	OIDCAuthConfig     *kubeconfig.OidcConfig
+	Cache              cache.Cache[interface{}]
+	Token              string
+	Cluster            string
+	Span               trace.Span
+	Writer             http.ResponseWriter
+	Request            *http.Request
+	TelemetryHandler   *telemetry.RequestHandler
+	OIDCUseAccessToken bool
+	OIDCIdpIssuerURL   string
+	BaseURL            string
+	SessionTTL         int
+}
+
+// RefreshAndSetToken refreshes an expiring token, updates the auth cookie,
+// and records telemetry based on the provided parameters.
+func RefreshAndSetToken(params RefreshAndSetTokenParams) {
+	// The token type to use
+	tokenType := "id_token"
+	if params.OIDCUseAccessToken {
+		tokenType = "access_token"
+	}
+
+	idpIssuerURL := params.OIDCIdpIssuerURL
+	if idpIssuerURL == "" {
+		idpIssuerURL = params.OIDCAuthConfig.IdpIssuerURL
+	}
+
+	newToken, err := RefreshAndCacheNewToken(
+		params.Ctx,
+		params.OIDCAuthConfig,
+		params.Cache,
+		tokenType,
+		params.Token,
+		idpIssuerURL,
+	)
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": params.Cluster},
+			err, "failed to refresh token")
+		params.TelemetryHandler.RecordError(params.Span, err, "Token refresh failed")
+		params.TelemetryHandler.RecordErrorCount(params.Ctx, attribute.String("error", "token_refresh_failure"))
+	} else if newToken != nil {
+		var newTokenString string
+		if params.OIDCUseAccessToken {
+			newTokenString = newToken.Extra("access_token").(string)
+		} else {
+			newTokenString = newToken.Extra("id_token").(string)
+		}
+
+		// Set refreshed token in cookie
+		SetTokenCookie(params.Writer, params.Request, params.Cluster, newTokenString, params.BaseURL, params.SessionTTL)
+
+		params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
+	}
 }

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -605,6 +606,17 @@ func newOIDCProviderServer(t *testing.T, tokenHandler http.HandlerFunc) *httptes
 	return srv
 }
 
+func findAuthCookie(resp *http.Response, cluster string) (string, bool) {
+	want := fmt.Sprintf("headlamp-auth-%s.0", auth.SanitizeClusterName(cluster))
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == want {
+			return cookie.Value, true
+		}
+	}
+
+	return "", false
+}
+
 var oauthSuccessBody = map[string]any{
 	"access_token":  "AT",
 	"token_type":    "Bearer",
@@ -795,6 +807,136 @@ func TestRefreshAndCacheNewToken_TokenError(t *testing.T) {
 	assert.Contains(t, err.Error(), "refreshing token")
 	assert.Len(t, fc.setCalls, 0)
 	assert.Len(t, fc.setWithTTLCalls, 0)
+}
+
+func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
+	const (
+		oldToken = "OLD"
+		cluster  = "test"
+	)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + oldToken: "REFRESH_OLD"}}
+
+	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
+		require.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
+	rr := httptest.NewRecorder()
+
+	auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
+		Ctx:              context.Background(),
+		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret", IdpIssuerURL: srv.URL},
+		Cache:            fc,
+		Token:            oldToken,
+		Cluster:          cluster,
+		Writer:           rr,
+		Request:          req,
+		TelemetryHandler: &telemetry.RequestHandler{},
+		OIDCIdpIssuerURL: "",
+		BaseURL:          "",
+	})
+
+	resp := rr.Result()
+
+	defer func() { _ = resp.Body.Close() }()
+
+	cookieVal, ok := findAuthCookie(resp, cluster)
+	require.True(t, ok, "expected auth cookie to be set")
+	assert.Equal(t, "NEW", cookieVal)
+}
+
+func TestRefreshAndSetToken_UsesAccessToken(t *testing.T) {
+	const (
+		oldToken = "OLD"
+		cluster  = "test"
+	)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + oldToken: "REFRESH_OLD"}}
+
+	tokenBody := map[string]any{
+		"access_token":  "ACCESS_NEW",
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"refresh_token": refreshNew,
+		"id_token":      "IGNORED",
+	}
+
+	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(tokenBody))
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
+	rr := httptest.NewRecorder()
+
+	auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
+		Ctx:                context.Background(),
+		OIDCAuthConfig:     &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
+		Cache:              fc,
+		Token:              oldToken,
+		Cluster:            cluster,
+		Writer:             rr,
+		Request:            req,
+		TelemetryHandler:   &telemetry.RequestHandler{},
+		OIDCUseAccessToken: true,
+		OIDCIdpIssuerURL:   srv.URL,
+		BaseURL:            "",
+	})
+
+	resp := rr.Result()
+
+	defer func() { _ = resp.Body.Close() }()
+
+	cookieVal, ok := findAuthCookie(resp, cluster)
+	require.True(t, ok, "expected auth cookie to be set")
+	assert.Equal(t, "ACCESS_NEW", cookieVal)
+}
+
+func TestRefreshAndSetToken_ErrorDoesNotSetCookie(t *testing.T) {
+	const (
+		oldToken = "OLD"
+		cluster  = "test"
+	)
+
+	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + oldToken: "REFRESH_OLD"}}
+
+	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "token refresh failed", http.StatusInternalServerError)
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/"+cluster, nil)
+	rr := httptest.NewRecorder()
+
+	auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
+		Ctx:              context.Background(),
+		OIDCAuthConfig:   &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"},
+		Cache:            fc,
+		Token:            oldToken,
+		Cluster:          cluster,
+		Writer:           rr,
+		Request:          req,
+		TelemetryHandler: &telemetry.RequestHandler{},
+		OIDCIdpIssuerURL: srv.URL,
+		BaseURL:          "",
+	})
+
+	resp := rr.Result()
+
+	defer func() { _ = resp.Body.Close() }()
+
+	_, ok := findAuthCookie(resp, cluster)
+	assert.False(t, ok, "expected no auth cookie to be set on error")
 }
 
 // TestConfigureTLSContext_NoConfig tests when both skipTLSVerify and caCert are not set.


### PR DESCRIPTION
This change extracts the RefreshAndSetToken function from headlamp.go into the auth package.

Part of:
- #3482

### Updates
- Add params struct to help move future functions
- Add comprehensive tests in `auth_test.go`

### Testing
```shell
cd backend
go test -v ./pkg/auth -run RefreshAndSetToken
```