### PR TITLE
Fix: Auto-detect platform for Apple Silicon Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,22 @@ DOCKER_EXT_REPO ?= docker.io/headlamp
 DOCKER_IMAGE_NAME ?= headlamp
 DOCKER_PLUGINS_IMAGE_NAME ?= plugins
 DOCKER_IMAGE_VERSION ?= $(shell git describe --tags --always --dirty)
-DOCKER_PLATFORM ?= local
+# Detect platform (Windows, macOS, Linux)
+ifeq ($(OS),Windows_NT)
+    DOCKER_PLATFORM ?= local
+else
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Darwin)
+        UNAME_M := $(shell uname -m)
+        ifeq ($(UNAME_M),arm64)
+            DOCKER_PLATFORM ?= linux/arm64
+        else
+            DOCKER_PLATFORM ?= linux/amd64
+        endif
+    else
+        DOCKER_PLATFORM ?= local
+    endif
+endif
 DOCKER_PUSH ?= false
 EMBED_BINARY_NAME := headlamp_app
 # Get version and app name from app/package.json


### PR DESCRIPTION
- Auto-detect Darwin arm64 and set DOCKER_PLATFORM=linux/arm64
- Preserves manual override capability

## Summary

Auto-detect the system architecture and set the appropriate Docker platform:

Apple Silicon (Darwin + arm64) → linux/arm64
All other systems → local

## Related Issue

Fixes #4578

## Changes

Added system detection using uname -s and uname -m
Auto-sets DOCKER_PLATFORM=linux/arm64 for Apple Silicon Macs
Preserves ability to override via environment variable
Updated docker build to docker buildx build --platform to support platform flag

## Steps to Test

- run `make image` on Apple Silicon Mac

## Screenshots (if applicable)
<img width="738" height="625" alt="Screenshot 2026-02-09 at 2 11 51 PM" src="https://github.com/user-attachments/assets/4af57c8a-dfbe-4750-a702-986028eb4fa1" />



## Notes for the Reviewer
Tested on:

- Apple Silicon Mac (M3) - make image works 
- Built image runs successfully 
