### PR TITLE
docs: Fix Dex OIDC block indentation in values.yaml snippet

### DIFF
--- a/docs/installation/in-cluster/dex/index.md
+++ b/docs/installation/in-cluster/dex/index.md
@@ -157,10 +157,10 @@ To configure Headlamp, you can use the Headlamp Helm chart. Follow these steps t
 ```yaml title="values.yaml"
 config:
   oidc:
-  clientID: "<YOUR-CLIENT-ID>"
-  clientSecret: "<YOUR-CLIENT-SECRET>"
-  issuerURL: "<YOUR-DEX-URL>"
-  scopes: "email"
+    clientID: "<YOUR-CLIENT-ID>"
+    clientSecret: "<YOUR-CLIENT-SECRET>"
+    issuerURL: "<YOUR-DEX-URL>"
+    scopes: "email"
 ```
 
 Replace `<YOUR-CLIENT-ID>`,`<YOUR-CLIENT-SECRET>`,`<YOUR-DEX-URL>` with your specific OIDC configuration details.


### PR DESCRIPTION
## Summary

This PR fixes oidc block indentation in values.yaml snippet in docs/installation/in-cluster/dex.

## Related Issue

## Changes

- Fixed [indentation]

## Steps to Test


## Screenshots (if applicable)


## Notes for the Reviewer

