### PR TITLE
fix(stories): PluginSettings heading hierarchy

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.stories.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.stories.tsx
@@ -24,8 +24,7 @@ export default {
   component: PluginSettingsPure,
   decorators: [
     Story => (
-      <div>
-        <h1 style={{ position: 'absolute', left: '-10000px' }}>Plugin Settings Test Page</h1>
+      <div aria-label="Plugin Settings Test Page">
         <Story />
       </div>
     ),

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -237,7 +237,7 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
 
                 return (
                   <>
-                    <Typography variant="subtitle1">
+                    <Typography variant="subtitle1" component="div">
                       <HeadlampLink
                         routeName={'pluginDetails'}
                         params={{ name: plugin.name, type: plugin.type || 'shipped' }}

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >
@@ -390,7 +387,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -399,7 +396,7 @@
                     >
                       plugin a 0
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -453,7 +450,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -462,7 +459,7 @@
                     >
                       plugin a 1
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -518,7 +515,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -527,7 +524,7 @@
                     >
                       plugin a 2
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -581,7 +578,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -590,7 +587,7 @@
                     >
                       plugin a 3
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -646,7 +643,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -655,7 +652,7 @@
                     >
                       plugin a 4
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.Empty.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.Empty.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >
@@ -390,7 +387,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -399,7 +396,7 @@
                     >
                       plugin a 0
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -453,7 +450,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -462,7 +459,7 @@
                     >
                       plugin a 1
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -518,7 +515,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -527,7 +524,7 @@
                     >
                       plugin a 2
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -581,7 +578,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -590,7 +587,7 @@
                     >
                       plugin a 3
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -646,7 +643,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -655,7 +652,7 @@
                     >
                       plugin a 4
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >
@@ -390,7 +387,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -399,7 +396,7 @@
                     >
                       plugin a 0
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -453,7 +450,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -462,7 +459,7 @@
                     >
                       plugin a 1
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -518,7 +515,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -527,7 +524,7 @@
                     >
                       plugin a 2
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -581,7 +578,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -590,7 +587,7 @@
                     >
                       plugin a 3
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -646,7 +643,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -655,7 +652,7 @@
                     >
                       plugin a 4
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >
@@ -390,7 +387,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -399,7 +396,7 @@
                     >
                       plugin a 0
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -453,7 +450,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -462,7 +459,7 @@
                     >
                       plugin a 1
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -518,7 +515,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -527,7 +524,7 @@
                     >
                       plugin a 2
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -581,7 +578,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -590,7 +587,7 @@
                     >
                       plugin a 3
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -646,7 +643,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -655,7 +652,7 @@
                     >
                       plugin a 4
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -709,7 +706,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -718,7 +715,7 @@
                     >
                       plugin a 5
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -774,7 +771,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -783,7 +780,7 @@
                     >
                       plugin a 6
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -837,7 +834,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -846,7 +843,7 @@
                     >
                       plugin a 7
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -902,7 +899,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -911,7 +908,7 @@
                     >
                       plugin a 8
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -965,7 +962,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -974,7 +971,7 @@
                     >
                       plugin a 9
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1030,7 +1027,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1039,7 +1036,7 @@
                     >
                       plugin a 10
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1093,7 +1090,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1102,7 +1099,7 @@
                     >
                       plugin a 11
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1158,7 +1155,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1167,7 +1164,7 @@
                     >
                       plugin a 12
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1221,7 +1218,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1230,7 +1227,7 @@
                     >
                       plugin a 13
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1286,7 +1283,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1295,7 +1292,7 @@
                     >
                       plugin a 14
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >
@@ -390,7 +387,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -399,7 +396,7 @@
                     >
                       prometheus
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -453,7 +450,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -462,7 +459,7 @@
                     >
                       flux
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -516,7 +513,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -525,7 +522,7 @@
                     >
                       my-dev-plugin
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -579,7 +576,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -588,7 +585,7 @@
                     >
                       default-dashboard
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >
@@ -390,7 +387,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -399,7 +396,7 @@
                     >
                       plugin a 0
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -453,7 +450,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -462,7 +459,7 @@
                     >
                       plugin a 1
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -518,7 +515,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -527,7 +524,7 @@
                     >
                       plugin a 2
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -581,7 +578,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -590,7 +587,7 @@
                     >
                       plugin a 3
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -646,7 +643,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -655,7 +652,7 @@
                     >
                       plugin a 4
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -709,7 +706,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -718,7 +715,7 @@
                     >
                       plugin a 5
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -774,7 +771,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -783,7 +780,7 @@
                     >
                       plugin a 6
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -837,7 +834,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -846,7 +843,7 @@
                     >
                       plugin a 7
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -902,7 +899,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -911,7 +908,7 @@
                     >
                       plugin a 8
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -965,7 +962,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -974,7 +971,7 @@
                     >
                       plugin a 9
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1030,7 +1027,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1039,7 +1036,7 @@
                     >
                       plugin a 10
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1093,7 +1090,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1102,7 +1099,7 @@
                     >
                       plugin a 11
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1158,7 +1155,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1167,7 +1164,7 @@
                     >
                       plugin a 12
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1221,7 +1218,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1230,7 +1227,7 @@
                     >
                       plugin a 13
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1286,7 +1283,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1295,7 +1292,7 @@
                     >
                       plugin a 14
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
@@ -1,11 +1,8 @@
 <body>
   <div>
-    <div>
-      <h1
-        style="position: absolute; left: -10000px;"
-      >
-        Plugin Settings Test Page
-      </h1>
+    <div
+      aria-label="Plugin Settings Test Page"
+    >
       <div
         class="MuiBox-root css-j1fy4m"
       >
@@ -390,7 +387,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -408,7 +405,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -462,7 +459,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -480,7 +477,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -536,7 +533,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -554,7 +551,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -610,7 +607,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -628,7 +625,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -682,7 +679,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -700,7 +697,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -756,7 +753,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -765,7 +762,7 @@
                     >
                       dev-only-plugin
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -819,7 +816,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -828,7 +825,7 @@
                     >
                       custom-plugin
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -882,7 +879,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -891,7 +888,7 @@
                     >
                       default-plugin
                     </a>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -945,7 +942,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -963,7 +960,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1017,7 +1014,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1035,7 +1032,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />
@@ -1089,7 +1086,7 @@
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
                 >
-                  <h6
+                  <div
                     class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
                   >
                     <a
@@ -1107,7 +1104,7 @@
                         Multiple versions
                       </span>
                     </div>
-                  </h6>
+                  </div>
                   <span
                     class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
                   />


### PR DESCRIPTION
## Summary

This PR fixes heading hierarchy accessibility violations in the PluginSettings component and its stories.

## Related Issue

Fixes : 
#4582 
#4583  
#4584  
#4585  
#4586  
#4587  
#4588  


## Changes

- Updated Typography variant="subtitle1" to render as div instead of the default h6 fixing the root cause of heading hierarchy violations
- Removed the workaround hidden h1 from the stories decorator in PluginSettings.stories.tsx , replacing it with an aria-label on the wrapper div
- Fixes heading hierarchy issues across all 8 stories: FewItems, DefaultSaveEnable, ManyItems, MoreItems, EmptyHomepageItems, MultipleLocations, and MigrationScenario