### PR TITLE
Templates: Deployment: Fixed Deployment.yaml

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -212,11 +212,11 @@ spec:
             {{- end }}
             {{- if $oidc.useAccessToken }}
             - name: OIDC_USE_ACCESS_TOKEN
-              value: {{ $oidc.useAccessToken }}
+              value: {{ $oidc.useAccessToken | quote }}
             {{- end }}
             {{- if $oidc.usePKCE }}
             - name: OIDC_USE_PKCE
-              value: {{ $oidc.usePKCE }}
+              value: {{ $oidc.usePKCE | quote }}
             {{- end }}
             {{- if $oidc.meUserInfoURL }}
             - name: ME_USER_INFO_URL

--- a/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
@@ -107,7 +107,7 @@ spec:
             - name: OIDC_SCOPES
               value: testScope
             - name: OIDC_USE_PKCE
-              value: true
+              value: "true"
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -111,7 +111,7 @@ spec:
             - name: OIDC_VALIDATOR_ISSUER_URL
               value: overriddenIssuerURL
             - name: OIDC_USE_ACCESS_TOKEN
-              value: true
+              value: "true"
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"


### PR DESCRIPTION
## Summary:
Fixes deployment to add quotes to useAccessToken and PKCE

## Related Issue:
Fixes #4364
- #4364

## Changes:
- Added `{{ | quote }}` to `OIDC_USE_ACCESS_TOKEN` and `OIDC_USE_PKCE`.
- Error arises as value is taken to be a boolean (`true`) while it should be taken as a string (`"true"`).

## Steps to Test:
Run:
```
helm upgrade --install headlamp-test ./charts/headlamp \
  --namespace kube-system \
  --set config.oidc.useAccessToken=true \
  --set config.oidc.secret.create=false
```
Inside root folder of headlamp
After that Run:
```
kubectl get deployment headlamp-test -n kube-system -o yaml | grep OIDC_USE_ACCESS_TOKEN -A 1
```
Runs Successfully (output):
```
        - -oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)
        env:
        - name: OIDC_USE_ACCESS_TOKEN
          value: "true"
```

Note: Accidentally closed my previous PR on the same issue, hence creating a new one fixing the issue
