### PR TITLE
Fixed MaxListenersExceededWarning

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1327,6 +1327,11 @@ function adjustZoom(delta: number) {
 function startElectron() {
   console.info('App starting...');
 
+  // Increase max listeners to prevent false positive warnings
+  // The app legitimately needs multiple IPC listeners (currently 11)
+  // Default is 10, setting to 20 provides headroom for future additions
+  ipcMain.setMaxListeners(20);
+
   let appVersion: string;
   if (isDev && process.env.HEADLAMP_APP_VERSION) {
     appVersion = process.env.HEADLAMP_APP_VERSION;


### PR DESCRIPTION
## Summary

Fixes #4431

## Changes

- raised the limit locally via ipcMain.setMaxListeners(20) to avoid the false-positive warning.

## Screenshots (if applicable)

<img width="465" height="248" alt="Screenshot 2026-01-24 at 6 41 50 PM" src="https://github.com/user-attachments/assets/b0804e34-e1a3-4272-9d70-1f35a2e8fd12" />

