### PR TITLE
Add configurable default theme support

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -108,6 +108,9 @@ type clientConfig struct {
 	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
 	AllowKubeconfigChanges  bool      `json:"allowKubeconfigChanges"`
 	DefaultPodDebugImage    string    `json:"defaultPodDebugImage"`
+	DefaultLightTheme       string    `json:"defaultLightTheme,omitempty"`
+	DefaultDarkTheme        string    `json:"defaultDarkTheme,omitempty"`
+	ForceTheme              string    `json:"forceTheme,omitempty"`
 }
 
 type OauthConfig struct {
@@ -1975,6 +1978,9 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 		IsDynamicClusterEnabled: c.EnableDynamicClusters,
 		AllowKubeconfigChanges:  c.AllowKubeconfigChanges,
 		DefaultPodDebugImage:    c.PodDebugImage,
+		DefaultLightTheme:       c.DefaultLightTheme,
+		DefaultDarkTheme:        c.DefaultDarkTheme,
+		ForceTheme:              c.ForceTheme,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -104,6 +104,9 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		SessionTTL:             conf.SessionTTL,
 		PodDebugImage:          conf.PodDebugImage,
 		OidcUseCookie:          conf.OidcUseCookie,
+		DefaultLightTheme:      conf.DefaultLightTheme,
+		DefaultDarkTheme:       conf.DefaultDarkTheme,
+		ForceTheme:             conf.ForceTheme,
 	}
 }
 

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -184,6 +184,9 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 		Clusters:                contexts,
 		IsDynamicClusterEnabled: c.EnableDynamicClusters,
 		AllowKubeconfigChanges:  c.AllowKubeconfigChanges,
+		DefaultLightTheme:       c.DefaultLightTheme,
+		DefaultDarkTheme:        c.DefaultDarkTheme,
+		ForceTheme:              c.ForceTheme,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -99,6 +99,14 @@ type Config struct {
 	ForceTheme        string `koanf:"force-theme"`
 }
 
