### PR TITLE
fix(a11y)-10: add accessible name to Loader progress indicator when t…

### DIFF
--- a/frontend/src/components/common/Loader.tsx
+++ b/frontend/src/components/common/Loader.tsx
@@ -25,7 +25,7 @@ export interface LoaderProps extends CircularProgressProps {
 
 export default function Loader(props: LoaderProps) {
   const { noContainer = false, title, ...other } = props;
-  const progress = <CircularProgress title={title} {...other} />;
+  const progress = <CircularProgress title={title} aria-label={title || 'Loading'} {...other} />;
 
   if (noContainer) return progress;
 


### PR DESCRIPTION
## Summary

This PR fixes an accessibility issue by ensuring the Loader progress indicator always has an accessible name.

## Related Issue

Partially fixes #4385  
Addresses point 10 (ARIA progressbar name)

## Changes

- Updated `Loader` to add an `aria-label` to `CircularProgress`
- Added a fallback accessible name (`"Loading"`) when the `title` prop is empty
- Fixed ARIA progressbar name violation in Storybook

## Steps to Test

1. Run `npm run frontend:test:a11y`
2. Open Storybook and navigate to the **Loader → WithEmptyTitle** story
3. Verify no ARIA progressbar name violations are reported

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- Uses a minimal, standards-compliant ARIA fix
