### PR TITLE
frontend,backend: support exec/teleport/cert based auth to clusters

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -143,6 +143,7 @@ interface AuthRouteProps {
   requiresAuth: boolean;
   requiresCluster: boolean;
   requiresToken: () => boolean;
+  clusters: ReturnType<typeof useClustersConf>;
   [otherProps: string]: any;
 }
 
@@ -153,15 +154,24 @@ function AuthRoute(props: AuthRouteProps) {
     requiresAuth = true,
     requiresCluster = true,
     computedMatch = {},
+    clusters,
     ...other
   } = props;
   const redirectRoute = getCluster() ? 'login' : 'chooser';
   useSidebarItem(sidebar, computedMatch);
   const cluster = useCluster();
+
+  // Get the cluster's auth type - for tsh/exec/client-cert, the backend handles auth
+  const clusterConfig = cluster && clusters ? clusters[cluster] : null;
+  const authType = clusterConfig?.auth_type || '';
+  const isExecOrCertAuth = authType === 'tsh' || authType === 'exec' || authType === 'client-cert';
+
   const query = useQuery({
-    queryKey: ['auth', cluster],
-    queryFn: () => testAuth(cluster!),
-    enabled: !!cluster && requiresAuth,
+    queryKey: ['auth', cluster, authType],
+    queryFn: () => testAuth(cluster!, { authType }),
+    // Run auth test for all auth types including exec/client-cert
+    // Wait for clusters to be loaded to ensure we have the correct authType
+    enabled: !!cluster && requiresAuth && !!clusters,
     retry: 0,
   });
 
@@ -182,6 +192,30 @@ function AuthRoute(props: AuthRouteProps) {
     }
 
     if (query.isError) {
+      // For tsh/exec/client-cert auth, show a helpful error message
+      if (isExecOrCertAuth) {
+        let errorMessage: string;
+        if (authType === 'tsh') {
+          errorMessage =
+            'Teleport authentication failed. Please run `tsh login` to refresh your credentials, then reload this page in your browser.';
+        } else if (authType === 'exec') {
+          errorMessage =
+            'Exec credential plugin authentication failed. Please refresh your credentials and try again.';
+        } else {
+          errorMessage =
+            'Client certificate authentication failed. Please check your certificates.';
+        }
+        return (
+          <ErrorComponent
+            error={{
+              name: 'AuthenticationError',
+              message: errorMessage,
+              stack: query.error instanceof Error ? query.error.message : String(query.error),
+            }}
+          />
+        );
+      }
+
       return (
         <Redirect
           to={{

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -105,7 +105,15 @@ function AuthChooser({ children }: AuthChooserProps) {
       //   cluster, then we check here.
       // With clusterAuthType == oidc,
       //   they are presented with a choice of login or enter token.
-      if (clusterAuthType !== 'oidc' && cluster.useToken === undefined) {
+      // With clusterAuthType == exec, client-cert, or tsh,
+      //   RouteSwitcher handles auth - don't run testAuth here to avoid conflicts.
+      if (
+        clusterAuthType !== 'oidc' &&
+        clusterAuthType !== 'exec' &&
+        clusterAuthType !== 'client-cert' &&
+        clusterAuthType !== 'tsh' &&
+        cluster.useToken === undefined
+      ) {
         let useToken = true;
 
         setTestingAuth(true);


### PR DESCRIPTION
## Summary

### Problem
Headlamp didn't properly handle Teleport's exec credential plugin authentication. When users loaded clusters configured with tsh kube credentials, they would see:
- Token prompt dialogs (which don't apply to Teleport)
- Redirect loops
- Failed auth tests (because SelfSubjectRulesReview API is blocked by Teleport's RBAC proxy)


### Solution

Added first-class support for Teleport's tsh authentication:

- Backend: Detect tsh auth type (backend/pkg/kubeconfig/kubeconfig.go) 
  - Added detection for tsh in exec command
  - Returns auth_type: "tsh" instead of generic "exec" for Teleport clusters
- Frontend: Use /version endpoint for auth test (frontend/src/lib/k8s/api/v1/clusterApi.ts)
  - For tsh/exec/client-cert auth, use /version endpoint instead of SelfSubjectRulesReview
  - The /version endpoint is accessible to any authenticated user without RBAC restrictions
  - Keeps original SelfSubjectRulesReview flow for token/OIDC auth
- Frontend: Teleport-specific error messages (frontend/src/components/App/RouteSwitcher.tsx)
  - When tsh auth fails (expired session), shows: "Teleport authentication failed. Please run 'tsh login' to refresh your credentials"
  - No redirect to login page (since Teleport auth is handled externally)
## Related Issue

## Steps to Test

I built the frontend backend and app locally and tried it with these changes and the tsh based auth worked.

## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
