### PR TITLE
app-catalog: support scoped headlamp-k8s package name

### DIFF
--- a/app/app-build-manifest.json
+++ b/app/app-build-manifest.json
@@ -3,7 +3,7 @@
   "plugins": [
     {
       "name": "app-catalog",
-      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/app-catalog-0.8.0/app-catalog-0.8.0.tar.gz"
+      "archive": "https://github.com/headlamp-k8s/plugins/releases/download/app-catalog-0.8.0/headlamp-k8s-app-catalog-0.8.0.tar.gz"
     },
     {
       "name": "plugin-catalog",

--- a/plugins/pluginctl/test-pluginctl.js
+++ b/plugins/pluginctl/test-pluginctl.js
@@ -26,7 +26,7 @@ Assumes being run within the plugins/pluginctl folder
 const PACKAGE_NAME = "appcatalog_headlamp_plugin";
 const PACKAGE_URL =
   "https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin";
-const PACKAGE_NAME_TO_UNINSTALL = "app-catalog";
+const PACKAGE_NAME_TO_UNINSTALL = "@headlamp-k8s/app-catalog";
 
 function testPluginctl() {
   // remove some temporary files.


### PR DESCRIPTION
## Summary

This PR updates Headlamp core to support the scoped plugin package name
`@headlamp-k8s/app-catalog` while maintaining backward compatibility with the legacy `app-catalog` name

## Related Issue

A follow up to issue: headlamp-k8s/plugins#412 and PR: headlamp-k8s/plugins#497

## Changes
- Normalize plugin names in `plugins/pluginctl` to allow legacy and scoped matches
- Update pluginctl tests for new package name
- Add tests to verify update/uninstall work with both scoped and legacy plugin names


## Steps to Test

1. In Headlamp repo run:
```bash
   cd headlamp-k8s/headlamp/app
   npm install
   npm start
   ```
2. In Plugins repo run:
 ```bash
   cd headlamp-k8s/plugins/app-catalog
   npm install
   npm start
   ```
3. app-catalog must appear in `Settings -> Plugins`

## Screenshots (if applicable)
<img width="1433" height="506" alt="image" src="https://github.com/user-attachments/assets/a8d63779-e484-4e5a-836a-35cb88614e92" />


## Notes for the Reviewer

None
