### PR TITLE
frontend: Minimize activities blocking the main content when needed

### DIFF
--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -40,6 +40,7 @@ import React, {
 import { createPortal } from 'react-dom';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { Trans, useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import { useTypedSelector } from '../../redux/hooks';
 import store from '../../redux/stores/store';
 import { activitySlice } from './activitySlice';
@@ -731,6 +732,28 @@ export const ActivitiesRenderer = React.memo(function ActivitiesRenderer() {
   const history = useTypedSelector(state => state.activity.history) as string[];
   const lastElement = history.at(-1);
   const [isOverview, setIsOverview] = useState(false);
+  const location = useLocation();
+  const locationRef = useRef(location.pathname);
+
+  // Minimize activities that block the main content on route change.
+  // Activities in 'split-right' location are kept visible since they
+  // allow the user to see most of the main content.
+  useEffect(() => {
+    activities.forEach(activity => {
+      // If we were triggered just because of the activities changing but the
+      // location hasn't changed, we have nothing to do.
+      if (locationRef.current === location.pathname) {
+        return;
+      }
+
+      if (activity.location !== 'split-right' && !activity.minimized) {
+        Activity.update(activity.id, { minimized: true });
+      }
+    });
+
+    locationRef.current = location.pathname;
+  }, [location.pathname, activities]);
+
   useEffect(() => {
     if (activities.length === 0 && isOverview) {
       setIsOverview(false);


### PR DESCRIPTION
## Summary

When the user clicks a resource and sees its details views, the details opens by default in a side panel. This panel still lets the user view most of the content, so changing to other routes is fine. However, then the user has a panel that maximized or snapped to the left, it will block the main contents in that page; this leads to a situation where we can have e.g the logs view showing and change to a different list view without realizing that the view has not shown up because it's rendered behind the logs panel.

This PR solves that by minimizing the activity when a route changes AND the panel is not snapped to the right. i.e. when the panel is snapped to the right, we keep it opened as before. This is something I am happy with changing (to minimize all activities regardless of the snap position) if others agree it's the best way forward.

## Related Issue

Fixes #4003 

## Steps to Test

1. Go to a cluster view > Pods
2. Click on a Pod -> should open snapped to the right
3. Change to Deployments -> should keep the Pod activity open and snapped to the right
4. Click the pod's logs view -> should open maximized
5. Click any other list view from the sidebar (like Pods) -> the logs activity should be minimized automatically
6. Maximize the Pod details view (the panel that was snapped to the right), then click on another list view (like Deployments again) -> the Pod details activity should now be minimized automatically


