### PR TITLE
charts: Quote OIDC_USE_PKCE value to ensure it's a string

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -216,7 +216,7 @@ spec:
             {{- end }}
             {{- if $oidc.usePKCE }}
             - name: OIDC_USE_PKCE
-              value: {{ $oidc.usePKCE }}
+              value: {{ $oidc.usePKCE | quote }}
             {{- end }}
             {{- if $oidc.meUserInfoURL }}
             - name: ME_USER_INFO_URL

--- a/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
@@ -107,7 +107,7 @@ spec:
             - name: OIDC_SCOPES
               value: testScope
             - name: OIDC_USE_PKCE
-              value: true
+              value: "true"
           args:
             - "-in-cluster"
             - "-plugins-dir=/headlamp/plugins"


### PR DESCRIPTION
## Summary

This PR adds/fixes helm deployments that use PKCE OIDC without a separate secret

## Related Issue

None

## Changes

- Fixed bug

## Steps to Test

Use Helm for deployment with PKCE & OIDC without saving the values in a secret.

## Screenshots (if applicable)

None

## Notes for the Reviewer

None

