### PR TITLE
app: Fix uninstalling plugins

### DIFF
--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -306,13 +306,13 @@ export class PluginManager {
   /**
    * Uninstalls a plugin from the specified folder.
    * @param {string} name - The name of the plugin to uninstall.
-   * @param {string} [folder=defaultPluginsDir()] - The folder where the plugin is installed.
+   * @param {string} [folder=defaultUserPluginsDir()] - The folder where the plugin is installed.
    * @param {function} [progressCallback=null] - Optional callback for progress updates.
    * @returns {void}
    */
   static uninstall(
     name: string,
-    folder = defaultPluginsDir(),
+    folder = defaultUserPluginsDir(),
     progressCallback: null | ProgressCallback = null
   ) {
     try {


### PR DESCRIPTION
## Summary

The app's plugin management module was looking at the default plugins dir rather than the default user's plugin dir.

## Steps to Test

1. Build the app (`npm i && npm run install:all && npm run app:build:dir`); then run it (`./app/dist/PLATFORM-unpacked/headlamp`)
2. Install a plugin via the catalog + refresh
3. Delete that plugin using the trash icon in its detail page -> it should successfully delete it
