### PR TITLE
fix(a11y): correct heading hierarchy in PluginSettings

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -237,7 +237,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
 
                 return (
                   <>
-                    <Typography variant="subtitle1">
+                    <Typography variant="subtitle1" component="div">
                       <HeadlampLink
                         routeName={'pluginDetails'}
                         params={{ name: plugin.name, type: plugin.type || 'shipped' }}


### PR DESCRIPTION
## Summary

This PR fixes an accessibility issue related to heading hierarchy by preventing unintended heading elements from being rendered in the Plugin Settings UI.

## Related Issue

Fixes #4582

## Changes

- Updated `PluginSettings.tsx` to avoid rendering implicit `h6` headings
- Ensured text uses a non-heading semantic element while preserving existing UI styles
- Resolves axe accessibility violations related to heading order

## Steps to Test

1. Navigate to **Settings → Plugins** in the Headlamp UI
2. Verify that the plugin list renders correctly with no visual changes
3. Run accessibility tests (axe / a11y checks) and confirm heading-order violations are resolved

## Screenshots (if applicable)

N/A (no visual changes)

## Notes for the Reviewer

- This is a small, scoped accessibility fix aligned with the existing a11y tracking issue
- No snapshots, baselines, or unrelated files were modified
