### PR TITLE
Frontend: Namespace: Feature to save selected namespace per cluster

### DIFF
--- a/frontend/src/components/App/Layout.tsx
+++ b/frontend/src/components/App/Layout.tsx
@@ -28,11 +28,13 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { getCluster } from '../../lib/cluster';
 import { getSelectedClusters } from '../../lib/cluster';
-import { useClustersConf } from '../../lib/k8s';
+import { useCluster, useClustersConf } from '../../lib/k8s';
 import { request } from '../../lib/k8s/api/v1/clusterRequests';
 import { Cluster } from '../../lib/k8s/cluster';
+import { getSavedNamespaces } from '../../lib/storage';
 import { setConfig } from '../../redux/configSlice';
 import { ConfigState } from '../../redux/configSlice';
+import { setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import store from '../../redux/stores/store';
 import { useUIPanelsGroupedBySide } from '../../redux/uiSlice';
@@ -211,6 +213,14 @@ export default function Layout({}: LayoutProps) {
   useEffect(() => {
     document.body.removeAttribute('style');
   }, []);
+
+  const cluster = useCluster();
+  useEffect(() => {
+    if (cluster) {
+      const saved = getSavedNamespaces(cluster);
+      dispatch(setNamespaceFilter(saved));
+    }
+  }, [cluster, dispatch]);
 
   const urlClusters = getSelectedClusters();
   const clustersNotInURL =

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getCluster } from './cluster';
+
+const NAMESPACE_STORAGE_KEY = 'headlamp-selected-namespace';
+
+export function getSavedNamespaces(cluster?: string): string[] {
+  const activeCluster = cluster || getCluster();
+  if (!activeCluster) {
+    return [];
+  }
+  try {
+    const saved = localStorage.getItem(`${NAMESPACE_STORAGE_KEY}_${activeCluster}`);
+    if (!saved) {
+      return [];
+    }
+
+    const namespaces = JSON.parse(saved);
+    if (Array.isArray(namespaces)) {
+      const sanitized = namespaces
+        .map(ns => (typeof ns === 'string' ? ns.trim() : ''))
+        .filter(ns => ns !== '');
+
+      return Array.from(new Set(sanitized));
+    }
+    return [];
+  } catch (e) {
+    console.error('Failed to load namespaces from Local Storage', e);
+    return [];
+  }
+}
+
+export function saveNamespaces(namespaces: string[], cluster?: string) {
+  const activeCluster = cluster || getCluster();
+  if (!activeCluster) {
+    return;
+  }
+  try {
+    const sanitized = namespaces
+      .map(ns => (typeof ns === 'string' ? ns.trim() : ''))
+      .filter(ns => ns !== '');
+
+    const unique = Array.from(new Set(sanitized));
+
+    localStorage.setItem(`${NAMESPACE_STORAGE_KEY}_${activeCluster}`, JSON.stringify(unique));
+  } catch (e) {
+    console.error('Failed to save namespaces in Local Storage:', e);
+  }
+}

--- a/frontend/src/redux/filterSlice.ts
+++ b/frontend/src/redux/filterSlice.ts
@@ -21,6 +21,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { KubeEvent } from '../lib/k8s/event';
 import type { KubeObjectInterface } from '../lib/k8s/KubeObject';
+import { getSavedNamespaces, saveNamespaces } from '../lib/storage';
 
 export interface FilterState {
   /** The namespaces to filter on. */
@@ -28,7 +29,7 @@ export interface FilterState {
 }
 
 export const initialState: FilterState = {
-  namespaces: new Set(),
+  namespaces: new Set(getSavedNamespaces()),
 };
 
 /**
@@ -139,13 +140,21 @@ const filterSlice = createSlice({
      * Sets the namespace filter with an array of strings.
      */
     setNamespaceFilter(state, action: PayloadAction<string[]>) {
-      state.namespaces = new Set(action.payload);
+      const namespaces = action.payload
+        .map(ns => (typeof ns === 'string' ? ns.trim() : ''))
+        .filter(Boolean);
+
+      const namespacesSet = new Set(namespaces);
+      state.namespaces = namespacesSet;
+
+      saveNamespaces([...namespacesSet]);
     },
     /**
      * Resets the filter state.
      */
     resetFilter(state) {
       state.namespaces = new Set();
+      saveNamespaces([]);
     },
   },
 });


### PR DESCRIPTION
## Summary

This PR adds a feature to save all selected namespace for every cluster in local storage.

## Related Issue

Closes #4119 

## Changes

- Added `storage.ts` file to save/get namespaces to/from `localStorage`
- Modified `Layout.tsx` and `filterSlice.ts` to load filter on cluster change.

## Screenshots

https://github.com/user-attachments/assets/4d491eaf-6a16-4494-9047-2a5d02eae2fe



