### PR TITLE
headlamp-plugin: Fix package failing on dist subdirectories

### DIFF
--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -232,7 +232,11 @@ function extract(pluginPackagesPath, outputPlugins, logSteps = true) {
         const srcFile = path.join(distPath, file);
         const destFile = path.join(plugName, file);
         console.log(`Copying "${srcFile}" to "${destFile}".`);
-        fs.copyFileSync(srcFile, destFile);
+        if (fs.statSync(srcFile).isDirectory()) {
+          fs.copySync(srcFile, destFile);
+        } else {
+          fs.copyFileSync(srcFile, destFile);
+        }
       });
 
       const inputPackageJson = path.join(pluginPackagesPath, 'package.json');
@@ -264,7 +268,11 @@ function extract(pluginPackagesPath, outputPlugins, logSteps = true) {
         const srcFile = path.join(distPath, file);
         const destFile = path.join(plugName, file);
         console.log(`Copying "${srcFile}" to "${destFile}".`);
-        fs.copyFileSync(srcFile, destFile);
+        if (fs.statSync(srcFile).isDirectory()) {
+          fs.copySync(srcFile, destFile);
+        } else {
+          fs.copyFileSync(srcFile, destFile);
+        }
       });
 
       const inputPackageJson = path.join(pluginPackagesPath, folder.name, 'package.json');


### PR DESCRIPTION
This change fixes `extractPackage` and `extractFolderOfPackages` to handle directories in the dist folder.

Fixes #4471 

### Testing
- Create a new plugin with `npx @kinvolk/headlamp-plugin create test-plugin`
- Add a `locales/en/translation.json` file with `{}`
- Add `"headlamp": { "i18n": ["en"] }` to `package.json`
- Run `npm run build && npm run package`
- Without fix: fails with `EISDIR` error
- With fix: creates tarball successfully