### PR TITLE
headlamp-plugin: Add AGENTS.md to created plugins and bundle examples

### DIFF
--- a/plugins/headlamp-plugin/.gitignore
+++ b/plugins/headlamp-plugin/.gitignore
@@ -2,3 +2,6 @@ node_modules
 kinvolk-headlamp-plugin-*.tgz
 kinvolk-headlamp-plugin-*.tar.gz
 lib
+examples
+official-plugins
+.temp-official-plugins

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -952,6 +952,7 @@ function upgrade(packageFolder, skipPackageUpdates, headlampPluginVersion) {
       path.join('.vscode', 'settings.json'),
       path.join('.vscode', 'tasks.json'),
       'tsconfig.json',
+      'AGENTS.md',
     ];
     const templateFolder = path.resolve(__dirname, '..', 'template');
 
@@ -967,9 +968,14 @@ function upgrade(packageFolder, skipPackageUpdates, headlampPluginVersion) {
         fs.copyFileSync(from, to);
       }
       // Add file if it is different
-      if (fs.readFileSync(from, 'utf8') !== fs.readFileSync(to, 'utf8')) {
-        console.log(`Updating file: "${to}"`);
-        fs.copyFileSync(from, to);
+      if (fs.existsSync(to)) {
+        const fromContent = fs.readFileSync(from, 'utf8');
+        const toContent = fs.readFileSync(to, 'utf8');
+
+        if (fromContent !== toContent) {
+          console.log(`Updating file: "${to}"`);
+          fs.writeFileSync(to, fromContent);
+        }
       }
     });
   }

--- a/plugins/headlamp-plugin/package.json
+++ b/plugins/headlamp-plugin/package.json
@@ -7,7 +7,10 @@
   "bin": "bin/headlamp-plugin.js",
   "scripts": {
     "prepack": "(node -e \"if (! require('fs').existsSync('./lib/components')) {process.exit(1)} \" || (echo 'lib dir is empty. Remember to run `npm run build` before packing' && exit 1))",
-    "build": "npx shx rm -rf lib types lib/assets lib/components lib/helpers lib/i18n lib/lib lib/plugin lib/redux lib/resources && npx shx cp -r ../../frontend/src/assets ../../frontend/src/components ../../frontend/src/helpers ../../frontend/src/stateless ../../frontend/src/i18n ../../frontend/src/lib ../../frontend/src/plugin ../../frontend/src/redux ../../frontend/src/resources src/ && tsc --build ./tsconfig.json && npx shx cp -r src/additional.d.ts lib/ && npx shx cp -r ../../frontend/src/assets lib/ && npx shx cp -r ../../frontend/src/resources lib/ && npx shx cp -r ../../frontend/src/i18n/locales lib/i18n && node scripts/copy-static-assets.js",
+    "build": "npm run prepare-bundle && npx shx rm -rf lib types lib/assets lib/components lib/helpers lib/i18n lib/lib lib/plugin lib/redux lib/resources && npx shx cp -r ../../frontend/src/assets ../../frontend/src/components ../../frontend/src/helpers ../../frontend/src/stateless ../../frontend/src/i18n ../../frontend/src/lib ../../frontend/src/plugin ../../frontend/src/redux ../../frontend/src/resources src/ && tsc --build ./tsconfig.json && npx shx cp -r src/additional.d.ts lib/ && npx shx cp -r ../../frontend/src/assets lib/ && npx shx cp -r ../../frontend/src/resources lib/ && npx shx cp -r ../../frontend/src/i18n/locales lib/i18n && node scripts/copy-static-assets.js",
+    "bundle-examples": "node scripts/bundle-examples.js",
+    "fetch-official-plugins": "node scripts/fetch-official-plugins.js",
+    "prepare-bundle": "npm run bundle-examples && npm run fetch-official-plugins",
     "update-dependencies": "node dependencies-sync.js update && npm install && node scripts/copy-package-lock.js",
     "check-dependencies": "node dependencies-sync.js check",
     "copy-package-lock": "node scripts/copy-package-lock.js"
@@ -132,6 +135,8 @@
     "lib",
     "types",
     ".storybook",
+    "examples",
+    "official-plugins",
     "plugin-management/plugin-management.js",
     "plugin-management/multi-plugin-management.js"
   ],

