### PR TITLE
app: package:Add Missing Deb-Dependencies

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -49,7 +49,19 @@
       "allowToChangeInstallationDirectory": true
     },
     "deb": {
-      "artifactName": "${name}_${version}-1_${arch}.${ext}"
+      "artifactName": "${name}_${version}-1_${arch}.${ext}",
+      "depends": [
+        "libgtk-3-0",
+        "libnotify4",
+        "libnss3",
+        "libxss1",
+        "libxtst6",
+        "xdg-utils",
+        "libatspi2.0-0",
+        "libuuid1",
+        "libsecret-1-0",
+        "libasound2"
+      ]
     },
     "linux": {
       "target": [


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Debian package build configuration where the libasound2 dependency was missing.

## Related Issue

Fixes #4190

## Changes

- Updated app/package.json 
- Added libasound2 (the missing dependency).
- Added standard Electron dependencies (libnotify4, libnss3, libgtk-3-0, etc.) to effectively replicate the default dependency list, as defining depends overwrites the auto-generated defaults.

## Steps to Test

1. Build the package : 
>  cd app && npm install
>  npm run package -- --linux deb

2.Inspect the generated package dependencies:
>dpkg-deb -I dist/headlamp_*.deb | grep Depends

4. Finally we see libsound2 is present.

## Screenshots (if applicable)


## Notes for the Reviewer


