### PR TITLE
backend, frontend: Enable plugin reload on non-cluster pages

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -265,6 +265,7 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	}
 
 	addPluginListRoute(config, r)
+	addPluginRefreshRoute(config, r)
 
 	// Serve development plugins
 	pluginHandler := http.StripPrefix(config.BaseURL+"/plugins/", http.FileServer(http.Dir(config.PluginDir)))
@@ -387,6 +388,31 @@ func addPluginListRoute(config *HeadlampConfig, r *mux.Router) {
 			} else if config.Telemetry != nil {
 				span.SetStatus(codes.Ok, "Plugin list retrieved successfully")
 			}
+		}
+	}).Methods("GET")
+}
+
+// addPluginRefreshRoute registers a GET endpoint handler at "/plugin-refresh" that checks
+// if plugins need to be reloaded. This allows non-cluster pages (like Settings)
+// to poll this endpoint for plugin changes or reload signals.
+func addPluginRefreshRoute(config *HeadlampConfig, r *mux.Router) {
+	r.HandleFunc("/plugin-refresh", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		var span trace.Span
+
+		if config.Telemetry != nil {
+			_, span = telemetry.CreateSpan(ctx, r, "plugins", "checkPluginRefresh")
+
+			defer span.End()
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		plugins.HandlePluginReload(config.cache, w)
+		response := map[string]bool{"ok": true}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			logger.Log(logger.LevelError, nil, err, "encoding plugin refresh response")
+		} else if config.Telemetry != nil {
+			span.SetStatus(codes.Ok, "Plugin refresh check completed")
 		}
 	}).Methods("GET")
 }

--- a/frontend/src/plugin/usePluginRefreshCheck.test.ts
+++ b/frontend/src/plugin/usePluginRefreshCheck.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePluginRefreshCheck } from './usePluginRefreshCheck';
+
+vi.mock('../helpers/debugVerbose', () => ({
+  isDebugVerbose: vi.fn(),
+  debugVerbose: vi.fn(),
+}));
+
+describe('usePluginRefreshCheck', () => {
+  let fetchSpy: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      headers: new Headers(),
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('should set up polling with configured interval and call fetch', async () => {
+    let intervalCallback: (() => Promise<void>) | undefined;
+
+    const setIntervalSpy = vi.spyOn(global, 'setInterval').mockImplementation((cb: Function) => {
+      intervalCallback = cb as () => Promise<void>;
+      return 123 as any;
+    });
+
+    const pollInterval = 1000;
+    renderHook(() => usePluginRefreshCheck(true, pollInterval));
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), pollInterval);
+    expect(intervalCallback).toBeDefined();
+
+    if (intervalCallback) {
+      await intervalCallback();
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchSpy.mock.calls[0][0].toString();
+    expect(calledUrl).toContain('plugin-refresh');
+  });
+
+  it('should not set interval when enabled is false', () => {
+    const setIntervalSpy = vi.spyOn(global, 'setInterval');
+    renderHook(() => usePluginRefreshCheck(false));
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetch errors gracefully', async () => {
+    const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const debugVerboseModule = await import('../helpers/debugVerbose');
+    vi.mocked(debugVerboseModule.isDebugVerbose).mockReturnValue(true);
+
+    let intervalCallback: (() => Promise<void>) | undefined;
+    vi.spyOn(global, 'setInterval').mockImplementation((cb: Function) => {
+      intervalCallback = cb as () => Promise<void>;
+      return 123 as any;
+    });
+
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    renderHook(() => usePluginRefreshCheck(true, 1000));
+
+    if (intervalCallback) {
+      await intervalCallback();
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(consoleDebugSpy).toHaveBeenCalledWith('Plugin refresh check failed:', expect.any(Error));
+  });
+
+  it('should clean up interval on unmount', () => {
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    vi.spyOn(global, 'setInterval').mockReturnValue(999 as any);
+
+    const { unmount } = renderHook(() => usePluginRefreshCheck(true, 1000));
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(999);
+  });
+});

--- a/frontend/src/plugin/usePluginRefreshCheck.ts
+++ b/frontend/src/plugin/usePluginRefreshCheck.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from 'react';
+import { isDebugVerbose } from '../helpers/debugVerbose';
+import { backendFetch } from '../lib/k8s/api/v2/fetch';
+
+const PLUGIN_REFRESH_POLL_INTERVAL = 5000;
+
+/**
+ * Hook that periodically polls the /plugin-refresh endpoint to check for plugin changes.
+ *
+ * @param enabled - Whether polling should be active. Defaults to true.
+ * @param pollInterval - Interval in milliseconds between polls. Defaults to 5000ms.
+ */
+export function usePluginRefreshCheck(
+  enabled: boolean = true,
+  pollInterval: number = PLUGIN_REFRESH_POLL_INTERVAL
+) {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const checkPluginRefresh = async () => {
+      try {
+        await backendFetch('/plugin-refresh');
+      } catch (error) {
+        if (isDebugVerbose('plugin/usePluginRefreshCheck')) {
+          console.debug('Plugin refresh check failed:', error);
+        }
+      }
+    };
+
+    intervalRef.current = setInterval(checkPluginRefresh, pollInterval);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [enabled, pollInterval]);
+}


### PR DESCRIPTION
## Summary

The backend detects the change, and the frontend (polling every 5s) sees the signal and triggers the refresh automatically.

## Related Issue

Fixes #3040 

## Changes

- Added usePluginRefreshCheck hook: Implemented a new hook that polls the /plugin-refresh endpoint to detect plugin changes. Use setInterval to check periodically (default 5s).
- Updated Plugins.tsx: Integrated the new hook to run specifically in Electron or Development environments when not viewing a cluster page.
- Fixed plugin hot-reloading: Resolved an issue where plugin updates were ignored (no reload triggered) when users were on non-cluster pages (e.g., Home, Settings).
- Added Unit Tests: Added comprehensive tests in usePluginRefreshCheck.test.ts to verify polling logic, enabled/disabled states, error handling, and cleanup.





## Steps to Test

1. Navigate to Non-Cluster Page: Go to the main Home page or Settings page (ensure you are not inside a specific cluster view).
2. Modify a Plugin: In your local plugins directory, make a small change to a plugin (e.g., update its package.json version).
3. Observe Behavior: usage of the app should automatically trigger a page reload within 5 seconds to apply the plugin change.
4. Verify Polling: Open the browser's Network tab and confirm that requests to /plugin-refresh are occurring every 5 seconds while on the Home page, and that they stop when you navigate to a specific cluster page.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/a928db5e-f53f-4a6d-8ea3-3f38f1e9cee5



