### PR TITLE
frontend: Deduplicate CRDs in sidebar items

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.ts
+++ b/frontend/src/components/Sidebar/useSidebarItems.ts
@@ -90,13 +90,18 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
           ],
         });
       } else {
-        const entryGroup = entriesGroup.get(group)!;
-        entryGroup.subList?.push({
-          name: item.jsonData.metadata.name,
-          label: item.jsonData.spec.names.kind,
-          isCR: true,
-        });
-        //entryGroup.subList =
+        const entryGroup = entriesGroup.get(group);
+        if (entryGroup?.subList) {
+          const crdName = item.jsonData.metadata.name;
+
+          if (!entryGroup.subList.some(subItem => subItem.name === crdName)) {
+            entryGroup.subList.push({
+              name: crdName,
+              label: item.jsonData.spec.names.kind,
+              isCR: true,
+            });
+          }
+        }
       }
     });
     entriesGroup.forEach(item => {


### PR DESCRIPTION
## Summary

This PR fixes duplicated CustomResourceDefinition entries in the in-cluster sidebar by de-duplicating CRDs within each group when building the sidebar items.

## Related Issue

N/A

## Changes

- Updated `useSidebarItems` CRD grouping logic to avoid pushing duplicate CRDs into a group's `subList`.
- Ensured `subList` initialization is robust when a group entry already exists.
- Kept the existing alphabetical sorting behavior for CRD sidebar entries.

## Steps to Test

1. Start Headlamp and connect to a cluster that exposes multiple CRDs.
2. Open the in-cluster sidebar and navigate to `Custom Resources`.
3. Expand a CRD group and verify that each CRD appears only once per group, with no duplicate entries.

## Screenshots (if applicable)

### Before
<img width="200" alt="" src="https://github.com/user-attachments/assets/8f11297f-e135-421b-a479-fa6a011a6727" />

### After
<img width="200" alt="" src="https://github.com/user-attachments/assets/5301a695-78ff-4a18-a70a-864064f8105f" />


## Notes for the Reviewer
