### PR TITLE
frontend: Loader: Add translatable aria-label fallback

### DIFF
--- a/frontend/src/components/common/Loader.test.tsx
+++ b/frontend/src/components/common/Loader.test.tsx
@@ -72,8 +72,19 @@ describe('Loader Component', () => {
     const progress = screen.getByRole('progressbar');
     expect(progress).toHaveClass('MuiCircularProgress-colorSecondary');
   });
+  it('uses title as aria-label when provided', () => {
+    render(
+      <TestContext>
+        <Loader title="Fetching data..." />
+      </TestContext>
+    );
 
-  it('renders with empty title', () => {
+    const progress = screen.getByRole('progressbar');
+    // Verify the explicit title is used as the accessible label
+    expect(progress).toHaveAttribute('title', 'Fetching data...');
+    expect(progress).toHaveAttribute('aria-label', 'Fetching data...');
+  });
+  it('uses translated fallback aria-label when title is empty', () => {
     render(
       <TestContext>
         <Loader title="" />
@@ -81,7 +92,8 @@ describe('Loader Component', () => {
     );
 
     const progress = screen.getByRole('progressbar');
-    expect(progress).toHaveAttribute('title', '');
+    expect(progress).toHaveAttribute('title', 'Loading...');
+    expect(progress).toHaveAttribute('aria-label', 'Loading...');
   });
 
   it('passes additional props to CircularProgress', () => {

--- a/frontend/src/components/common/Loader.tsx
+++ b/frontend/src/components/common/Loader.tsx
@@ -17,6 +17,7 @@
 import Box from '@mui/material/Box';
 import CircularProgress, { CircularProgressProps } from '@mui/material/CircularProgress';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface LoaderProps extends CircularProgressProps {
   noContainer?: boolean;
@@ -24,8 +25,15 @@ export interface LoaderProps extends CircularProgressProps {
 }
 
 export default function Loader(props: LoaderProps) {
+  const { t } = useTranslation();
   const { noContainer = false, title, ...other } = props;
-  const progress = <CircularProgress title={title} aria-label={title} {...other} />;
+  const progress = (
+    <CircularProgress
+      title={title || t('Loading...')}
+      aria-label={title || t('Loading...')}
+      {...other}
+    />
+  );
 
   if (noContainer) return progress;
 

--- a/frontend/src/components/common/__snapshots__/Loader.NoTitleProvided.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Loader.NoTitleProvided.stories.storyshot
@@ -4,11 +4,11 @@
       class="MuiBox-root css-5cned0"
     >
       <span
-        aria-label=""
+        aria-label="Loading..."
         class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1g0vz9s-MuiCircularProgress-root"
         role="progressbar"
         style="width: 40px; height: 40px;"
-        title=""
+        title="Loading..."
       >
         <svg
           class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"


### PR DESCRIPTION
## Summary
Adds a translatable `aria-label` fallback to the `Loader` component to fix accessibility issue #4613. This ensures screen readers announce "Loading..." when the `title` prop is empty.

## Related Issue
Fixes #4613

## Changes
- **Loader.tsx**: Added `aria-label={title || t('Loading...')}` using the existing i18n key.
- **Snapshots**: Updated the `Loader` snapshot to reflect the added attribute.

## Steps to Test
1. Open Storybook: `common/Loader` -> `With Empty Title`.
2. Inspect the element and verify the **Accessibility Tree** shows the name `Loading...`.

## Notes for the Reviewer
- Used the existing `"Loading..."` translation key to avoid unnecessary JSON updates.
- Note: While the `Loader` snapshots are included, any parent components (like `Home`) consuming this loader may require a snapshot refresh in the CI.