### PR TITLE
frontend: themes: Add missing properties to HeadlampTables interface

### DIFF
--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -19,25 +19,128 @@ import { createTheme, getContrastRatio, useTheme } from '@mui/material/styles';
 import React from 'react';
 import type { AppTheme } from './AppTheme';
 
+export interface HeadlampChartStyles {
+  defaultFillColor: string;
+  fillColor?: string;
+  labelColor: string;
+}
+
+export interface HeadlampHeaderStyle {
+  normal: {
+    fontSize: string;
+    fontWeight: string;
+  };
+  main: {
+    fontSize: string;
+    fontWeight: string;
+  };
+  subsection: {
+    fontSize: string;
+    fontWeight: string;
+  };
+  label: {
+    fontSize: string;
+    paddingTop: string;
+  };
+}
+
+export interface HeadlampTables {
+  head: {
+    background: string;
+    color: string;
+    borderColor: string;
+    text?: string;
+  };
+  body: {
+    background: string;
+  };
+  headerText?: string;
+}
+
+export interface HeadlampHome {
+  status: {
+    error: string;
+    success: string;
+    warning: string;
+    unknown: string;
+  };
+}
+
+export interface HeadlampClusterChooser {
+  button: {
+    color: string;
+    background: string;
+    hover: {
+      background: string;
+    };
+  };
+}
+
+export interface HeadlampSidebarButtonInLinkArea {
+  color: string;
+  primary: {
+    background: string;
+  };
+  hover: {
+    background: string;
+  };
+}
+
+export interface HeadlampSquareButton {
+  background: string;
+}
+
+export interface HeadlampResourceToolTip {
+  color: string;
+}
+
+export interface HeadlampSidebar {
+  background: string;
+  color: string;
+  selectedBackground: string;
+  selectedColor: string;
+  actionBackground: string;
+}
+
+export interface HeadlampNavbar {
+  background: string;
+  color: string;
+}
+
 declare module '@mui/material/styles/createPalette.d' {
   interface Palette {
     success: PaletteColor;
     background: TypeBackground;
-    sidebar: {
-      background: string;
-      color: string;
-      selectedBackground: string;
-      selectedColor: string;
-      actionBackground: string;
-    };
-    navbar: {
-      background: string;
-      color: string;
-    };
+    sidebar: HeadlampSidebar;
+    navbar: HeadlampNavbar;
+    chartStyles: HeadlampChartStyles;
+    headerStyle: HeadlampHeaderStyle;
+    tables: HeadlampTables;
+    home: HeadlampHome;
+    clusterChooser: HeadlampClusterChooser;
+    sidebarButtonInLinkArea: HeadlampSidebarButtonInLinkArea;
+    squareButton: HeadlampSquareButton;
+    resourceToolTip: HeadlampResourceToolTip;
+    normalEventBg: string;
+    metadataBgColor: string;
+    notificationBorderColor: string;
     [propName: string]: any;
   }
   interface PaletteOptions {
     success?: PaletteColorOptions;
+    sidebar?: Partial<HeadlampSidebar>;
+    navbar?: Partial<HeadlampNavbar>;
+    chartStyles?: Partial<HeadlampChartStyles>;
+    headerStyle?: Partial<HeadlampHeaderStyle>;
+    tables?: Partial<HeadlampTables>;
+    home?: Partial<HeadlampHome>;
+    clusterChooser?: Partial<HeadlampClusterChooser>;
+    sidebarButtonInLinkArea?: Partial<HeadlampSidebarButtonInLinkArea>;
+    squareButton?: Partial<HeadlampSquareButton>;
+    resourceToolTip?: Partial<HeadlampResourceToolTip>;
+    normalEventBg?: string;
+    metadataBgColor?: string;
+    notificationBorderColor?: string;
     [propName: string]: any;
   }
 

--- a/plugins/headlamp-plugin/src/additional.d.ts
+++ b/plugins/headlamp-plugin/src/additional.d.ts
@@ -18,6 +18,135 @@
 /// <reference types="react" />
 /// <reference types="react-dom" />
 
+export interface HeadlampChartStyles {
+  defaultFillColor: string;
+  fillColor?: string;
+  labelColor: string;
+}
+
+export interface HeadlampHeaderStyle {
+  normal: {
+    fontSize: string;
+    fontWeight: string;
+  };
+  main: {
+    fontSize: string;
+    fontWeight: string;
+  };
+  subsection: {
+    fontSize: string;
+    fontWeight: string;
+  };
+  label: {
+    fontSize: string;
+    paddingTop: string;
+  };
+}
+
+export interface HeadlampTables {
+  head: {
+    background: string;
+    color: string;
+    borderColor: string;
+    text?: string;
+  };
+  body: {
+    background: string;
+  };
+  headerText?: string;
+}
+
+export interface HeadlampHome {
+  status: {
+    error: string;
+    success: string;
+    warning: string;
+    unknown: string;
+  };
+}
+
+export interface HeadlampClusterChooser {
+  button: {
+    color: string;
+    background: string;
+    hover: {
+      background: string;
+    };
+  };
+}
+
+export interface HeadlampSidebarButtonInLinkArea {
+  color: string;
+  primary: {
+    background: string;
+  };
+  hover: {
+    background: string;
+  };
+}
+
+export interface HeadlampSquareButton {
+  background: string;
+}
+
+export interface HeadlampResourceToolTip {
+  color: string;
+}
+
+export interface HeadlampSidebar {
+  background: string;
+  color: string;
+  selectedBackground: string;
+  selectedColor: string;
+  actionBackground: string;
+}
+
+export interface HeadlampNavbar {
+  background: string;
+  color: string;
+}
+
+declare module '@mui/material/styles' {
+  interface Palette {
+    sidebar: HeadlampSidebar;
+    navbar: HeadlampNavbar;
+    chartStyles: HeadlampChartStyles;
+    headerStyle: HeadlampHeaderStyle;
+    tables: HeadlampTables;
+    home: HeadlampHome;
+    clusterChooser: HeadlampClusterChooser;
+    sidebarButtonInLinkArea: HeadlampSidebarButtonInLinkArea;
+    squareButton: HeadlampSquareButton;
+    resourceToolTip: HeadlampResourceToolTip;
+    normalEventBg: string;
+    metadataBgColor: string;
+    notificationBorderColor: string;
+    [propName: string]: any;
+  }
+  interface PaletteOptions {
+    sidebar?: Partial<HeadlampSidebar>;
+    navbar?: Partial<HeadlampNavbar>;
+    chartStyles?: Partial<HeadlampChartStyles>;
+    headerStyle?: Partial<HeadlampHeaderStyle>;
+    tables?: Partial<HeadlampTables>;
+    home?: Partial<HeadlampHome>;
+    clusterChooser?: Partial<HeadlampClusterChooser>;
+    sidebarButtonInLinkArea?: Partial<HeadlampSidebarButtonInLinkArea>;
+    squareButton?: Partial<HeadlampSquareButton>;
+    resourceToolTip?: Partial<HeadlampResourceToolTip>;
+    normalEventBg?: string;
+    metadataBgColor?: string;
+    notificationBorderColor?: string;
+    [propName: string]: any;
+  }
+
+  interface TypeBackground {
+    default: string;
+    paper: string;
+    muted: string;
+  }
+}
+
 declare namespace NodeJS {
   interface ProcessEnv {
     readonly NODE_ENV: 'development' | 'production' | 'test';


### PR DESCRIPTION
## Summary

This PR exports TypeScript types for Headlamp's custom theme palette properties so plugins can use them with proper type safety.

## Related Issue

Fixes #4072

## Changes

- Added exported interfaces for custom palette types (HeadlampChartStyles, HeadlampTables, HeadlampHome, etc) 
- Added the same interfaces and MUI module augmentation in plugins/headlamp-plugin/src/additional.d.ts for plugin consumers

## Steps to Test

```
cd plugins/headlamp-plugin
npm run build && npm pack

# in other terminal go into an example plugin
cd plugins/examples/custom-theme
npm i ../../headlamp-plugin/kinvolk-headlamp-plugin-0.13.0.tgz
# make modifications to src/index.tsx so your changes are used in the plugin
npm run tsc
```

## Screenshots (if applicable)


https://github.com/user-attachments/assets/d9cb292e-3697-4559-8a7a-95dd407046ea