### PR TITLE
frontend: storybook: Add descriptive titles to AuthToken stories

### DIFF
--- a/frontend/src/components/account/AuthToken.stories.tsx
+++ b/frontend/src/components/account/AuthToken.stories.tsx
@@ -42,7 +42,7 @@ const Template: StoryFn<PureAuthTokenProps> = args => <PureAuthToken {...args} /
 
 export const ShowError = Template.bind({});
 ShowError.args = {
-  title: 'a title',
+  title: 'Authentication Error',
   token: 'a token',
   showError: true,
   showActions: false,
@@ -50,7 +50,7 @@ ShowError.args = {
 
 export const ShowActions = Template.bind({});
 ShowActions.args = {
-  title: 'a title',
+  title: 'Authentication Token',
   token: 'a token',
   showError: false,
   showActions: true,

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -88,7 +88,7 @@
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                 >
-                  a title
+                  Authentication Token
                 </h1>
               </div>
             </div>

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -111,7 +111,7 @@
                   class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
                   style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                 >
-                  a title
+                  Authentication Error
                 </h1>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Changed `AuthToken` story titles from generic "a title" to "Authentication Token" and "Authentication Error" to fix accessibility violations.

## Related Issue
Fixes #4594, #4595

## Changes
- Updated placeholder title to **"Authentication Error"** in the `ShowError` story.
- Updated placeholder title to **"Authentication Token"** in the `ShowActions` story.
- Regenerated storybook snapshots to reflect title changes.

## Screenshots

| Authentication Token | Authentication Error |
| :---: | :---: |
| <img width="712" height="450" alt="Auth Error" src="https://github.com/user-attachments/assets/8a7bb612-c9a2-457c-b05a-668037e46ea7" /> | <img width="698" height="464" alt="Auth Token" src="https://github.com/user-attachments/assets/2a64825a-9079-4b3e-aeeb-9c743661530d" /> |


## Steps to Test
1. Run `npm run storybook` in the `frontend` directory.
2. Navigate to `AuthToken` in the sidebar.
3. Check `ShowError` and `ShowActions` stories to verify the titles are no longer placeholders.