### PR TITLE
fix(a11y)-3: prevent rendering empty dialog title headings

### DIFF
--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -46,6 +46,11 @@ export interface OurDialogTitleProps extends DialogTitleProps {
 export function DialogTitle(props: OurDialogTitleProps) {
   const { children, focusTitle, buttons, disableTypography = false, ...other } = props;
 
+  // Don't render heading if there's no content to avoid empty heading violations
+  if (!children && (!buttons || buttons.length === 0)) {
+    return null;
+  }
+
   const focusedRef = React.useCallback((node: HTMLElement) => {
     if (node !== null) {
       if (focusTitle) {
@@ -58,23 +63,25 @@ export function DialogTitle(props: OurDialogTitleProps) {
   return (
     <MuiDialogTitle style={{ display: 'flex' }} {...other}>
       <Grid container justifyContent="space-between" alignItems="center">
-        <Grid item>
-          {disableTypography ? (
-            children
-          ) : (
-            <Typography
-              ref={focusedRef}
-              variant="h1"
-              style={{
-                fontSize: '1.25rem',
-                fontWeight: 500,
-                lineHeight: 1.6,
-              }}
-            >
-              {children}
-            </Typography>
-          )}
-        </Grid>
+        {children && (
+          <Grid item>
+            {disableTypography ? (
+              children
+            ) : (
+              <Typography
+                ref={focusedRef}
+                variant="h1"
+                style={{
+                  fontSize: '1.25rem',
+                  fontWeight: 500,
+                  lineHeight: 1.6,
+                }}
+              >
+                {children}
+              </Typography>
+            )}
+          </Grid>
+        )}
         {buttons && buttons.length > 0 && (
           <Grid item>
             <Box>


### PR DESCRIPTION
## Summary

This PR fixes accessibility violations by preventing `DialogTitle` from rendering empty heading elements when no title content is provided.

## Related Issue

-  #4385 

Addresses point 3 from the accessibility issue

## Changes

- Updated `DialogTitle` to return `null` when both `children` and action buttons are absent
- Conditionally render the heading only when title content exists
- Preserved rendering of dialog action buttons when present

## Steps to Test

1. Open Storybook and navigate to dialogs without a title
2. Run accessibility checks (Axe)
3. Verify no empty heading violations are reported

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- Centralized fix in `Dialog.tsx`; no story files were modified
- Maintains existing dialog behavior while improving accessibility