### PR TITLE
frontend: Add tabIndex to scrollable cluster list

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -257,6 +257,7 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
         />
         <MenuList
           id="cluster-chooser-list"
+          tabIndex={0}
           sx={{
             width: '280px',
             minWidth: '280px',

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoClustersButRecent.stories.storyshot
@@ -69,7 +69,7 @@
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="menu"
-          tabindex="-1"
+          tabindex="0"
         >
           <li
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.NoRecentClusters.stories.storyshot
@@ -69,7 +69,7 @@
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="menu"
-          tabindex="-1"
+          tabindex="0"
         >
           <li
             class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-aom5s3-MuiButtonBase-root-MuiMenuItem-root"

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Normal.stories.storyshot
@@ -69,7 +69,7 @@
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="menu"
-          tabindex="-1"
+          tabindex="0"
         >
           <li
             class="MuiListSubheader-root MuiListSubheader-gutters css-1ac4l9u-MuiListSubheader-root"

--- a/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/ClusterChooserPopup.Scrollbar.stories.storyshot
@@ -69,7 +69,7 @@
           class="MuiList-root MuiList-padding MuiList-dense css-1k1lw4j-MuiList-root"
           id="cluster-chooser-list"
           role="menu"
-          tabindex="-1"
+          tabindex="0"
         >
           <li
             class="MuiListSubheader-root MuiListSubheader-gutters css-1ac4l9u-MuiListSubheader-root"


### PR DESCRIPTION
## Summary

This PR fixes an a11y where the scrollable cluster list in `ClusterChooserPopup` was not keyboard-accessible. Users who rely on keyboard navigation could not Tab to the list and scroll through clusters.

## Related Issue

Fixes #4611 

## Changes

- Added `tabIndex={0}` to `MenuList` in `ClusterChooserPopup.tsx` to make the scrollable region focusable

## Steps to Test

1. Run Storybook: `npm run frontend:storybook`
2. Navigate to ClusterChooserPopup stories