--- a/plugins/headlamp-plugin/scripts/bundle-examples.js
+++ b/plugins/headlamp-plugin/scripts/bundle-examples.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This script copies example plugins from plugins/examples into
+ * examples/ directory for bundling with headlamp-plugin package.
+ * These plugins are referenced in AGENTS.md and help agents write good plugins.
+ */
+
+const fs = require('fs-extra');
+const path = require('path');
+const { getLocalGitHash, storeHash, shouldSkipBasedOnHash } = require('./git-hash-utils');
+
+const scriptDir = __dirname;
+const pluginDir = path.resolve(scriptDir, '..');
+const examplesSourceDir = path.resolve(pluginDir, '..', 'examples');
+const examplesDestDir = path.resolve(pluginDir, 'examples');
+const hashFile = path.resolve(examplesDestDir, '.git-hash');
+
+console.log('Bundling example plugins...');
+console.log(`Source: ${examplesSourceDir}`);
+console.log(`Destination: ${examplesDestDir}`);
+
+// Get the current git hash
+const currentHash = getLocalGitHash('plugins/examples', path.resolve(pluginDir, '..', '..'));
+
+// Check if we can skip bundling
+if (shouldSkipBasedOnHash(examplesDestDir, hashFile, currentHash)) {
+  console.log('Example plugins are already up to date (git hash matches)');
+  console.log('Skipping bundle...');
+  process.exit(0);
+}
+
+// Remove existing examples directory if it exists
+if (fs.existsSync(examplesDestDir)) {
+  console.log('Removing existing examples directory...');
+  fs.rmSync(examplesDestDir, { recursive: true });
+}
+
+// Create examples directory
+fs.mkdirSync(examplesDestDir, { recursive: true });
+
+// Get list of example plugins
+const examplePlugins = fs
+  .readdirSync(examplesSourceDir, { withFileTypes: true })
+  .filter(dirent => dirent.isDirectory())
+  .map(dirent => dirent.name);
+
+console.log(`Found ${examplePlugins.length} example plugins to bundle`);
+
+// Copy each example plugin
+examplePlugins.forEach(pluginName => {
+  const sourcePath = path.join(examplesSourceDir, pluginName);
+  const destPath = path.join(examplesDestDir, pluginName);
+
+  console.log(`Copying ${pluginName}...`);
+
+  // Copy the plugin directory
+  fs.copySync(sourcePath, destPath, {
+    filter: src => {
+      // Skip node_modules, dist, and other build artifacts
+      const relativePath = path.relative(sourcePath, src);
+      if (relativePath.includes('node_modules')) return false;
+      if (relativePath.includes('dist')) return false;
+      if (relativePath.includes('.eslintcache')) return false;
+      if (relativePath.includes('storybook-static')) return false;
+      if (relativePath.includes('package-lock.json')) return false;
+      return true;
+    },
+  });
+});
+
+// Store the git hash if available
+if (currentHash) {
+  storeHash(hashFile, currentHash);
+  console.log(`Successfully bundled ${examplePlugins.length} example plugins to examples/`);
+  console.log(`Git hash: ${currentHash}`);
+} else {
+  console.log(`Successfully bundled ${examplePlugins.length} example plugins to examples/`);
+}

