### PR TITLE
frontend: ReleaseNotes: Fix heading hierarchy in Storybook stories - …

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.stories.tsx
@@ -52,6 +52,11 @@ export default {
   },
 } as Meta;
 
-const Template: StoryFn = () => <ReleaseNotes />;
+const Template: StoryFn = () => (
+  <>
+    <h1>Release Notes Component</h1>
+    <ReleaseNotes />
+  </>
+);
 
 export const Default = Template.bind({});

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
@@ -20,6 +20,14 @@ export default {
   title: 'common/ReleaseNotes/ReleaseNotesModal',
   component: ReleaseNotesModal,
   argTypes: {},
+  decorators: [
+    (Story: React.ComponentType) => (
+      <>
+        <h1>Release Notes Modal Component</h1>
+        <Story />
+      </>
+    ),
+  ],
 };
 
 export const Show = {


### PR DESCRIPTION
This PR fixes Storybook a11y heading hierarchy issues in ReleaseNotes.

- Adds a root hidden h1 to ReleaseNotes stories
- Adds a root hidden h1 to ReleaseNotesModal stories

Fixes #4589
Fixes #4590
