### PR TITLE
frontend: Fix new project heading a11y issue

### DIFF
--- a/frontend/src/components/project/NewProjectPopup.tsx
+++ b/frontend/src/components/project/NewProjectPopup.tsx
@@ -88,7 +88,7 @@ function ProjectTypeButton({
     >
       <Box sx={{ width: '52px', height: '52px', alignSelf: 'center' }}>{icon}</Box>
       <Box>
-        <Typography variant="h6" sx={{ display: 'flex' }}>
+        <Typography variant="h6" component="span" sx={{ display: 'flex' }}>
           {title}
         </Typography>
         <Typography variant="body2" color="text.secondary">
@@ -346,7 +346,9 @@ export function NewProjectPopup({ open, onClose }: { open: boolean; onClose: () 
     <Dialog open={open} maxWidth={false} onClose={onClose}>
       {projectStep === undefined && (
         <>
-          <DialogTitle sx={{ display: 'flex' }}>{t('Create a Project')}</DialogTitle>
+          <DialogTitle component="h1" sx={{ display: 'flex' }}>
+            {t('Create a Project')}
+          </DialogTitle>
           <DialogContent sx={{ maxWidth: '540px' }}>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
               <Trans>

--- a/frontend/src/components/project/__snapshots__/NewProjectPopup.Default.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/NewProjectPopup.Default.stories.storyshot
@@ -30,12 +30,12 @@
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthFalse css-v61m47-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <h2
+        <h1
           class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-q5kqw8-MuiTypography-root-MuiDialogTitle-root"
           id=":mock-test-id:"
         >
           Create a Project
-        </h2>
+        </h1>
         <div
           class="MuiDialogContent-root css-15ohtq7-MuiDialogContent-root"
         >
@@ -58,11 +58,11 @@
               <div
                 class="MuiBox-root css-0"
               >
-                <h6
+                <span
                   class="MuiTypography-root MuiTypography-h6 css-16yif3g-MuiTypography-root"
                 >
                   New Project
-                </h6>
+                </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
                 >
@@ -84,11 +84,11 @@
               <div
                 class="MuiBox-root css-0"
               >
-                <h6
+                <span
                   class="MuiTypography-root MuiTypography-h6 css-16yif3g-MuiTypography-root"
                 >
                   New Project from YAML
-                </h6>
+                </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
                 >

--- a/frontend/src/components/project/__snapshots__/NewProjectPopup.WithExistingProjects.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/NewProjectPopup.WithExistingProjects.stories.storyshot
@@ -30,12 +30,12 @@
         class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthFalse css-v61m47-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
-        <h2
+        <h1
           class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-q5kqw8-MuiTypography-root-MuiDialogTitle-root"
           id=":mock-test-id:"
         >
           Create a Project
-        </h2>
+        </h1>
         <div
           class="MuiDialogContent-root css-15ohtq7-MuiDialogContent-root"
         >
@@ -58,11 +58,11 @@
               <div
                 class="MuiBox-root css-0"
               >
-                <h6
+                <span
                   class="MuiTypography-root MuiTypography-h6 css-16yif3g-MuiTypography-root"
                 >
                   New Project
-                </h6>
+                </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
                 >
@@ -84,11 +84,11 @@
               <div
                 class="MuiBox-root css-0"
               >
-                <h6
+                <span
                   class="MuiTypography-root MuiTypography-h6 css-16yif3g-MuiTypography-root"
                 >
                   New Project from YAML
-                </h6>
+                </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
                 >


### PR DESCRIPTION
## Summary

This PR fixes an a11y issue identified by Lighthouse where headings were not in sequential order for the "New Project" option.

The title component was visually styled as an h6 header with no larger headers present on the screen. This caused Lighthouse to flag improper heading hierarchy which can negatively impact screen reader navigation.

## Related Issue

Fixes https://github.com/Azure/aks-desktop/issues/199

## Changes

- Fixes the following a11y issue: "Heading elements are not in a sequentially-descending order"

How to Test:

- Navigate to the Projects tab
- Click the "+ Create Projects" button
- Use inspect tools and open Lighthouse
- Scan at this view