### PR TITLE
fix(a11y)-11: wrap RestartMultipleButton in MenuList to satisfy ARIA …

### DIFF
--- a/frontend/src/components/common/Resource/RestartMultipleButton.stories.tsx
+++ b/frontend/src/components/common/Resource/RestartMultipleButton.stories.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import MenuList from '@mui/material/MenuList';
+import Paper from '@mui/material/Paper';
 import { Meta, StoryFn } from '@storybook/react';
 import { getTestDate } from '../../../helpers/testHelpers';
 import { TestContext } from '../../../test';
@@ -54,7 +56,15 @@ AfterConfirmCallback.args = {
   },
 };
 
-export const MenuButtonStyle = Template.bind({});
+const MenuTemplate: StoryFn<typeof RestartMultipleButton> = args => (
+  <Paper>
+    <MenuList>
+      <RestartMultipleButton {...args} />
+    </MenuList>
+  </Paper>
+);
+
+export const MenuButtonStyle = MenuTemplate.bind({});
 MenuButtonStyle.args = {
   items: [
     { metadata: { uid: '1', name: 'Resource 1', creationTimestamp: getTestDate().toISOString() } },


### PR DESCRIPTION
## Summary

This PR fixes an accessibility issue by ensuring menu items are rendered within a proper ARIA parent.

## Related Issue

Partially fixes #4385  
Addresses point 11 (ARIA required parent)

## Changes

- Updated `RestartMultipleButton.stories.tsx` to wrap the component in `MenuList`
- Added `Paper` wrapper to provide a valid menu container in Storybook
- Fixed ARIA required-parent violation for `MenuItem`

## Steps to Test

1. Run `npm run frontend:test:a11y`
2. Open Storybook and navigate to the **RestartMultipleButton → MenuButtonStyle** story
3. Verify no ARIA required-parent violations are reported

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- Aligns with MUI and ARIA best practices
