### PR TITLE
backend: handle partial discoveryClient errors in cacheInvalidation

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -281,8 +281,17 @@ func runWatcher(
 	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(config)
 
 	apiResourceLists, err := discoveryClient.ServerPreferredResources()
-	if apiResourceLists == nil && err != nil {
-		logger.Log(logger.LevelError, nil, err, "error fetching resource list for context: "+redactContextKey(contextKey))
+
+	if err != nil {
+		if discovery.IsGroupDiscoveryFailedError(err) {
+			logger.Log(logger.LevelWarn, nil, err, "partial resource list returned for context: "+redactContextKey(contextKey))
+		} else {
+			logger.Log(logger.LevelError, nil, err, "error fetching resource list for context: "+redactContextKey(contextKey))
+			return
+		}
+	}
+
+	if apiResourceLists == nil {
 		return
 	}
 


### PR DESCRIPTION
## Summary

This PR improves how cache invalidation handles errors returned by the Kubernetes discovery client.
`ServerPreferredResources()` can return partial results along with an error, and this change ensures those cases are handled correctly instead of being treated as a full failure.
## Related Issue

Fixes #4507 

## Changes

- Handle partial errors returned by Kubernetes discovery without stopping cache invalidation
- Log partial discovery failures as warnings while continuing with available resources