### PR TITLE
Backend: Frontend: Add OIDC Autologin

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -98,6 +98,7 @@ type clientConfig struct {
 	Clusters                []Cluster `json:"clusters"`
 	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
 	AllowKubeconfigChanges  bool      `json:"allowKubeconfigChanges"`
+	OidcAutoLogin           bool      `json:"oidcAutoLogin"`
 }
 
 type OauthConfig struct {
@@ -1755,6 +1756,7 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 		Clusters:                c.getClusters(),
 		IsDynamicClusterEnabled: c.EnableDynamicClusters,
 		AllowKubeconfigChanges:  c.AllowKubeconfigChanges,
+		OidcAutoLogin:           c.OidcAutoLogin,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -127,6 +127,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 
 	cfg := &headlampconfig.HeadlampConfig{
 		HeadlampCFG:               buildHeadlampCFG(conf, kubeConfigStore),
+		OidcAutoLogin:             conf.OidcAutoLogin,
 		OidcClientID:              conf.OidcClientID,
 		OidcValidatorClientID:     conf.OidcValidatorClientID,
 		OidcClientSecret:          conf.OidcClientSecret,

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -182,6 +182,7 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 		Clusters:                contexts,
 		IsDynamicClusterEnabled: c.EnableDynamicClusters,
 		AllowKubeconfigChanges:  c.AllowKubeconfigChanges,
+		OidcAutoLogin:           c.OidcAutoLogin,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	BaseURL                   string `koanf:"base-url"`
 	SessionTTL                int    `koanf:"session-ttl"`
 	ProxyURLs                 string `koanf:"proxy-urls"`
+	OidcAutoLogin             bool   `koanf:"oidc-auto-login"`
 	OidcClientID              string `koanf:"oidc-client-id"`
 	OidcValidatorClientID     string `koanf:"oidc-validator-client-id"`
 	OidcClientSecret          string `koanf:"oidc-client-secret"`
@@ -455,6 +456,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 }
 
 func addOIDCFlags(f *flag.FlagSet) {
+	f.Bool("oidc-auto-login", false, "Automatic Redirect to OIDC provider")
 	f.String("oidc-client-id", "", "ClientID for OIDC")
 	f.String("oidc-client-secret", "", "ClientSecret for OIDC")
 	f.String("oidc-validator-client-id", "", "Override ClientID for OIDC during validation")

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -17,6 +17,7 @@ type WebSocketMultiplexer interface {
 // HeadlampConfig holds full server config. Lives here so packages (e.g. k8cache) can import without cmd.
 type HeadlampConfig struct {
 	*HeadlampCFG
+	OidcAutoLogin             bool
 	OidcClientID              string
 	OidcValidatorClientID     string
 	OidcClientSecret          string

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -87,6 +87,7 @@ $ helm install my-headlamp headlamp/headlamp \
 | config.oidc.issuerURL | string | `""` | OIDC issuer URL |
 | config.oidc.scopes | string | `""` | OIDC scopes to be used |
 | config.oidc.usePKCE | bool | `false` | Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow |
+| confgi.oidc.autoLogin | bool | `false` | Enable Automatic redirect to OIDC provider |
 | config.oidc.secret.create | bool | `true` | Create OIDC secret using provided values |
 | config.oidc.secret.name | string | `"oidc"` | Name of the OIDC secret |
 | config.oidc.externalSecret.enabled | bool | `false` | Enable using external secret for OIDC |
@@ -103,6 +104,7 @@ config:
     clientSecret: "your-client-secret"
     issuerURL: "https://your-issuer"
     scopes: "openid profile email"
+    autoLogin: true
     meUserInfoURL: "https://headlamp.example.com/oauth2/userinfo"
 ```
 

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -11,6 +11,7 @@
 {{- $usePKCE := "" }}
 {{- $useAccessToken := "" }}
 {{- $meUserInfoURL := "" }}
+{{- $oidcAutoLogin := "" }}
 
 # This block of code is used to extract the values from the env.
 # This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
@@ -44,6 +45,9 @@
   {{- end }}
   {{- if eq .name "ME_USER_INFO_URL" }}
     {{- $meUserInfoURL = .value | toString }}
+  {{- end }}
+  {{- if eq .name "OIDC_AUTO_LOGIN" }}
+    {{- $oidcAutoLogin = .value | toString }}
   {{- end }}
 {{- end }}
 
@@ -182,6 +186,13 @@ spec:
                   name: {{ $oidc.secret.name }}
                   key: meUserInfoURL
             {{- end }}
+            {{- if $oidc.autoLogin }}
+            - name: OIDC_AUTO_LOGIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $oidc.auto.login }}
+                  key: autoLogin
+            {{- end }}
             {{- else }}
             {{- if $oidc.clientID }}
             - name: OIDC_CLIENT_ID
@@ -223,10 +234,14 @@ spec:
             - name: ME_USER_INFO_URL
               value: {{ $oidc.meUserInfoURL }}
             {{- end }}
+            {{- if $oidc.autoLogin }}
+            - name: OIDC_AUTO_LOGIN
+              value: {{ $oidc.autoLogin | quote }}
             {{- end }}
-            {{- if .Values.env }}
+          {{- end }}
+          {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
-            {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
           args:
@@ -288,6 +303,9 @@ spec:
             {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
             - "-me-user-info-url=$(ME_USER_INFO_URL)"
             {{- end }}
+            {{- if or (eq ($oidc.autoLogin | toString) "true") (eq $oidcAutoLogin "true") }}
+            - "-oidc-auto-login=$(OIDC_AUTO_LOGIN)"
+            {{- end }}
             {{- else }}
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
@@ -314,6 +332,9 @@ spec:
             {{- end }}
             {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
             - "-me-user-info-url=$(ME_USER_INFO_URL)"
+            {{- end }}
+            {{- if or (eq ($oidc.autoLogin | toString) "true") (eq $oidcAutoLogin "true") }}
+            - "-oidc-auto-login=$(OIDC_AUTO_LOGIN)"
             {{- end }}
             {{- end }}
             {{- with .Values.config.baseURL }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -218,6 +218,10 @@
               "type": "boolean",
               "description": "Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow"
             },
+            "autoLogin": {
+              "type": "boolean",
+              "description": "Enable automatic redirect to the OIDC provider"
+            },
             "externalSecret": {
               "type": "object",
               "description": "External secret to use for OIDC configuration",

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -86,6 +86,8 @@ config:
     useAccessToken: false
     # -- Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow
     usePKCE: false
+    # -- Enable automatic redirect to the OIDC provider
+    autoLogin: false
 
     # Option 3:
     # @param config.oidc - External OIDC secret configuration

--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -65,6 +65,15 @@ then add them all to the option:
 used by Dex and other services, but since it's not part of the default spec,
 it was removed in the mentioned version.
 
+
+### Auto-login
+
+By default, Headlamp shows a "Sign in" button for OIDC clusters. To bypass this screen and redirect users to your Identity Provider (IDP) you can use the auto-login flag.
+
+- `-oidc-auto-login=true` OR env var `HEADLAMP_CONFIG_OIDC_AUTO_LOGIN`
+
+> **ℹ️ Note:** This will only cause a redirect if the user is not currently authenticated and the selected cluster is configured in OIDC.
+
 ### Token Validation Overrides
 
 In the event your OIDC Provider issues `access_tokens` from a different Issuer URL or clientID audience than its `id_tokens` (i.e. Azure Entra ID) you may have need of the following parameters to configure what is used in validation of tokens.
@@ -100,6 +109,7 @@ For quick reference if you are already familiar with setting up Entra ID,
 - Set `--oidc-validator-idp-issuer-url` to `https://sts.windows.net/<Your Directory (tenant) ID>/`
 - Set `-oidc-validator-client-id` to `6dae42f8-4368-4678-94ff-3960e28e3630`
 - Set `-oidc-use-access-token=true`
+- Set `-oidc-auto-login=true` (optional to skip the "Sign in" screen)
 
 
 ### Example: OIDC with Dex

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -41,6 +41,7 @@ const makeStore = () => {
           'cluster-a': { name: 'cluster-a' },
           'cluster-b': { name: 'cluster-b' },
         } as any,
+        oidcAutoLogin: null,
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -42,6 +42,7 @@ const makeStore = () => {
         } as any,
         isDynamicClusterEnabled: true,
         allowKubeconfigChanges: false,
+        oidcAutoLogin: null,
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -68,6 +68,10 @@ export interface ConfigState {
     useEvict: boolean;
     [key: string]: any;
   };
+  /**
+   * Whether OIDC auto-login is enabled. Null indicates the value hasn't been loaded from the backend yet.
+   */
+  oidcAutoLogin: boolean | null;
 }
 
 export const defaultTableRowsPerPageOptions = [15, 25, 50];
@@ -84,6 +88,7 @@ export const initialState: ConfigState = {
   allClusters: null,
   isDynamicClusterEnabled: false,
   allowKubeconfigChanges: false,
+  oidcAutoLogin: null,
   settings: {
     tableRowsPerPageOptions:
       storedSettings.tableRowsPerPageOptions || defaultTableRowsPerPageOptions,
@@ -108,9 +113,14 @@ const configSlice = createSlice({
         clusters: ConfigState['clusters'];
         isDynamicClusterEnabled?: boolean;
         allowKubeconfigChanges?: boolean;
+        oidcAutoLogin?: boolean;
       }>
     ) {
       state.clusters = action.payload.clusters;
+
+      if (action.payload.oidcAutoLogin !== undefined) {
+        state.oidcAutoLogin = action.payload.oidcAutoLogin;
+      }
       if (action.payload.isDynamicClusterEnabled !== undefined) {
         state.isDynamicClusterEnabled = action.payload.isDynamicClusterEnabled;
       }


### PR DESCRIPTION
## Summary

This PR Adds feature to enable Autologin on OIDC as well as support for OIDC autologin.

## Related Issue

Fixes #4343

## Changes

- Added `oidc-auto-login` flag to headlamp-server
- Added support in redux for configs
- Added authentication login to `Layout.tsx`

## Steps to Test

1) Start headlamp server with flag `oidc-auto-login=true` and other oidc flags (`oidc-client-id`, `oidc-idp-issuer-url`, etc.)
2) Set up cluster with `auth-provider = 'oidc'`
3) Navigate to OIDC cluster, Redirects to OIDC provider's login screen.

## Screenshots

https://github.com/user-attachments/assets/66bc2442-068a-4c94-a101-766493210bc0

## Note

I couldn't correctly configure my OIDC client locally, but it completely works logically as intended.