### PR TITLE
frontend: components: redux: Add feature to keep resource maps expanded by default

### DIFF
--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -44,11 +44,13 @@ export default function Settings() {
   const storedTimezone = settingsObj.timezone;
   const storedRowsPerPageOptions = settingsObj.tableRowsPerPageOptions;
   const storedSortSidebar = settingsObj.sidebarSortAlphabetically;
+  const expandLargeGraph = settingsObj.expandLargeGraph;
   const storedUseEvict = settingsObj.useEvict;
   const [selectedTimezone, setSelectedTimezone] = useState<string>(
     storedTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone
   );
   const [sortSidebar, setSortSidebar] = useState<boolean>(storedSortSidebar);
+  const [expandGraph, setExpandGraph] = useState<boolean>(expandLargeGraph);
   const [useEvict, setUseEvict] = useState<boolean>(storedUseEvict);
   const dispatch = useDispatch();
   const themeName = useTypedSelector(state => state.theme.name);
@@ -78,10 +80,19 @@ export default function Settings() {
     );
   }, [useEvict]);
 
+  useEffect(() => {
+    dispatch(
+      setAppSettings({
+        expandLargeGraph: expandGraph,
+      })
+    );
+  }, [expandGraph]);
+
   const sidebarLabelID = 'sort-sidebar-label';
   const evictLabelID = 'use-evict-label';
   const tableRowsLabelID = 'rows-per-page-label';
   const timezoneLabelID = 'timezone-label';
+  const expandGraphID = 'expand-graph-label';
 
   return (
     <SectionBox
@@ -160,6 +171,20 @@ export default function Settings() {
               />
             ),
             nameID: evictLabelID,
+          },
+          {
+            name: t('translation|Keep Large Graph Groups Expanded'),
+            value: (
+              <Switch
+                color="primary"
+                checked={expandGraph}
+                onChange={e => setExpandGraph(e.target.checked)}
+                inputProps={{
+                  'aria-labelledby': expandGraphID,
+                }}
+              />
+            ),
+            nameID: expandGraphID,
           },
         ]}
       />

--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -382,13 +382,13 @@
             </span>
           </dd>
           <dt
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
             id="use-evict-label"
           >
             Use evict for pod deletion
           </dt>
           <dd
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
           >
             <span
               class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
@@ -399,6 +399,38 @@
                 <input
                   aria-labelledby="use-evict-label"
                   checked=""
+                  class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                  type="checkbox"
+                />
+                <span
+                  class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                />
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <span
+                class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+              />
+            </span>
+          </dd>
+          <dt
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+            id="expand-graph-label"
+          >
+            Keep Large Graph Groups Expanded
+          </dt>
+          <dd
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+          >
+            <span
+              class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1emuodk-MuiButtonBase-root-MuiSwitch-switchBase"
+              >
+                <input
+                  aria-labelledby="expand-graph-label"
                   class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
                   type="checkbox"
                 />

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -45,6 +45,8 @@ const makeStore = () => {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',
           useEvict: true,
+          sidebarSortAlphabetically: false,
+          expandLargeGraph: false,
         },
       },
       projects: {

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -44,6 +44,8 @@ const makeStore = () => {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',
           useEvict: true,
+          sidebarSortAlphabetically: false,
+          expandLargeGraph: false,
         },
       },
       projects: {

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -168,6 +168,9 @@ function GraphViewContent({
   // Expand all groups state
   const [expandAll, setExpandAll] = useState(false);
 
+  // Expand by Default
+  const expandLargeGraph = useTypedSelector(state => state.config.settings.expandLargeGraph);
+
   // Load source data
   const { nodes, edges, selectedSources, sourceData, isLoading, toggleSelection } = useSources();
 
@@ -198,11 +201,18 @@ function GraphViewContent({
       namespaces: allNamespaces ?? [],
       k8sNodes: allNodes ?? [],
     });
-
-    const visibleGraph = collapseGraph(graph, { selectedNodeId, expandAll });
+    const visibleGraph = collapseGraph(graph, { selectedNodeId, expandAll, expandLargeGraph });
 
     return { visibleGraph, fullGraph: graph };
-  }, [filteredGraph, groupBy, selectedNodeId, expandAll, allNamespaces]);
+  }, [
+    filteredGraph,
+    groupBy,
+    selectedNodeId,
+    expandAll,
+    allNamespaces,
+    allNodes,
+    expandLargeGraph,
+  ]);
 
   const viewport = useGraphViewport();
 

