### PR TITLE
frontend: cluster: Provide accessible name for ClusterDialog

### DIFF
--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -45,6 +45,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <div
                   class="MuiBox-root css-19midj6"
                 />

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -68,6 +68,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <div
                   class="MuiBox-root css-19midj6"
                 />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -41,6 +41,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <div
                   class="MuiBox-root css-19midj6"
                 />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -41,6 +41,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <div
                   class="MuiBox-root css-19midj6"
                 />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -41,6 +41,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <div
                   class="MuiBox-root css-19midj6"
                 />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -41,6 +41,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <div
                   class="MuiBox-root css-19midj6"
                 />

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
@@ -41,6 +41,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <div
                   class="MuiBox-root css-19midj6"
                 />

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -31,6 +31,7 @@ import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { visuallyHidden } from '@mui/utils';
 import _ from 'lodash';
 import React, { isValidElement, PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -333,6 +334,9 @@ export function ClusterDialog(props: ClusterDialogProps) {
           ),
         ]}
       >
+        <Box component="span" sx={visuallyHidden}>
+          {t('Headlamp')}
+        </Box>
         <AppLogo
           logoType={'large'}
           sx={{

--- a/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
@@ -46,6 +46,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <svg
                   fill="none"
                   height="38"

--- a/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
@@ -46,6 +46,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <svg
                   fill="none"
                   height="38"

--- a/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
@@ -46,6 +46,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <svg
                   fill="none"
                   height="38"

--- a/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
@@ -46,6 +46,11 @@
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
                 <svg
                   fill="none"
                   height="38"

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "Aktuelle Cluster",
   "All clusters": "Alle Cluster",
   "Show build information": "Build-Informationen anzeigen",
+  "Headlamp": "",
   "Choose a cluster": "Wählen Sie einen Cluster",
   "Wait while fetching clusters…": "Rufe Cluster ab; einen Moment bitte…",
   "Loading cluster information": "Laden der Clusterinformationen",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "Recent clusters",
   "All clusters": "All clusters",
   "Show build information": "Show build information",
+  "Headlamp": "Headlamp",
   "Choose a cluster": "Choose a cluster",
   "Wait while fetching clusters…": "Wait while fetching clusters…",
   "Loading cluster information": "Loading cluster information",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "Clusters recientes",
   "All clusters": "Todos los clusters",
   "Show build information": "Mostrar información de versión",
+  "Headlamp": "",
   "Choose a cluster": "Elija un cluster",
   "Wait while fetching clusters…": "Espere mientras se obtienen los clusters…",
   "Loading cluster information": "Cargando información de cluster",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "Groupes récents",
   "All clusters": "Tous les groupes",
   "Show build information": "Afficher les informations de construction",
+  "Headlamp": "",
   "Choose a cluster": "Choisir un groupe",
   "Wait while fetching clusters…": "Veuillez patienter pendant la récupération des clusters…",
   "Loading cluster information": "Chargement des informations sur les clusters",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "हाल के क्लस्टर",
   "All clusters": "सभी क्लस्टर",
   "Show build information": "बिल्ड जानकारी दिखाएँ",
+  "Headlamp": "",
   "Choose a cluster": "एक क्लस्टर चुनें",
   "Wait while fetching clusters…": "क्लस्टर प्राप्त करते समय प्रतीक्षा करें…",
   "Loading cluster information": "क्लस्टर जानकारी लोड हो रही है",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "Cluster recenti",
   "All clusters": "Tutti i cluster",
   "Show build information": "Mostra informazioni di build",
+  "Headlamp": "",
   "Choose a cluster": "Scegli un cluster",
   "Wait while fetching clusters…": "Attendi mentre vengono recuperati i cluster…",
   "Loading cluster information": "Caricamento delle informazioni del cluster",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "最近のクラスター",
   "All clusters": "すべてのクラスター",
   "Show build information": "ビルド情報を表示",
+  "Headlamp": "",
   "Choose a cluster": "クラスターを選択",
   "Wait while fetching clusters…": "クラスターを取得中につき、お待ちください…",
   "Loading cluster information": "クラスター情報を読み込み中",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "최근 클러스터",
   "All clusters": "모든 클러스터",
   "Show build information": "빌드 정보 표시",
+  "Headlamp": "",
   "Choose a cluster": "클러스터 선택",
   "Wait while fetching clusters…": "클러스터를 가져오는 중입니다…",
   "Loading cluster information": "클러스터 정보 불러오는 중",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "Clusters recentes",
   "All clusters": "Todos os clusters",
   "Show build information": "Mostrar informação de versão",
+  "Headlamp": "",
   "Choose a cluster": "Escolha um cluster",
   "Wait while fetching clusters…": "Espere enquanto se obtêm os cluster…",
   "Loading cluster information": "A carregar informação de cluster",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "சமீபத்திய க்ளஸ்டர்கள்",
   "All clusters": "அனைத்து க்ளஸ்டர்கள்",
   "Show build information": "பில்ட் தகவல்களைக் காட்டு",
+  "Headlamp": "",
   "Choose a cluster": "ஒரு க்ளஸ்டரைத் தேர்ந்தெடுக்கவும்",
   "Wait while fetching clusters…": "க்ளஸ்டர்களைப் பெறும்போது காத்திருக்கவும்…",
   "Loading cluster information": "க்ளஸ்டர் தகவல்களை ஏற்றுகிறது",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "最近的叢集",
   "All clusters": "所有叢集",
   "Show build information": "顯示建構訊息",
+  "Headlamp": "",
   "Choose a cluster": "選擇一個叢集",
   "Wait while fetching clusters…": "正在獲取叢集，請稍候…",
   "Loading cluster information": "讀取叢集訊息",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -213,6 +213,7 @@
   "Recent clusters": "最近的集群",
   "All clusters": "所有集群",
   "Show build information": "显示构建信息",
+  "Headlamp": "",
   "Choose a cluster": "选择一个集群",
   "Wait while fetching clusters…": "正在获取集群，请稍候…",
   "Loading cluster information": "正在加载集群信息",


### PR DESCRIPTION
## Summary

Fixes **11 "Empty Heading" accessibility violations** across the Authentication and Cluster Selection flows. 

## Related Issue

Fixes #4594, #4595, #4596, #4597, #4598, #4599, #4600, #4601, #4602, #4603, #4604

## Changes

- Updated `frontend/src/components/cluster/Chooser.tsx` to include a `visuallyHidden` span containing "Headlamp" in the `DialogTitle`.
- Updated 11 storyshot snapshots across `AuthToken`, `AuthChooser`, and `Chooser` to reflect the new accessible DOM structure.
- Imported `@mui/utils` to utilize the standard `visuallyHidden` utility.

## Steps to Test

1. Navigate to Storybook by running `npm run storybook`.
2. Open any affected story (e.g., `AuthToken -> Show Error` or `cluster/Chooser -> Normal`).
3. Open the canvas in a new tab and inspect the header using DevTools.
4. Verify the **Accessibility Tree** reflects the `Name` property as "Headlamp" or "Headlamp Show build information".

## Screenshots (if applicable)

`N/A`

## Notes for the Reviewer

- This is an architectural fix; updating the shared `ClusterDialog` resolved all 11 reported heading issues efficiently.
- All related story snapshots are included to ensure CI/CD pipeline compliance.