### PR TITLE
fix(frontend): add crossorigin to manifest link

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <!--
       Unlike "/favicon.ico" or "favicon.ico", "/favicon.ico" will
       work correctly both with client-side routing and a non-root public URL.


### PR DESCRIPTION
## Summary
This PR adds the `crossorigin="use-credentials"` attribute to the `manifest.json` link in `index.html`. This ensures that cookies are sent with the request when fetching the manifest, fixing issues where Headlamp is hosted behind an authentication proxy (like Authelia).

## Related Issue
Fixes #4572

## Changes
- Updated `frontend/index.html` to include `crossorigin="use-credentials"` in the manifest link tag.

## Steps to Test
1. Inspect `frontend/index.html` and verify the link tag:
   `<link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />`
2. Run Headlamp behind an auth proxy (if available) and verify no CORS errors for `manifest.json`.