### PR TITLE
backend: Move HeadlampConfig to headlampconfig package

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -187,15 +187,17 @@ func TestDynamicClusters(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()
 			c := HeadlampConfig{
-				HeadlampCFG: &headlampconfig.HeadlampCFG{
-					UseInCluster:          false,
-					KubeConfigPath:        "",
-					EnableDynamicClusters: true,
-					KubeConfigStore:       kubeConfigStore,
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:          false,
+						KubeConfigPath:        "",
+						EnableDynamicClusters: true,
+						KubeConfigStore:       kubeConfigStore,
+					},
+					Cache:            cache,
+					TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+					TelemetryHandler: &telemetry.RequestHandler{},
 				},
-				cache:            cache,
-				telemetryConfig:  GetDefaultTestTelemetryConfig(),
-				telemetryHandler: &telemetry.RequestHandler{},
 			}
 			handler := createHeadlampHandler(&c)
 
@@ -278,15 +280,17 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 	kubeConfigStore := kubeconfig.NewContextStore()
 
 	c := HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			UseInCluster:          false,
-			KubeConfigPath:        "",
-			EnableDynamicClusters: true,
-			KubeConfigStore:       kubeConfigStore,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "",
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache:            cache,
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
 		},
-		cache:            cache,
-		telemetryConfig:  GetDefaultTestTelemetryConfig(),
-		telemetryHandler: &telemetry.RequestHandler{},
 	}
 	handler := createHeadlampHandler(&c)
 
@@ -330,13 +334,15 @@ func TestInvalidKubeConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	c := HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			UseInCluster:          false,
-			KubeConfigPath:        absPath,
-			EnableDynamicClusters: true,
-			KubeConfigStore:       kubeConfigStore,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        absPath,
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache: cache,
 		},
-		cache: cache,
 	}
 
 	err = kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, absPath, kubeconfig.KubeConfig, nil)
@@ -379,34 +385,40 @@ func TestExternalProxy(t *testing.T) {
 	tests := []test{
 		{
 			handler: createHeadlampHandler(&HeadlampConfig{
-				HeadlampCFG: &headlampconfig.HeadlampCFG{
-					UseInCluster:    false,
-					ProxyURLs:       []string{proxyURL.String()},
-					KubeConfigStore: kubeConfigStore,
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:    false,
+						ProxyURLs:       []string{proxyURL.String()},
+						KubeConfigStore: kubeConfigStore,
+					},
+					Cache: cache,
 				},
-				cache: cache,
 			}),
 			useForwardedHeaders: true,
 		},
 		{
 			handler: createHeadlampHandler(&HeadlampConfig{
-				HeadlampCFG: &headlampconfig.HeadlampCFG{
-					UseInCluster:    false,
-					ProxyURLs:       []string{},
-					KubeConfigStore: kubeConfigStore,
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:    false,
+						ProxyURLs:       []string{},
+						KubeConfigStore: kubeConfigStore,
+					},
+					Cache: cache,
 				},
-				cache: cache,
 			}),
 			useNoProxyURL: true,
 		},
 		{
 			handler: createHeadlampHandler(&HeadlampConfig{
-				HeadlampCFG: &headlampconfig.HeadlampCFG{
-					UseInCluster:    false,
-					KubeConfigStore: kubeConfigStore,
-					ProxyURLs:       []string{proxyURL.String()},
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:    false,
+						KubeConfigStore: kubeConfigStore,
+						ProxyURLs:       []string{proxyURL.String()},
+					},
+					Cache: cache,
 				},
-				cache: cache,
 			}),
 			useProxyURL: true,
 		},
@@ -462,14 +474,16 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 	tests := []test{
 		{
 			handler: createHeadlampHandler(&HeadlampConfig{
-				HeadlampCFG: &headlampconfig.HeadlampCFG{
-					UseInCluster:    false,
-					KubeConfigPath:  config.GetDefaultKubeConfigPath(),
-					KubeConfigStore: kubeConfigStore,
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:    false,
+						KubeConfigPath:  config.GetDefaultKubeConfigPath(),
+						KubeConfigStore: kubeConfigStore,
+					},
+					Cache:            cache,
+					TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+					TelemetryHandler: &telemetry.RequestHandler{},
 				},
-				cache:            cache,
-				telemetryConfig:  GetDefaultTestTelemetryConfig(),
-				telemetryHandler: &telemetry.RequestHandler{},
 			}),
 		},
 	}
