### PR TITLE
charts: headlamp: Use HEADLAMP_CONFIG_ env var 

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -1,51 +1,7 @@
 {{- $oidc := .Values.config.oidc }}
 {{- $env := .Values.env }}
 
-{{- $clientID := "" }}
-{{- $clientSecret := "" }}
-{{- $issuerURL := "" }}
-{{- $scopes := "" }}
-{{- $callbackURL := "" }}
-{{- $validatorClientID := "" }}
-{{- $validatorIssuerURL := "" }}
-{{- $usePKCE := "" }}
-{{- $useAccessToken := "" }}
-{{- $meUserInfoURL := "" }}
 
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-{{- range $env }}
-  {{- if eq .name "OIDC_CLIENT_ID" }}
-    {{- $clientID = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_CLIENT_SECRET" }}
-    {{- $clientSecret = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_ISSUER_URL" }}
-    {{- $issuerURL = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_SCOPES" }}
-    {{- $scopes = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_CALLBACK_URL" }}
-    {{- $callbackURL = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_VALIDATOR_CLIENT_ID" }}
-    {{- $validatorClientID = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_VALIDATOR_ISSUER_URL" }}
-    {{- $validatorIssuerURL = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_USE_ACCESS_TOKEN" }}
-    {{- $useAccessToken = .value | toString }}
-  {{- end }}
-  {{- if eq .name "OIDC_USE_PKCE" }}
-    {{- $usePKCE = .value | toString }}
-  {{- end }}
-  {{- if eq .name "ME_USER_INFO_URL" }}
-    {{- $meUserInfoURL = .value | toString }}
-  {{- end }}
-{{- end }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -112,70 +68,70 @@ spec:
           env:
             {{- if $oidc.secret.create }}
             {{- if $oidc.clientID }}
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: clientID
             {{- end }}
             {{- if $oidc.clientSecret }}
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: clientSecret
             {{- end }}
             {{- if $oidc.issuerURL }}
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: issuerURL
             {{- end }}
             {{- if $oidc.scopes }}
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: scopes
             {{- end }}
             {{- if $oidc.callbackURL }}
-            - name: OIDC_CALLBACK_URL
+            - name: HEADLAMP_CONFIG_OIDC_CALLBACK_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: callbackURL
             {{- end }}
             {{- if $oidc.validatorClientID }}
-            - name: OIDC_VALIDATOR_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: validatorClientID
             {{- end }}
             {{- if $oidc.validatorIssuerURL }}
-            - name: OIDC_VALIDATOR_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: validatorIssuerURL
             {{- end }}
             {{- if $oidc.useAccessToken }}
-            - name: OIDC_USE_ACCESS_TOKEN
+            - name: HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: useAccessToken
             {{- end }}
             {{- if $oidc.usePKCE }}
-            - name: OIDC_USE_PKCE
+            - name: HEADLAMP_CONFIG_OIDC_USE_PKCE
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: usePKCE
             {{- end }}
             {{- if $oidc.meUserInfoURL }}
-            - name: ME_USER_INFO_URL
+            - name: HEADLAMP_CONFIG_ME_USER_INFO_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
@@ -183,43 +139,43 @@ spec:
             {{- end }}
             {{- else }}
             {{- if $oidc.clientID }}
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: {{ $oidc.clientID }}
             {{- end }}
             {{- if $oidc.clientSecret }}
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: {{ $oidc.clientSecret }}
             {{- end }}
             {{- if $oidc.issuerURL }}
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: {{ $oidc.issuerURL }}
             {{- end }}
             {{- if $oidc.scopes }}
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: {{ $oidc.scopes }}
             {{- end }}
             {{- if $oidc.callbackURL }}
-            - name: OIDC_CALLBACK_URL
+            - name: HEADLAMP_CONFIG_OIDC_CALLBACK_URL
               value: {{ $oidc.callbackURL }}
             {{- end }}
             {{- if $oidc.validatorClientID }}
-            - name: OIDC_VALIDATOR_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID
               value: {{ $oidc.validatorClientID }}
             {{- end }}
             {{- if $oidc.validatorIssuerURL }}
-            - name: OIDC_VALIDATOR_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL
               value: {{ $oidc.validatorIssuerURL }}
             {{- end }}
             {{- if $oidc.useAccessToken }}
-            - name: OIDC_USE_ACCESS_TOKEN
+            - name: HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN
               value: {{ $oidc.useAccessToken }}
             {{- end }}
             {{- if $oidc.usePKCE }}
-            - name: OIDC_USE_PKCE
+            - name: HEADLAMP_CONFIG_OIDC_USE_PKCE
               value: {{ $oidc.usePKCE }}
             {{- end }}
             {{- if $oidc.meUserInfoURL }}
-            - name: ME_USER_INFO_URL
+            - name: HEADLAMP_CONFIG_ME_USER_INFO_URL
               value: {{ $oidc.meUserInfoURL }}
             {{- end }}
             {{- end }}
@@ -241,74 +197,8 @@ spec:
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
             {{- end }}
-            {{- if not $oidc.externalSecret.enabled}}
-            # Check if externalSecret is disabled
-            {{- if or (ne $oidc.clientID "") (ne $clientID "") }}
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            {{- end }}
-            {{- if or (ne $oidc.clientSecret "") (ne $clientSecret "") }}
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            {{- end }}
-            {{- if or (ne $oidc.issuerURL "") (ne $issuerURL "") }}
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            {{- end }}
-            {{- if or (ne $oidc.scopes "") (ne $scopes "") }}
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
-            {{- end }}
-            {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
-            # Check if callbackURL is non empty either from env or oidc.config
-            - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorClientID "") (ne $validatorClientID "") }}
-            # Check if validatorClientID is non empty either from env or oidc.config
-            - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorIssuerURL "") (ne $validatorIssuerURL "") }}
-            # Check if validatorIssuerURL is non empty either from env or oidc.config
-            - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
-            {{- end }}
-            {{- if or (ne ($oidc.useAccessToken | toString) "false") (ne $useAccessToken "") }}
-            # Check if useAccessToken is non false either from env or oidc.config
-            - "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)"
-            {{- end }}
-            {{- if or (eq ($oidc.usePKCE | toString) "true") (eq $usePKCE "true") }}
-            - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
-            {{- end }}
-            {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
-            - "-me-user-info-url=$(ME_USER_INFO_URL)"
-            {{- end }}
-            {{- else }}
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            - "-oidc-scopes=$(OIDC_SCOPES)"
-            {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
-            # Check if callbackURL is non empty either from env or oidc.config
-            - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"
-            {{- end }}
-            {{- if or (eq ($oidc.usePKCE | toString) "true") (eq $usePKCE "true") }}
-            - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorClientID "") (ne $validatorClientID "") }}
-            # Check if validatorClientID is non empty either from env or oidc.config
-            - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorIssuerURL "") (ne $validatorIssuerURL "") }}
-            # Check if validatorIssuerURL is non empty either from env or oidc.config
-            - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
-            {{- end }}
-            {{- if or (eq ($oidc.useAccessToken | toString) "true") (eq $useAccessToken "true") }}
-            # Check if useAccessToken is non false either from env or oidc.config
-            - "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)"
-            {{- end }}
-            {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
-            - "-me-user-info-url=$(ME_USER_INFO_URL)"
-            {{- end }}
-            {{- end }}
+
+
             {{- with .Values.config.baseURL }}
             - "-base-url={{ . }}"
             {{- end }}
@@ -370,6 +260,9 @@ spec:
               mountPath: {{ .Values.config.pluginsDir }}
             - name: plugin-config
               mountPath: /config
+            {{- with .Values.pluginsManager.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.pluginsManager.resources | nindent 12 }}
           securityContext:


### PR DESCRIPTION
Summary
This PR fixes an issue where the Helm chart could override valid OIDC settings with empty values.It removes hardcoded command-line flags and relies only on the standard HEADLAMP_CONFIG_ environment variables. This ensures that user-provided configuration is read correctly and not ignored.

Related Issue
Fixes #4080

Changes
-Updated charts/headlamp/templates/deployment.yaml to strictly use HEADLAMP_CONFIG_ prefixed environment variables for all OIDC settings, aligning with Headlamp's native configuration system.
-Removed the logic that passed OIDC settings as command-line arguments. This prevents empty values from overriding valid environment variable configuration.
-Removed redundant variable extraction logic from the top of the deployment template.

Steps to Test
1.Navigate to chart directory : cd charts/headlamp
2.Use any dummy OIDC values :
 >helm template . --set config.oidc.clientID=test-client-id --set config.oidc.issuerURL=https://test-issuer.com

3.After inspecting we will get that environment variables like HEADLAMP_CONFIG_OIDC_CLIENT_ID are present and correctly set with no no command-line arguments.

Screenshots (if applicable)

Notes for the Reviewer