### PR TITLE
Move yolossn from headlamp-reviewers to headlamp-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,11 +3,11 @@ aliases:
     - joaquimrocha
     - illume
     - sniok
+    - yolossn
   headlamp-reviewers:
     - joaquimrocha
     - illume
     - sniok
     - ashu8912
-    - yolossn
     - vyncent-t
     - skoeva


### PR DESCRIPTION
## SUMMARY

I was previously listed as a maintainer and during the kubernetes-sigs org move was listed as reviewer. This PR reverts the ownership back to maintainer. 

Refer:
https://raw.githubusercontent.com/cncf/foundation/refs/heads/main/project-maintainers.csv