### PR TITLE
backend: cmd: pkg: Add flag for non-in cluster OIDC authentication

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -72,6 +72,7 @@ import (
 
 type HeadlampConfig struct {
 	*headlampcfg.HeadlampCFG
+	OidcAllowContext          bool
 	oidcClientID              string
 	oidcValidatorClientID     string
 	oidcClientSecret          string
@@ -1303,7 +1304,7 @@ func (c *HeadlampConfig) helmRouteReleaseHandler(
 	context = context.Copy()
 
 	// If headlamp is running in cluster, use the token from the cookie for oidc auth
-	if c.UseInCluster && context.OidcConf != nil {
+	if (c.UseInCluster || c.OidcAllowContext) && context.OidcConf != nil {
 		setTokenFromCookie(r, clusterName)
 	}
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	UserPluginsDir            string `koanf:"user-plugins-dir"`
 	BaseURL                   string `koanf:"base-url"`
 	ProxyURLs                 string `koanf:"proxy-urls"`
+	OidcAllowContext          bool   `koanf:"oidc-allow-context"`
 	OidcClientID              string `koanf:"oidc-client-id"`
 	OidcValidatorClientID     string `koanf:"oidc-validator-client-id"`
 	OidcClientSecret          string `koanf:"oidc-client-secret"`
@@ -84,10 +85,10 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if !c.InCluster && (c.OidcClientID != "" || c.OidcClientSecret != "" || c.OidcIdpIssuerURL != "" ||
-		c.OidcValidatorClientID != "" || c.OidcValidatorIdpIssuerURL != "") {
-		return errors.New(`oidc-client-id, oidc-client-secret, oidc-idp-issuer-url, oidc-validator-client-id,
-		oidc-validator-idp-issuer-url, flags are only meant to be used in inCluster mode`)
+	if !c.InCluster && !c.OidcAllowContext && (c.OidcClientID != "" || c.OidcClientSecret != "" ||
+		c.OidcIdpIssuerURL != "" || c.OidcValidatorClientID != "" ||
+		c.OidcValidatorIdpIssuerURL != "") {
+		return errors.New(`oidc flags require in-cluster mode or --oidc-allow-context`)
 	}
 
 	// OIDC TLS verification warning.
@@ -433,6 +434,8 @@ func addGeneralFlags(f *flag.FlagSet) {
 }
 
 func addOIDCFlags(f *flag.FlagSet) {
+	f.Bool("oidc-allow-context", false, "Allow OIDC authentication for clusters "+
+		"defined in kubeconfig for non-inCluster mode")
 	f.String("oidc-client-id", "", "ClientID for OIDC")
 	f.String("oidc-client-secret", "", "ClientSecret for OIDC")
 	f.String("oidc-validator-client-id", "", "Override ClientID for OIDC during validation")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -150,9 +150,9 @@ func TestParseErrors(t *testing.T) {
 		errorContains string
 	}{
 		{
-			name:          "oidc_settings_without_incluster",
+			name:          "oidc_settings_without_incluster_or_allow_context",
 			args:          []string{"go run ./cmd", "-oidc-client-id=noClient"},
-			errorContains: "are only meant to be used in inCluster mode",
+			errorContains: "require in-cluster mode or --oidc-allow-context",
 		},
 		{
 			name:          "invalid_base_url",


### PR DESCRIPTION
## Summary

This PR adds a flag to allow OIDC authentication for kubeconfig clusters when inCluster mode is false.

## Related Issue

Fixes #4481

## Changes

- Added `oidc-allow-context` flag
- Added flag logic to use token from cookie if set
- Modified test name and message

