### PR TITLE
headlamp-plugin: Remove unused dependencies

### DIFF
--- a/plugins/headlamp-plugin/dependencies-sync.js
+++ b/plugins/headlamp-plugin/dependencies-sync.js
@@ -71,6 +71,7 @@ const dependenciesToNotCopy = [
   'openapi-types',
   'resize-observer-polyfill',
   'vitest-canvas-mock',
+  '@tanstack/react-query-devtools',
 ];
 
 const yargs = require('yargs/yargs');

--- a/plugins/headlamp-plugin/package-lock.json
+++ b/plugins/headlamp-plugin/package-lock.json
@@ -30,7 +30,6 @@
         "@storybook/react-vite": "^9.1.2",
         "@storybook/react-webpack5": "^9.1.2",
         "@tanstack/react-query": "^5.51.24",
-        "@tanstack/react-query-devtools": "^5.51.24",
         "@testing-library/dom": "^10.1.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
@@ -3492,16 +3491,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.84.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.84.0.tgz",
-      "integrity": "sha512-fbF3n+z1rqhvd9EoGp5knHkv3p5B2Zml1yNRjh7sNXklngYI5RVIWUrUjZ1RIcEoscarUb0+bOvIs5x9dwzOXQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@tanstack/react-query": {
       "version": "5.85.5",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.5.tgz",
@@ -3515,23 +3504,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.85.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.85.5.tgz",
-      "integrity": "sha512-6Ol6Q+LxrCZlQR4NoI5181r+ptTwnlPG2t7H9Sp3klxTBhYGunONqcgBn2YKRPsaKiYM8pItpKMdMXMEINntMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.84.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.85.5",
         "react": "^18 || ^19"
       }
     },

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -35,7 +35,6 @@
     "@storybook/react-vite": "^9.1.2",
     "@storybook/react-webpack5": "^9.1.2",
     "@tanstack/react-query": "^5.51.24",
-    "@tanstack/react-query-devtools": "^5.51.24",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
This continues the work of removing unused dependencies in Headlamp.

Related issue: https://github.com/kubernetes-sigs/headlamp/issues/3425

### Testing
- [x] Run `npm i && npm run build` in `headlamp-plugin` and ensure no failures