### PR TITLE
backend: Allow configuring log level via environment variable

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -55,6 +55,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	logger.Init(conf.LogLevel)
+
 	if conf.Version {
 		fmt.Printf("%s %s (%s/%s)\n", kubeconfig.AppName, kubeconfig.Version, runtime.GOOS, runtime.GOARCH)
 		return

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	InClusterContextName string `koanf:"in-cluster-context-name"`
 	DevMode              bool   `koanf:"dev"`
 	InsecureSsl          bool   `koanf:"insecure-ssl"`
+	LogLevel             string `koanf:"log-level"`
 	// NoBrowser disables automatically opening the default browser when running
 	// a locally embedded Headlamp binary (non in-cluster with spa.UseEmbeddedFiles == true).
 	// It has no effect in in-cluster mode or when running without embedded frontend.
@@ -418,6 +419,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.Bool("cache-enabled", false, "K8s cache in backend")
 	f.Bool("no-browser", false, "Disable automatically opening the browser when using embedded frontend")
 	f.Bool("insecure-ssl", false, "Accept/Ignore all server SSL certificates")
+	f.String("log-level", "info", "Set backend log verbosity. Options: debug, info (default), warn, error")
 	f.Bool("enable-dynamic-clusters", false, "Enable dynamic clusters, which stores stateless clusters in the frontend.")
 	// Note: When running in-cluster and if not explicitly set, this flag defaults to false.
 	f.Bool("watch-plugins-changes", true, "Reloads plugins when there are changes to them or their directory")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -44,6 +44,7 @@ func TestParseBasic(t *testing.T) {
 				assert.Equal(t, config.DefaultMeUsernamePath, conf.MeUsernamePath)
 				assert.Equal(t, config.DefaultMeEmailPath, conf.MeEmailPath)
 				assert.Equal(t, config.DefaultMeGroupsPath, conf.MeGroupsPath)
+				assert.Equal(t, "info", conf.LogLevel)
 			},
 		},
 		{
@@ -128,6 +129,16 @@ var ParseWithEnvTests = []struct {
 		},
 		verify: func(t *testing.T, conf *config.Config) {
 			assert.Equal(t, "mycluster", conf.InClusterContextName)
+		},
+	},
+	{
+		name: "log_level_from_env",
+		args: []string{"go run ./cmd"},
+		env: map[string]string{
+			"HEADLAMP_CONFIG_LOG_LEVEL": "warn",
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, "warn", conf.LogLevel)
 		},
 	},
 }
@@ -230,6 +241,13 @@ func TestParseFlags(t *testing.T) {
 			args: []string{"go run ./cmd", "--in-cluster-context-name=mycluster"},
 			verify: func(t *testing.T, conf *config.Config) {
 				assert.Equal(t, "mycluster", conf.InClusterContextName)
+			},
+		},
+		{
+			name: "log_level_flag",
+			args: []string{"go run ./cmd", "--log-level=warn"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, "warn", conf.LogLevel)
 			},
 		},
 	}

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -18,6 +18,7 @@ package logger
 
 import (
 	"runtime"
+	"strings"
 
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
@@ -40,6 +41,35 @@ type LogFunc func(level uint, str map[string]string, err interface{}, msg string
 
 // logFunc holds the actual logging function.
 var logFunc LogFunc = log
+
+// Init configures the global zerolog log level from environment variables.
+// The HEADLAMP_CONFIG_LOG_LEVEL environment variable controls the global log level.
+func Init(loglevel string) {
+	logLevel := strings.ToLower(strings.TrimSpace(loglevel))
+
+	// If no log level is provided, default to info.
+	if logLevel == "" {
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		return
+	}
+
+	level, err := zerolog.ParseLevel(logLevel)
+	// If an invalid log level is provided, log a warning and default to info.
+	if err != nil {
+		zlog.Warn().
+			Str("value", logLevel).
+			Msg("Invalid HEADLAMP_CONFIG_LOG_LEVEL, defaulting to info")
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+		return
+	}
+
+	// Set the global log level.
+	zerolog.SetGlobalLevel(level)
+	zlog.Info().
+		Str("level", level.String()).
+		Msg("Log level set from HEADLAMP_CONFIG_LOG_LEVEL")
+}
 
 // Log logs the message, source file, and line number at the specified level.
 func Log(level uint, str map[string]string, err interface{}, msg string) {

--- a/docs/development/backend.md
+++ b/docs/development/backend.md
@@ -27,6 +27,30 @@ Once built, it can be run in development mode (insecure / don't use in productio
 npm run backend:start
 ```
 
+## Logging configuration
+
+Headlamp’s backend supports configurable log levels to control verbosity.
+
+Log level can be configured using either a flag or an environment variable:
+- the log level: `--log-level` or env var `HEADLAMP_CONFIG_LOG_LEVEL`
+
+Supported Values:
+- `debug`
+- `info` (default)
+- `warn` 
+- `error`
+
+> **Note:** Headlamp uses zerolog defaults.  
+> Zerolog’s default log level is `info`, and Headlamp follows this behavior.
+
+### Examples
+
+Run with warning level:
+
+```bash
+./headlamp-server --log-level warn
+```
+
 ## Lint
 
 To lint the backend/ code.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -60,6 +60,19 @@ and in a different terminal instance:
 npm run frontend:start
 ```
 
+### Backend logging
+
+Backend log verbosity can be controlled using either a flag or an environment variable.
+- `--log-level`
+- `HEADLAMP_CONFIG_LOG_LEVEL`
+
+Supported Values: `debug`, `info`, `warn`, `error` (default: `info`) 
+
+Example:
+```bash
+npm run backend:start -- --log-level warn
+```
+
 ## Generate API documentation
 
 To generate the TypeScript API documentation:


### PR DESCRIPTION
## Summary

This PR adds the ability to configure the Headlamp backend log level via the `HEADLAMP_CONFIG_LOG_LEVEL` environment variable.  

## Related Issue

Fixes #4139 

## Changes

- Added a backend configuration flag `--log-level` with environment variable support via `HEADLAMP_CONFIG_LOG_LEVEL`.
- Ensured invalid, empty, or missing log level values safely fall back to` info`.
- Added unit tests for both flag and environment based log level configuration.
- Updated backend and development documentation to describe log level configuration.

## Steps to Test

1. Go backend folder:
   ```bash
   cd backend
2. Run the following command:
   ```bash
   npm run backend:start -- --log-level debug
   
If it doesnt work, build the backend again using `npm run backend:build` and follow the above steps.

## Screenshots (if applicable)

1. Debug log level
<img width="942" height="214" alt="SCR-20260202-tydl" src="https://github.com/user-attachments/assets/43a115cc-88b0-4a8d-88ca-57eca97caf13" />

2. Warn log level
<img width="923" height="142" alt="SCR-20260202-tyhm" src="https://github.com/user-attachments/assets/f2732163-942a-48e6-8a4e-b6e168e2bb20" />


## Notes for the Reviewer

None