### PR TITLE
fix(a11y)-9: remove label role from DropZoneBox UploadFiles button to meet ARIA specs

### DIFF
--- a/frontend/src/components/common/DropZoneBox.stories.tsx
+++ b/frontend/src/components/common/DropZoneBox.stories.tsx
@@ -34,7 +34,6 @@ UploadFiles.args = {
       <Typography sx={{ m: 2 }}>{'Select a file or drag and drop here'}</Typography>
       <Button
         variant="contained"
-        component="label"
         startIcon={<InlineIcon icon="mdi:upload" width={32} />}
         sx={{ fontWeight: 500 }}
       >


### PR DESCRIPTION
## Summary

This PR fixes an accessibility issue by adding an accessible name to the VersionDialog.

## Related Issue

Partially fixes #4385  
Addresses point 9 from the issues #4385

## Changes

- Updated `VersionDialog` to include an `aria-label`
- Fixed ARIA dialog name violation

## Steps to Test

1. Open the Version dialog in the application
2. Run `npm run frontend:test:a11y`
3. Verify no ARIA dialog name issues are reported

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- This change is scoped to accessibility compliance only