@@ -550,14 +564,16 @@ func TestDeletePlugin(t *testing.T) {
 	kubeConfigStore := kubeconfig.NewContextStore()
 
 	c := HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			UseInCluster:    false,
-			KubeConfigPath:  config.GetDefaultKubeConfigPath(),
-			PluginDir:       devPluginDir,
-			UserPluginDir:   userPluginDir,
-			KubeConfigStore: kubeConfigStore,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigPath:  config.GetDefaultKubeConfigPath(),
+				PluginDir:       devPluginDir,
+				UserPluginDir:   userPluginDir,
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache: cache,
 		},
-		cache: cache,
 	}
 
 	handler := createHeadlampHandler(&c)
@@ -596,14 +612,16 @@ func TestHandleClusterAPI_XForwardedHost(t *testing.T) {
 	cache := cache.New[interface{}]()
 
 	c := HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			UseInCluster:    false,
-			KubeConfigPath:  config.GetDefaultKubeConfigPath(),
-			KubeConfigStore: kubeConfigStore,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigPath:  config.GetDefaultKubeConfigPath(),
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache:            cache,
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
 		},
-		cache:            cache,
-		telemetryConfig:  GetDefaultTestTelemetryConfig(),
-		telemetryHandler: &telemetry.RequestHandler{},
 	}
 
 	handler := createHeadlampHandler(&c)
@@ -714,15 +732,17 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 	kubeConfigStore := kubeconfig.NewContextStore()
 
 	c := HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			UseInCluster:          false,
-			KubeConfigPath:        "./headlamp_testdata/kubeconfig",
-			EnableDynamicClusters: true,
-			KubeConfigStore:       kubeConfigStore,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "./headlamp_testdata/kubeconfig",
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache:            cache,
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
 		},
-		cache:            cache,
-		telemetryConfig:  GetDefaultTestTelemetryConfig(),
-		telemetryHandler: &telemetry.RequestHandler{},
 	}
 	handler := createHeadlampHandler(&c)
 
