### PR TITLE
frontend: Guard header actions when resource is null

### DIFF
--- a/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.tsx
+++ b/frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.tsx
@@ -83,7 +83,7 @@ export function MainInfoHeader<T extends KubeObject>(props: MainInfoHeaderProps<
       return <ErrorBoundary>{Action}</ErrorBoundary>;
     } else if (Action === null) {
       return null;
-    } else if (typeof Action === 'function') {
+    } else if (typeof Action === 'function' && resource) {
       return (
         <ErrorBoundary>
           <Action item={resource} />

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Error.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Error.stories.storyshot
@@ -41,26 +41,6 @@
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
             />
-            <div
-              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Error.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Error.stories.storyshot
@@ -54,26 +54,6 @@
                 />
               </div>
             </div>
-            <div
-              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Error.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Error.stories.storyshot
@@ -41,26 +41,6 @@
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
             />
-            <div
-              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Error.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Error.stories.storyshot
@@ -41,26 +41,6 @@
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
             />
-            <div
-              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Error.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Error.stories.storyshot
@@ -41,26 +41,6 @@
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
             />
-            <div
-              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Error.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Error.stories.storyshot
@@ -41,26 +41,6 @@
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
             />
-            <div
-              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Error.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Error.stories.storyshot
@@ -41,26 +41,6 @@
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
             />
-            <div
-              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-            >
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-                <div
-                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
-                />
-              </div>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

This PR fixes an intermittent console error: `TypeError: Cannot read properties of null (reading 'metadata')`.  
The root cause was that `MainInfoSectionHeader` could render header actions (including `EditButton`) while the `resource` was still `null`, passing a null `item` down the tree.  
We now **guard header actions so they only render once `resource` is available**, preventing null from being passed to actions.

## Related Issue

- Fixes #ISSUE_NUMBER

## Changes

- Guarded header action rendering in `frontend/src/components/common/Resource/MainInfoSection/MainInfoSectionHeader.tsx` to avoid passing a null `resource` to action components (e.g. `EditButton`).

## Steps to Test

1. Open a resource details page (ideally under slow network / first load conditions).
2. Check the browser console.
3. Confirm `TypeError: Cannot read properties of null (reading 'metadata')` no longer appears.
4. After the resource finishes loading, confirm header actions (Edit, Delete, etc.) appear and work as expected.

## Screenshots (if applicable)

Before:
<img width="2276" height="322" alt="CleanShot 2025-12-14 at 11 58 59@2x" src="https://github.com/user-attachments/assets/85616624-cfd9-4181-a6ac-0b42ebc0abcb" />

After:
No Error 🙌 

## Notes for the Reviewer
