### PR TITLE
helm: add extraContainers field

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -382,6 +382,9 @@ spec:
               {{- toYaml $defaultSC | nindent 12 }}
             {{- end }}
         {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -28,6 +28,9 @@ namespaceOverride: ""
 # -- An optional list of init containers to be run before the main containers.
 initContainers: []
 
+# -- An optional list of extra containers to be run along side the main containers.
+extraContainers: []
+
 config:
   inCluster: true
   # -- base url path at which headlamp should run


### PR DESCRIPTION
## Summary

This PR adds option to define extraContainers.

## Related Issue

Fixes #4239

## Changes

- Added extraContainers field to values.yaml
- Added extraContainers to deployment.yaml

## Steps to Test

1. Set desired extraContainers
2. execute helm template

Example output:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-release-headlamp
  namespace: default
  labels:
    helm.sh/chart: headlamp-0.38.0
    app.kubernetes.io/name: headlamp
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/version: "0.38.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: headlamp
      app.kubernetes.io/instance: my-release
  template:
    metadata:
      labels:
        app.kubernetes.io/name: headlamp
        app.kubernetes.io/instance: my-release
    spec:
      serviceAccountName: my-release-headlamp
      automountServiceAccountToken: true
      securityContext:
        {}
      containers:
        - name: headlamp
          securityContext:
            privileged: false
            runAsGroup: 101
            runAsNonRoot: true
            runAsUser: 100
          image: "ghcr.io/headlamp-k8s/headlamp:v0.38.0"
          imagePullPolicy: IfNotPresent
          
          env:
          args:
            - "-in-cluster"
            - "-plugins-dir=/headlamp/plugins"
            # Check if externalSecret is disabled
          ports:
            - name: http
              containerPort: 4466
              protocol: TCP
          livenessProbe:
            httpGet:
              path: "/"
              port: http
          readinessProbe:
            httpGet:
              path: "/"
              port: http
          resources:
            {}
        - image: image1
          name: extraContainer1
        - image: image2
          name: extraContainer2
```
