### PR TITLE
frontend:clusterRename:fix alignment name and button

### DIFF
--- a/frontend/src/components/App/Settings/ClusterNameEditor.tsx
+++ b/frontend/src/components/App/Settings/ClusterNameEditor.tsx
@@ -223,7 +223,7 @@ export function ClusterNameEditor({
               }}
               InputProps={{
                 endAdornment: (
-                  <Box pt={2} textAlign="right">
+                  <Box display="flex" alignItems="center">
                     <ConfirmButton
                       onConfirm={() => {
                         if (isValidCurrentName) {

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterNameEditor.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterNameEditor.Default.stories.storyshot
@@ -33,7 +33,7 @@
               value=""
             />
             <div
-              class="MuiBox-root css-oxzk7u"
+              class="MuiBox-root css-70qvj9"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterNameEditor.WithInvalidName.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterNameEditor.WithInvalidName.stories.storyshot
@@ -33,7 +33,7 @@
               value="Invalid Cluster Name"
             />
             <div
-              class="MuiBox-root css-oxzk7u"
+              class="MuiBox-root css-70qvj9"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"

--- a/frontend/src/components/App/Settings/__snapshots__/ClusterNameEditor.WithNewName.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ClusterNameEditor.WithNewName.stories.storyshot
@@ -33,7 +33,7 @@
               value="new-cluster-name"
             />
             <div
-              class="MuiBox-root css-oxzk7u"
+              class="MuiBox-root css-70qvj9"
             >
               <button
                 class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"


### PR DESCRIPTION
## Summary

This PR fixes a **UI alignment issue** in the **Rename Cluster** input field by ensuring the **Apply button remains properly aligned** with the cluster name text

## Related Issue

Fixes #4548

## Screenshots (if applicable)
before-> 

<img width="749" height="240" alt="Screenshot from 2026-02-05 03-15-57" src="https://github.com/user-attachments/assets/f4e4d9e3-6077-498a-b787-ff65dce66f6c" />

After-> 



<img width="749" height="240" alt="Screenshot from 2026-02-05 03-14-56" src="https://github.com/user-attachments/assets/2c9c6270-68a6-4712-adca-8def30c93795" />
