### PR TITLE
fix(a11y)6-7-8: replace menu with list and make cluster chooser focusable

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -18,11 +18,11 @@ import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import ListSubheader from '@mui/material/ListSubheader';
-import MenuItem from '@mui/material/MenuItem';
-import MenuList from '@mui/material/MenuList';
 import Popover from '@mui/material/Popover';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
@@ -44,7 +44,7 @@ function ClusterListItem(props: { cluster: Cluster; onClick: () => void; selecte
   const theme = useTheme();
 
   return (
-    <MenuItem
+    <ListItemButton
       selected={selected}
       key={`recent_cluster_${cluster.name}`}
       onClick={onClick}
@@ -60,7 +60,7 @@ function ClusterListItem(props: { cluster: Cluster; onClick: () => void; selecte
         primary={cluster.name}
         secondary={!!cluster.isCurrent ? t('Current', { context: 'cluster' }) : ''}
       />
-    </MenuItem>
+    </ListItemButton>
   );
 }
 
@@ -251,8 +251,9 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
           }}
           {...activeDescendantProp}
         />
-        <MenuList
+        <List
           id="cluster-chooser-list"
+          tabIndex={0}
           sx={{
             width: '280px',
             minWidth: '280px',
@@ -305,7 +306,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
               selected={cluster.name === getActiveDescendantCluster()?.name}
             />
           ))}
-        </MenuList>
+        </List>
       </Box>
       {isElectron() && (
         <>


### PR DESCRIPTION
## Summary

This PR fixes multiple accessibility issues in `ClusterChooserPopup` by correcting ARIA roles, list structure, and focus behavior.

## Related Issue

Partially fixes #4385  
Addresses points 6, 7, and 8 from issue #4385

## Changes

- Replaced `MenuList` / `MenuItem` with semantic `List` / `ListItemButton`
- Fixed invalid ARIA menu role and required-children violations
- Ensured `ListSubheader` is contained within a proper list parent
- Made the scrollable cluster list focusable using `tabIndex={0}`
- Avoided introducing new ARIA role violations by not using `role="listbox"`

## Tested by:

```bash
# Install frontend dependencies if not already installed
npm run install:frontend

# Check if TypeScript compiles (most important)
npm run frontend:tsc

# Run linting
npm run frontend:lint

# (Optional) Start Storybook after dependencies are installed
npm run frontend:storybook
