### PR TITLE
fix: correct aria attributes in ShowHideLabel component

### DIFF
--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
@@ -19,6 +19,7 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useId } from '../../../lib/util';
 
 export interface ShowHideLabelProps {
   children: string;
@@ -31,14 +32,9 @@ export default function ShowHideLabel(props: ShowHideLabelProps) {
   const { show = false, labelId = '', maxChars = 256, children } = props;
   const { t } = useTranslation();
   const [expanded, setExpanded] = React.useState(show);
+  const generatedId = useId('show-hide-label-');
 
-  const labelIdOrRandom = React.useMemo(() => {
-    if (!!labelId || !!import.meta.env.UNDER_TEST) {
-      return labelId;
-    }
-
-    return `${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 5)}`;
-  }, [labelId]);
+  const labelIdOrRandom = labelId || generatedId;
 
   const [actualText, needsButton] = React.useMemo(() => {
     if (typeof children !== 'string') {
@@ -58,27 +54,24 @@ export default function ShowHideLabel(props: ShowHideLabelProps) {
 
   return (
     <Box display={expanded ? 'block' : 'flex'}>
-      <label
-        id={labelIdOrRandom}
-        style={{ wordBreak: 'break-all', whiteSpace: 'normal' }}
-        aria-expanded={!needsButton ? undefined : expanded}
-      >
+      <span id={labelIdOrRandom} style={{ wordBreak: 'break-all', whiteSpace: 'normal' }}>
         {actualText}
         {needsButton && (
           <>
             {!expanded && '…'}
             <IconButton
               aria-controls={labelIdOrRandom}
+              aria-expanded={expanded}
               sx={{ display: 'inline' }}
               onClick={() => setExpanded(expandedVal => !expandedVal)}
               size="small"
-              arial-label={expanded ? t('translation|Collapse') : t('translation|Expand')}
+              aria-label={expanded ? t('translation|Collapse') : t('translation|Expand')}
             >
               <Icon icon={expanded ? 'mdi:menu-up' : 'mdi:menu-down'} />
             </IconButton>
           </>
         )}
-      </label>
+      </span>
     </Box>
   );
 }

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Basic.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Basic.stories.storyshot
@@ -6,8 +6,7 @@
       <div
         class="MuiBox-root css-k008qs"
       >
-        <label
-          aria-expanded="false"
+        <span
           id="label-id"
           style="word-break: break-all; white-space: normal;"
         >
@@ -15,7 +14,8 @@
           …
           <button
             aria-controls="label-id"
-            arial-label="Expand"
+            aria-expanded="false"
+            aria-label="Expand"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-z81te2-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
@@ -24,7 +24,7 @@
               class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </button>
-        </label>
+        </span>
       </div>
     </div>
   </div>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Expanded.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.Expanded.stories.storyshot
@@ -6,15 +6,15 @@
       <div
         class="MuiBox-root css-13o7eu2"
       >
-        <label
-          aria-expanded="true"
+        <span
           id="my-label"
           style="word-break: break-all; white-space: normal;"
         >
           This is a placeholder label text that is many characters long. It is meant to be used as a temporary label for a UI element until the actual label is available. The text is long enough to fill up the space allocated for the label and provide a realistic preview of how the label will look in the final UI. You can replace this text with the actual label text once it is available. This will ensure that the UI looks complete and professional even during the development phase. Thank you for using this placeholder text!
           <button
             aria-controls="my-label"
-            arial-label="Collapse"
+            aria-expanded="true"
+            aria-label="Collapse"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-z81te2-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
@@ -23,7 +23,7 @@
               class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
           </button>
-        </label>
+        </span>
       </div>
     </div>
   </div>

--- a/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ShortText.stories.storyshot
+++ b/frontend/src/components/common/ShowHideLabel/__snapshots__/ShowHideLabel.ShortText.stories.storyshot
@@ -6,12 +6,12 @@
       <div
         class="MuiBox-root css-k008qs"
       >
-        <label
+        <span
           id="my-label2"
           style="word-break: break-all; white-space: normal;"
         >
           Short text
-        </label>
+        </span>
       </div>
     </div>
   </div>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -108,12 +108,12 @@
                   <div
                     class="MuiBox-root css-k008qs"
                   >
-                    <label
+                    <span
                       id="event-uid-1"
                       style="word-break: break-all; white-space: normal;"
                     >
                       Successfully assigned default/test-pod-for-events to worker-node-1
-                    </label>
+                    </span>
                   </div>
                 </td>
                 <td
@@ -152,12 +152,12 @@
                   <div
                     class="MuiBox-root css-k008qs"
                   >
-                    <label
+                    <span
                       id="event-uid-2"
                       style="word-break: break-all; white-space: normal;"
                     >
                       Container image "nginx:latest" already present on machine
-                    </label>
+                    </span>
                   </div>
                 </td>
                 <td


### PR DESCRIPTION
## Summary

This PR fixes accessibility issues in ShowHideLabel component by removing aria-expanded from non-interactive label element and correcting aria-label typo on IconButton.

## Related Issue

Fixes #4615 #4616 

## Changes

- Changed label to span element to remove semantic confusion
- Removed aria-expanded attribute from label element
- Moved aria-expanded attribute to IconButton where it belongs
- Fixed typo: arial-label → aria-label on IconButton