### PR TITLE
frontend: Label: Fix warning label color contrast

### DIFF
--- a/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Warning.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/StatusLabel.Warning.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <span
-      class="MuiTypography-root MuiTypography-body1 css-1cqtycm-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
     >
       warning
     </span>

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -104,9 +104,12 @@ export const StatusLabel = forwardRef<HTMLSpanElement, StatusLabelProps>((props,
       borderColor: theme.palette.divider,
     };
   } else if (isLight) {
+    const bg = baseColor;
+    const fg = status === 'warning' ? '#000000ff' : theme.palette.getContrastText(bg);
+
     params = {
-      backgroundColor: baseColor,
-      color: theme.palette.getContrastText(baseColor),
+      backgroundColor: bg,
+      color: fg,
       borderColor: 'transparent',
     };
   } else {

--- a/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.Initializing.stories.storyshot
@@ -796,7 +796,7 @@
                         class="MuiBox-root css-0"
                       >
                         <span
-                          class="MuiTypography-root MuiTypography-body1 css-1cqtycm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
                         >
                           Waiting (PodInitializing)
                         </span>
@@ -1046,7 +1046,7 @@
                         class="MuiBox-root css-0"
                       >
                         <span
-                          class="MuiTypography-root MuiTypography-body1 css-1cqtycm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
                         >
                           Waiting (PodInitializing)
                         </span>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.LivenessFailed.stories.storyshot
@@ -239,7 +239,7 @@
                         data-mui-internal-clone-element="true"
                       >
                         <span
-                          class="MuiTypography-root MuiTypography-body1 css-1cqtycm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
                         >
                           CrashLoopBackOff
                         </span>
@@ -791,7 +791,7 @@
                       >
                         <span
                           aria-describedby="container-state-message-liveness"
-                          class="MuiTypography-root MuiTypography-body1 css-1cqtycm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
                         >
                           Waiting (CrashLoopBackOff)
                         </span>

--- a/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodDetails.PullBackOff.stories.storyshot
@@ -791,7 +791,7 @@
                       >
                         <span
                           aria-describedby="container-state-message-imagepullbackoff"
-                          class="MuiTypography-root MuiTypography-body1 css-1cqtycm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
                         >
                           Waiting (ImagePullBackOff)
                         </span>

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -1423,7 +1423,7 @@
                     data-mui-internal-clone-element="true"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-body1 css-1cqtycm-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
                     >
                       CrashLoopBackOff
                     </span>


### PR DESCRIPTION
## Summary

<img width="1898" height="658" alt="image" src="https://github.com/user-attachments/assets/93ad02fc-10a2-40b2-aaba-bc5ebecd9a59" />

Ran FastPass and it seems there is an issue when using white text and orange background. I have tried adjusting the background color to be darker to match allowed contrast, but this results in the "allowed" orange basically being just red. (Please refer to the image above for details)

This clashes with the red color used for failures so I am opting for a use of black text when displaying orange labels in light mode.  


## Changes

- Adjusts label text color to black when on light mode

## Steps to Test

1. Navigate to a resource that is displaying warning label
2. Note that the white text is now black
3. Run FastPass if available and observe no issues

## Screenshots

### Before

<img width="1074" height="105" alt="image" src="https://github.com/user-attachments/assets/f494d0aa-66de-49ae-9f56-cf81febb9898" />

### After

<img width="1106" height="98" alt="image" src="https://github.com/user-attachments/assets/794472da-f00b-4735-b8cb-4129583974cc" />

