### PR TITLE
frontend: Fix ARIA labels for input fields

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -499,8 +499,12 @@ export function DataField(props: DataFieldProps) {
   );
 }
 
-export function SecretField(props: InputProps) {
-  const { value, ...other } = props;
+export interface SecretFieldProps extends InputProps {
+  nameID?: string;
+}
+
+export function SecretField(props: SecretFieldProps) {
+  const { value, nameID, ...other } = props;
   const [showPassword, setShowPassword] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
   const { t } = useTranslation();
@@ -555,6 +559,7 @@ export function SecretField(props: InputProps) {
       </Grid>
       <Grid item xs>
         <Input
+          aria-labelledby={nameID}
           readOnly={!showPassword}
           type="password"
           fullWidth

--- a/frontend/src/components/secret/Details.tsx
+++ b/frontend/src/components/secret/Details.tsx
@@ -100,12 +100,18 @@ export default function SecretDetails(props: {
                 lastDataRef.current = _.cloneDeep(data);
               };
 
-              const mainRows: NameValueTableRow[] = Object.entries(data).map((item: unknown[]) => ({
-                name: item[0] as string,
+              const mainRows: NameValueTableRow[] = (
+                Object.entries(data) as [string, unknown][]
+              ).map(([key, val]) => ({
+                name: key,
+                nameID: key,
                 value: (
                   <SecretField
-                    value={item[1]}
-                    onChange={e => handleFieldChange(item[0] as string, e.target.value)}
+                    value={val}
+                    nameID={key}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+                      handleFieldChange(key, e.target.value)
+                    }
                   />
                 ),
               }));

--- a/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
@@ -234,6 +234,7 @@
               >
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+                  id="storageClassName"
                 >
                   storageClassName
                 </dt>
@@ -272,6 +273,7 @@
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1z0dvx8-MuiGrid-root"
                     >
                       <div
+                        aria-labelledby="storageClassName"
                         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-readOnly MuiInputBase-readOnly css-zam05p-MuiInputBase-root-MuiInput-root"
                       >
                         <input
@@ -286,6 +288,7 @@
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-1iczkge-MuiGrid-root"
+                  id="volumeMode"
                 >
                   volumeMode
                 </dt>
@@ -324,6 +327,7 @@
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1z0dvx8-MuiGrid-root"
                     >
                       <div
+                        aria-labelledby="volumeMode"
                         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-readOnly MuiInputBase-readOnly css-zam05p-MuiInputBase-root-MuiInput-root"
                       >
                         <input
@@ -338,6 +342,7 @@
                 </dd>
                 <dt
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-iqixpy-MuiGrid-root"
+                  id="volumeName"
                 >
                   volumeName
                 </dt>
@@ -376,6 +381,7 @@
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1z0dvx8-MuiGrid-root"
                     >
                       <div
+                        aria-labelledby="volumeName"
                         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-readOnly MuiInputBase-readOnly css-zam05p-MuiInputBase-root-MuiInput-root"
                       >
                         <input


### PR DESCRIPTION
## Summary

This PR fixes some a11y issues around missing labels for inputs in our custom component for secrets data fields.

FastPass scan
<img width="1638" height="630" alt="Image" src="https://github.com/user-attachments/assets/67422917-e684-4b76-9d30-ed4cc2828b0c" />

Inputs that need fixes
<img width="796" height="536" alt="Image" src="https://github.com/user-attachments/assets/c85937f6-0e91-45fd-ba05-a71d683c2a55" />

## Related Issue

Fixes #4344 

## Changes

- Adds aria labels for input component

## Steps to Test

1. Launch FastPass in a different window
2. Navigate to the Secrets list view
3. Navigate to any Secrets resource view
4. Run FastPass on the opened Secrets resource
5. Note the missing inputs are now fixed

