### PR TITLE
frontend: Deduplicate namespaces from multi-cluster lists in autocomplete

### DIFF
--- a/frontend/src/components/common/NamespacesAutocomplete.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.tsx
@@ -22,6 +22,7 @@ import Checkbox from '@mui/material/Checkbox';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { uniq } from 'lodash';
 import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -266,10 +267,9 @@ function NamespacesFromClusterAutocomplete(
   const [namespacesList, error] = Namespace.useList();
   const namespaceNames = useMemo(
     () =>
-      namespacesList
-        ?.map(namespace => namespace.metadata.name)
+      uniq(namespacesList?.map(namespace => namespace.metadata.name) ?? [])
         .slice()
-        .sort((a, b) => a.localeCompare(b)) ?? [],
+        .sort((a, b) => a.localeCompare(b)),
     [namespacesList]
   );
 


### PR DESCRIPTION
## Summary

This PR fixes namespace duplication in the Namespaces autocomplete by deduplicating namespace names coming from multi-cluster `Namespace.useList()` results.

## Related Issue

Fixes #ISSUE_NUMBER  

## Changes

- Updated `NamespacesAutocomplete` to build the options list from `Namespace.useList()` with namespace names deduplicated across clusters.
- Ensured the resulting namespace names are sorted alphabetically for a consistent user experience.
- Kept the existing behavior for cluster-scoped allowed namespaces while only adjusting how we build the fallback list from the cluster API.

## Steps to Test

1. Configure Headlamp with multiple clusters that share at least one namespace name (e.g. both clusters have a `default` namespace).
2. Start Headlamp and open any page that shows the global Namespaces autocomplete (e.g. the main dashboard).
3. Open the Namespaces dropdown and verify that each namespace name appears only once, even if it exists in multiple clusters.

## Screenshots (if applicable)

### Before
<img width="200" alt="" src="https://github.com/user-attachments/assets/dbee0d22-952d-444f-9eae-d46d1b3664a2" />

### After

<img width="200" alt="" src="https://github.com/user-attachments/assets/12581256-98a7-435b-88af-dbcc839eec1a" />


## Notes for the Reviewer
