### PR TITLE
helm: Add extraContainers support for sidecar containers

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -382,6 +382,9 @@ spec:
               {{- toYaml $defaultSC | nindent 12 }}
             {{- end }}
         {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -28,6 +28,9 @@ namespaceOverride: ""
 # -- An optional list of init containers to be run before the main containers.
 initContainers: []
 
+# -- An optional list of extra containers to be added to the pod (sidecars).
+extraContainers: []
+
 config:
   inCluster: true
   # -- base url path at which headlamp should run


### PR DESCRIPTION
## Summary

This PR adds extraContainers support to the Helm chart for sidecar containers.

## Related Issue

Fixes #4239

## Changes

- Added `extraContainers` field to `values.yaml`
- Updated `deployment.yaml` template to include extra containers

## Steps to Test

1. Add an extra container in values:
```yaml
extraContainers:
- name: my-sidecar
  image: busybox
```
2. Run helm template test ./charts/headlamp --set 'extraContainers[0].name=sidecar'
3. Verify sidecar container appears in deployment