### PR TITLE
Frontend: Secrets: Added Toggle Switch to filter helm secrets

### DIFF
--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -14,17 +14,63 @@
  * limitations under the License.
  */
 
+import { FormControlLabel, Switch } from '@mui/material';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Secret from '../../lib/k8s/secret';
+import { useNamespaces } from '../../redux/filterSlice';
+import { CreateResourceButton } from '../common';
 import ResourceListView from '../common/Resource/ResourceListView';
 
 export default function SecretList() {
+  const SECRET_LIST_HELM_SECRET_HIDE_STORAGE_KEY = 'SECRET_LIST_HELM_SECRET_HIDE_STORAGE_KEY';
+  const SECRET_LIST_HELM_SECRET_HIDE_DEFAULT = true;
   const { t } = useTranslation(['glossary', 'translation']);
+  const storedHideHelm = localStorage.getItem(SECRET_LIST_HELM_SECRET_HIDE_STORAGE_KEY);
+  const [hideHelm, setHideHelm] = React.useState<boolean>(
+    JSON.parse(storedHideHelm || SECRET_LIST_HELM_SECRET_HIDE_DEFAULT.toString())
+  );
+
+  const [secrets, error] = Secret.useList({ namespace: useNamespaces() });
+
+  const filteredSecrets = React.useMemo(() => {
+    if (!secrets) {
+      return null;
+    }
+    return hideHelm ? secrets.filter(secret => secret.type !== 'helm.sh/release.v1') : secrets;
+  }, [secrets, hideHelm]);
 
   return (
     <ResourceListView
+      id="headlamp-secrets"
       title={t('Secrets')}
-      resourceClass={Secret}
+      data={filteredSecrets}
+      errorMessage={Secret.getErrorMessage(error)}
+      headerProps={{
+        noNamespaceFilter: false,
+        titleSideActions: [
+          <CreateResourceButton key="create-button" resourceClass={Secret} />,
+          <FormControlLabel
+            key="helm-switch"
+            checked={hideHelm}
+            control={
+              <Switch
+                checked={hideHelm}
+                onChange={(e, checked) => {
+                  localStorage.setItem(
+                    SECRET_LIST_HELM_SECRET_HIDE_STORAGE_KEY,
+                    checked.toString()
+                  );
+                  setHideHelm(checked);
+                }}
+                color="primary"
+              />
+            }
+            label={t('translation|Hide Helm Secrets')}
+            sx={{ marginLeft: '0.5rem' }}
+          />,
+        ],
+      }}
       columns={[
         'name',
         'namespace',

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -31,6 +31,37 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
+              <label
+                class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-b28cjl-MuiFormControlLabel-root"
+              >
+                <span
+                  class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+                >
+                  <span
+                    class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-1emuodk-MuiButtonBase-root-MuiSwitch-switchBase"
+                  >
+                    <input
+                      checked=""
+                      class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                      type="checkbox"
+                    />
+                    <span
+                      class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                    />
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </span>
+                  <span
+                    class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1ezega9-MuiTypography-root"
+                >
+                  Hide Helm Secrets
+                </span>
+              </label>
             </div>
           </div>
         </div>

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -685,6 +685,7 @@
   "Users": "Benutzer",
   "Handler": "Handler",
   "No data in this secret": "Keine Daten in dieser Secret",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "Seitenleiste verkleinern",
   "Expand sidebar": "Seitenleiste erweitern",
   "Main Navigation": "Hauptnavigation",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -685,6 +685,7 @@
   "Users": "Users",
   "Handler": "Handler",
   "No data in this secret": "No data in this secret",
+  "Hide Helm Secrets": "Hide Helm Secrets",
   "Shrink sidebar": "Shrink sidebar",
   "Expand sidebar": "Expand sidebar",
   "Main Navigation": "Main Navigation",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -689,6 +689,7 @@
   "Users": "Usuarios",
   "Handler": "Manejador",
   "No data in this secret": "Sin datos en este secret",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "Reducir barra lateral",
   "Expand sidebar": "Expandir barra lateral",
   "Main Navigation": "Navegación principal",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -689,6 +689,7 @@
   "Users": "Utilisateurs",
   "Handler": "Gestionnaire",
   "No data in this secret": "Aucune donnée pour cette secret",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "Réduire la barre latérale",
   "Expand sidebar": "Développer la barre latérale",
   "Main Navigation": "Navigation principale",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -685,6 +685,7 @@
   "Users": "उपयोगकर्ता",
   "Handler": "",
   "No data in this secret": "",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "साइडबार संकुचित करें",
   "Expand sidebar": "साइडबार विस्तृत करें",
   "Main Navigation": "मुख्य नेविगेशन",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -689,6 +689,7 @@
   "Users": "Utenti",
   "Handler": "Gestore",
   "No data in this secret": "Nessun dato in questo segreto",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "Comprimi barra laterale",
   "Expand sidebar": "Espandi barra laterale",
   "Main Navigation": "Navigazione Principale",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -681,6 +681,7 @@
   "Users": "ユーザー",
   "Handler": "ハンドラー",
   "No data in this secret": "このシークレットにデータがありません",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "サイドバーを縮小",
   "Expand sidebar": "サイドバーを展開",
   "Main Navigation": "メインナビゲーション",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -681,6 +681,7 @@
   "Users": "Users",
   "Handler": "Handler",
   "No data in this secret": "이 비밀에 데이터가 없습니다",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "사이드바 축소",
   "Expand sidebar": "사이드바 확장",
   "Main Navigation": "메인 탐색",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -689,6 +689,7 @@
   "Users": "Utilizadores",
   "Handler": "Handler",
   "No data in this secret": "Sem dados neste secret",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "Encolher barra lateral",
   "Expand sidebar": "Expandir barra lateral",
   "Main Navigation": "Navegação Principal",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -685,6 +685,7 @@
   "Users": "யூஸர்கள்",
   "Handler": "ஹாண்ட்லர்",
   "No data in this secret": "இந்த சீக்ரெட்டில் டேட்டா இல்லை",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "சைட்பாரை சுருக்கு",
   "Expand sidebar": "சைட்பாரை விரிவாக்கு",
   "Main Navigation": "முக்கிய நேவிகேஷன்",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -681,6 +681,7 @@
   "Users": "使用者",
   "Handler": "處理程式",
   "No data in this secret": "此金鑰中無資料",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "收縮側邊欄",
   "Expand sidebar": "展開側邊欄",
   "Main Navigation": "主導航",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -681,6 +681,7 @@
   "Users": "用户",
   "Handler": "处理程序",
   "No data in this secret": "此 Secret 中无数据",
+  "Hide Helm Secrets": "",
   "Shrink sidebar": "收缩侧边栏",
   "Expand sidebar": "展开侧边栏",
   "Main Navigation": "主导航",


### PR DESCRIPTION
## Summary

This PR adds a toggle switch to hide helm secrets

## Related Issue

Fixes #4335 

## Changes

Changes `SecretList()` component to include a toggle switch in the header to hide secrets of type `helm.sh/release.v1`.
(It is turned on by default)

## Screenshots (if applicable)

<img width="1522" height="525" alt="image" src="https://github.com/user-attachments/assets/b2998d4f-7f6b-4b34-bed0-a0d21c2e2032" />

<img width="1501" height="643" alt="image" src="https://github.com/user-attachments/assets/a2c09a12-ca90-45f9-8369-6de29285134e" />

