### PR TITLE
Templates: Secret: Added meUserInfoURL to secrets

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -90,7 +90,7 @@ $ helm install my-headlamp headlamp/headlamp \
 | config.oidc.secret.name | string | `"oidc"` | Name of the OIDC secret |
 | config.oidc.externalSecret.enabled | bool | `false` | Enable using external secret for OIDC |
 | config.oidc.externalSecret.name | string | `""` | Name of external OIDC secret |
-| config.oidc.meUserInfoURL | string | `""` | URL to fetch additional user info for the /me endpoint. For oauth2proxy /oauth2/userinfo can be used. |
+| config.oidc.meUserInfoURL | string | `""` | URL to fetch additional user info for the /me endpoint. Useful for providers like oauth2-proxy. |
 
 There are three ways to configure OIDC:
 
@@ -102,6 +102,7 @@ config:
     clientSecret: "your-client-secret"
     issuerURL: "https://your-issuer"
     scopes: "openid profile email"
+    meUserInfoURL: "https://headlamp.example.com/oauth2/userinfo"
 ```
 
 2. Using automatic secret creation:

--- a/charts/headlamp/templates/secret.yaml
+++ b/charts/headlamp/templates/secret.yaml
@@ -34,5 +34,8 @@ data:
 {{- with .usePKCE }}
   usePKCE: {{ . | toString | b64enc | quote }}
 {{- end }}
+{{- with .meUserInfoURL }}
+  meUserInfoURL: {{ . | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: default
 type: Opaque
 data:
+  meUserInfoURL: "L29hdXRoMi91c2VyaW5mb2N1c3RvbTI="
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

Added meUserInfoURL to secrets

## Related Issue

Fixes #4363 
-  #4363 

## Changes

Added:
```
{{- with .meUserInfoURL }}
  meUserInfoURL: {{ . | b64enc | quote }}
```
to secrets.yaml

## Steps to Test

Run:
```
helm template headlamp-test ./charts/headlamp   --set config.oidc.createSecret=true   --set config.oidc.meUserInfoURL="https://example.com/userinfo"   --show-only templates/secret.yaml
```
Output:
```
# Source: headlamp/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: oidc
  namespace: default
type: Opaque
data:
  meUserInfoURL: "aHR0cHM6Ly9leGFtcGxlLmNvbS91c2VyaW5mbw=="
```
(Succesful)