### PR TITLE
frontend: Default to init container if main container not yet running

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -27,6 +27,7 @@ import { Terminal as XTerminal } from '@xterm/xterm';
 import _ from 'lodash';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getDefaultContainer } from '../../helpers/podContainer';
 import Pod from '../../lib/k8s/pod';
 import { Dialog } from './Dialog';
 
@@ -60,7 +61,7 @@ type execReturn = ReturnType<Pod['exec']>;
 export default function Terminal(props: TerminalProps) {
   const { item, onClose, isAttach, noDialog, ...other } = props;
   const [terminalContainerRef, setTerminalContainerRef] = React.useState<HTMLElement | null>(null);
-  const [container, setContainer] = useState<string | null>(getDefaultContainer());
+  const [container, setContainer] = useState<string | null>(() => getDefaultContainer(item));
   const execOrAttachRef = React.useRef<execReturn | null>(null);
   const fitAddonRef = React.useRef<FitAddon | null>(null);
   const xtermRef = React.useRef<XTerminalConnected | null>(null);
@@ -69,10 +70,6 @@ export default function Terminal(props: TerminalProps) {
     currentIdx: 0,
   });
   const { t } = useTranslation(['translation', 'glossary']);
-
-  function getDefaultContainer() {
-    return item.spec.containers.length > 0 ? item.spec.containers[0].name : '';
-  }
 
   // @todo: Give the real exec type when we have it.
   function setupTerminal(containerRef: HTMLElement, xterm: XTerminal, fitAddon: FitAddon) {
@@ -338,7 +335,7 @@ export default function Terminal(props: TerminalProps) {
   React.useEffect(
     () => {
       if (props.open && container === null) {
-        setContainer(getDefaultContainer());
+        setContainer(getDefaultContainer(item));
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -430,7 +427,7 @@ export default function Terminal(props: TerminalProps) {
           <Select
             labelId="container-name-chooser-label"
             id="container-name-chooser"
-            value={container !== null ? container : getDefaultContainer()}
+            value={container !== null ? container : getDefaultContainer(item)}
             onChange={handleContainerChange}
           >
             {item?.spec?.containers && (

--- a/frontend/src/helpers/podContainer.ts
+++ b/frontend/src/helpers/podContainer.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Pod from '../lib/k8s/pod';
+
+/**
+ * Gets the default container name for a pod based on its current execution state.
+ *
+ * It prioritizes running main containers, then running init containers,
+ * falling back to the first container in the spec if none are running.
+ *
+ * @param item - The pod object to check.
+ * @returns The name of the default container or an empty string if none exist.
+ */
+
+export function getDefaultContainer(item: Pod): string {
+  if (!item) {
+    return '';
+  }
+
+  // Prefer a running main container
+  const runningMain = item.status?.containerStatuses?.find(s => s.state?.running);
+  if (runningMain) {
+    return runningMain.name;
+  }
+
+  // Otherwise use running init container
+  const runningInit = item.status?.initContainerStatuses?.find(s => s.state?.running);
+  if (runningInit) {
+    return runningInit.name;
+  }
+
+  // Fallback to first main container
+  return item.spec?.containers?.[0]?.name ?? '';
+}


### PR DESCRIPTION
## Summary
This PR fixes the UX when viewing logs or launching a terminal for pods with init containers. When the main container hasn't started yet, it now defaults to the running init container instead of showing an empty screen or failing.

## Related Issue
Fixes #4501

## Changes
- Updated `getDefaultContainer()` in `frontend/src/components/pod/Details.tsx` to check for running init containers
- Updated `getDefaultContainer()` in `frontend/src/components/common/Terminal.tsx` with the same logic
- Added `useEffect` in `PodLogViewer` to update container selection when pod status changes

## Steps to Test
1. Create a pod with a slow init container:
```bash
   cat <<EOF | kubectl apply -f -
   apiVersion: v1
   kind: Pod
   metadata:
     name: init-test
   spec:
     initContainers:
     - name: slow-init
       image: busybox
       command: ['sh', '-c', 'echo "Init starting..." && sleep 300']
     containers:
     - name: main
       image: busybox
       command: ['sh', '-c', 'echo "Main started" && sleep 3600']
   EOF
```
2. Open Headlamp and navigate to the pod while init container is running
3. Click "Show Logs" - should default to `slow-init` container
4. Click "Terminal" - should default to `slow-init` container if the main container is not yet running. One can switch to main later once it starts running.

## Screenshots (if applicable)
N/A

## Notes for the Reviewer
- No new i18n strings were added
- Logic prioritizes: running main container → running init container → first main container (fallback)