### PR TITLE
Backend cache integration tests

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1684,7 +1684,9 @@ func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 
 	if clusterName == "" {
 		clusters := (&HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{KubeConfigStore: kubeConfigStore},
+			HeadlampConfig: &headlampconfig.HeadlampConfig{
+				HeadlampCFG: &headlampconfig.HeadlampCFG{KubeConfigStore: kubeConfigStore},
+			},
 		}).getClusters()
 		for _, c := range clusters {
 			if c.Error == "" {
@@ -1699,17 +1701,19 @@ func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 	}
 
 	c := &HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			UseInCluster:    false,
-			KubeConfigPath:  kubeConfigPath,
-			KubeConfigStore: kubeConfigStore,
-			CacheEnabled:    true,
-			PluginDir:       pluginDir,
-			UserPluginDir:   userPluginDir,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigPath:  kubeConfigPath,
+				KubeConfigStore: kubeConfigStore,
+				CacheEnabled:    true,
+				PluginDir:       pluginDir,
+				UserPluginDir:   userPluginDir,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
 		},
-		cache:            cache.New[interface{}](),
-		telemetryConfig:  GetDefaultTestTelemetryConfig(),
-		telemetryHandler: &telemetry.RequestHandler{},
 	}
 
 	return c, clusterName

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -183,10 +183,77 @@ func GetContextKeyAndKContext(w http.ResponseWriter,
 	return ctx, span, contextKey, kContext, nil
 }
 
+// handleCacheRequest processes a request with caching logic.
+func handleCacheRequest(c *HeadlampConfig, next http.Handler, w http.ResponseWriter, r *http.Request) {
+	if k8cache.SkipWebSocket(r, next, w) {
+		return
+	}
+
+	ctx, span, contextKey, kContext, err := GetContextKeyAndKContext(w, r, c)
+	if err != nil {
+		return
+	}
+
+	if err := k8cache.HandleNonGETCacheInvalidation(k8sResponseCache, w, r, next, contextKey); err != nil {
+		// ErrHandled is a sentinel error indicating the request was fully
+		// processed during cache invalidation. For non-GET requests
+		// (POST/PUT/DELETE), HandleNonGETCacheInvalidation invalidates the
+		// cache, makes a fresh request to K8s, stores the response, and
+		// writes the response to the client. When ErrHandled is returned,
+		// the request has already been handled and we must return early to
+		// avoid processing the request again or writing duplicate responses.
+		if errors.Is(err, k8cache.ErrHandled) {
+			return
+		}
+
+		c.handleError(w, ctx, span, err, "error while invalidating keys", http.StatusInternalServerError)
+
+		return
+	}
+
+	rcw := k8cache.NewResponseCapture(w)
+
+	key, err := k8cache.GenerateKey(r.URL, contextKey)
+	if err != nil {
+		c.handleError(w, ctx, span, err, "failed to generate key ", http.StatusBadRequest)
+		return
+	}
+
+	isAllowed, authErr := k8cache.IsAllowed(kContext, r)
+	if authErr != nil {
+		k8cache.ServeFromCacheOrForwardToK8s(k8sResponseCache, isAllowed, next, key, w, r, rcw)
+
+		return
+	} else if !isAllowed && k8cache.IsAuthBypassURL(r.URL.Path) {
+		_ = k8cache.ReturnAuthErrorResponse(w, r, contextKey)
+
+		return
+	}
+
+	served, err := k8cache.LoadFromCache(k8sResponseCache, isAllowed, key, w, r)
+	if err != nil {
+		c.handleError(w, ctx, span, errors.New(kContext.Error), "failed to load from cache", http.StatusServiceUnavailable)
+		return
+	}
+
+	if served {
+		c.TelemetryHandler.RecordEvent(span, "Served from cache")
+		return
+	}
+
+	k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext)
+
+	next.ServeHTTP(rcw, r)
+
+	err = k8cache.StoreK8sResponseInCache(k8sResponseCache, r.URL, rcw, r, key)
+	if err != nil {
+		c.handleError(w, ctx, span, errors.New(kContext.Error), "error while storing into cache", http.StatusBadRequest)
+		return
+	}
+}
+
 // CacheMiddleWare is Middleware for Caching purpose. It involves generating key for a request,
 // authorizing user , store resource data in cache and returns data if key is present.
