### PR TITLE
backend: charts: Add session-ttl flag and logic

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -391,6 +391,7 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 	logger.Log(logger.LevelInfo, nil, nil, "me Groups Paths: "+config.MeGroupsPaths)
 	logger.Log(logger.LevelInfo, nil, nil, "me User Info URL: "+config.MeUserInfoURL)
 	logger.Log(logger.LevelInfo, nil, nil, "Base URL: "+config.BaseURL)
+	logger.Log(logger.LevelInfo, nil, nil, "Session TTL: "+fmt.Sprint(config.SessionTTL))
 	logger.Log(logger.LevelInfo, nil, nil, "Use In Cluster: "+fmt.Sprint(config.UseInCluster))
 	logger.Log(logger.LevelInfo, nil, nil, "Watch Plugins Changes: "+fmt.Sprint(config.WatchPluginsChanges))
 
@@ -859,7 +860,7 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 		}
 
 		// Set auth cookie
-		auth.SetTokenCookie(w, r, oauthConfig.Cluster, rawUserToken, config.BaseURL)
+		auth.SetTokenCookie(w, r, oauthConfig.Cluster, rawUserToken, config.BaseURL, config.SessionTTL)
 
 		redirectURL += fmt.Sprintf("auth?cluster=%1s", oauthConfig.Cluster)
 
@@ -942,7 +943,7 @@ func (c *HeadlampConfig) refreshAndSetToken(oidcAuthConfig *kubeconfig.OidcConfi
 		}
 
 		// Set refreshed token in cookie
-		auth.SetTokenCookie(w, r, cluster, newTokenString, c.BaseURL)
+		auth.SetTokenCookie(w, r, cluster, newTokenString, c.BaseURL, c.SessionTTL)
 
 		c.TelemetryHandler.RecordEvent(span, "Token refreshed successfully")
 	}
@@ -2534,7 +2535,7 @@ func (c *HeadlampConfig) handleSetToken(w http.ResponseWriter, r *http.Request) 
 	if req.Token == "" {
 		auth.ClearTokenCookie(w, r, cluster, c.BaseURL)
 	} else {
-		auth.SetTokenCookie(w, r, cluster, req.Token, c.BaseURL)
+		auth.SetTokenCookie(w, r, cluster, req.Token, c.BaseURL, c.SessionTTL)
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -100,6 +100,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		ProxyURLs:             strings.Split(conf.ProxyURLs, ","),
 		TLSCertPath:           conf.TLSCertPath,
 		TLSKeyPath:            conf.TLSKeyPath,
+		SessionTTL:            conf.SessionTTL,
 	}
 }
 

--- a/backend/pkg/auth/cookies.go
+++ b/backend/pkg/auth/cookies.go
@@ -75,7 +75,7 @@ func IsSecureContext(r *http.Request) bool {
 }
 
 // SetTokenCookie sets an authentication cookie for a specific cluster.
