### PR TITLE
Revert "frontend: Add cluster picker to CreateResourceButton in multi-cluster view"

### DIFF
--- a/frontend/src/components/common/CreateResourceButton.tsx
+++ b/frontend/src/components/common/CreateResourceButton.tsx
@@ -15,15 +15,6 @@
  */
 
 import { Icon } from '@iconify/react';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelectedClusters } from '../../lib/k8s';
@@ -43,52 +34,10 @@ export function CreateResourceButton(props: CreateResourceButtonProps) {
   const { t } = useTranslation(['glossary', 'translation']);
   const [errorMessage, setErrorMessage] = React.useState('');
   const clusters = useSelectedClusters();
-  const [isClusterChooserOpen, setIsClusterChooserOpen] = React.useState(false);
-  const [targetCluster, setTargetCluster] = React.useState<string | undefined>(clusters[0]);
-  const canCreate = clusters.length > 0;
 
   const baseObject = resourceClass.getBaseObject();
   const name = resourceName ?? baseObject.kind;
   const activityId = 'create-resource-' + resourceClass.apiName;
-
-  // Keep targetCluster in sync with current selection.
-  React.useEffect(() => {
-    setTargetCluster(currentTargetCluster =>
-      currentTargetCluster && clusters.includes(currentTargetCluster)
-        ? currentTargetCluster
-        : clusters[0]
-    );
-  }, [clusters]);
-
-  const launchCreateActivity = React.useCallback(
-    (clusterName: string) => {
-      Activity.launch({
-        id: activityId,
-        title: t('translation|Create {{ name }}', { name }),
-        location: 'full',
-        cluster: clusterName,
-        icon: <Icon icon="mdi:plus-circle" />,
-        content: (
-          <EditorDialog
-            noDialog
-            // Pass cluster to ensure Apply targets the chosen cluster.
-            item={{ ...baseObject, cluster: clusterName }}
-            open
-            setOpen={() => {}}
-            onClose={() => Activity.close(activityId)}
-            saveLabel={t('translation|Apply')}
-            errorMessage={errorMessage}
-            onEditorChanged={() => setErrorMessage('')}
-            title={t('translation|Create {{ name }}', { name })}
-            aria-label={t('translation|Create {{ name }}', { name })}
-          />
-        ),
-      });
-    },
-    [activityId, baseObject, errorMessage, name, t]
-  );
-
-  if (!canCreate) return null;
 
   return (
     <AuthVisible item={resourceClass} authVerb="create">
@@ -96,70 +45,30 @@ export function CreateResourceButton(props: CreateResourceButtonProps) {
         color="primary"
         description={t('translation|Create {{ name }}', { name })}
         icon={'mdi:plus-circle'}
-        longDescription={t('translation|Choose a cluster')}
         onClick={() => {
-          if (clusters.length > 1) {
-            setIsClusterChooserOpen(true);
-            return;
-          }
-          // clusters.length > 0 is guaranteed by canCreate.
-          launchCreateActivity(clusters[0]!);
+          Activity.launch({
+            id: activityId,
+            title: t('translation|Create {{ name }}', { name }),
+            location: 'full',
+            cluster: clusters[0],
+            icon: <Icon icon="mdi:plus-circle" />,
+            content: (
+              <EditorDialog
+                noDialog
+                item={baseObject}
+                open
+                setOpen={() => {}}
+                onClose={() => Activity.close(activityId)}
+                saveLabel={t('translation|Apply')}
+                errorMessage={errorMessage}
+                onEditorChanged={() => setErrorMessage('')}
+                title={t('translation|Create {{ name }}', { name })}
+                aria-label={t('translation|Create {{ name }}', { name })}
+              />
+            ),
+          });
         }}
       />
-
-      <Dialog
-        open={isClusterChooserOpen}
-        onClose={() => setIsClusterChooserOpen(false)}
-        maxWidth="xs"
-        fullWidth
-      >
-        <DialogTitle>{t('translation|Choose a cluster')}</DialogTitle>
-        <DialogContent>
-          <FormControl variant="outlined" size="small" fullWidth margin="dense">
-            <InputLabel id="create-resource-target-cluster-label">
-              {t('glossary|Cluster')}
-            </InputLabel>
-            <Select
-              labelId="create-resource-target-cluster-label"
-              id="create-resource-target-cluster-select"
-              value={targetCluster ?? ''}
-              label={t('glossary|Cluster')}
-              onChange={event => {
-                const value = event.target.value as string;
-                setTargetCluster(value || undefined);
-              }}
-            >
-              {clusters.map(cluster => (
-                <MenuItem key={cluster} value={cluster}>
-                  {cluster}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            color="secondary"
-            variant="contained"
-            onClick={() => setIsClusterChooserOpen(false)}
-          >
-            {t('translation|Cancel')}
-          </Button>
-          <Button
-            variant="contained"
-            onClick={() => {
-              setIsClusterChooserOpen(false);
-              if (!targetCluster) {
-                return;
-              }
-              launchCreateActivity(targetCluster);
-            }}
-            disabled={!targetCluster}
-          >
-            {t('translation|Next')}
-          </Button>
-        </DialogActions>
-      </Dialog>
     </AuthVisible>
   );
 }

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create ConfigMap"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -498,7 +498,19 @@
                   </h1>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Create MyCustomResource"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
               <div

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create MyCustomResource"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
           <p
             class="MuiTypography-root MuiTypography-h6 css-1fggqnx-MuiTypography-root"

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
@@ -280,7 +280,19 @@
                   </h1>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Create Job"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
@@ -280,7 +280,19 @@
                   </h1>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Create Job"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create CronJob"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -22,7 +22,19 @@
               </h1>
               <div
                 class="MuiBox-root css-ldp2l3"
-              />
+              >
+                <button
+                  aria-label="Create DaemonSet"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -22,7 +22,19 @@
               </h1>
               <div
                 class="MuiBox-root css-ldp2l3"
-              />
+              >
+                <button
+                  aria-label="Create Deployment"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create EndpointSlice"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Endpoints"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create BackendTLSPolicy"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create XBackendTrafficPolicy"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create GatewayClass"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create GRPCRoute"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Gateway"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create HTTPRoute"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create ReferenceGrant"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create HorizontalPodAutoscaler"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create IngressClass"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Ingress"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Job"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Lease"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create LimitRange"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
@@ -207,7 +207,19 @@
                   </h1>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Create ResourceQuota"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -256,7 +268,19 @@
                   </h1>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Create LimitRange"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -305,7 +329,19 @@
                   </h1>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Create Pod"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create NetworkPolicy"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -22,7 +22,19 @@
               </h1>
               <div
                 class="MuiBox-root css-ldp2l3"
-              />
+              >
+                <button
+                  aria-label="Create Node"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Pod"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create PodDisruptionBudget"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create PriorityClass"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -22,7 +22,19 @@
               </h1>
               <div
                 class="MuiBox-root css-ldp2l3"
-              />
+              >
+                <button
+                  aria-label="Create ReplicaSet"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
           <div

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create ResourceQuota"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create RuntimeClass"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Secret"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Service"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Service"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create StatefulSet"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/statefulset/__snapshots__/List.EmptyList.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.EmptyList.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create StatefulSet"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create StatefulSet"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create StatefulSet"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create PersistentVolumeClaim"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create StorageClass"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create StorageClass"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create VerticalPodAutoscaler"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -22,7 +22,19 @@
               </h1>
               <div
                 class="MuiBox-root css-ldp2l3"
-              />
+              >
+                <button
+                  aria-label="Create MutatingWebhookConfiguration"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -22,7 +22,19 @@
               </h1>
               <div
                 class="MuiBox-root css-ldp2l3"
-              />
+              >
+                <button
+                  aria-label="Create ValidatingWebhookConfiguration"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This reverts the change introduced by https://github.com/kubernetes-sigs/headlamp/pull/4272 .

The commit instroduced the following issues, at least in a single-cluster
view:
1. The + button for creating a resource (e.g. in the ConfigMap list view)
   has a tooltip showing "Choose cluster";
2. The resulting resource code now has a cluster field at the bottom
   which is not the standard spec. Using it will apparently not do
   anything anyway.