+func (c *Config) warnRedundantThemeDefaults() {
+	if c.ForceTheme != "" && (c.DefaultLightTheme != "" || c.DefaultDarkTheme != "") {
+		logger.Log(logger.LevelWarn, nil, nil,
+			"force-theme is set together with default-light-theme/default-dark-theme, "+
+				"default themes will be ignored when force-theme is active")
+	}
+}
+
 func (c *Config) Validate() error {
 	if !c.InCluster && !c.OidcUseCookie && (c.OidcClientID != "" || c.OidcClientSecret != "" || c.OidcIdpIssuerURL != "" ||
 		c.OidcValidatorClientID != "" || c.OidcValidatorIdpIssuerURL != "") {
@@ -107,12 +115,8 @@ func (c *Config) Validate() error {
 			"meant to be used in inCluster mode or with --oidc-use-cookie")
 	}
 
-	// Theme configuration warning.
-	if c.ForceTheme != "" && (c.DefaultLightTheme != "" || c.DefaultDarkTheme != "") {
-		logger.Log(logger.LevelWarn, nil, nil,
-			"force-theme is set together with default-light-theme/default-dark-theme, "+
-				"default themes will be ignored when force-theme is active")
-	}
+	// Extracted to keep Validate's cognitive complexity within the linter limit.
+	c.warnRedundantThemeDefaults()
 
 	// OIDC TLS verification warning.
 	if c.OidcSkipTLSVerify {

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -93,6 +93,10 @@ type Config struct {
 	// TLS config
 	TLSCertPath string `koanf:"tls-cert-path"`
 	TLSKeyPath  string `koanf:"tls-key-path"`
+	// Theme config
+	DefaultLightTheme string `koanf:"default-light-theme"`
+	DefaultDarkTheme  string `koanf:"default-dark-theme"`
+	ForceTheme        string `koanf:"force-theme"`
 }
 
 func (c *Config) Validate() error {
@@ -101,6 +105,13 @@ func (c *Config) Validate() error {
 		return errors.New("oidc-client-id, oidc-client-secret, oidc-idp-issuer-url, " +
 			"oidc-validator-client-id, oidc-validator-idp-issuer-url, flags are only " +
 			"meant to be used in inCluster mode or with --oidc-use-cookie")
+	}
+
+	// Theme configuration warning.
+	if c.ForceTheme != "" && (c.DefaultLightTheme != "" || c.DefaultDarkTheme != "") {
+		logger.Log(logger.LevelWarn, nil, nil,
+			"force-theme is set together with default-light-theme/default-dark-theme, "+
+				"default themes will be ignored when force-theme is active")
 	}
 
 	// OIDC TLS verification warning.
@@ -472,6 +483,9 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")
 	f.Bool("enable-helm", false, "Enable Helm operations")
+	f.String("default-light-theme", "", "Default theme to use when user prefers light mode")
+	f.String("default-dark-theme", "", "Default theme to use when user prefers dark mode")
+	f.String("force-theme", "", "Force a specific theme, overriding user preferences")
 }
 
 func addOIDCFlags(f *flag.FlagSet) {

--- a/backend/pkg/config/config_theme_test.go
+++ b/backend/pkg/config/config_theme_test.go
@@ -1,0 +1,118 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseThemeConfiguration_DefaultLightTheme(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd", "--default-light-theme=corporate-light"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "corporate-light", conf.DefaultLightTheme)
+	assert.Equal(t, "", conf.DefaultDarkTheme)
+	assert.Equal(t, "", conf.ForceTheme)
+}
+
+func TestParseThemeConfiguration_DefaultDarkTheme(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd", "--default-dark-theme=corporate-dark"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "", conf.DefaultLightTheme)
+	assert.Equal(t, "corporate-dark", conf.DefaultDarkTheme)
+	assert.Equal(t, "", conf.ForceTheme)
+}
+
+func TestParseThemeConfiguration_BothDefaults(t *testing.T) {
+	conf, err := config.Parse([]string{
+		"go run ./cmd",
+		"--default-light-theme=corporate-light",
+		"--default-dark-theme=corporate-dark",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "corporate-light", conf.DefaultLightTheme)
+	assert.Equal(t, "corporate-dark", conf.DefaultDarkTheme)
+	assert.Equal(t, "", conf.ForceTheme)
+}
+
+func TestParseThemeConfiguration_ForceTheme(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd", "--force-theme=corporate-branded"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "", conf.DefaultLightTheme)
+	assert.Equal(t, "", conf.DefaultDarkTheme)
+	assert.Equal(t, "corporate-branded", conf.ForceTheme)
+}
+
+func TestParseThemeConfiguration_ForceWithDefaults(t *testing.T) {
+	conf, err := config.Parse([]string{
+		"go run ./cmd",
+		"--default-light-theme=light",
+		"--default-dark-theme=dark",
+		"--force-theme=corporate",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "light", conf.DefaultLightTheme)
+	assert.Equal(t, "dark", conf.DefaultDarkTheme)
+	assert.Equal(t, "corporate", conf.ForceTheme)
+}
+
+func TestParseThemeConfiguration_FromEnv(t *testing.T) {
+	os.Setenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME", "env-light")
+	os.Setenv("HEADLAMP_CONFIG_DEFAULT_DARK_THEME", "env-dark")
+
+	defer func() {
+		os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME")
+		os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_DARK_THEME")
+	}()
+
+	conf, err := config.Parse([]string{"go run ./cmd"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "env-light", conf.DefaultLightTheme)
+	assert.Equal(t, "env-dark", conf.DefaultDarkTheme)
+}
+
+func TestParseThemeConfiguration_ForceFromEnv(t *testing.T) {
+	os.Setenv("HEADLAMP_CONFIG_FORCE_THEME", "env-forced")
+	defer os.Unsetenv("HEADLAMP_CONFIG_FORCE_THEME")
+
+	conf, err := config.Parse([]string{"go run ./cmd"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "env-forced", conf.ForceTheme)
+}
+
+func TestParseThemeConfiguration_ArgsOverrideEnv(t *testing.T) {
+	os.Setenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME", "env-theme")
+	defer os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME")
+
+	conf, err := config.Parse([]string{"go run ./cmd", "--default-light-theme=arg-theme"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "arg-theme", conf.DefaultLightTheme)
+}
+
+func TestParseThemeConfiguration_NoConfig(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "", conf.DefaultLightTheme)
+	assert.Equal(t, "", conf.DefaultDarkTheme)
+	assert.Equal(t, "", conf.ForceTheme)
+}

--- a/backend/pkg/config/config_theme_test.go
+++ b/backend/pkg/config/config_theme_test.go
@@ -69,12 +69,12 @@ func TestParseThemeConfiguration_ForceWithDefaults(t *testing.T) {
 }
 
 func TestParseThemeConfiguration_FromEnv(t *testing.T) {
-	os.Setenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME", "env-light")
-	os.Setenv("HEADLAMP_CONFIG_DEFAULT_DARK_THEME", "env-dark")
+	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME", "env-light"))
+	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_DEFAULT_DARK_THEME", "env-dark"))
 
 	defer func() {
-		os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME")
-		os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_DARK_THEME")
+		require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME"))
+		require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_DARK_THEME"))
 	}()
 
 	conf, err := config.Parse([]string{"go run ./cmd"})
@@ -86,8 +86,9 @@ func TestParseThemeConfiguration_FromEnv(t *testing.T) {
 }
 
 func TestParseThemeConfiguration_ForceFromEnv(t *testing.T) {
-	os.Setenv("HEADLAMP_CONFIG_FORCE_THEME", "env-forced")
-	defer os.Unsetenv("HEADLAMP_CONFIG_FORCE_THEME")
+	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_FORCE_THEME", "env-forced"))
+
+	defer func() { require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_FORCE_THEME")) }()
 
 	conf, err := config.Parse([]string{"go run ./cmd"})
 	require.NoError(t, err)
@@ -97,8 +98,9 @@ func TestParseThemeConfiguration_ForceFromEnv(t *testing.T) {
 }
 
 func TestParseThemeConfiguration_ArgsOverrideEnv(t *testing.T) {
-	os.Setenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME", "env-theme")
-	defer os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME")
+	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME", "env-theme"))
+
+	defer func() { require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME")) }()
 
 	conf, err := config.Parse([]string{"go run ./cmd", "--default-light-theme=arg-theme"})
 	require.NoError(t, err)

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -71,4 +71,7 @@ type HeadlampCFG struct {
 	SessionTTL             int
 	PodDebugImage          string
 	OidcUseCookie          bool
+	DefaultLightTheme      string
+	DefaultDarkTheme       string
+	ForceTheme             string
 }

--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -47,6 +47,7 @@ import DetailsDrawer from '../common/Resource/DetailsDrawer';
 import Sidebar, { NavigationTabs } from '../Sidebar';
 import RouteSwitcher from './RouteSwitcher';
 import ShortcutsSettings from './Settings/ShortcutsSettings';
+import { applyBackendThemeConfig } from './themeSlice';
 import TopBar from './TopBar';
 import VersionDialog from './VersionDialog';
 
@@ -168,6 +169,17 @@ const fetchConfig = (dispatch: Dispatch<UnknownAction>) => {
           })
         );
       }
+    }
+
+    // Apply backend theme configuration if provided
+    if (config?.defaultLightTheme || config?.defaultDarkTheme || config?.forceTheme) {
+      dispatch(
+        applyBackendThemeConfig({
+          defaultLightTheme: config.defaultLightTheme,
+          defaultDarkTheme: config.defaultDarkTheme,
+          forceTheme: config.forceTheme,
+        })
+      );
     }
 
     /**

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -53,6 +53,7 @@ export default function Settings() {
   const dispatch = useDispatch();
   const themeName = useTypedSelector(state => state.theme.name);
   const appThemes = useAppThemes();
+  const forceTheme = useTypedSelector(state => state.config.forceTheme);
 
   useEffect(() => {
     dispatch(
@@ -204,6 +205,19 @@ export default function Settings() {
             pb: 5,
           }}
         >
+          {forceTheme && (
+            <Typography
+              variant="body2"
+              sx={theme => ({
+                textAlign: 'center',
+                color: theme.palette.text.secondary,
+                fontStyle: 'italic',
+                mb: 2,
+              })}
+            >
+              {t('translation|Theme has been forced by your administrator')}
+            </Typography>
+          )}
           <Box
             sx={{
               display: 'grid',
@@ -214,18 +228,25 @@ export default function Settings() {
                 gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))',
                 gap: 2,
               },
+              opacity: forceTheme ? 0.5 : 1,
+              pointerEvents: forceTheme ? 'none' : 'auto',
             }}
           >
             {appThemes.map(it => (
               <Box
                 key={it.name}
                 role="button"
-                tabIndex={0}
+                tabIndex={forceTheme ? -1 : 0}
                 onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') dispatch(setTheme(it.name));
+                  if (forceTheme) {
+                    return;
+                  }
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    dispatch(setTheme(it.name));
+                  }
                 }}
                 sx={{
-                  cursor: 'pointer',
+                  cursor: forceTheme ? 'not-allowed' : 'pointer',
                   border: themeName === it.name ? '2px solid' : '1px solid',
                   borderColor: themeName === it.name ? 'primary' : 'divider',
                   borderRadius: 2,
@@ -235,10 +256,10 @@ export default function Settings() {
                   alignItems: 'center',
                   transition: '0.2 ease',
                   '&:hover': {
-                    backgroundColor: 'divider',
+                    backgroundColor: forceTheme ? 'transparent' : 'divider',
                   },
                 }}
-                onClick={() => dispatch(setTheme(it.name))}
+                onClick={() => !forceTheme && dispatch(setTheme(it.name))}
               >
                 <ThemePreview theme={it} size={110} />
                 <Box sx={{ mt: 1 }}>{capitalize(it.name)}</Box>

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -431,7 +431,7 @@
             class="MuiBox-root css-exrnj3"
           >
             <div
-              class="MuiBox-root css-1a2ne5x"
+              class="MuiBox-root css-1smd7c5"
             >
               <div
                 class="MuiBox-root css-1yhz2ch"

--- a/frontend/src/components/App/themeSlice.test.tsx
+++ b/frontend/src/components/App/themeSlice.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { vi } from 'vitest';
 import { AppLogoProps, AppLogoType } from './AppLogo';
 import themeReducer, {
   applyBackendThemeConfig,
@@ -54,11 +55,11 @@ describe('themeSlice', () => {
       expect(actual.name).toEqual('corporate');
     });
 
-    it('should clear localStorage preference when forced theme is applied', () => {
+    it('should preserve localStorage preference when forced theme is applied', () => {
       localStorage.setItem('headlampThemePreference', 'dark');
       const state = { ...initialState, name: 'light' };
       themeReducer(state, applyBackendThemeConfig({ forceTheme: 'corporate' }));
-      expect(localStorage.getItem('headlampThemePreference')).toBeNull();
+      expect(localStorage.getItem('headlampThemePreference')).toEqual('dark');
     });
 
     it('should not update state if theme has not changed', () => {
@@ -68,13 +69,19 @@ describe('themeSlice', () => {
     });
 
     it('should persist to localStorage when theme is not forced', () => {
+      // Stub matchMedia to prefer light so getThemeName deterministically picks defaultLightTheme.
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: vi.fn(query => ({ matches: query === '(prefers-color-scheme: light)' })),
+      });
       const state = { ...initialState, name: 'old-theme' };
-      const config = { defaultLightTheme: 'solarized-light' };
-      const actual = themeReducer(state, applyBackendThemeConfig(config));
-      // Theme changed, so it should be persisted via setTheme (property assignment)
-      if (actual.name !== state.name) {
-        expect(localStorage.headlampThemePreference).toEqual(actual.name);
-      }
+      const actual = themeReducer(
+        state,
+        applyBackendThemeConfig({ defaultLightTheme: 'solarized-light' })
+      );
+      expect(actual.name).toEqual('solarized-light');
+      expect(localStorage.headlampThemePreference).toEqual('solarized-light');
     });
   });
 });

--- a/frontend/src/components/App/themeSlice.test.tsx
+++ b/frontend/src/components/App/themeSlice.test.tsx
@@ -47,6 +47,9 @@ describe('themeSlice', () => {
   describe('applyBackendThemeConfig', () => {
     beforeEach(() => {
       localStorage.clear();
+      // The mock's clear() only resets store; setTheme() writes localStorage.headlampThemePreference
+      // as a direct property that survives clear(). Delete it explicitly so tests start clean.
+      delete (localStorage as any).headlampThemePreference;
     });
 
     it('should apply forced theme and override current theme', () => {
@@ -69,12 +72,11 @@ describe('themeSlice', () => {
     });
 
     it('should persist to localStorage when theme is not forced', () => {
-      // Stub matchMedia to prefer light so getThemeName deterministically picks defaultLightTheme.
-      Object.defineProperty(window, 'matchMedia', {
-        writable: true,
-        configurable: true,
-        value: vi.fn(query => ({ matches: query === '(prefers-color-scheme: light)' })),
-      });
+      // setupTests defines matchMedia with writable:true so direct assignment works;
+      // Object.defineProperty with configurable:true would throw on a non-configurable property.
+      (window as any).matchMedia = vi.fn((query: string) => ({
+        matches: query === '(prefers-color-scheme: light)',
+      }));
       const state = { ...initialState, name: 'old-theme' };
       const actual = themeReducer(
         state,

--- a/frontend/src/components/App/themeSlice.ts
+++ b/frontend/src/components/App/themeSlice.ts
@@ -72,6 +72,35 @@ const themeSlice = createSlice({
         setAppTheme(defaultThemeName);
       }
     },
+    /**
+     * Applies backend theme configuration if set.
+     * Should be called after config is loaded from backend.
+     */
+    applyBackendThemeConfig(
+      state,
+      action: PayloadAction<{
+        defaultLightTheme?: string;
+        defaultDarkTheme?: string;
+        forceTheme?: string;
+      }>
+    ) {
+      const backendConfig = action.payload;
+      const newThemeName = getThemeName(backendConfig);
+
+      // Only update if theme has changed
+      if (newThemeName !== state.name) {
+        state.name = newThemeName;
+        // Only persist to localStorage if not forced
+        if (!backendConfig.forceTheme) {
+          setAppTheme(newThemeName);
+        } else {
+          // Clear any previously stored user theme preference when a forced theme is applied
+          try {
+            localStorage.removeItem('headlampThemePreference');
+          } catch (e) {}
+        }
+      }
+    },
   },
 });
 
@@ -111,6 +140,11 @@ export const useCurrentAppTheme = () => {
   return currentTheme ?? defaultAppThemes[0];
 };
 
-export const { setBrandingAppLogoComponent, setTheme } = themeSlice.actions;
+export const {
+  setBrandingAppLogoComponent,
+  setTheme,
+  applyBackendThemeConfig,
+  ensureValidThemeName,
+} = themeSlice.actions;
 export { themeSlice };
 export default themeSlice.reducer;

--- a/frontend/src/components/App/themeSlice.ts
+++ b/frontend/src/components/App/themeSlice.ts
@@ -90,14 +90,11 @@ const themeSlice = createSlice({
       // Only update if theme has changed
       if (newThemeName !== state.name) {
         state.name = newThemeName;
-        // Only persist to localStorage if not forced
+        // Do not persist to localStorage when a forced theme is active — getThemeName()
+        // already returns forceTheme before reading localStorage, so the stored preference
+        // is never consulted while force is active and will be restored when it is lifted.
         if (!backendConfig.forceTheme) {
           setAppTheme(newThemeName);
-        } else {
-          // Clear any previously stored user theme preference when a forced theme is applied
-          try {
-            localStorage.removeItem('headlampThemePreference');
-          } catch (e) {}
         }
       }
     },

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
   "Theme": "Design",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "Cluster-Einstellungen",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "Sort sidebar items alphabetically",
   "Use evict for pod deletion": "Use evict for pod deletion",
   "Theme": "Theme",
+  "Theme has been forced by your administrator": "Theme has been forced by your administrator",
   "Keyboard Shortcuts": "Keyboard Shortcuts",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "Configure keyboard shortcuts for quick access to various parts of the application.",
   "Cluster Settings": "Cluster Settings",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
   "Theme": "Tema",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "Configuración del cluster",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "Trier les éléments de la barre latérale par ordre alphabétique",
   "Use evict for pod deletion": "Utiliser l'éviction pour la suppression de pods",
   "Theme": "Thème",
+  "Theme has been forced by your administrator": "Le thème a été imposé par votre administrateur",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "Paramètres du cluster",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "साइडबार आइटमों को वर्णानुक्रम में सॉर्ट करें",
   "Use evict for pod deletion": "Pod हटाने के लिए निष्कासन का उपयोग करें",
   "Theme": "थीम",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "कीबोर्ड शॉर्टकट्स",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "एप्लिकेशन के विभिन्न हिस्सों तक तेज़ पहुँच के लिए कीबोर्ड शॉर्टकट्स कॉन्फ़िगर करें।",
   "Cluster Settings": "क्लस्टर सेटिंग्स",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
   "Theme": "Tema",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "Impostazioni Cluster",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
   "Theme": "テーマ",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "クラスター設定",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "사이드바 항목을 가나다순으로 정렬",
   "Use evict for pod deletion": "",
   "Theme": "테마",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "클러스터 설정",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
   "Theme": "Tema",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "Definições do Cluster",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "Сортировка элементов боковой панели по алфавиту",
   "Use evict for pod deletion": "Использовать Evict при удалении Pod",
   "Theme": "Тема",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "Сочетания клавиш",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "Настройте сочетания клавиш для быстрого доступа к различным частям приложения.",
   "Cluster Settings": "Настройки кластера",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "பக்கப்பட்டி உருப்படிகளை அகரவரிசையில் வரிசைப்படுத்து",
   "Use evict for pod deletion": "பாட் நீக்குவதற்கு evict பயன்படுத்து",
   "Theme": "தீம்",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "க்ளஸ்டர் அமைப்புகள்",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "側邊欄項目按字母順序排序",
   "Use evict for pod deletion": "刪除 Pod 時使用 evict",
   "Theme": "主題",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "叢集設定",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -161,6 +161,7 @@
   "Sort sidebar items alphabetically": "侧边栏按字母排序",
   "Use evict for pod deletion": "使用驱逐方式删除 Pod",
   "Theme": "主题",
+  "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",
   "Cluster Settings": "集群设置",

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -168,4 +168,143 @@ describe('themes.ts', () => {
       expect(removeListener).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('getThemeName with backend configuration', () => {
+    it('should use force theme when provided', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: 'light',
+        clear: vi.fn(),
+      });
+
+      const backendConfig = {
+        forceTheme: 'corporate-branded',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('corporate-branded');
+    });
+
+    it('should prefer localStorage over backend defaults', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: 'dark',
+        clear: vi.fn(),
+      });
+      vi.stubGlobal('window', {
+        matchMedia: vi.fn(query => ({
+          matches: query === '(prefers-color-scheme: light)',
+        })),
+      });
+
+      const backendConfig = {
+        defaultLightTheme: 'corporate-light',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('dark');
+    });
+
+    it('should use backend default light theme when OS prefers light', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: null,
+        clear: vi.fn(),
+      });
+      vi.stubGlobal('window', {
+        matchMedia: vi.fn(query => ({
+          matches: query === '(prefers-color-scheme: light)',
+        })),
+      });
+
+      const backendConfig = {
+        defaultLightTheme: 'corporate-light',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('corporate-light');
+    });
+
+    it('should use backend default dark theme when OS prefers dark', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: null,
+        clear: vi.fn(),
+      });
+      vi.stubGlobal('window', {
+        matchMedia: vi.fn(query => ({
+          matches: query === '(prefers-color-scheme: dark)',
+        })),
+      });
+
+      const backendConfig = {
+        defaultDarkTheme: 'corporate-dark',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('corporate-dark');
+    });
+
+    it('should fall back to OS preference when no backend default matches', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: null,
+        clear: vi.fn(),
+      });
+      vi.stubGlobal('window', {
+        matchMedia: vi.fn(query => ({
+          matches: query === '(prefers-color-scheme: dark)',
+        })),
+      });
+
+      const backendConfig = {
+        defaultLightTheme: 'corporate-light',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('dark');
+    });
+
+    it('should handle both default themes with OS preference selection', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: null,
+        clear: vi.fn(),
+      });
+      vi.stubGlobal('window', {
+        matchMedia: vi.fn(query => ({
+          matches: query === '(prefers-color-scheme: light)',
+        })),
+      });
+
+      const backendConfig = {
+        defaultLightTheme: 'corporate-light',
+        defaultDarkTheme: 'corporate-dark',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('corporate-light');
+    });
+
+    it('should use force theme even with other defaults set', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: null,
+        clear: vi.fn(),
+      });
+
+      const backendConfig = {
+        defaultLightTheme: 'corporate-light',
+        defaultDarkTheme: 'corporate-dark',
+        forceTheme: 'forced-corporate',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('forced-corporate');
+    });
+
+    it('should work with plugin-provided theme names', () => {
+      vi.stubGlobal('localStorage', {
+        headlampThemePreference: null,
+        clear: vi.fn(),
+      });
+      vi.stubGlobal('window', {
+        matchMedia: vi.fn(query => ({
+          matches: query === '(prefers-color-scheme: light)',
+        })),
+      });
+
+      const backendConfig = {
+        defaultLightTheme: 'my-custom-plugin-theme',
+      };
+
+      expect(getThemeName(backendConfig)).toBe('my-custom-plugin-theme');
+    });
+  });
 });

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -560,28 +560,58 @@ export function usePrefersColorScheme() {
 /**
  * Hook gets theme based on user preference, and also OS/Browser preference.
  */
-export function getThemeName(): string {
+/**
+ * Computes the theme name based on user preference, backend configuration, and OS preference.
+ *
+ * Precedence order:
+ * 1. If forceTheme is set → use it (ignore user preference)
+ * 2. If user has selected theme in localStorage → use it
+ * 3. If backend has default theme matching OS preference → use it
+ * 4. Fallback to OS/browser preference (light/dark)
+ *
+ * @param backendConfig - Optional backend theme configuration
+ * @returns The theme name to use
+ */
+export function getThemeName(backendConfig?: {
+  defaultLightTheme?: string;
+  defaultDarkTheme?: string;
+  forceTheme?: string;
+}): string {
+  // If force theme is set, it overrides everything
+  if (backendConfig?.forceTheme) {
+    return backendConfig.forceTheme;
+  }
+
   const themePreference = localStorage.headlampThemePreference;
 
-  if (typeof window.matchMedia !== 'function') {
-    return 'light';
+  // User-selected theme preference takes precedence
+  if (themePreference) {
+    return themePreference;
   }
+
+  // Detect OS preference
+  if (typeof window.matchMedia !== 'function') {
+    return backendConfig?.defaultLightTheme || 'light';
+  }
+
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
 
-  let themeName = 'light';
-  if (themePreference) {
-    // A selected theme preference takes precedence.
-    themeName = themePreference;
-  } else {
-    if (prefersLight) {
-      themeName = 'light';
-    } else if (prefersDark) {
-      themeName = 'dark';
-    }
+  // Apply backend default theme based on OS preference
+  if (prefersLight && backendConfig?.defaultLightTheme) {
+    return backendConfig.defaultLightTheme;
+  } else if (prefersDark && backendConfig?.defaultDarkTheme) {
+    return backendConfig.defaultDarkTheme;
   }
 
-  return themeName;
+  // Fallback to OS preference
+  if (prefersLight) {
+    return 'light';
+  } else if (prefersDark) {
+    return 'dark';
+  }
+
+  return 'light';
 }
 
 export function setTheme(themeName: string) {

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -37,7 +37,7 @@ import * as Recharts from 'recharts';
 import semver from 'semver';
 import { Activity } from '../components/activity/Activity';
 import { runCommand } from '../components/App/runCommand';
-import { themeSlice } from '../components/App/themeSlice';
+import { applyBackendThemeConfig, ensureValidThemeName } from '../components/App/themeSlice';
 import * as CommonComponents from '../components/common';
 import { addBackstageAuthHeaders } from '../helpers/addBackstageAuthHeaders';
 import { getAppUrl } from '../helpers/getAppUrl';
@@ -704,7 +704,23 @@ async function afterPluginsRun(
   );
 
   // Refresh theme name if the theme that was used from a plugin was deleted
-  store.dispatch(themeSlice.actions.ensureValidThemeName());
+  store.dispatch(ensureValidThemeName());
+
+  // Reapply backend theme configuration now that plugins (which may provide themes) are loaded
+  const backendThemeConfig = store.getState().config;
+  if (
+    backendThemeConfig?.defaultLightTheme ||
+    backendThemeConfig?.defaultDarkTheme ||
+    backendThemeConfig?.forceTheme
+  ) {
+    store.dispatch(
+      applyBackendThemeConfig({
+        defaultLightTheme: backendThemeConfig.defaultLightTheme,
+        defaultDarkTheme: backendThemeConfig.defaultDarkTheme,
+        forceTheme: backendThemeConfig.forceTheme,
+      })
+    );
+  }
 }
 
 /**

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -59,6 +59,12 @@ export interface ConfigState {
    */
   defaultPodDebugImage: string;
   /**
+   * Theme configuration from the backend server.
+   */
+  defaultLightTheme?: string;
+  defaultDarkTheme?: string;
+  forceTheme?: string;
+  /**
    * Settings is a map of settings names to settings values.
    */
   settings: {
@@ -176,6 +182,9 @@ const configSlice = createSlice({
         isDynamicClusterEnabled?: boolean;
         allowKubeconfigChanges?: boolean;
         defaultPodDebugImage?: string;
+        defaultLightTheme?: string;
+        defaultDarkTheme?: string;
+        forceTheme?: string;
       }>
     ) {
       state.clusters = action.payload.clusters;
@@ -188,6 +197,9 @@ const configSlice = createSlice({
       if (action.payload.defaultPodDebugImage !== undefined) {
         state.defaultPodDebugImage = action.payload.defaultPodDebugImage;
       }
+      state.defaultLightTheme = action.payload.defaultLightTheme;
+      state.defaultDarkTheme = action.payload.defaultDarkTheme;
+      state.forceTheme = action.payload.forceTheme;
     },
     /**
      * Save the config. To both the store, and localStorage.


### PR DESCRIPTION
## Summary

This PR adds runtime configuration for default themes via command-line arguments, addressing the feedback from [#4307](https://github.com/kubernetes-sigs/headlamp/pull/4307)

## Related Issue

Addresses feedback from https://github.com/kubernetes-sigs/headlamp/pull/4307

## Changes

Adds three new CLI flags:
`--default-light-theme` - Default theme when OS prefers light mode
`--default-dark-theme` - Default theme when OS prefers dark mode
`--force-theme` - Force specific theme (overrides user preference)

Also available as environment variables: `HEADLAMP_CONFIG_DEFAULT_LIGHT_THEME`, `HEADLAMP_CONFIG_DEFAULT_DARK_THEME`, `HEADLAMP_CONFIG_FORCE_THEME`

When a theme is forced, the theme selection menu is greyed out, and "Theme has been forced by your administrator" is displayed. I localized it to French as I'm a native French speaker.

## Steps to Test

- use a browser in private browsing mode or clean your prefered theme from localstorage: run `delete localStorage.headlampThemePreference` from your browser JS console
- use the command line arguments to set a default or force a theme, for example  `--force-theme="Headlamp Classic"`

I also added unit tests: 
- Backend tests: `go test ./pkg/config -run TestParseThemeConfiguration`
- Frontend tests: `npm test -- themes.test.ts`

