### PR TITLE
github: charts: Skip chart release if it already exists

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           config: .github/cr.yaml
           mark_as_latest: false # only headlamp is set to latest
+          skip_existing: true # skip package upload if release already exists
 
       - name: Push Charts to GHCR
         run: |


### PR DESCRIPTION
I've noticed that CI on main branch fails when there are any changes to the charts because it always tries to release them.

This PR adds a parameter that will skip a release if it already exists

CI failure example https://github.com/kubernetes-sigs/headlamp/actions/runs/20723742245/job/59494089289