--- a/frontend/src/components/resourceMap/graph/graphGrouping.tsx
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.tsx
@@ -395,14 +395,21 @@ export function findGroupContaining(
  * @param graph Single graph node
  * @param params.selectedNodeId Graph node that is selected
  * @param params.expandAll Display all the children within all groups
+ * @param params.expandLargeGraph When true, Keeps Large groups expanded
  * @returns Collapsed graph
  */
 export function collapseGraph(
   graph: GraphNode,
-  { selectedNodeId = 'root', expandAll }: { selectedNodeId?: string; expandAll: boolean }
+  {
+    selectedNodeId = 'root',
+    expandAll,
+    expandLargeGraph = false,
+  }: { selectedNodeId?: string; expandAll: boolean; expandLargeGraph?: boolean }
 ) {
   let root = { ...graph };
   let selectedGroup: GraphNode | undefined;
+
+  const primaryNodeIds = new Set(graph.nodes?.map(n => n.id) || []);
 
   if (selectedNodeId) {
     selectedGroup = findGroupContaining(graph, selectedNodeId);
@@ -418,8 +425,9 @@ export function collapseGraph(
     const isBig = (group.nodes?.length ?? 0) > 10 || (group.edges?.length ?? 0) > 0;
     const isSelectedGroup = selectedGroup?.id === group.id;
     const isRoot = group.id === 'root';
-
-    const collapsed = !expandAll && !isRoot && !isSelectedGroup && isBig;
+    const isPrimaryGroup = primaryNodeIds.has(group.id);
+    const shouldExpandPrimary = !expandLargeGraph || !isPrimaryGroup;
+    const collapsed = !expandAll && !isRoot && !isSelectedGroup && isBig && shouldExpandPrimary;
 
     return {
       ...group,

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "Zeitzone",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "Design",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "Timezone to display for dates",
   "Sort sidebar items alphabetically": "Sort sidebar items alphabetically",
   "Use evict for pod deletion": "Use evict for pod deletion",
+  "Keep Large Graph Groups Expanded": "Keep Large Graph Groups Expanded",
   "Theme": "Theme",
   "Keyboard Shortcuts": "Keyboard Shortcuts",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "Configure keyboard shortcuts for quick access to various parts of the application.",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "Huso horario para mostrar en fechas",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "Tema",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "Fuseau horaire à afficher pour les dates",
   "Sort sidebar items alphabetically": "Trier les éléments de la barre latérale par ordre alphabétique",
   "Use evict for pod deletion": "Utiliser l'éviction pour la suppression de pods",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "Thème",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "तिथियों के लिए प्रदर्शित करने का समय क्षेत्र",
   "Sort sidebar items alphabetically": "साइडबार आइटमों को वर्णानुक्रम में सॉर्ट करें",
   "Use evict for pod deletion": "Pod हटाने के लिए निष्कासन का उपयोग करें",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "थीम",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "Fuso orario per la visualizzazione delle date",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "Tema",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "日付表示のタイムゾーン",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "テーマ",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "날짜 표시용 시간대",
   "Sort sidebar items alphabetically": "사이드바 항목을 가나다순으로 정렬",
   "Use evict for pod deletion": "",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "테마",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "Fuso horário para mostrar em datas",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "Tema",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "தேதிகளுக்கு காட்ட வேண்டிய நேர மண்டலம்",
   "Sort sidebar items alphabetically": "பக்கப்பட்டி உருப்படிகளை அகரவரிசையில் வரிசைப்படுத்து",
   "Use evict for pod deletion": "பாட் நீக்குவதற்கு evict பயன்படுத்து",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "தீம்",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "顯示日期的時區",
   "Sort sidebar items alphabetically": "側邊欄項目按字母順序排序",
   "Use evict for pod deletion": "刪除 Pod 時使用 evict",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "主題",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -157,6 +157,7 @@
   "Timezone to display for dates": "显示日期的时区",
   "Sort sidebar items alphabetically": "侧边栏按字母排序",
   "Use evict for pod deletion": "使用驱逐方式删除 Pod",
+  "Keep Large Graph Groups Expanded": "",
   "Theme": "主题",
   "Keyboard Shortcuts": "",
   "Configure keyboard shortcuts for quick access to various parts of the application.": "",

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -55,6 +55,8 @@ export interface ConfigState {
      */
     timezone: string;
     useEvict: boolean;
+    sidebarSortAlphabetically: boolean;
+    expandLargeGraph: boolean;
     [key: string]: any;
   };
 }
@@ -76,7 +78,8 @@ export const initialState: ConfigState = {
       storedSettings.tableRowsPerPageOptions || defaultTableRowsPerPageOptions,
     timezone: storedSettings.timezone || defaultTimezone(),
     sidebarSortAlphabetically: storedSettings.sidebarSortAlphabetically || false,
-    useEvict: storedSettings.useEvict || true,
+    expandLargeGraph: storedSettings.expandLargeGraph || false,
+    useEvict: storedSettings.useEvict ?? true,
   },
 };
 


### PR DESCRIPTION
## Summary

This PR adds switch in Settings to keep resource map groups expanded by default.

## Related Issue

Fixes #4486

## Changes

- Added Switch in Settings to toggle feature
- Modified `configSlice.ts` to add setting
- Modified Expansion logic in `GraphView.tsx` and `graphGrouping.tsx`

## Screenshots

https://github.com/user-attachments/assets/b0d2d58e-9675-4d08-b92e-6fc1e4146972

