### PR TITLE
Frontend: Router: Unauthenticated users can now follow deeplinks.

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -155,7 +155,7 @@ function AuthRoute(props: AuthRouteProps) {
     computedMatch = {},
     ...other
   } = props;
-  const redirectRoute = getCluster() ? 'login' : 'chooser';
+
   useSidebarItem(sidebar, computedMatch);
   const cluster = useCluster();
   const query = useQuery({
@@ -164,6 +164,24 @@ function AuthRoute(props: AuthRouteProps) {
     enabled: !!cluster && requiresAuth,
     retry: 0,
   });
+
+  const clusters = useClustersConf();
+  const currentCluster = getCluster();
+  const clusterConf = currentCluster && clusters ? clusters[currentCluster] : null;
+  const authError = query.error as any;
+  const isExplicitAuthError = [401, 403].includes(authError?.status);
+
+  let redirectRoute: string;
+
+  if (!currentCluster) {
+    redirectRoute = 'chooser';
+  } else if (clusterConf?.auth_type === 'oidc') {
+    redirectRoute = 'login';
+  } else if (query.isError && isExplicitAuthError) {
+    redirectRoute = 'token';
+  } else {
+    redirectRoute = 'login';
+  }
 
   function getRenderer({ location }: RouteProps) {
     if (!requiresAuth) {

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -25,7 +25,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { generatePath, useHistory } from 'react-router-dom';
+import { generatePath, useHistory, useLocation } from 'react-router-dom';
 import { setToken } from '../../lib/auth';
 import { getCluster, getClusterPrefixedPath } from '../../lib/cluster';
 import { useClustersConf } from '../../lib/k8s';
@@ -37,6 +37,7 @@ import HeadlampLink from '../common/Link';
 
 export default function AuthToken() {
   const history = useHistory();
+  const location = useLocation<{ from?: Location }>();
   const clusterConf = useClustersConf();
   const [token, setToken] = React.useState('');
   const [showError, setShowError] = React.useState(false);
@@ -47,11 +48,15 @@ export default function AuthToken() {
     loginWithToken(token).then(code => {
       // If successful, redirect.
       if (code === 200) {
-        history.replace(
-          generatePath(getClusterPrefixedPath(), {
-            cluster: getCluster() as string,
-          })
-        );
+        if (location.state && location.state.from) {
+          history.replace(location.state.from);
+        } else {
+          history.replace(
+            generatePath(getClusterPrefixedPath(), {
+              cluster: getCluster() as string,
+            })
+          );
+        }
       } else {
         setToken('');
         setShowError(true);


### PR DESCRIPTION
## Summary

This PR fixes unauthenticated user getting redirected to homepage rather than the page they visited.

## Related Issue

Closes #4314 

## Changes

- RouteSwitcher.tsx to send correct redirect route
- Auth.tsx added fallback if location is undefined

## Steps to Test

- Logout, visit an unauthorized page.
- Add authentication token
- Gets redirected to the same page as before(as expected)

## Screenshots 

https://github.com/user-attachments/assets/cbe3adcd-b5bc-4338-85b1-4cf19f634a5c





