### PR TITLE
docs: Deprecation of homebrew --no-quarantine flag

### DIFF
--- a/docs/installation/desktop/mac-installation.md
+++ b/docs/installation/desktop/mac-installation.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 Once you have the [Homebrew package manager](https://brew.sh/) itself installed, you can install the latest Headlamp release by running the following command:
 
 ```sh
-brew install --cask --no-quarantine headlamp
+brew install --cask headlamp
 ```
 
 ### Upgrading


### PR DESCRIPTION
## Summary

As of November 12, 2025 (Homebrew 5.0.0), the --no-quarantine flag has been officially deprecated, this PR removes for the installation part.

## Related Issue

- https://github.com/Homebrew/brew/pull/20929
- https://brew.sh/2025/11/12/homebrew-5.0.0/

## Changes

- Updated mac-installation.md

## Steps to Test

1. [Step 1: e.g., Navigate to ...]
2. [Step 2: Click on ...]
3. [Step 3: Observe behavior or check logs/output]

## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]

- By September 1st, 2026, Homebrew is requiring all casks to pass Gatekeeper checks, so we should be prepared.
