### PR TITLE
fix(a11y): populate empty DialogTitle in AuthTypeoidc story

### DIFF
--- a/frontend/src/components/authchooser/AuthChooser.stories.tsx
+++ b/frontend/src/components/authchooser/AuthChooser.stories.tsx
@@ -70,6 +70,7 @@ export const AuthTypeoidc = Template.bind({});
 AuthTypeoidc.args = {
   ...argFixture,
   clusterAuthType: 'oidc',
+  title: 'Sign in with OpenID Connect',
 };
 
 export const AnError = Template.bind({});

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -88,7 +88,7 @@
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >
-                    some title
+                    Sign in with OpenID Connect
                   </h1>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

This PR improves accessibility in the `AuthTypeoidc` Storybook story. Previously, the dialog inherited a generic placeholder title ("some title") from `argFixture`. This change provides a descriptive and context-specific title instead.

## Related Issue

Fixes #4599

## Changes

- Updated `frontend/src/components/authchooser/AuthChooser.stories.tsx` to include a `title` prop ("Sign in with OpenID Connect") for the `AuthTypeoidc` story.

## Steps to Test

1. Navigate to the frontend directory: `cd frontend`.
2. Run Storybook: `npm run storybook`.
3. Open the browser to the local Storybook URL (usually `http://localhost:6006`).
4. Navigate to **AuthChooser** > **AuthTypeoidc** in the sidebar.
5. Observe that the dialog now displays the heading "Sign in with OpenID Connect" instead of the generic placeholder title.

## Screenshots (if applicable)

<img width="928" height="879" alt="Screenshot from 2026-02-09 19-30-30" src="https://github.com/user-attachments/assets/dcda9179-d039-456e-86bd-d61788f5d4f3" />


## Notes for the Reviewer

This change ensures the `DialogTitle` uses a meaningful and descriptive heading rather than a generic placeholder.
- The text "Sign in with OpenID Connect" was chosen to be descriptive for the OIDC auth flow.