### PR TITLE
fix(a11y): correct heading hierarchy in PluginSettings stories

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.stories.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.stories.tsx
@@ -25,7 +25,7 @@ export default {
   decorators: [
     Story => (
       <div>
-        <h1 style={{ position: 'absolute', left: '-10000px' }}>Plugin Settings Test Page</h1>
+        <h1 style={{ position: 'absolute', left: '-10000px' }}>Plugin Settings</h1>
         <Story />
       </div>
     ),

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -237,7 +237,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
 
                 return (
                   <>
-                    <Typography variant="subtitle1">
+                    <Typography variant="subtitle1" component="div">
                       <HeadlampLink
                         routeName={'pluginDetails'}
                         params={{ name: plugin.name, type: plugin.type || 'shipped' }}


### PR DESCRIPTION
This PR fixes Storybook a11y heading hierarchy issues in PluginSettings.

- Prevents unintended h6 elements by updating Typography usage
- Adds a root hidden h1 to PluginSettings stories for proper heading structure

Fixes #4582
Fixes #4583
Fixes #4584
Fixes #4585
Fixes #4587
Fixes #4588