### PR TITLE
plugins/examples/activity: Bump dependencies

### DIFF
--- a/plugins/examples/activity/package-lock.json
+++ b/plugins/examples/activity/package-lock.json
@@ -8995,9 +8995,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
These changes update the following dependencies in the activity example plugin:
- `js-yaml` to 4.1.1
- `mdast-util-to-hast` to 13.2.1
- `vite` to 6.4.1
- `glob` to 10.5.0

### Testing
- [x] `npm run build` does not fail