-//
-//nolint:gocognit,funlen
 func CacheMiddleWare(c *HeadlampConfig) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		if !c.CacheEnabled {
@@ -194,63 +261,7 @@ func CacheMiddleWare(c *HeadlampConfig) mux.MiddlewareFunc {
 		}
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if k8cache.SkipWebSocket(r, next, w) {
-				return
-			}
-
-			ctx, span, contextKey, kContext, err := GetContextKeyAndKContext(w, r, c)
-			if err != nil {
-				return
-			}
-
-			if err := k8cache.HandleNonGETCacheInvalidation(k8sResponseCache, w, r, next, contextKey); err != nil {
-				if errors.Is(err, k8cache.ErrHandled) {
-					return
-				}
-
-				c.handleError(w, ctx, span, err, "error while invalidating keys", http.StatusInternalServerError)
-
-				return
-			}
-
-			rcw := k8cache.NewResponseCapture(w)
-
-			key, err := k8cache.GenerateKey(r.URL, contextKey)
-			if err != nil {
-				c.handleError(w, ctx, span, err, "failed to generate key ", http.StatusBadRequest)
-				return
-			}
-
-			isAllowed, authErr := k8cache.IsAllowed(kContext, r)
-			if authErr != nil {
-				k8cache.ServeFromCacheOrForwardToK8s(k8sResponseCache, isAllowed, next, key, w, r, rcw)
-
-				return
-			} else if !isAllowed && k8cache.IsAuthBypassURL(r.URL.Path) {
-				_ = k8cache.ReturnAuthErrorResponse(w, r, contextKey)
-
-				return
-			}
-
-			served, err := k8cache.LoadFromCache(k8sResponseCache, isAllowed, key, w, r)
-			if err != nil {
-				c.handleError(w, ctx, span, errors.New(kContext.Error), "failed to load from cache", http.StatusServiceUnavailable)
-			}
-
-			if served {
-				c.TelemetryHandler.RecordEvent(span, "Served from cache")
-				return
-			}
-
-			k8cache.CheckForChanges(k8sResponseCache, contextKey, *kContext)
-
-			next.ServeHTTP(rcw, r)
-
-			err = k8cache.StoreK8sResponseInCache(k8sResponseCache, r.URL, rcw, r, key)
-			if err != nil {
-				c.handleError(w, ctx, span, errors.New(kContext.Error), "error while storing into cache", http.StatusBadRequest)
-				return
-			}
+			handleCacheRequest(c, next, w, r)
 		})
 	}
 }

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -21,6 +21,7 @@ package k8cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -88,7 +89,7 @@ func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.Response
 }
 
 // ErrHandled indicates the request was fully handled by cache invalidation; middleware must return.
-var ErrHandled = fmt.Errorf("handled by cache invalidation")
+var ErrHandled = errors.New("handled by cache invalidation")
 
 // SkipWebSocket skip all the websocket requests coming from the client/ frontend to ensure
 // real time data updation in the frontend.


### PR DESCRIPTION
Summary
This PR adds integration tests for the CacheMiddleware with a real Kubernetes cluster and fixes a bug where non-GET requests (DELETE/POST/PUT) were handled twice by the cache middleware, causing EOF errors for clients.

Related Issue
Fixes #4510

Changes
Added TestCacheMiddleware_CacheHitAndCacheMiss_RealK8s and TestCacheMiddleware_CacheInvalidation_RealK8s in backend/cmd/headlamp_test.go
Added helper newRealK8sHeadlampConfig to set up Headlamp for integration tests
Fixed double-handling of non-GET requests in HandleNonGETCacheInvalidation – middleware now stops after serving DELETE/POST/PUT via ErrHandled instead of calling next again

Steps to Test
Ensure a Kubernetes cluster is running (e.g. minikube).
Run:
   HEADLAMP_RUN_INTEGRATION_TESTS=true npm run backend:test -- -run "TestCacheMiddleware_CacheHitAndCacheMiss_RealK8s|TestCacheMiddleware_CacheInvalidation_RealK8s"
Confirm both tests pass.

Screenshots (if applicable)

<img width="478" height="314" alt="Screenshot 2026-02-05 at 10 54 48 AM" src="https://github.com/user-attachments/assets/e1f2980d-44c0-42b1-93e0-0eb31cc78b0e" />

Notes for the Reviewer
Integration tests require HEADLAMP_RUN_INTEGRATION_TESTS=true and are skipped in normal CI.
The cache fix prevents next.ServeHTTP from being called twice for non-GET requests, which caused "invalid Read on closed Body" and EOF on the client.