### PR TITLE
Frontend Blocker: Storage Pools and Snapshot pages broken due to Headlamp v0.39 CRD rendering crash

### DIFF
--- a/frontend/src/lib/k8s/crd.ts
+++ b/frontend/src/lib/k8s/crd.ts
@@ -195,29 +195,30 @@ export function makeCustomResourceClass(
     static getBaseObject(): Omit<KubeObjectInterface, 'metadata'> & {
       metadata: Partial<import('./KubeMetadata').KubeMetadata>;
     } {
-      // For custom resources - use the storage version from the CRD if available,
-      // otherwise fall back to the first apiInfo entry
-      let group: string;
-      let version: string;
-      if (crClassArgs.customResourceDefinition) {
-        [group, version] = crClassArgs.customResourceDefinition.getMainAPIGroup();
-      } else {
-        if (!apiInfoArgs.length) {
-          throw new Error(
-            'makeCustomResourceClass requires at least one apiInfo entry when customResourceDefinition is not provided'
-          );
-        }
-        [group, version] = apiInfoArgs[0];
-      }
-      const apiVersion = group ? `${group}/${version}` : version;
+      const crd = crClassArgs.customResourceDefinition;
 
-      return {
-        apiVersion,
-        kind: this.kind,
-        metadata: {
-          name: '',
-        },
-      };
+      if (crd && typeof crd.getMainAPIGroup === 'function') {
+        try {
+          const [group, version] = crd.getMainAPIGroup();
+
+          // Fall back when CRD returns incomplete API info
+          if (!version) {
+            return super.getBaseObject();
+          }
+
+          const apiVersion = group ? `${group}/${version}` : version;
+
+          return {
+            ...super.getBaseObject(),
+            apiVersion,
+          };
+        } catch {
+          // Fall through to the default base object for malformed/partial CRDs.
+        }
+      }
+
+      // fallback
+      return super.getBaseObject();
     }
   };
 }

--- a/frontend/src/lib/k8s/index.test.ts
+++ b/frontend/src/lib/k8s/index.test.ts
@@ -17,6 +17,7 @@
 import { createRouteURL } from '../router/createRouteURL';
 import { labelSelectorToQuery, ResourceClasses } from '.';
 import { LabelSelector } from './cluster';
+import { makeCustomResourceClass } from './crd';
 import { KubeObjectClass } from './KubeObject';
 import Namespace from './namespace';
 
@@ -346,6 +347,81 @@ describe('Namespace testing', () => {
       // Label says kube-system even though metadata.name differs.
       expect(makeNamespace('renamed', 'kube-system').isProtected()).toBe(true);
       expect(makeNamespace('kube-system', 'my-app').isProtected()).toBe(false);
+    });
+  });
+});
+
+describe('makeCustomResourceClass.getBaseObject regression tests', () => {
+  it('falls back to apiInfoArgs when customResourceDefinition is undefined', () => {
+    const ResourceClass = makeCustomResourceClass({
+      kind: 'StoragePool',
+      pluralName: 'storagepools',
+      singularName: 'storagepool',
+      apiInfo: [{ group: 'storage.k8s.io', version: 'v1' }],
+      isNamespaced: false,
+    });
+
+    expect(() => ResourceClass.getBaseObject()).not.toThrow();
+
+    expect(ResourceClass.getBaseObject()).toMatchObject({
+      apiVersion: 'storage.k8s.io/v1',
+    });
+  });
+
+  it('falls back to default base object when getMainAPIGroup throws', () => {
+    const ResourceClass = makeCustomResourceClass({
+      kind: 'StoragePool',
+      pluralName: 'storagepools',
+      singularName: 'storagepool',
+      apiInfo: [{ group: 'storage.k8s.io', version: 'v1' }],
+      isNamespaced: false,
+      customResourceDefinition: {
+        getMainAPIGroup: () => {
+          throw new Error('invalid CRD');
+        },
+      } as any,
+    });
+
+    expect(() => ResourceClass.getBaseObject()).not.toThrow();
+
+    expect(ResourceClass.getBaseObject()).toMatchObject({
+      apiVersion: 'storage.k8s.io/v1',
+    });
+  });
+
+  it('falls back to default base object when getMainAPIGroup returns invalid version', () => {
+    const ResourceClass = makeCustomResourceClass({
+      kind: 'StoragePool',
+      pluralName: 'storagepools',
+      singularName: 'storagepool',
+      apiInfo: [{ group: 'storage.k8s.io', version: 'v1' }],
+      isNamespaced: false,
+      customResourceDefinition: {
+        getMainAPIGroup: () => ['storage.k8s.io', undefined],
+      } as any,
+    });
+
+    expect(() => ResourceClass.getBaseObject()).not.toThrow();
+
+    expect(ResourceClass.getBaseObject()).toMatchObject({
+      apiVersion: 'storage.k8s.io/v1',
+    });
+  });
+
+  it('uses the CRD storage version when getMainAPIGroup returns valid API info', () => {
+    const ResourceClass = makeCustomResourceClass({
+      kind: 'StoragePool',
+      pluralName: 'storagepools',
+      singularName: 'storagepool',
+      apiInfo: [{ group: 'storage.k8s.io', version: 'v1' }],
+      isNamespaced: false,
+      customResourceDefinition: {
+        getMainAPIGroup: () => ['storage.k8s.io', 'v1beta1'],
+      } as any,
+    });
+
+    expect(ResourceClass.getBaseObject()).toMatchObject({
+      apiVersion: 'storage.k8s.io/v1beta1',
     });
   });
 });


### PR DESCRIPTION
This PR is wrt to fix the following issue - https://github.com/kubernetes-sigs/headlamp/issues/4301

Headlamp v0.39 is crashing when rendering CreateResourceButton for some CRDs
because getMainAPIGroup() is called on an undefined CRD reference.

This PR adds a safe fallback to derive apiVersion without crashing.
The change is minimal and backward-compatible.

Tested locally with v0.39:
- Storage Pools
- Volume Snapshots
- Snapshot Classes


**Root Cause Analysis -**

CreateResourceButton
   ↓
ResourceListView
   ↓
KubeObjectClass.getBaseObject()
   ↓
makeCustomResourceClass() 
   ↓
customResourceDefinition.getMainAPIGroup() ❌ (was breaking)

