### PR TITLE
workflows: secret refs: Fix invalid space after secrets.

### DIFF
--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -99,7 +99,7 @@ jobs:
       uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
       with:
         client-id: ${{ secrets.WINDOWS_CLIENT_ID }}
-        tenant-id: ${{ secrets. AZ_TENANT_ID }}
+        tenant-id: ${{ secrets.AZ_TENANT_ID }}
         subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
     - name: Fetch certificates
       if: ${{ inputs.signBinaries }}

--- a/.github/workflows/pr-to-update-minikube.yml
+++ b/.github/workflows/pr-to-update-minikube.yml
@@ -41,13 +41,13 @@ jobs:
         run: |
           gh repo sync headlamp-k8s/minikube
         env:
-          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KINVOLK_REPOS_TOKEN }}
       - name: Check out minikube repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: headlamp-k8s/minikube
           path: minikube
-          token: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+          token: ${{ secrets.KINVOLK_REPOS_TOKEN }}
           fetch-depth: 0
       - name: Update headlamp version in minikube
         run: |
@@ -90,4 +90,4 @@ jobs:
             cc: @$user" \
         env:
           LATEST_HEADLAMP_TAG: ${{ env.LATEST_HEADLAMP_TAG }}
-          GITHUB_TOKEN: ${{ secrets. KINVOLK_REPOS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KINVOLK_REPOS_TOKEN }}


### PR DESCRIPTION
## Summary

While auditing secrets for documentation, I found 4 typos where secrets. has an extra space. These affect `app-artifacts-mac.yml` (Azure login) and `pr-to-update-minikube.yml` (3 times). Both secrets work correctly in other workflows.

Fixes #3992

## Changes
- headlamp/.github/workflows/app-artifacts-mac.yml
- headlamp/.github/workflows/pr-to-update-minikube.yml

Both workflows are `workflow_dispatch` only (manually triggered), which may explain why these bugs haven't been noticed
