### PR TITLE
backend: allow OIDC cookies when in-cluster is false via flag

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1286,8 +1286,8 @@ func (c *HeadlampConfig) helmRouteReleaseHandler(
 	// Create a copy of the context to avoid modifying the cached context
 	context = context.Copy()
 
-	// If headlamp is running in cluster, use the token from the cookie for oidc auth
-	if c.UseInCluster && context.OidcConf != nil {
+	// If running in cluster or explicitly enabled via flag, use the token from the cookie for oidc auth
+	if (c.UseInCluster || c.OidcUseCookie) && context.OidcConf != nil {
 		setTokenFromCookie(r, clusterName)
 	}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1972,3 +1972,28 @@ func TestHandleClusterServiceProxy(t *testing.T) {
 		assert.Equal(t, "OK", rr.Body.String())
 	}
 }
+
+// TestOidcUseCookieLogic verifies that the mechanism for promoting an OIDC token
+// from a cookie to the Authorization header works as expected.
+func TestOidcUseCookieLogic(t *testing.T) {
+	clusterName := "test-cluster-oidc"
+	testToken := "fake-token-for-testing"
+	cookieName := "headlamp-auth-" + clusterName + ".0"
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/api/v1/clusters/"+clusterName, nil)
+	assert.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{
+		Name:  cookieName,
+		Value: testToken,
+	})
+
+	setTokenFromCookie(req, clusterName)
+
+	got := req.Header.Get("Authorization")
+	want := "Bearer " + testToken
+
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -102,6 +102,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		TLSCertPath:            conf.TLSCertPath,
 		TLSKeyPath:             conf.TLSKeyPath,
 		SessionTTL:             conf.SessionTTL,
+		OidcUseCookie:          conf.OidcUseCookie,
 	}
 }
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	OidcValidatorIdpIssuerURL string `koanf:"oidc-validator-idp-issuer-url"`
 	OidcScopes                string `koanf:"oidc-scopes"`
 	OidcUseAccessToken        bool   `koanf:"oidc-use-access-token"`
+	OidcUseCookie             bool   `koanf:"oidc-use-cookie"`
 	OidcSkipTLSVerify         bool   `koanf:"oidc-skip-tls-verify"`
 	OidcCAFile                string `koanf:"oidc-ca-file"`
 	MeUsernamePath            string `koanf:"me-username-path"`
@@ -89,10 +90,11 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if !c.InCluster && (c.OidcClientID != "" || c.OidcClientSecret != "" || c.OidcIdpIssuerURL != "" ||
+	if !c.InCluster && !c.OidcUseCookie && (c.OidcClientID != "" || c.OidcClientSecret != "" || c.OidcIdpIssuerURL != "" ||
 		c.OidcValidatorClientID != "" || c.OidcValidatorIdpIssuerURL != "") {
-		return errors.New(`oidc-client-id, oidc-client-secret, oidc-idp-issuer-url, oidc-validator-client-id,
-		oidc-validator-idp-issuer-url, flags are only meant to be used in inCluster mode`)
+		return errors.New("oidc-client-id, oidc-client-secret, oidc-idp-issuer-url, " +
+			"oidc-validator-client-id, oidc-validator-idp-issuer-url, flags are only " +
+			"meant to be used in inCluster mode or with --oidc-use-cookie")
 	}
 
 	// OIDC TLS verification warning.
@@ -465,6 +467,7 @@ func addOIDCFlags(f *flag.FlagSet) {
 	f.Bool("oidc-skip-tls-verify", false, "Skip TLS verification for OIDC")
 	f.String("oidc-ca-file", "", "CA file for OIDC")
 	f.Bool("oidc-use-access-token", false, "Setup oidc to pass through the access_token instead of the default id_token")
+	f.Bool("oidc-use-cookie", false, "Enable OIDC cookie usage even when not running in-cluster")
 	f.Bool("oidc-use-pkce", false, "Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow")
 	f.String("me-username-path", DefaultMeUsernamePath,
 		"Comma separated JMESPath expressions used to read username from the JWT payload")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -55,6 +55,14 @@ func TestParseBasic(t *testing.T) {
 				assert.Equal(t, config.DefaultMeUsernamePath, conf.MeUsernamePath)
 			},
 		},
+		{
+			name: "oidc_use_cookie",
+			args: []string{"go run ./cmd", "--oidc-use-cookie", "--oidc-client-id=my-id"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, true, conf.OidcUseCookie)
+				assert.Equal(t, "my-id", conf.OidcClientID)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -173,7 +181,7 @@ func TestParseErrors(t *testing.T) {
 		{
 			name:          "oidc_settings_without_incluster",
 			args:          []string{"go run ./cmd", "-oidc-client-id=noClient"},
-			errorContains: "are only meant to be used in inCluster mode",
+			errorContains: "flags are only meant to be used in inCluster mode or with --oidc-use-cookie",
 		},
 		{
 			name:          "invalid_base_url",

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -64,4 +64,5 @@ type HeadlampCFG struct {
 	TLSCertPath            string
 	TLSKeyPath             string
 	SessionTTL             int
+	OidcUseCookie          bool
 }

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -87,6 +87,7 @@ $ helm install my-headlamp headlamp/headlamp \
 | config.oidc.issuerURL | string | `""` | OIDC issuer URL |
 | config.oidc.scopes | string | `""` | OIDC scopes to be used |
 | config.oidc.usePKCE | bool | `false` | Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow |
+| config.oidc.useCookie | bool | `false` | Enable using OIDC cookie for authentication outside of cluster |
 | config.oidc.secret.create | bool | `true` | Create OIDC secret using provided values |
 | config.oidc.secret.name | string | `"oidc"` | Name of the OIDC secret |
 | config.oidc.externalSecret.enabled | bool | `false` | Enable using external secret for OIDC |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -242,6 +242,9 @@ spec:
             {{- if .Values.config.watchPlugins }}
             - "-watch-plugins-changes"
             {{- end }}
+            {{- if .Values.config.oidc.useCookie }}  
+            - "-oidc-use-cookie"                     
+            {{- end }}
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
             {{- end }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -86,6 +86,8 @@ config:
     useAccessToken: false
     # -- Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow
     usePKCE: false
+    # -- Enable using OIDC cookie for authentication outside of cluster
+    useCookie: false
 
     # Option 3:
     # @param config.oidc - External OIDC secret configuration


### PR DESCRIPTION
## Summary
Adds the `--oidc-use-cookie` flag to allow OIDC authentication configuration when Headlamp is running in a local or development environment (non–in-cluster mode).

## Related Issue
Fixes #4481

## Changes
- **`pkg/config/config.go`**
  - Added the `OidcUseCookie` flag.
  - Updated `Validate()` logic to permit OIDC settings when this flag is enabled.

- **`pkg/config/config_test.go`**
  - Added test cases to `TestParseBasic` to verify the success path.
  - Added test cases to `TestParseErrors` to ensure proper error messaging when the flag is missing.

- **`cmd/server.go`**
  - Wired `OidcUseCookie` from the config parser into the internal server configuration.

- **Error messaging**
  - Improved validation errors to clearly indicate the requirement for either in-cluster mode or the `--oidc-use-cookie` flag.

## Steps to Test
1. Build the backend:
   ```bash
   go build ./cmd/headlamp