### PR TITLE
frontend: DropZoneBox: Remove role=button from label element

### DIFF
--- a/frontend/src/components/common/DropZoneBox.stories.tsx
+++ b/frontend/src/components/common/DropZoneBox.stories.tsx
@@ -34,7 +34,6 @@ UploadFiles.args = {
       <Typography sx={{ m: 2 }}>{'Select a file or drag and drop here'}</Typography>
       <Button
         variant="contained"
-        component="label"
         startIcon={<InlineIcon icon="mdi:upload" width={32} />}
         sx={{ fontWeight: 500 }}
       >

--- a/frontend/src/components/common/Resource/UploadDialog.tsx
+++ b/frontend/src/components/common/Resource/UploadDialog.tsx
@@ -70,6 +70,7 @@ const UploadFromFilesystem = ({
   const [files, setFiles] = React.useState<File[]>([]);
   const [dragOver, setDragOver] = React.useState(false);
   const [error, setError] = React.useState('');
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const onFilesPicked = (picked: FileList | null) => {
     setError('');
@@ -123,19 +124,20 @@ const UploadFromFilesystem = ({
         </Typography>
         <Button
           variant="contained"
-          component="label"
           startIcon={<InlineIcon icon="mdi:upload" width={32} />}
           sx={{ fontWeight: 500 }}
+          onClick={() => fileInputRef.current?.click()}
         >
           {t('translation|Select File')}
-          <input
-            type="file"
-            accept=".yaml,.yml,application/yaml"
-            multiple
-            hidden
-            onChange={e => onFilesPicked(e.target.files)}
-          />
         </Button>
+        <input
+          type="file"
+          accept=".yaml,.yml,application/yaml"
+          multiple
+          hidden
+          ref={fileInputRef}
+          onChange={e => onFilesPicked(e.target.files)}
+        />
       </DropZoneBox>
       {!!files.length && (
         <Box

--- a/frontend/src/components/common/__snapshots__/DropZoneBox.UploadFiles.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/DropZoneBox.UploadFiles.stories.storyshot
@@ -8,10 +8,10 @@
       >
         Select a file or drag and drop here
       </p>
-      <label
+      <button
         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-17g4n8r-MuiButtonBase-root-MuiButton-root"
-        role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
@@ -20,7 +20,7 @@
         <span
           class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </label>
+      </button>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary

This PR fixes an accessibility violation in the `DropZoneBox` component and its stories where a `<label>` element was incorrectly assigned a `role="button"` attribute.

## Related Issue

Fixes #4612

## Changes

- Updated `frontend/src/components/common/Resource/UploadDialog.tsx` to use a React `ref` for triggering the hidden file input instead of relying on Material UI's `component="label"` on the `Button`.
- Updated `frontend/src/components/common/DropZoneBox.stories.tsx` to remove the unnecessary `component="label"` from the `UploadFiles` story.
- Updated Storybook snapshots in `frontend/src/components/common/__snapshots__/DropZoneBox.UploadFiles.stories.storyshot` to reflect the change from a `<label>` element to a semantic `<button>` element.

## Steps to Test

1. Run the Storybook tests for `DropZoneBox`:
   ```bash
   cd frontend
   npx vitest src/storybook.test.tsx -t DropZoneBox
   ```
2. Manually verify the "Create new Project from YAML" dialog:
   - Navigate to the "Create from YAML" section (or open any dialog using `UploadDialog`).
   - Inspect the "Select File" button using browser dev tools.
   - Verify that the element is a `<button>` (and not a `<label>` with `role="button"`) and that clicking it still opens the file picker.

## Screenshots (if applicable)

N/A (Accessibility change)

## Notes for the Reviewer

- The change from `component="label"` to a manual `ref` is a standard way to handle file inputs in React while maintaining accessibility compliance (avoiding the ARIA allowed role violation).
