### PR TITLE
frontend: Dialog: Provide automatic aria-labelledby for accessibility

### DIFF
--- a/frontend/src/components/App/Settings/__snapshots__/ShortcutsSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ShortcutsSettings.Default.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                 tabindex="-1"
               >

--- a/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/VersionDialog.VersionDialog.stories.storyshot
@@ -41,6 +41,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Headlamp

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -86,6 +86,7 @@
               >
                 <h1
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                  id="authtoken-dialog-title"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                 >
                   a title

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -109,6 +109,7 @@
               >
                 <h1
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                  id="authtoken-dialog-title"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                 >
                   a title

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -85,6 +85,7 @@
                 >
                   <h1
                     class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                    id="authchooser-dialog-title"
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -85,6 +85,7 @@
                 >
                   <h1
                     class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                    id="authchooser-dialog-title"
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -85,6 +85,7 @@
                 >
                   <h1
                     class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                    id="authchooser-dialog-title"
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -85,6 +85,7 @@
                 >
                   <h1
                     class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                    id="authchooser-dialog-title"
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
@@ -85,6 +85,7 @@
                 >
                   <h1
                     class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                    id="authchooser-dialog-title"
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >

--- a/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
@@ -135,6 +135,7 @@
               >
                 <h1
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                  id="chooser-dialog-title"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                   tabindex="-1"
                 >

--- a/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
@@ -135,6 +135,7 @@
               >
                 <h1
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                  id="chooser-dialog-title"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                   tabindex="-1"
                 >

--- a/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
@@ -135,6 +135,7 @@
               >
                 <h1
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                  id="chooser-dialog-title"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                   tabindex="-1"
                 >

--- a/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
@@ -135,6 +135,7 @@
               >
                 <h1
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                  id="chooser-dialog-title"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                   tabindex="-1"
                 >

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -44,7 +44,7 @@ export interface OurDialogTitleProps extends DialogTitleProps {
  * reading can begin.
  */
 export function DialogTitle(props: OurDialogTitleProps) {
-  const { children, focusTitle, buttons, disableTypography = false, ...other } = props;
+  const { children, focusTitle, buttons, disableTypography = false, id, ...other } = props;
 
   // Don't render heading if there's no content to avoid empty heading violations
   if (!children && (!buttons || buttons.length === 0)) {
@@ -66,9 +66,10 @@ export function DialogTitle(props: OurDialogTitleProps) {
         {children && (
           <Grid item>
             {disableTypography ? (
-              children
+              <div id={id}>{children}</div>
             ) : (
               <Typography
+                id={id}
                 ref={focusedRef}
                 variant="h1"
                 style={{
@@ -156,11 +157,21 @@ export function Dialog(props: DialogProps) {
       />
     );
   }
+  const generatedId = React.useId();
+  const titleId = titleProps?.id || generatedId;
+  const dialogAriaProps = title ? { 'aria-labelledby': titleId } : {};
 
   return (
-    <MuiDialog maxWidth="lg" scroll="paper" fullWidth fullScreen={fullScreen} {...other}>
+    <MuiDialog
+      maxWidth="lg"
+      scroll="paper"
+      fullWidth
+      fullScreen={fullScreen}
+      {...dialogAriaProps}
+      {...other}
+    >
       {(!!title || withFullScreen) && (
-        <DialogTitle buttons={[<FullScreenButton />, <CloseButton />]} {...titleProps}>
+        <DialogTitle {...titleProps} id={titleId} buttons={[<FullScreenButton />, <CloseButton />]}>
           {title}
         </DialogTitle>
       )}

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -40,6 +40,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id="editor-dialog-title-id"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Edit: Dummy_Name

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -40,6 +40,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id="editor-dialog-title-id"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Edit: Dummy_Name

--- a/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialog.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialog.stories.storyshot
@@ -42,6 +42,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id="alert-dialog-title"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 A fine title

--- a/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialogCancelHidden.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConfirmDialog.ConfirmDialogCancelHidden.stories.storyshot
@@ -42,6 +42,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id="alert-dialog-title"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 A fine title

--- a/frontend/src/components/common/__snapshots__/Dialog.Dialog.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.Dialog.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 A fine title

--- a/frontend/src/components/common/__snapshots__/Dialog.DialogAlreadyInFullScreen.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.DialogAlreadyInFullScreen.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 A fine title

--- a/frontend/src/components/common/__snapshots__/Dialog.DialogWithCloseButton.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.DialogWithCloseButton.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 A fine title

--- a/frontend/src/components/common/__snapshots__/Dialog.DialogWithFullScreenButton.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.DialogWithFullScreenButton.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 A fine title

--- a/frontend/src/components/pod/__snapshots__/PodLogs.BigJsonLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.BigJsonLogs.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Logs: pod-name

--- a/frontend/src/components/pod/__snapshots__/PodLogs.FormattedJsonLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.FormattedJsonLogs.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Logs: pod-name

--- a/frontend/src/components/pod/__snapshots__/PodLogs.FormattingLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.FormattingLogs.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Logs: pod-name

--- a/frontend/src/components/pod/__snapshots__/PodLogs.JsonLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.JsonLogs.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Logs: pod-name

--- a/frontend/src/components/pod/__snapshots__/PodLogs.PlainLogs.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodLogs.PlainLogs.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Logs: pod-name


### PR DESCRIPTION
## Summary
Refactored the Dialog component to automatically manage the `aria-labelledby` relationship. Instead of manual attribute injection, the component now generates a unique ID for the `DialogTitle` and maps it to the `MuiDialog` container at the root level.

## Related Issue
Fixes #4605

## Changes
- **Dialog.tsx**: Implemented dynamic `aria-labelledby` generation using `React.useId()`. 
- **Internal Logic**: This  does not interfere with existing manual IDs in the codebase (preserving current behavior for specialized dialogs) and provide an automated fallback for all other instances.

## Steps to Test
1. Run `npm run storybook`.
2. Open the **Version Dialog** story.
3. Inspect the DOM to verify the `role="dialog"` container has an `aria-labelledby` attribute correctly pointing to the `id` of the title header.

## Notes for the Reviewer
- Fixed the root cause in the base component. This ensures all future dialogs are accessible by default.
- Used `React.useId()` to ensure ID uniqueness.