### PR TITLE
Fix build failures pr 4646

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -97,6 +97,7 @@ const (
 type clientConfig struct {
 	Clusters                []Cluster `json:"clusters"`
 	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
+	FiltersWarningsOnly     bool      `json:"filtersWarningsOnly"`
 }
 
 type OauthConfig struct {
@@ -1750,7 +1751,11 @@ func parseClusterFromKubeConfig(kubeConfigs []string) ([]Cluster, []error) {
 func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	clientConfig := clientConfig{c.getClusters(), c.EnableDynamicClusters}
+	clientConfig := clientConfig{
+		Clusters:                c.getClusters(),
+		IsDynamicClusterEnabled: c.EnableDynamicClusters,
+		FiltersWarningsOnly:     c.FiltersWarningsOnly,
+	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {
 		logger.Log(logger.LevelError, nil, err, "encoding config")

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -178,7 +178,11 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	clientConfig := clientConfig{contexts, c.EnableDynamicClusters}
+	clientConfig := clientConfig{
+		Clusters:                contexts,
+		IsDynamicClusterEnabled: c.EnableDynamicClusters,
+		FiltersWarningsOnly:     c.FiltersWarningsOnly,
+	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {
 		logger.Log(logger.LevelError, nil, err, "encoding config")

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -82,6 +82,8 @@ type Config struct {
 	UseOTLPHTTP        *bool    `koanf:"use-otlp-http"`
 	StdoutTraceEnabled *bool    `koanf:"stdout-trace-enabled"`
 	SamplingRate       *float64 `koanf:"sampling-rate"`
+	// FiltersWarningsOnly is the default state of the events filter (true = only warnings, false = all events).
+	FiltersWarningsOnly bool `koanf:"filters-warnings-only"`
 	// TLS config
 	TLSCertPath string `koanf:"tls-cert-path"`
 	TLSKeyPath  string `koanf:"tls-key-path"`
@@ -448,6 +450,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")
 	f.Bool("enable-helm", false, "Enable Helm operations")
+	f.Bool("filters-warnings-only", true, "Whether to filter events by warnings only by default")
 }
 
 func addOIDCFlags(f *flag.FlagSet) {

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -63,4 +63,5 @@ type HeadlampCFG struct {
 	TLSCertPath           string
 	TLSKeyPath            string
 	SessionTTL            int
+	FiltersWarningsOnly   bool
 }

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -325,6 +325,7 @@ spec:
             {{- with .Values.config.tlsKeyPath }}
             - "-tls-key-path={{ . }}"
             {{- end }}
+            - "-filters-warnings-only={{ dig "events" "warningsOnly" true .Values.config }}"
             {{- with .Values.config.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
+++ b/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
@@ -129,6 +129,7 @@ spec:
             - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
             # Check if validatorIssuerURL is non empty either from env or oidc.config
             - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
             - -insecure-ssl
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -131,6 +131,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/host-users-override.yaml
+++ b/charts/headlamp/tests/expected_templates/host-users-override.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
+++ b/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
@@ -117,6 +117,7 @@ spec:
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
             - "-me-user-info-url=$(ME_USER_INFO_URL)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
@@ -121,6 +121,7 @@ spec:
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
             - "-me-user-info-url=$(ME_USER_INFO_URL)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
@@ -146,6 +146,7 @@ spec:
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/namespace-override.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
+++ b/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
@@ -121,6 +121,7 @@ spec:
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -146,6 +146,7 @@ spec:
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -130,6 +130,7 @@ spec:
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -121,6 +121,7 @@ spec:
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -111,6 +111,7 @@ spec:
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
@@ -124,6 +124,7 @@ spec:
             # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
             - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -133,6 +133,7 @@ spec:
             - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
             # Check if useAccessToken is non false either from env or oidc.config
             - "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/pod-disruption.yaml
+++ b/charts/headlamp/tests/expected_templates/pod-disruption.yaml
@@ -134,6 +134,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -140,6 +140,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/tls-added.yaml
+++ b/charts/headlamp/tests/expected_templates/tls-added.yaml
@@ -116,6 +116,7 @@ spec:
             # Check if externalSecret is disabled
             - "-tls-cert-path=/headlamp-cert/headlamp-ca.crt"
             - "-tls-key-path=/headlamp-cert/headlamp-tls.key"
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -114,6 +114,7 @@ spec:
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
             # Check if externalSecret is disabled
+            - "-filters-warnings-only=true"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -38,6 +38,9 @@ config:
   baseURL: ""
   # -- session token TTL in seconds (default is 24 hours)
   sessionTTL: 86400
+  events:
+    # -- Whether to filter events by warnings only by default
+    warningsOnly: true
   oidc:
     # Option 1:
     # @param config.oidc.secret - OIDC secret configuration
@@ -161,8 +164,7 @@ podLabels: {}
 hostUsers: true
 
 # -- Headlamp pod's Security Context
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
 # -- Headlamp containers Security Context
@@ -183,7 +185,6 @@ securityContext:
 #   capabilities:
 #     drop:
 #       - ALL
-
 
 service:
   # -- Annotations to add to the service
@@ -211,8 +212,7 @@ persistentVolumeClaim:
   # -- Enable Persistent Volume Claim
   enabled: false
   # -- Annotations to add to the persistent volume claim (if enabled)
-  annotations:
-    {}
+  annotations: {}
   # -- accessModes for the persistent volume claim, eg: ReadWriteOnce, ReadOnlyMany, ReadWriteMany etc.
   accessModes: []
   # -- size of the persistent volume claim, eg: 10Gi. Required if enabled is true.
@@ -228,8 +228,7 @@ ingress:
   # -- Enable ingress controller resource
   enabled: false
   # -- Annotations for Ingress resource
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/tls-acme: "true"
 
   # -- Additional labels to add to the Ingress resource
@@ -242,8 +241,7 @@ ingress:
 
   # -- Hostname(s) for the Ingress resource
   # Please refer to https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec for more information.
-  hosts:
-    []
+  hosts: []
     # - host: chart-example.local
     #   paths:
     #   - path: /
@@ -288,8 +286,7 @@ httpRoute:
   #         port: 80
 
 # -- CPU/Memory resource requests/limits
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -353,8 +350,7 @@ pluginsManager:
   #     cpu: "1000m"
   #     memory: "4096Mi"
   # If omitted, the plugin manager will inherit the global securityContext
-  securityContext:
-    {}
+  securityContext: {}
     # runAsUser: 1001
     # runAsNonRoot: true
     # allowPrivilegeEscalation: false

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -104,7 +104,8 @@ export default function Overview() {
 
 function EventsSection() {
   const EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY = 'EVENT_WARNING_SWITCH_FILTER_STORAGE_KEY';
-  const EVENT_WARNING_SWITCH_DEFAULT = true;
+  const filtersWarningsOnly = useTypedSelector(state => state.config.filtersWarningsOnly);
+  const EVENT_WARNING_SWITCH_DEFAULT = filtersWarningsOnly;
   const { t } = useTranslation(['translation', 'glossary']);
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -46,6 +46,7 @@ const makeStore = () => {
           timezone: 'UTC',
           useEvict: true,
         },
+        filtersWarningsOnly: true,
       },
       projects: {
         headerActions: {},

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -45,6 +45,7 @@ const makeStore = () => {
           timezone: 'UTC',
           useEvict: true,
         },
+        filtersWarningsOnly: true,
       },
       projects: {
         headerActions: {},

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -43,6 +43,10 @@ export interface ConfigState {
     [clusterName: string]: Cluster;
   } | null;
   /**
+   * Whether to filter events by warnings only by default.
+   */
+  filtersWarningsOnly: boolean;
+  /**
    * Settings is a map of settings names to settings values.
    */
   settings: {
@@ -71,6 +75,7 @@ export const initialState: ConfigState = {
   clusters: null,
   statelessClusters: null,
   allClusters: null,
+  filtersWarningsOnly: true,
   settings: {
     tableRowsPerPageOptions:
       storedSettings.tableRowsPerPageOptions || defaultTableRowsPerPageOptions,
@@ -89,8 +94,14 @@ const configSlice = createSlice({
      * @param state - The current state.
      * @param action - The payload action containing the config.
      */
-    setConfig(state, action: PayloadAction<{ clusters: ConfigState['clusters'] }>) {
+    setConfig(
+      state,
+      action: PayloadAction<{ clusters: ConfigState['clusters']; filtersWarningsOnly?: boolean }>
+    ) {
       state.clusters = action.payload.clusters;
+      if (action.payload.filtersWarningsOnly !== undefined) {
+        state.filtersWarningsOnly = action.payload.filtersWarningsOnly;
+      }
     },
     /**
      * Save the config. To both the store, and localStorage.


### PR DESCRIPTION
# fix(build): Resolve frontend type errors and update helm test templates

##  Summary
This PR addresses build failures found in #4646. It resolves TypeScript errors in the frontend build process (specifically `build-typedoc`) and updates the Helm chart expected templates to align with the new default configuration for event severity filtering.

##  Issues Fixed
- **Frontend Build Failure**: The `build-typedoc` command was failing due to a strict TypeScript check. The `filtersWarningsOnly` property was required in [ConfigState](cci:2://file:///Users/zyzz_mohit/Documents/lfx-headlamp/headlamp/frontend/src/redux/configSlice.ts:20:0-63:1) but missing from mock states in [configSlice.test.ts](cci:7://file:///Users/zyzz_mohit/Documents/lfx-headlamp/headlamp/frontend/src/redux/configSlice.test.ts:0:0-0:0) and Storybook stories.
- **Helm Chart Test Failure**: The `helm-lint-test` step failed because the new default `config.events.warningsOnly: true` introduced a new flag (`-filters-warnings-only=true`) into the rendered deployment templates, causing a mismatch with the existing expected templates.

##  Changes

### Frontend
- **Updated [configSlice.ts](cci:7://file:///Users/zyzz_mohit/Documents/lfx-headlamp/headlamp/frontend/src/redux/configSlice.ts:0:0-0:0)**: Made `filtersWarningsOnly` optional in the [setConfig](cci:1://file:///Users/zyzz_mohit/Documents/lfx-headlamp/headlamp/frontend/src/redux/configSlice.ts:91:4-104:5) action payload to allow partial updates in tests.
- **Updated Storybook**: Added `filtersWarningsOnly: true` to the mock state in [NewProjectPopup.stories.tsx](cci:7://file:///Users/zyzz_mohit/Documents/lfx-headlamp/headlamp/frontend/src/components/project/NewProjectPopup.stories.tsx:0:0-0:0) and [ProjectCreateFromYaml.stories.tsx](cci:7://file:///Users/zyzz_mohit/Documents/lfx-headlamp/headlamp/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx:0:0-0:0) to fix type errors.
- **Updated API Docs**: Re-generated API documentation to reflect the latest changes.

### Helm Charts
- **Updated Expected Templates**: Regenerated all expected templates in `charts/headlamp/tests/expected_templates/` using `helm template` to include the new default `-filters-warnings-only=true` argument. This ensures all test cases now pass with the new configuration.

##  Verification
I have verified these fixes locally with the following commands:

- [x] **Frontend Docs Build**: `npm run build-typedoc` (PASSED)
- [x] **Plugin Build**: `npm run build` in `plugins/headlamp-plugin` (PASSED)
- [x] **Helm Template Tests**: [./charts/headlamp/tests/test.sh](cci:7://file:///Users/zyzz_mohit/Documents/lfx-headlamp/headlamp/charts/headlamp/tests/test.sh:0:0-0:0) (PASSED for all test cases)

##  Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (documentation, refactoring, maintenance)

##  Related Issues
Fixes build failures in #4646