@@ -889,6 +909,7 @@ func TestBaseURLReplaceWithCurrentIndexHTMLContentAndRSPackBuild(t *testing.T) {
 `)
 }
 
+//nolint:funlen
 func TestGetOidcCallbackURL(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -903,7 +924,11 @@ func TestGetOidcCallbackURL(t *testing.T) {
 				Host: "example.com",
 				TLS:  &tls.ConnectionState{},
 			},
-			config:         &HeadlampConfig{HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: ""}},
+			config: &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: ""},
+				},
+			},
 			expectedResult: "https://example.com/oidc-callback",
 		},
 		{
@@ -912,7 +937,11 @@ func TestGetOidcCallbackURL(t *testing.T) {
 				URL:  &url.URL{Scheme: "http"},
 				Host: "example.com",
 			},
-			config:         &HeadlampConfig{HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: "/headlamp"}},
+			config: &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: "/headlamp"},
+				},
+			},
 			expectedResult: "http://example.com/headlamp/oidc-callback",
 		},
 		{
@@ -922,7 +951,11 @@ func TestGetOidcCallbackURL(t *testing.T) {
 				Host:   "example.com",
 				Header: http.Header{"X-Forwarded-Proto": []string{"https"}},
 			},
-			config:         &HeadlampConfig{HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: ""}},
+			config: &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: ""},
+				},
+			},
 			expectedResult: "https://example.com/oidc-callback",
 		},
 		{
@@ -931,7 +964,11 @@ func TestGetOidcCallbackURL(t *testing.T) {
 				URL:  &url.URL{},
 				Host: "localhost:8080",
 			},
-			config:         &HeadlampConfig{HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: ""}},
+			config: &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{BaseURL: ""},
+				},
+			},
 			expectedResult: "http://localhost:8080/oidc-callback",
 		},
 	}
@@ -949,11 +986,11 @@ func TestGetOidcCallbackURL(t *testing.T) {
 func TestOIDCTokenRefreshMiddleware(t *testing.T) {
 	kubeConfigStore := kubeconfig.NewContextStore()
 	config := &HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			KubeConfigStore: kubeConfigStore,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeConfigStore},
+			Cache:            cache.New[interface{}](),
+			TelemetryHandler: &telemetry.RequestHandler{},
 		},
-		cache:            cache.New[interface{}](),
-		telemetryHandler: &telemetry.RequestHandler{},
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -983,13 +1020,15 @@ func TestStartHeadlampServer(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := &HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			Port:            8080,
-			PluginDir:       tempDir,
-			KubeConfigStore: kubeconfig.NewContextStore(),
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				Port:            8080,
+				PluginDir:       tempDir,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache:           cache.New[interface{}](),
+			TelemetryConfig: GetDefaultTestTelemetryConfig(),
 		},
-		cache:           cache.New[interface{}](),
-		telemetryConfig: GetDefaultTestTelemetryConfig(),
 	}
 
 	// Use a channel to signal when the server is ready
@@ -1038,15 +1077,17 @@ func TestStartHeadlampServerTLS(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	cfg := &HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			Port:            8185,
-			PluginDir:       tempDir,
-			KubeConfigStore: kubeconfig.NewContextStore(),
-			TLSCertPath:     "headlamp_testdata/headlamp.crt",
-			TLSKeyPath:      "headlamp_testdata/headlamp.key",
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				Port:            8185,
+				PluginDir:       tempDir,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+				TLSCertPath:     "headlamp_testdata/headlamp.crt",
+				TLSKeyPath:      "headlamp_testdata/headlamp.key",
+			},
+			Cache:           cache.New[interface{}](),
+			TelemetryConfig: GetDefaultTestTelemetryConfig(),
 		},
-		cache:           cache.New[interface{}](),
-		telemetryConfig: GetDefaultTestTelemetryConfig(),
 	}
 
 	go StartHeadlampServer(cfg)
@@ -1084,13 +1125,12 @@ func TestHandleClusterHelm(t *testing.T) {
 	defer os.Unsetenv("HEADLAMP_BACKEND_TOKEN")
 
 	config := &HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			KubeConfigStore: kubeconfig.NewContextStore(),
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeconfig.NewContextStore()},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
 		},
-		cache: cache.New[interface{}](),
-
-		telemetryConfig:  GetDefaultTestTelemetryConfig(),
-		telemetryHandler: &telemetry.RequestHandler{},
 	}
 
 	// Add a mock context to the kubeConfigStore
@@ -1349,12 +1389,11 @@ func newHeadlampConfig(fakeK8s *httptest.Server, testName string) *HeadlampConfi
 	}
 
 	return &HeadlampConfig{
-		HeadlampCFG: &headlampconfig.HeadlampCFG{
-			KubeConfigStore: store,
-			CacheEnabled:    true,
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: store, CacheEnabled: true},
+			TelemetryHandler: &telemetry.RequestHandler{},
+			Cache:            cache.New[interface{}](),
 		},
-		telemetryHandler: &telemetry.RequestHandler{},
-		cache:            cache.New[interface{}](),
 	}
 }
 
@@ -1574,9 +1613,11 @@ func TestCacheMiddleware_CacheInvalidation(t *testing.T) {
 //nolint:funlen
 func TestHandleClusterServiceProxy(t *testing.T) {
 	cfg := &HeadlampConfig{
-		HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeconfig.NewContextStore()},
-		telemetryHandler: &telemetry.RequestHandler{},
-		telemetryConfig:  GetDefaultTestTelemetryConfig(),
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeconfig.NewContextStore()},
+			TelemetryHandler: &telemetry.RequestHandler{},
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+		},
 	}
 
 	// Backend service the proxy should call

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -123,25 +123,25 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 	kubeConfigStore := kubeconfig.NewContextStore()
 	multiplexer := NewMultiplexer(kubeConfigStore)
 
-	headlampConfig := &HeadlampConfig{
+	cfg := &headlampconfig.HeadlampConfig{
 		HeadlampCFG:               buildHeadlampCFG(conf, kubeConfigStore),
-		oidcClientID:              conf.OidcClientID,
-		oidcValidatorClientID:     conf.OidcValidatorClientID,
-		oidcClientSecret:          conf.OidcClientSecret,
-		oidcIdpIssuerURL:          conf.OidcIdpIssuerURL,
-		oidcCallbackURL:           conf.OidcCallbackURL,
-		oidcValidatorIdpIssuerURL: conf.OidcValidatorIdpIssuerURL,
-		oidcScopes:                strings.Split(conf.OidcScopes, ","),
-		oidcSkipTLSVerify:         conf.OidcSkipTLSVerify,
-		oidcUseAccessToken:        conf.OidcUseAccessToken,
-		oidcUsePKCE:               conf.OidcUsePKCE,
-		meUsernamePaths:           conf.MeUsernamePath,
-		meEmailPaths:              conf.MeEmailPath,
-		meGroupsPaths:             conf.MeGroupsPath,
-		meUserInfoURL:             conf.MeUserInfoURL,
-		cache:                     cache,
-		multiplexer:               multiplexer,
-		telemetryConfig:           buildTelemetryConfig(conf),
+		OidcClientID:              conf.OidcClientID,
+		OidcValidatorClientID:     conf.OidcValidatorClientID,
+		OidcClientSecret:          conf.OidcClientSecret,
+		OidcIdpIssuerURL:          conf.OidcIdpIssuerURL,
+		OidcCallbackURL:           conf.OidcCallbackURL,
+		OidcValidatorIdpIssuerURL: conf.OidcValidatorIdpIssuerURL,
+		OidcScopes:                strings.Split(conf.OidcScopes, ","),
+		OidcSkipTLSVerify:         conf.OidcSkipTLSVerify,
+		OidcUseAccessToken:        conf.OidcUseAccessToken,
+		OidcUsePKCE:               conf.OidcUsePKCE,
+		MeUsernamePaths:           conf.MeUsernamePath,
+		MeEmailPaths:              conf.MeEmailPath,
+		MeGroupsPaths:             conf.MeGroupsPath,
+		MeUserInfoURL:             conf.MeUserInfoURL,
+		Cache:                     cache,
+		Multiplexer:               multiplexer,
+		TelemetryConfig:           buildTelemetryConfig(conf),
 	}
 
 	if conf.OidcCAFile != "" {
@@ -151,10 +151,10 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 			os.Exit(1)
 		}
 
-		headlampConfig.oidcCACert = string(caFileContents)
+		cfg.OidcCACert = string(caFileContents)
 	}
 
-	return headlampConfig
+	return &HeadlampConfig{HeadlampConfig: cfg}
 }
 
 // GetContextKeyAndContext returns Kcontext , ContextKey for using these in CacheMiddleWare function.
@@ -231,7 +231,7 @@ func CacheMiddleWare(c *HeadlampConfig) mux.MiddlewareFunc {
 			}
 
 			if served {
-				c.telemetryHandler.RecordEvent(span, "Served from cache")
+				c.TelemetryHandler.RecordEvent(span, "Served from cache")
 				return
 			}
 

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -75,13 +75,15 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()
 			c := HeadlampConfig{
-				HeadlampCFG: &headlampconfig.HeadlampCFG{
-					UseInCluster:          false,
-					KubeConfigPath:        "",
-					EnableDynamicClusters: true,
-					KubeConfigStore:       kubeConfigStore,
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:          false,
+						KubeConfigPath:        "",
+						EnableDynamicClusters: true,
+						KubeConfigStore:       kubeConfigStore,
+					},
+					Cache: cache,
 				},
-				cache: cache,
 			}
 			handler := createHeadlampHandler(&c)
 
@@ -109,6 +111,7 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestStatelessClusterApiRequest(t *testing.T) {
 	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")
 	require.NoError(t, err)
@@ -130,14 +133,17 @@ func TestStatelessClusterApiRequest(t *testing.T) {
 			cache := cache.New[interface{}]()
 			kubeConfigStore := kubeconfig.NewContextStore()
 			c := HeadlampConfig{
-				HeadlampCFG: &headlampconfig.HeadlampCFG{
-					UseInCluster: false, KubeConfigPath: "",
-					EnableDynamicClusters: true,
-					KubeConfigStore:       kubeConfigStore,
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:          false,
+						KubeConfigPath:        "",
+						EnableDynamicClusters: true,
+						KubeConfigStore:       kubeConfigStore,
+					},
+					Cache:            cache,
+					TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+					TelemetryHandler: &telemetry.RequestHandler{},
 				},
-				cache:            cache,
-				telemetryConfig:  GetDefaultTestTelemetryConfig(),
-				telemetryHandler: &telemetry.RequestHandler{},
 			}
 			handler := createHeadlampHandler(&c)
 			headers := map[string]string{

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -1,9 +1,42 @@
 package headlampconfig
 
 import (
+	"net/http"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 )
+
+// WebSocketMultiplexer handles client websocket connections. Implemented in cmd to avoid circular import.
+type WebSocketMultiplexer interface {
+	HandleClientWebSocket(http.ResponseWriter, *http.Request)
+}
+
+// HeadlampConfig holds full server config. Lives here so packages (e.g. k8cache) can import without cmd.
+type HeadlampConfig struct {
+	*HeadlampCFG
+	OidcClientID              string
+	OidcValidatorClientID     string
+	OidcClientSecret          string
+	OidcIdpIssuerURL          string
+	OidcCallbackURL           string
+	OidcValidatorIdpIssuerURL string
+	OidcUseAccessToken        bool
+	OidcSkipTLSVerify         bool
+	OidcCACert                string
+	OidcUsePKCE               bool
+	OidcScopes                []string
+	Cache                     cache.Cache[interface{}]
+	Multiplexer               WebSocketMultiplexer
+	TelemetryConfig           config.Config
+	TelemetryHandler          *telemetry.RequestHandler
+	MeUsernamePaths           string
+	MeEmailPaths              string
+	MeGroupsPaths             string
+	MeUserInfoURL             string
+}
 
 type HeadlampCFG struct {
 	UseInCluster          bool


### PR DESCRIPTION
## Summary

This PR refactors backend configuration by moving the `HeadlampConfig` struct from `backend/cmd/headlamp.go` to `backend/pkg/headlampconfig/headlampConfig.go`. This makes the configuration type importable by other backend packages without depending on `cmd`, improving modularity and reducing coupling.

## Related Issue

Fixes #4511

## Changes

- Added `backend/pkg/headlampconfig/headlampConfig.go` with the exported `HeadlampConfig` struct and `WebSocketMultiplexer` interface
- Refactored `backend/cmd/headlamp.go`: `cmd.HeadlampConfig` now embeds `*headlampconfig.HeadlampConfig`, field references updated to exported names (`config.Cache`, etc.), and added nil check for `Multiplexer` before registering websocket route
- Updated `backend/cmd/server.go`: `createHeadlampConfig` builds `headlampconfig.HeadlampConfig` and wraps it in `cmd.HeadlampConfig`
- Updated `backend/cmd/headlamp_test.go` and `backend/cmd/stateless_test.go` to use the new wrapper structure and `headlampconfig.HeadlampConfig`

## Steps to Test

1. Run `npm run backend:build`
2. Run `npm run backend:test`
3. Run `npm start` and confirm the backend starts and UI loads
4. Open the app, navigate, and confirm core features work as before

## Screenshots (if applicable)

N/A – backend-only refactor, no UI changes.

## Notes for the Reviewer

- This is a structural refactor; behavior is intended to be unchanged.
- `HeadlampConfig` fields are now exported in the `headlampconfig` package for use by other packages.
- Focus review on `cmd.HeadlampConfig` wrapper usage and the `createHeadlampConfig` flow in `server.go`.