### PR TITLE
helm: Add ability to set scheme for probes

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -246,6 +246,42 @@ httpRoute:
           port: 80
 ```
 
+### Probe Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| probes.scheme | string | `"HTTP"` | Scheme for liveness/readiness probes (HTTP or HTTPS). Set to HTTPS when TLS is enabled at the backend. |
+| probes.livenessProbe.initialDelaySeconds | int | `0` | Initial delay before liveness probe starts |
+| probes.livenessProbe.periodSeconds | int | `10` | Period between liveness checks |
+| probes.livenessProbe.timeoutSeconds | int | `1` | Timeout for liveness probe |
+| probes.livenessProbe.successThreshold | int | `1` | Must be 1 for liveness probes (Kubernetes requirement) |
+| probes.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures |
+| probes.readinessProbe.initialDelaySeconds | int | `0` | Initial delay before readiness probe starts |
+| probes.readinessProbe.periodSeconds | int | `10` | Period between readiness checks |
+| probes.readinessProbe.timeoutSeconds | int | `1` | Timeout for readiness probe |
+| probes.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes |
+| probes.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures |
+
+When using TLS termination at the backend server, you must set `probes.scheme` to `HTTPS`:
+
+```yaml
+config:
+  tlsCertPath: "/headlamp-cert/tls.crt"
+  tlsKeyPath: "/headlamp-cert/tls.key"
+
+probes:
+  scheme: HTTPS  # Required when TLS is enabled at backend
+
+volumes:
+  - name: headlamp-cert
+    secret:
+      secretName: headlamp-tls
+
+volumeMounts:
+  - name: headlamp-cert
+    mountPath: /headlamp-cert
+```
+
 ### Resource Management
 
 | Key | Type | Default | Description |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -333,10 +333,22 @@ spec:
             httpGet:
               path: "{{ .Values.config.baseURL }}/"
               port: http
+              scheme: {{ .Values.probes.scheme | default "HTTP" }}
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: 1
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
               path: "{{ .Values.config.baseURL }}/"
               port: http
+              scheme: {{ .Values.probes.scheme | default "HTTP" }}
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds | default 1 }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.pluginsManager.enabled .Values.volumeMounts }}

--- a/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
+++ b/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
@@ -136,9 +136,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -121,9 +121,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -122,9 +122,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -138,9 +138,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/host-users-override.yaml
+++ b/charts/headlamp/tests/expected_templates/host-users-override.yaml
@@ -121,9 +121,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
+++ b/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
@@ -121,10 +121,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
 ---

--- a/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
@@ -124,9 +124,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
@@ -128,9 +128,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
@@ -153,9 +153,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/namespace-override.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override.yaml
@@ -121,9 +121,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
+++ b/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
@@ -128,9 +128,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -153,9 +153,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -137,9 +137,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -128,9 +128,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -118,9 +118,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
@@ -131,9 +131,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -140,9 +140,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/pod-disruption.yaml
+++ b/charts/headlamp/tests/expected_templates/pod-disruption.yaml
@@ -141,9 +141,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -147,10 +147,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/tls-added.yaml
+++ b/charts/headlamp/tests/expected_templates/tls-added.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTPS
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTPS
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
@@ -121,10 +121,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
       topologySpreadConstraints:

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
@@ -121,10 +121,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
       topologySpreadConstraints:

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -121,10 +121,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
       volumes:

--- a/charts/headlamp/tests/test_cases/tls-added.yaml
+++ b/charts/headlamp/tests/test_cases/tls-added.yaml
@@ -2,6 +2,9 @@ config:
   tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
   tlsKeyPath: "/headlamp-cert/headlamp-tls.key"
 
+probes:
+  scheme: HTTPS
+
 volumes:
   - name: "headlamp-cert"
     secret:

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -565,6 +565,92 @@
       "items": {
         "type": "string"
       }
+    },
+    "probes": {
+      "type": "object",
+      "description": "Probe configuration for liveness and readiness checks",
+      "properties": {
+        "scheme": {
+          "type": "string",
+          "description": "Scheme for probes (HTTP or HTTPS). Set to HTTPS when TLS is enabled at the backend server.",
+          "enum": ["HTTP", "HTTPS"],
+          "default": "HTTP"
+        },
+        "livenessProbe": {
+          "type": "object",
+          "description": "Liveness probe settings",
+          "properties": {
+            "initialDelaySeconds": {
+              "type": "integer",
+              "description": "Initial delay in seconds before starting liveness probe",
+              "minimum": 0,
+              "default": 0
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "description": "Period in seconds between liveness probe checks",
+              "minimum": 1,
+              "default": 10
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "description": "Timeout in seconds for liveness probe",
+              "minimum": 1,
+              "default": 1
+            },
+            "successThreshold": {
+              "type": "integer",
+              "description": "Minimum consecutive successes for the probe to be considered successful (must be 1 for liveness probes per Kubernetes API)",
+              "minimum": 1,
+              "maximum": 1,
+              "const": 1,
+              "default": 1
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "description": "Minimum consecutive failures for the probe to be considered failed",
+              "minimum": 1,
+              "default": 3
+            }
+          }
+        },
+        "readinessProbe": {
+          "type": "object",
+          "description": "Readiness probe settings",
+          "properties": {
+            "initialDelaySeconds": {
+              "type": "integer",
+              "description": "Initial delay in seconds before starting readiness probe",
+              "minimum": 0,
+              "default": 0
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "description": "Period in seconds between readiness probe checks",
+              "minimum": 1,
+              "default": 10
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "description": "Timeout in seconds for readiness probe",
+              "minimum": 1,
+              "default": 1
+            },
+            "successThreshold": {
+              "type": "integer",
+              "description": "Minimum consecutive successes for the probe to be considered successful",
+              "minimum": 1,
+              "default": 1
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "description": "Minimum consecutive failures for the probe to be considered failed",
+              "minimum": 1,
+              "default": 3
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -324,6 +324,34 @@ topologySpreadConstraints: []
 # -- Pod priority class
 priorityClassName: ""
 
+# Probe configuration for liveness and readiness checks
+probes:
+  # -- Scheme to use for liveness and readiness probes (HTTP or HTTPS).
+  # Set to HTTPS when TLS is enabled at the backend server.
+  scheme: HTTP
+  livenessProbe:
+    # -- Initial delay in seconds before starting liveness probe
+    initialDelaySeconds: 0
+    # -- Period in seconds between liveness probe checks
+    periodSeconds: 10
+    # -- Timeout in seconds for liveness probe
+    timeoutSeconds: 1
+    # -- Minimum consecutive successes for the probe to be considered successful (must be 1 for liveness probes per Kubernetes API)
+    successThreshold: 1
+    # -- Minimum consecutive failures for the probe to be considered failed
+    failureThreshold: 3
+  readinessProbe:
+    # -- Initial delay in seconds before starting readiness probe
+    initialDelaySeconds: 0
+    # -- Period in seconds between readiness probe checks
+    periodSeconds: 10
+    # -- Timeout in seconds for readiness probe
+    timeoutSeconds: 1
+    # -- Minimum consecutive successes for the probe to be considered successful
+    successThreshold: 1
+    # -- Minimum consecutive failures for the probe to be considered failed
+    failureThreshold: 3
+
 # Plugin Manager Sidecar Container Configuration
 pluginsManager:
   # -- Enable plugin manager


### PR DESCRIPTION
## Summary

- Adds configurable probe settings to the Helm chart to support TLS termination at the backend server
- When TLS is enabled, liveness and readiness probes can now correctly use HTTPS instead of HTTP
- Adds full probe timing configuration (initialDelaySeconds, periodSeconds, timeoutSeconds, successThreshold, failureThreshold)

## New Configuration Options

```yaml
probes:
  scheme: HTTPS  # HTTP or HTTPS (default: HTTP)
  livenessProbe:
    initialDelaySeconds: 0
    periodSeconds: 10
    timeoutSeconds: 1
    successThreshold: 1
    failureThreshold: 3
  readinessProbe:
    initialDelaySeconds: 0
    periodSeconds: 10
    timeoutSeconds: 1
    successThreshold: 1
    failureThreshold: 3
```

## Example Usage with TLS

```yaml
config:
  tlsCertPath: "/headlamp-cert/tls.crt"
  tlsKeyPath: "/headlamp-cert/tls.key"

probes:
  scheme: HTTPS  # Required when TLS is enabled at backend

volumes:
  - name: headlamp-cert
    secret:
      secretName: headlamp-tls

volumeMounts:
  - name: headlamp-cert
    mountPath: /headlamp-cert
```

## Test Plan

- [x] Verified helm template renders correctly with default HTTP scheme
- [x] Verified helm template renders correctly with HTTPS scheme
- [x] Deployed to test cluster with TLS enabled and HTTPS probes
- [x] Confirmed pod starts successfully and probes work correctly
- [x] Updated all expected test templates

Fixes #4406
