### PR TITLE
ci: Remove more unecessary file unconditionally

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -122,10 +122,13 @@ jobs:
         cd ../../
         ls -laR .plugins
     - name: Remove unnecessary files
-      if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/share/swift
+        sudo apt-get clean
     - name: Build image
       if: steps.cache-image-restore2.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
Our current workflow is starting to run out space and causing errors. 
For example https://github.com/kubernetes-sigs/headlamp/actions/runs/19871509666/job/56948144556

This change will free up some space for us 