-func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, baseURL string) {
+func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, baseURL string, sessionTTL int) {
 	// Validate inputs
 	if cluster == "" || token == "" {
 		return
@@ -101,7 +101,7 @@ func SetTokenCookie(w http.ResponseWriter, r *http.Request, cluster, token, base
 			Secure:   secure,
 			SameSite: http.SameSiteStrictMode,
 			Path:     GetCookiePath(baseURL, cluster),
-			MaxAge:   86400, // 24 hours
+			MaxAge:   sessionTTL,
 		}
 
 		http.SetCookie(w, cookie)

--- a/backend/pkg/auth/cookies_test.go
+++ b/backend/pkg/auth/cookies_test.go
@@ -166,7 +166,8 @@ func TestSetAndGetAuthCookie(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// Test setting a cookie
-	auth.SetTokenCookie(w, req, "test-cluster", "test-token", "")
+	testTTL := 100
+	auth.SetTokenCookie(w, req, "test-cluster", "test-token", "", testTTL)
 
 	// Check if cookie was set
 	cookies := w.Result().Cookies()
@@ -191,6 +192,10 @@ func TestSetAndGetAuthCookie(t *testing.T) {
 		t.Error("Expected SameSite to be SameSiteStrictMode")
 	}
 
+	if cookie.MaxAge != testTTL {
+		t.Errorf("Expected MaxAge to be %d, got %d", testTTL, cookie.MaxAge)
+	}
+
 	// Test getting the cookie
 	req.AddCookie(cookie)
 
@@ -213,7 +218,7 @@ func TestGetAuthCookieChunked(t *testing.T) {
 	longToken := strings.Repeat("a", 5000)
 
 	// Test setting a cookie
-	auth.SetTokenCookie(w, req, "test-cluster", longToken, "")
+	auth.SetTokenCookie(w, req, "test-cluster", longToken, "", 86400)
 
 	// Check if cookie was set
 	cookies := w.Result().Cookies()

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -62,4 +62,5 @@ type HeadlampCFG struct {
 	ProxyURLs             []string
 	TLSCertPath           string
 	TLSKeyPath            string
+	SessionTTL            int
 }

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -71,6 +71,7 @@ $ helm install my-headlamp headlamp/headlamp \
 |--------------------|--------|-----------------------|---------------------------------------------------------------------------|
 | config.inCluster   | bool   | `true`                | Run Headlamp in-cluster                                                   |
 | config.baseURL     | string | `""`                  | Base URL path for Headlamp UI                                             |
+| config.sessionTTL  | int    | `86400`               | The time in seconds for the internal session to remain valid (Default: 86400/24h, Min: 1 , Max: 31536000/1yr) |
 | config.pluginsDir  | string | `"/headlamp/plugins"` | Directory to load Headlamp plugins from                                   |
 | config.enableHelm  | bool   | `false`               | Enable Helm operations like install, upgrade and uninstall of Helm charts |
 | config.extraArgs   | array  | `[]`                  | Additional arguments for Headlamp server                                  |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -245,6 +245,9 @@ spec:
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
             {{- end }}
+            {{- if hasKey .Values.config "sessionTTL" }}
+            - "-session-ttl={{ .Values.config.sessionTTL }}"
+            {{- end }}
             {{- if not $oidc.externalSecret.enabled}}
             # Check if externalSecret is disabled
             {{- if or (ne $oidc.clientID "") (ne $clientID "") }}

--- a/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
+++ b/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
@@ -115,6 +115,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             - -insecure-ssl
           ports:

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -129,6 +129,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/host-users-override.yaml
+++ b/charts/headlamp/tests/expected_templates/host-users-override.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
+++ b/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
@@ -114,6 +114,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             - "-me-user-info-url=$(ME_USER_INFO_URL)"
           ports:

--- a/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
@@ -118,6 +118,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             - "-me-user-info-url=$(ME_USER_INFO_URL)"
           ports:

--- a/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
@@ -136,6 +136,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/namespace-override.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
+++ b/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
@@ -111,6 +111,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -136,6 +136,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -120,6 +120,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -111,6 +111,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -106,6 +106,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"

--- a/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
@@ -113,6 +113,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -117,6 +117,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"

--- a/charts/headlamp/tests/expected_templates/pod-disruption.yaml
+++ b/charts/headlamp/tests/expected_templates/pod-disruption.yaml
@@ -132,6 +132,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -138,6 +138,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/tls-added.yaml
+++ b/charts/headlamp/tests/expected_templates/tls-added.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
             - "-tls-cert-path=/headlamp-cert/headlamp-ca.crt"
             - "-tls-key-path=/headlamp-cert/headlamp-tls.key"

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -112,6 +112,7 @@ spec:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
             # Check if externalSecret is disabled
           ports:
             - name: http

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -173,6 +173,13 @@
           "type": "string",
           "description": "Base URL of the application"
         },
+        "sessionTTL": {
+          "type": "integer",
+          "description": "The time in seconds for the session to be valid",
+          "default": 86400,
+          "minimum": 1,
+          "maximum": 31536000
+        },
         "oidc": {
           "type": "object",
           "description": "OIDC configuration",

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -36,6 +36,8 @@ config:
   inClusterContextName: "main"
   # -- base url path at which headlamp should run
   baseURL: ""
+  # -- session token TTL in seconds (default is 24 hours)
+  sessionTTL: 86400
   oidc:
     # Option 1:
     # @param config.oidc.secret - OIDC secret configuration


### PR DESCRIPTION
## Summary

This PR adds `session-ttl` flag to headlamp backend and helm chart

## Related Issue

Fixes #4538

## Changes

- Added new `session-ttl` flag in backend
- Updated `MaxAge` logic in `cookies.go`
- Updated helm chart and test snapshots

## Steps to Test

(Not tested yet, having problems with authenticating but have verified this from logs)
- Build backend
- Run it with `-session-ttl=120`
- Open headlamp in browser, Authenticate
- Developer tools -> cookies -> check for auth cookie -> MaxAge column should have a 2 minute timestamp from that period

## Notes for the Reviewer

Many files have been changed as charts snapshots have been updated.
