### PR TITLE
frontend: Fix a11y roles in ClusterChooserPopup

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -46,9 +46,11 @@ function ClusterListItem(props: { cluster: Cluster; onClick: () => void; selecte
   return (
     <MenuItem
       selected={selected}
+      aria-selected={!!cluster.isCurrent}
       key={`recent_cluster_${cluster.name}`}
       onClick={onClick}
       id={cluster.name}
+      role="option"
       sx={theme => ({
         borderRadius: theme.shape.borderRadius + 'px',
       })}
@@ -257,6 +259,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
         />
         <MenuList
           id="cluster-chooser-list"
+          role="listbox"
           tabIndex={0}
           sx={{
             width: '280px',

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
@@ -68,13 +68,14 @@
         <ul
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
-          role="menu"
+          role="listbox"
           tabindex="0"
         >
           <li
+            aria-selected="true"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster0"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -100,9 +101,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster1"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -119,9 +121,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster2"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
@@ -68,13 +68,14 @@
         <ul
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
-          role="menu"
+          role="listbox"
           tabindex="0"
         >
           <li
+            aria-selected="true"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster0"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -100,9 +101,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster1"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -119,9 +121,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster2"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -138,9 +141,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster3"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -157,9 +161,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster4"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
@@ -68,7 +68,7 @@
         <ul
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
-          role="menu"
+          role="listbox"
           tabindex="0"
         >
           <li
@@ -78,9 +78,10 @@
             Recent clusters
           </li>
           <li
+            aria-selected="true"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster2"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -106,9 +107,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster1"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -125,9 +127,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster3"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -148,9 +151,10 @@
             role="separator"
           />
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster0"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -167,9 +171,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster4"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
@@ -68,7 +68,7 @@
         <ul
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
-          role="menu"
+          role="listbox"
           tabindex="0"
         >
           <li
@@ -78,9 +78,10 @@
             Recent clusters
           </li>
           <li
+            aria-selected="true"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster2"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -106,9 +107,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster3"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -125,9 +127,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster4"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -148,9 +151,10 @@
             role="separator"
           />
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster0"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -167,9 +171,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster1"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -186,9 +191,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster10"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -205,9 +211,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster11"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -224,9 +231,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster12"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -243,9 +251,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster13"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -262,9 +271,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster14"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -281,9 +291,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster15"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -300,9 +311,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster16"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -319,9 +331,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster17"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -338,9 +351,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster18"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -357,9 +371,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster19"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -376,9 +391,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster5"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -395,9 +411,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster6"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -414,9 +431,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster7"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -433,9 +451,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster8"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div
@@ -452,9 +471,10 @@
             />
           </li>
           <li
+            aria-selected="false"
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"
             id="cluster9"
-            role="menuitem"
+            role="option"
             tabindex="-1"
           >
             <div


### PR DESCRIPTION
## Summary

This PR fixes an accessibility violation in `ClusterChooserPopup` where the ARIA roles were mismatched. The input declared `aria-haspopup="listbox"` but the popup used `role="menu"` with `role="menuitem"` children instead of the expected `role="listbox"` with `role="option"` children.

## Related Issue

Fixes #4608
- #4608

Fixes #4609
- #4609


## Changes

- Changed `MenuList` in `ClusterChooserPopup.tsx` to use `role="listbox"` instead of `role="menu"`
- Changed `MenuItem` in `ClusterListItem` component to use `role="option"` instead of `role="menuitem"`

## Steps to Test

1. Run Storybook: `npm run frontend:storybook`
2. Navigate to ClusterChooserPopup stories