--- a/plugins/headlamp-plugin/scripts/fetch-official-plugins.js
+++ b/plugins/headlamp-plugin/scripts/fetch-official-plugins.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This script fetches official plugins from https://github.com/headlamp-k8s/plugins/
+ * and bundles them into official-plugins/ directory for inclusion with headlamp-plugin package.
+ * These plugins are referenced in AGENTS.md and help agents write good plugins.
+ */
+
+const fs = require('fs-extra');
+const path = require('path');
+const { execSync } = require('child_process');
+const { getRemoteGitHash, storeHash, shouldSkipBasedOnHash } = require('./git-hash-utils');
+
+const scriptDir = __dirname;
+const pluginDir = path.resolve(scriptDir, '..');
+const officialPluginsDir = path.resolve(pluginDir, 'official-plugins');
+const hashFile = path.resolve(officialPluginsDir, '.git-hash');
+const officialPluginsRepo = 'https://github.com/headlamp-k8s/plugins.git';
+
+console.log('Fetching official plugins...');
+
+// Get the current remote hash
+const remoteHash = getRemoteGitHash(officialPluginsRepo);
+
+// Check if we can skip fetching
+if (shouldSkipBasedOnHash(officialPluginsDir, hashFile, remoteHash)) {
+  console.log('Official plugins are already up to date (git hash matches)');
+  console.log('Skipping fetch...');
+  process.exit(0);
+}
+
+console.log('Fetching latest official plugins from GitHub...');
+
+// Remove existing directory if it exists
+if (fs.existsSync(officialPluginsDir)) {
+  console.log('Removing existing official-plugins directory...');
+  fs.rmSync(officialPluginsDir, { recursive: true });
+}
+
+// Create official-plugins directory
+fs.mkdirSync(officialPluginsDir, { recursive: true });
+
+// Clone the repository into a temporary directory
+const tempDir = path.resolve(pluginDir, '.temp-official-plugins');
+if (fs.existsSync(tempDir)) {
+  fs.rmSync(tempDir, { recursive: true });
+}
+
+try {
+  console.log('Cloning official plugins repository...');
+  execSync(`git clone --depth 1 ${officialPluginsRepo} ${tempDir}`, {
+    stdio: 'inherit',
+  });
+
+  // Get the current commit hash
+  const currentHash = execSync('git rev-parse HEAD', {
+    cwd: tempDir,
+    encoding: 'utf8',
+  }).trim();
+
+  // Get list of plugin directories (skip .git and README.md)
+  const pluginDirs = fs
+    .readdirSync(tempDir, { withFileTypes: true })
+    .filter(
+      dirent =>
+        dirent.isDirectory() && dirent.name !== '.git' && !dirent.name.startsWith('.')
+    )
+    .map(dirent => dirent.name);
+
+  console.log(`Found ${pluginDirs.length} official plugins`);
+
+  // Copy each plugin directory
+  pluginDirs.forEach(pluginName => {
+    const sourcePath = path.join(tempDir, pluginName);
+    const destPath = path.join(officialPluginsDir, pluginName);
+
+    console.log(`Copying ${pluginName}...`);
+
+    // Copy the plugin directory
+    fs.copySync(sourcePath, destPath, {
+      filter: src => {
+        // Skip node_modules, dist, and other build artifacts
+        const relativePath = path.relative(sourcePath, src);
+        if (relativePath.includes('node_modules')) return false;
+        if (relativePath.includes('dist')) return false;
+        if (relativePath.includes('.git')) return false;
+        if (relativePath.includes('.eslintcache')) return false;
+        if (relativePath.includes('storybook-static')) return false;
+        if (relativePath.includes('package-lock.json')) return false;
+        return true;
+      },
+    });
+  });
+
+  // Store the git hash
+  storeHash(hashFile, currentHash);
+
+  console.log(
+    `Successfully fetched ${pluginDirs.length} official plugins to official-plugins/`
+  );
+  console.log(`Git hash: ${currentHash}`);
+} catch (error) {
+  console.error('Failed to fetch official plugins:', error.message);
+  process.exit(1);
+} finally {
+  // Clean up temporary directory
+  if (fs.existsSync(tempDir)) {
+    console.log('Cleaning up temporary directory...');
+    fs.rmSync(tempDir, { recursive: true });
+  }
+}

