### PR TITLE
frontend: GlobalSearch: Fix color contrast for search hint Increase o…

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearch.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearch.tsx
@@ -96,7 +96,12 @@ export function GlobalSearch({ isIconButton }: { isIconButton?: boolean }) {
           </InputAdornment>
         ),
         endAdornment: (
-          <Box display="flex" flexShrink={0} gap={0.5} sx={{ opacity: 0.7, pointerEvents: 'none' }}>
+          <Box
+            display="flex"
+            flexShrink={0}
+            gap={0.5}
+            sx={{ opacity: 0.85, pointerEvents: 'none' }}
+          >
             <Trans>
               Press
               <Box


### PR DESCRIPTION
## Summary

This PR fixes a color contrast accessibility issue in the TopBar search hint text.

## Related Issue

Fixes #4591

## Changes

- Updated the search hint text color to meet WCAG 4.5:1 contrast requirements

## Steps to Test

1. Run Storybook: `npm run frontend:storybook`
2. Open TopBar stories
3. Verify no color contrast a11y warnings appear
