### PR TITLE
frontend: theme: add env var to set default theme

### DIFF
--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -444,9 +444,15 @@ export function usePrefersColorScheme() {
 
 /**
  * Hook gets theme based on user preference, and also OS/Browser preference.
+ * Priority order:
+ * 1. User's explicit preference (localStorage)
+ * 2. Enterprise default theme (REACT_APP_DEFAULT_THEME env var)
+ * 3. OS/Browser preference (prefers-color-scheme)
+ * 4. Fallback to 'light'
  */
 export function getThemeName(): string {
   const themePreference = localStorage.headlampThemePreference;
+  const enterpriseDefaultTheme = import.meta.env.REACT_APP_DEFAULT_THEME;
 
   if (typeof window.matchMedia !== 'function') {
     return 'light';
@@ -458,6 +464,9 @@ export function getThemeName(): string {
   if (themePreference) {
     // A selected theme preference takes precedence.
     themeName = themePreference;
+  } else if (enterpriseDefaultTheme) {
+    // Use enterprise default theme if set (can be any valid theme name)
+    themeName = enterpriseDefaultTheme;
   } else {
     if (prefersLight) {
       themeName = 'light';


### PR DESCRIPTION
## Summary

This PR adds the possibility to set a default theme by setting the environment variable `REACT_APP_DEFAULT_THEME`.

My org created a theme with our color palette, and we need a way to set it as default. An env var seemed the easiest. The user is still able to change it in the preferences.

## Related Issue

none

## Changes

- Updated function `getThemeName()` in `frontend/src/lib/themes.ts` to set the default theme from the value of the `REACT_APP_DEFAULT_THEME` environment variable if it exists.

 * Priority order:
 * 1. User's explicit preference 
 * 2. Enterprise default theme from the REACT_APP_DEFAULT_THEME env var
 * 3. OS/Browser preference light/dark
 * 4. Fallback to 'light'

## Steps to Test

1. clean your prefered theme: run `delete localStorage.headlampThemePreference` from your browser JS console
2. set the env var, for example: `export REACT_APP_DEFAULT_THEME="Headlamp Classic"`
3. run headlamp with `npm start`, check that you have the "Headlamp Classic" theme as default