--- a/plugins/headlamp-plugin/scripts/git-hash-utils.js
+++ b/plugins/headlamp-plugin/scripts/git-hash-utils.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared utilities for git hash tracking used by bundling scripts.
+ * These hashing functions make development faster by meaning the plugins
+ * are not copied again and again if they don't change.
+ */
+
+const fs = require('fs-extra');
+const { execSync } = require('child_process');
+
+/**
+ * Get the stored hash from a hash file
+ * @param {string} hashFile - Path to the hash file
+ * @returns {string|null} - The stored hash or null if file doesn't exist
+ */
+function getStoredHash(hashFile) {
+  if (fs.existsSync(hashFile)) {
+    return fs.readFileSync(hashFile, 'utf8').trim();
+  }
+  return null;
+}
+
+/**
+ * Store a hash to a hash file
+ * @param {string} hashFile - Path to the hash file
+ * @param {string} hash - The hash to store
+ */
+function storeHash(hashFile, hash) {
+  fs.writeFileSync(hashFile, hash);
+}
+
+/**
+ * Get the git hash of a local directory path
+ * @param {string} dirPath - The directory path relative to git root (e.g., 'plugins/examples')
+ * @param {string} cwd - The working directory to run git command from
+ * @returns {string|null} - The git hash or null if git is not available
+ */
+function getLocalGitHash(dirPath, cwd) {
+  try {
+    const output = execSync(`git log -1 --format=%H -- ${dirPath}`, {
+      cwd: cwd,
+      encoding: 'utf8',
+    });
+    return output.trim();
+  } catch (error) {
+    console.log('Git not available or not in a git repository');
+    return null;
+  }
+}
+
+/**
+ * Get the remote git hash from a repository
+ * @param {string} repoUrl - The repository URL
+ * @returns {string|null} - The remote hash or null if failed
+ */
+function getRemoteGitHash(repoUrl) {
+  try {
+    const output = execSync(`git ls-remote ${repoUrl} HEAD`, {
+      encoding: 'utf8',
+    });
+    return output.split('\t')[0].trim();
+  } catch (error) {
+    console.error('Failed to get remote hash:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Check if a directory should be skipped based on hash comparison
+ * @param {string} targetDir - The target directory to check
+ * @param {string} hashFile - Path to the hash file
+ * @param {string} currentHash - The current hash to compare against
+ * @returns {boolean} - True if should skip, false otherwise
+ */
+function shouldSkipBasedOnHash(targetDir, hashFile, currentHash) {
+  // Check if directory exists and has content
+  if (!fs.existsSync(targetDir)) {
+    return false;
+  }
+
+  const entries = fs.readdirSync(targetDir).filter(e => e !== '.git-hash');
+  if (entries.length === 0) {
+    return false;
+  }
+
+  // Check if hashes match
+  const storedHash = getStoredHash(hashFile);
+
+  if (!currentHash || !storedHash) {
+    return false;
+  }
+
+  return currentHash === storedHash;
+}
+
+module.exports = {
+  getStoredHash,
+  storeHash,
+  getLocalGitHash,
+  getRemoteGitHash,
+  shouldSkipBasedOnHash,
+};

--- a/plugins/headlamp-plugin/template/AGENTS.md
+++ b/plugins/headlamp-plugin/template/AGENTS.md
@@ -1,0 +1,150 @@
+# AGENTS.md
+
+This file provides guidance for AI coding agents working on this Headlamp plugin.
+
+## Available Scripts
+
+The following npm scripts are available for development and testing:
+
+- **`npm run format`** - Format code with prettier
+- **`npm run lint`** - Lint code with eslint for coding issues
+- **`npm run lint-fix`** - Automatically fix linting issues
+- **`npm run build`** - Build the plugin for production
+- **`npm run tsc`** - Type check code with TypeScript compiler
+- **`npm run test`** - Run tests with vitest
+- **`npm start`** - Start development server watching for changes
+- **`npm run storybook`** - Start Storybook for component development
+- **`npm run storybook-build`** - Build static Storybook
+- **`npm run i18n`** - Extract translatable strings for internationalization
+- **`npm run package`** - Create a tarball of the plugin package
+
+## Plugin Development Resources
+
+### Example Plugins
+
+Explore these example plugins in `node_modules/@kinvolk/headlamp-plugin/examples/` to learn common patterns:
+
+- **activity** - Shows how to add activity tracking and monitoring
+- **app-menus** - Demonstrates adding custom menus to the app bar
+- **change-logo** - Shows how to customize the Headlamp logo
+- **cluster-chooser** - Demonstrates cluster selection UI
+- **custom-theme** - Shows how to create custom themes
+- **customizing-map** - Demonstrates customizing resource visualization maps
+- **details-view** - Shows how to customize resource detail views
+- **dynamic-clusters** - Demonstrates dynamic cluster configuration
+- **headlamp-events** - Shows how to work with Kubernetes events
+- **pod-counter** - Simple example counting pods and displaying in app bar
+- **projects** - Demonstrates project/namespace organization
+- **resource-charts** - Shows how to add custom charts for resources
+- **sidebar** - Demonstrates customizing the sidebar navigation
+- **tables** - Shows how to create custom resource tables
+- **ui-panels** - Demonstrates adding custom UI panels
+
+### Official Plugins
+
+Check out production-ready plugins in `node_modules/@kinvolk/headlamp-plugin/official-plugins/` for advanced patterns:
+
+#### Using Custom Resource Definitions (CRDs)
+
+- **cert-manager** - Complete CRD integration for cert-manager resources
+  - Files: `official-plugins/cert-manager/src/resources/` (certificate.ts, issuer.ts, clusterIssuer.ts, etc.)
+  - Shows how to register and display custom resources for certificates, issuers, challenges, and orders
+- **flux** - GitOps CRDs for Flux resources
+  - Files: `official-plugins/flux/src/` (kustomization, helmrelease, gitrepository resources)
+  - Demonstrates working with Flux CRDs for GitOps workflows
+- **keda** - Kubernetes Event Driven Autoscaling CRDs
+  - Files: `official-plugins/keda/src/resources/` (scaledobject.ts, scaledjob.ts, triggerauthentication.ts)
+  - Shows CRD integration for event-driven autoscaling
+- **karpenter** - Node provisioning CRDs
+  - Files: `official-plugins/karpenter/src/` (NodeClass, EC2NodeClass resources)
+  - Demonstrates multiple CRD deployment types (EKS Auto Mode, self-installed)
+
+#### Visualizing Relationships with Maps
+
+- **keda** - Map view showing KEDA resource relationships
+  - File: `official-plugins/keda/src/mapView.tsx`
+  - Uses edge creation (`makeKubeToKubeEdge`) to visualize connections between ScaledObjects, ScaledJobs, and TriggerAuthentications
+  - Shows how to build graph visualizations of resource dependencies
+
+#### Adding Metrics and Charts
+
+- **prometheus** - Advanced charts for workload resources
+  - Files: `official-plugins/prometheus/src/components/Chart/`
+  - Provides CPU, memory, network, and disk charts using Prometheus metrics
+  - Includes specialized charts for Karpenter (KarpenterChart, KarpenterNodeClaimCreationChart)
+  - Shows KEDA metrics (KedaActiveJobsChart, KedaScalerMetricsChart, KedaHPAReplicasChart)
+  - File: `official-plugins/prometheus/src/request.tsx` for fetching Prometheus data
+- **opencost** - Cost metrics and visualization
+  - File: `official-plugins/opencost/src/detail.tsx`
+  - Uses `recharts` library (AreaChart, CartesianGrid, Tooltip) to display cost data
+  - Shows how to fetch and display custom metrics from external services
+  - Demonstrates time-series data visualization with stacked area charts
+
+#### Other Advanced Patterns
+
+- **ai-assistant** - AI integration for cluster management
+- **app-catalog** - Helm chart catalog powered by ArtifactHub
+- **backstage** - Integration with Backstage developer portal
+
+### Key Topics and Examples
+
+#### Adding Items to the App Bar
+
+- **Example:** `pod-counter` - Shows `registerAppBarAction` to add items to top bar
+- **File:** `examples/pod-counter/src/index.tsx`
+
+#### Customizing the Sidebar
+
+- **Example:** `sidebar` - Demonstrates `registerSidebarEntry` and `registerSidebarEntryFilter`
+- **File:** `examples/sidebar/src/index.tsx`
+
+#### Working with Resource Details
+
+- **Example:** `details-view` - Shows how to customize resource detail pages
+- **File:** `examples/details-view/src/index.tsx`
+
+#### Creating Custom Tables
+
+- **Example:** `tables` - Demonstrates custom table implementations
+- **File:** `examples/tables/src/index.tsx`
+
+#### Adding Charts and Visualizations
+
+- **Example:** `resource-charts` - Shows how to add custom charts
+- **File:** `examples/resource-charts/src/index.tsx`
+
+#### Theme Customization
+
+- **Example:** `custom-theme` - Demonstrates theme customization
+- **File:** `examples/custom-theme/src/index.tsx`
+
+#### Internationalization (i18n)
+
+- Use `npm run i18n <locale>` to add new locales (e.g., `npm run i18n es` for Spanish)
+- Translation files are in `locales/<locale>/translation.json`
+- Use `useTranslation()` hook from `@kinvolk/headlamp-plugin/i18n`
+
+## Development Workflow
+
+1. **Start Development:** Run `npm start` to watch for changes
+2. **Make Changes:** Edit files in `src/`
+3. **Type Check:** Run `npm run tsc` to check for TypeScript errors
+4. **Lint:** Run `npm run lint` to check for code quality issues
+5. **Format:** Run `npm run format` to format code
+6. **Test:** Run `npm run test` to run tests
+7. **Build:** Run `npm run build` to create production build
+
+## Best Practices
+
+- Follow the patterns shown in the example plugins
+- Use TypeScript for type safety
+- Keep plugins focused on a single feature or enhancement
+- Document your plugin's functionality in the README.md
+
+## API Documentation
+
+For detailed API documentation, visit:
+
+- [Headlamp Plugin API Reference](https://headlamp.dev/docs/latest/development/api/)
+- [Plugin Development Guide](https://headlamp.dev/docs/latest/development/plugins/)
+- [UI Component Storybook](https://headlamp.dev/docs/latest/development/frontend/#storybook)


### PR DESCRIPTION
Bundle example plugins so agents know what to do a bit better.
The bundle scripts skip work if there is a not a change.

## Testing

- [x] there's a test to see that the AGENTS.md file is added when a new plugin is created
- [x] there's a test to see that the example plugins are bundled correctly with headlamp-plugin so AGENTS.md can refer to them
- [x] `npm run build && npm pack && tar tvf kinvolk-headlamp-plugin-0.13.0.tgz` makes a kinvolk-headlamp-plugin-0.13.0.tgz file with AGENTS.md and the example plugins in there.
- [x] Running `npm run build` twice in the headlamp-plugin folder does not download and copy the example plugins twice. 

```shell
npm run build && npm pack
tar tvf kinvolk-headlamp-plugin-0.13.0.tgz | grep AGENT
-rw-r--r--  0 0      0        6679 Oct 26  1985 package/template/AGENTS.md
```