### PR TITLE
charts: Volume mounts on plugin helper sidecar

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -286,6 +286,7 @@ Ensure your replicaCount and maintenance procedures respect the configured PDB t
 | version       | string  | `latest`          | Headlamp plugin package version to install                                                |
 | env           | list    | `[]`              | Plugin manager env variable configuration                                                 |
 | resources     | object  | `{}`              | Plugin manager resource requests/limits                                                   |
+| volumeMounts  | list    | `[]`              | Plugin manager volume mounts                                                              |
 
 Example resource configuration:
 

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -370,6 +370,9 @@ spec:
               mountPath: {{ .Values.config.pluginsDir }}
             - name: plugin-config
               mountPath: /config
+            {{- with .Values.pluginsManager.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.pluginsManager.resources | nindent 12 }}
           securityContext:

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -278,6 +278,8 @@ pluginsManager:
   baseImage: node:lts-alpine
   # -- Headlamp plugin package version to install
   version: latest
+  # -- Plugin manager containers volume mounts
+  volumeMounts: []
   # -- Plugin manager env variable configuration
   # env:
   # - name: HTTPS_PROXY


### PR DESCRIPTION
## Summary

This PR adds volumeMounts to the helm chart.

## Changes

- Updated `charts/headlamp` to include` pluginsManager.volumeMounts`.
   With this change a user can for example inject custom CA certificates into the plugin sidecar. This might be required when using a TLS inspecting proxy or when mirroring plugins on an internal server.

## Steps to Test

1. set pluginsManager.enable to true in values.yaml, add an entry in the volumes list and one in pluginsManager/volumeMounts:
   for example
    ```YAML
    volumes:
       - name: ca-secret
         secret:
           secretName: my-ca-secret
    pluginsManager:
      enabled: true
      volumeMounts:
          - mountPath: /etc/ssl/certs/ca-certificates.crt
            name: ca-secret
            subPath: ca.crt
     ```
2. Deploy the helm chart
3. Check whether the headlamp-plugin container has the volume mounted.
