### PR TITLE
 Enhance StorageClass details view to display all specification fields

### DIFF
--- a/frontend/src/components/storage/ClassDetails.tsx
+++ b/frontend/src/components/storage/ClassDetails.tsx
@@ -81,7 +81,7 @@ export default function StorageClassDetails(props: { name?: string; cluster?: st
                 {item.allowedTopologies.map((topology, topologyIndex) => (
                   <div key={`topology-${topologyIndex}`}>
                     {topology.matchLabelExpressions?.map((expr, exprIndex) => (
-                      <div key={`expr-${exprIndex}`} style={{ marginLeft: '8px' }}>
+                      <div key={`expr-${exprIndex}`}>
                         {expr.key}: {expr.values.join(', ')}
                       </div>
                     ))}

--- a/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
@@ -165,6 +165,34 @@
                   <dt
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
                   >
+                    Default
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      No
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+                  >
+                    Provisioner
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      csi.test
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+                  >
                     Reclaim Policy
                   </dt>
                   <dd
@@ -191,18 +219,77 @@
                     </span>
                   </dd>
                   <dt
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-iqixpy-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
                   >
-                    Provisioner
+                    Allow Volume Expansion
                   </dt>
                   <dd
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-1xrovmc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
                   >
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
                     >
-                      csi.test
+                      Yes
                     </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+                  >
+                    Parameters
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                  >
+                    <div>
+                      type
+                      : 
+                      gp3
+                    </div>
+                    <div>
+                      iopsPerGB
+                      : 
+                      10
+                    </div>
+                    <div>
+                      fsType
+                      : 
+                      ext4
+                    </div>
+                    <div>
+                      encrypted
+                      : 
+                      true
+                    </div>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+                  >
+                    Mount Options
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-deb4a-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      debug, nfsvers=4.1
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-iqixpy-MuiGrid-root"
+                  >
+                    Allowed Topologies
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 css-1xrovmc-MuiGrid-root"
+                  >
+                    <div>
+                      <div>
+                        topology.kubernetes.io/zone
+                        : 
+                        us-east-1a, us-east-1b
+                      </div>
+                    </div>
                   </dd>
                 </dl>
               </div>


### PR DESCRIPTION
## Summary

See the following MR: https://github.com/kubernetes-sigs/headlamp/pull/4029#issue-3507472356


## Notes for the Reviewer

- This is my first contribution to this project and I thought it would be a good introduction to set my dev setup by reviewing a Copilot generated MR. I am not sure if I am following the right procedure, as the documentation (https://headlamp.dev/docs/latest/contributing/) wasn't really clear for existing MRs.
- While revewing I confirmed that the before and after setup added what the issue asked for correctly:
### Before:
<img width="1196" height="610" alt="Pasted image 20260103120645" src="https://github.com/user-attachments/assets/d069abc3-fd5b-4656-891d-d319080211ec" />


### After:
<img width="1196" height="691" alt="Pasted image 20260103122713" src="https://github.com/user-attachments/assets/2b06c158-2bc0-41c7-8505-09994779cc19" />

But taking a further look, while reviewing the Storybook, I saw that there was seemingly an indent problem with the allowed topologies value (it is more indented than the other points).
<img width="700" height="677" alt="Pasted image 20260103123450" src="https://github.com/user-attachments/assets/59e040c7-2a2f-462e-951b-4423fbecbfc9" />


I then corrected the indent:
<img width="661" height="659" alt="Pasted image 20260103132406" src="https://github.com/user-attachments/assets/adff1cf7-177e-4210-8ee7-305adc39688a" />



- While following the MR procedure, I ran the frontend test, and saw the snapshot was not updated, so I ran it and updated the StoryBook test for ClassDetails