### PR TITLE
headlamp-plugin/scripts: Replace execSync with execFileSync

### DIFF
--- a/plugins/headlamp-plugin/scripts/fetch-official-plugins.js
+++ b/plugins/headlamp-plugin/scripts/fetch-official-plugins.js
@@ -24,7 +24,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { getRemoteGitHash, storeHash, shouldSkipBasedOnHash } = require('./git-hash-utils');
 
 const scriptDir = __dirname;
@@ -64,12 +64,12 @@ if (fs.existsSync(tempDir)) {
 
 try {
   console.log('Cloning official plugins repository...');
-  execSync(`git clone --depth 1 ${officialPluginsRepo} ${tempDir}`, {
+  execFileSync('git', ['clone', '--depth', '1', officialPluginsRepo, tempDir], {
     stdio: 'inherit',
   });
 
   // Get the current commit hash
-  const currentHash = execSync('git rev-parse HEAD', {
+  const currentHash = execFileSync('git', ['rev-parse', 'HEAD'], {
     cwd: tempDir,
     encoding: 'utf8',
   }).trim();

--- a/plugins/headlamp-plugin/scripts/git-hash-utils.js
+++ b/plugins/headlamp-plugin/scripts/git-hash-utils.js
@@ -23,7 +23,7 @@
  */
 
 const fs = require('fs-extra');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 /**
  * Get the stored hash from a hash file
@@ -54,7 +54,7 @@ function storeHash(hashFile, hash) {
  */
 function getLocalGitHash(dirPath, cwd) {
   try {
-    const output = execSync(`git log -1 --format=%H -- ${dirPath}`, {
+    const output = execFileSync('git', ['log', '-1', '--format=%H', '--', dirPath], {
       cwd: cwd,
       encoding: 'utf8',
     });
@@ -72,7 +72,7 @@ function getLocalGitHash(dirPath, cwd) {
  */
 function getRemoteGitHash(repoUrl) {
   try {
-    const output = execSync(`git ls-remote ${repoUrl} HEAD`, {
+    const output = execFileSync('git', ['ls-remote', repoUrl, 'HEAD'], {
       encoding: 'utf8',
     });
     return output.split('\t')[0].trim();


### PR DESCRIPTION
These changes replace usage of `execSync` in the headlamp-plugin scripts with `execFileSync`.

### Testing
- [x] Run `npm run fetch-official-plugins` and `npm run bundle-examples` locally and ensure they work as expected