### PR TITLE
feat: add HTTPRoute support for Gateway API via new values and template.

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -205,6 +205,43 @@ ingress:
         - headlamp.example.com
 ```
 
+### HTTPRoute Configuration (Gateway API)
+
+For users who prefer Gateway API over classic Ingress resources, Headlamp supports HTTPRoute configuration.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| httpRoute.enabled | bool | `false` | Enable HTTPRoute resource for Gateway API |
+| httpRoute.annotations | object | `{}` | Annotations for HTTPRoute resource |
+| httpRoute.labels | object | `{}` | Additional labels for HTTPRoute resource |
+| httpRoute.parentRefs | list | `[]` | Parent gateway references (REQUIRED when enabled) |
+| httpRoute.hostnames | list | `[]` | Hostnames for the HTTPRoute |
+| httpRoute.rules | list | `[]` | Custom routing rules (optional, defaults to path prefix /) |
+
+Example HTTPRoute configuration:
+```yaml
+httpRoute:
+  enabled: true
+  annotations:
+    gateway.example.com/custom-annotation: "value"
+  labels:
+    app.kubernetes.io/component: ingress
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-namespace
+  hostnames:
+    - headlamp.example.com
+  # Optional custom rules (defaults to path prefix / if not specified)
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /headlamp
+      backendRefs:
+        - name: my-headlamp
+          port: 80
+```
+
 ### Resource Management
 
 | Key | Type | Default | Description |

--- a/charts/headlamp/templates/httproute.yaml
+++ b/charts/headlamp/templates/httproute.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "headlamp.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "headlamp.namespace" . }}
+  labels:
+    {{- include "headlamp.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- required "A valid .Values.httpRoute.parentRefs entry is required when httpRoute.enabled is true" .Values.httpRoute.parentRefs | toYaml | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/headlamp/tests/test_cases/httproute-enabled.yaml
+++ b/charts/headlamp/tests/test_cases/httproute-enabled.yaml
@@ -1,0 +1,12 @@
+# Test case for HTTPRoute Gateway API configuration
+httpRoute:
+  enabled: true
+  annotations:
+    gateway.example.com/annotation: "test"
+  labels:
+    app.kubernetes.io/component: ingress
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-namespace
+  hostnames:
+    - headlamp.example.com

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -445,6 +445,60 @@
         }
       }
     },
+    "httpRoute": {
+      "type": "object",
+      "description": "HTTPRoute configuration for Gateway API",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable HTTPRoute resource for Gateway API"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for HTTPRoute resource"
+        },
+        "labels": {
+          "type": "object",
+          "description": "Additional labels for HTTPRoute resource"
+        },
+        "parentRefs": {
+          "type": "array",
+          "description": "Parent references (REQUIRED when enabled - HTTPRoute will not work without this)",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the parent gateway"
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Namespace of the parent gateway"
+              },
+              "sectionName": {
+                "type": "string",
+                "description": "Section name of the parent gateway listener"
+              }
+            },
+            "required": ["name"]
+          }
+        },
+        "hostnames": {
+          "type": "array",
+          "description": "Hostnames for the HTTPRoute",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules": {
+          "type": "array",
+          "description": "Custom routing rules (optional, defaults to path prefix /)",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
     "podDisruptionBudget": {
       "type": "object",
       "properties": {

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -240,6 +240,39 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# HTTPRoute configuration for Gateway API
+# Please refer to https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute
+httpRoute:
+  # -- Enable HTTPRoute resource for Gateway API
+  enabled: false
+  # -- Annotations for HTTPRoute resource
+  annotations: {}
+  # -- Additional labels for HTTPRoute resource
+  labels: {}
+  # -- Parent references (REQUIRED when enabled - HTTPRoute will not work without this)
+  # Example:
+  # parentRefs:
+  #   - name: my-gateway
+  #     namespace: gateway-namespace
+  parentRefs: []
+  # -- Hostnames for the HTTPRoute
+  # Example:
+  # hostnames:
+  #   - headlamp.example.com
+  hostnames: []
+  # -- Custom routing rules (optional, defaults to path prefix /)
+  # If not specified, a default rule routing all traffic to the service is used
+  rules: []
+  # Example custom rules:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /headlamp
+  #     backendRefs:
+  #       - name: "{{ .Release.Name }}-headlamp"
+  #         port: 80
+
 # -- CPU/Memory resource requests/limits
 resources:
   {}


### PR DESCRIPTION
## Summary
This PR adds HTTPRoute support to the Helm chart for users who prefer Gateway API over classic Ingress resources.
## Related Issue
Fixes #4244
## Changes
- Added `templates/httproute.yaml` for Gateway API HTTPRoute resource
- Added `httpRoute` values section with configurable options:
  - `enabled`: Enable/disable HTTPRoute
  - `parentRefs`: Gateway references (required)
  - `hostnames`: List of hostnames
  - `annotations/labels`: Custom metadata
  - `rules`: Custom routing rules (optional)
## Steps to Test
1. Enable HTTPRoute in values:
   ```yaml
   httpRoute:
     enabled: true
     parentRefs:
       - name: my-gateway
 2. Run helm template test ./charts/headlamp --set httpRoute.enabled=true
 3. Verify HTTPRoute resource is generated correctly