### PR TITLE
fix(a11y)-2: improve color contrast for search hint and plugin type chip

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -283,7 +283,21 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                   },
                 };
                 const typeInfo = typeLabels[plugin.type || 'shipped'];
-                return <Chip label={typeInfo.label} size="small" color={typeInfo.color} />;
+                return (
+                  <Chip
+                    label={typeInfo.label}
+                    size="small"
+                    color={typeInfo.color}
+                    sx={
+                      typeInfo.color === 'info'
+                        ? {
+                            bgcolor: 'info.dark',
+                            color: theme => theme.palette.getContrastText(theme.palette.info.dark),
+                          }
+                        : undefined
+                    }
+                  />
+                );
               },
             },
             {

--- a/frontend/src/components/globalSearch/GlobalSearch.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearch.tsx
@@ -95,7 +95,12 @@ export function GlobalSearch({ isIconButton }: { isIconButton?: boolean }) {
           </InputAdornment>
         ),
         endAdornment: (
-          <Box display="flex" flexShrink={0} gap={0.5} sx={{ opacity: 0.7, pointerEvents: 'none' }}>
+          <Box
+            display="flex"
+            flexShrink={0}
+            gap={0.5}
+            sx={{ pointerEvents: 'none', color: 'text.secondary' }}
+          >
             <Trans>
               Press
               <Box


### PR DESCRIPTION
## Summary

This PR improves color contrast to meet WCAG accessibility requirements by adjusting text and chip styling in the UI.

## Related Issue

Fixes #4385  
Addresses point 2 from issue #4385

## Changes

- Improved contrast of the “Press / to search” hint in GlobalSearch by removing opacity and using theme text colors
- Updated the “User-installed” (info) plugin type chip to use a darker background with sufficient text contrast

## Steps to Test

1. Open the application header and locate the global search input
2. Verify that the “Press / to search” hint text is clearly readable
3. Navigate to **Settings → Plugins**
4. Check that the “User-installed” chip has readable text with sufficient contrast

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- Changes are visual-only and should not affect functionality
- Verified against WCAG 2.1 contrast guidelines
