### PR TITLE
for #4246 context with TLS parameters not passed to refresh process

### DIFF
--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -171,10 +171,8 @@ func CacheRefreshedToken(token *oauth2.Token, tokenType string, oldToken string,
 // token from the cache to obtain a new OAuth2 token
 // from the specified token URL endpoint.
 func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
-	tokenType string, token string, tokenURL string,
+	tokenType string, token string, tokenURL string, ctx context.Context,
 ) (*oauth2.Token, error) {
-	ctx := context.Background()
-
 	// get refresh token
 	refreshToken, err := cache.Get(ctx, oidcKeyPrefix+token)
 	if err != nil {
@@ -267,6 +265,7 @@ func RefreshAndCacheNewToken(ctx context.Context, oidcAuthConfig *kubeconfig.Oid
 		tokenType,
 		token,
 		provider.Endpoint().TokenURL,
+		ctx,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("refreshing token: %w", err)

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -618,7 +618,7 @@ func TestGetNewToken_Success(t *testing.T) {
 	// Seed cache with old token -> old refresh mapping
 	fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
 
-	newTok, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL)
+	newTok, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background())
 	if err != nil {
 		t.Fatalf("GetNewToken unexpected error: %v", err)
 	}
@@ -677,7 +677,7 @@ func TestGetNewToken_PreHTTPFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Fails before HTTP; no server needed.
-			_, err := auth.GetNewToken("cid", "secret", tc.cache, "id_token", "OLD", "http://127.0.0.1")
+			_, err := auth.GetNewToken("cid", "secret", tc.cache, "id_token", "OLD", "http://127.0.0.1", context.Background())
 			if err == nil || !strings.Contains(err.Error(), tc.expect) {
 				t.Fatalf("want error containing %q, got %v", tc.expect, err)
 			}
@@ -700,7 +700,7 @@ func TestGetNewToken_EndpointFailures(t *testing.T) {
 			srv := newTokenServerJSON(t, tc.status, tc.body)
 			fc := &fakeCache{store: map[string]interface{}{"oidc-token-OLD": "REFRESH_OLD"}}
 
-			if _, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL); err == nil {
+			if _, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background()); err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})
@@ -724,7 +724,7 @@ func TestGetNewToken_CacheUpdateErrors(t *testing.T) {
 				errOnSetWithTTL: tc.setTTLErr,
 			}
 
-			if _, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL); err == nil {
+			if _, err := auth.GetNewToken("cid", "secret", fc, "id_token", "OLD", srv.URL, context.Background()); err == nil {
 				t.Fatal("expected error containing 'caching refreshed token', got nil")
 			}
 		})


### PR DESCRIPTION
## Summary

This PR adds/fixes #4246 by passing the context with the generated TLS parameters to the function that refreshes the token.

## Related Issue

Fixes #4246

## Changes

- Added/Updated backend/auth
- Fixed bug


## Steps to Test

Deploy an oidc identity provider with a short token life (in this instance, OpenUnison with 1 minute)
Deploy headlamp with the following helm values:

```yaml
# image:
#   tag: v0.38.0

volumeMounts:
- name: ouca
  mountPath: /etc/ouca

volumes:
- name: ouca
  configMap:
    name: ouca
  

config:
  inCluster: true
  baseURL: ""
  oidc:
    clientID: kubernetes
    issuerURL: https://k8sou.192-168-2-118.nip.io/auth/idp/k8sIdp
    scopes: "openid,email,profile"
    usePKCE: true
  extraArgs:
  - --oidc-ca-file
  - /etc/ouca/ca.pem

ingress:
  enabled: true
  ingressClassName: nginx
  hosts:
  - host: headlamp.192-168-2-118.nip.io
    paths:
    - path: "/"
      type: Prefix
  tls:
    - hosts:
      - headlamp.192-168-2-118.nip.io
      secretName: headlamp-tls
```

Login to headlamp, wait a few minutes

## Screenshots (if applicable)


## Notes for the Reviewer

- Tested with self signed certificate
