### PR TITLE
frontend: Sidebar: Fix collapsed sidebar buttons being unresponsive

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -319,7 +319,7 @@ export const PureSidebar = memo(
           direction="column"
           justifyContent="space-between"
           wrap="nowrap"
-          {...(!largeSideBarOpen && { inert: 'true' as any })}
+          {...(isTemporaryDrawer && !temporarySideBarOpen && { inert: 'true' as any })}
         >
           <Grid item>
             <List

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -12,7 +12,6 @@
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
-            inert="true"
           >
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -12,7 +12,6 @@
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column MuiGrid-wrap-xs-nowrap css-opqjvv-MuiGrid-root"
-            inert="true"
           >
             <div
               class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"


### PR DESCRIPTION
## Summary

This PR fixes the sidebar becoming unresponsive (and almost unusable) when collapsed by correcting the condition for applying the inert HTML attribute. The inert attribute was incorrectly applied to the collapsed desktop sidebar (where icons should be clickable), when it should only apply to the closed mobile drawer (where content is truly hidden).

## Related Issue

Fixes #4659  

## Changes

- Fixed `Sidebar.tsx`: Changed the inert attribute condition from `!largeSideBarOpen` to `isTemporaryDrawer && !temporarySideBarOpen`

## Steps to Test

1. Open Headlamp desktop application
2. Click the collapse button at the bottom of the sidebar to collapse it to icon-only view
3. Verify that all sidebar icon buttons are clickable and navigate correctly
4. Verify that the expand button works to restore the full sidebar
