### PR TITLE
Fix JSON logs prettify

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -35,6 +35,7 @@ import { KubeObject } from '../../../lib/k8s/KubeObject';
 import Pod from '../../../lib/k8s/pod';
 import ReplicaSet from '../../../lib/k8s/replicaSet';
 import { Activity } from '../../activity/Activity';
+import { colorizePrettifiedLog } from '../../pod/jsonHandling';
 import ActionButton from '../ActionButton';
 import { LogViewer } from '../LogViewer';
 import { LightTooltip } from '../Tooltip';
@@ -67,6 +68,9 @@ function LogsButtonContent({ item }: LogsButtonProps) {
   const [lines, setLines] = useState<number>(100);
   const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
   const [showReconnectButton, setShowReconnectButton] = useState(false);
+  const [prettifyLogs, setPrettifyLogs] = useState<boolean>(false);
+  const [formatJsonValues, setFormatJsonValues] = useState<boolean>(false);
+  const [hasJsonLogs, setHasJsonLogs] = useState<boolean>(false);
 
   const xtermRef = React.useRef<XTerminal | null>(null);
   const { t } = useTranslation(['glossary', 'translation']);
@@ -139,6 +143,14 @@ function LogsButtonContent({ item }: LogsButtonProps) {
 
   function handlePreviousChange() {
     setShowPrevious(previous => !previous);
+  }
+
+  function handlePrettifyChange() {
+    setPrettifyLogs(prev => !prev);
+  }
+
+  function handleFormatJsonValuesChange() {
+    setFormatJsonValues(prev => !prev);
   }
 
   // Handler for initial logs button click
@@ -222,16 +234,19 @@ function LogsButtonContent({ item }: LogsButtonProps) {
       return timestampA.localeCompare(timestampB);
     });
 
+    const displayLogs =
+      prettifyLogs && hasJsonLogs ? allLogs.map(log => colorizePrettifiedLog(log)) : allLogs;
+
     if (xtermRef.current) {
       xtermRef.current.clear();
-      xtermRef.current.write(allLogs.join('').replaceAll('\n', '\r\n'));
+      xtermRef.current.write(displayLogs.join('').replaceAll('\n', '\r\n'));
     }
 
     setLogs({
       logs: allLogs,
       lastLineShown: allLogs.length - 1,
     });
-  }, [allPodLogs]);
+  }, [allPodLogs, prettifyLogs, hasJsonLogs]);
 
   // Function to fetch and aggregate logs from all pods
   function fetchAllPodsLogs(pods: Pod[], container: string): () => void {
@@ -243,7 +258,16 @@ function LogsButtonContent({ item }: LogsButtonProps) {
     pods.forEach(pod => {
       const cleanup = pod.getLogs(
         container,
-        ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
+        ({
+          logs: newLogs,
+          hasJsonLogs: newHasJsonLogs,
+        }: {
+          logs: string[];
+          hasJsonLogs?: boolean;
+        }) => {
+          if (newHasJsonLogs) {
+            setHasJsonLogs(true);
+          }
           const podName = pod.getName();
           setAllPodLogs(current => {
             const updated = {
@@ -258,6 +282,8 @@ function LogsButtonContent({ item }: LogsButtonProps) {
           showPrevious,
           showTimestamps,
           follow,
+          prettifyLogs,
+          formatJsonValues,
           onReconnectStop: () => {
             setShowReconnectButton(true);
           },
@@ -277,6 +303,7 @@ function LogsButtonContent({ item }: LogsButtonProps) {
     if (selectedContainer) {
       clearLogs();
       setAllPodLogs({}); // Clear aggregated logs when switching pods
+      setHasJsonLogs(false);
 
       // Handle paused logs state
       if (!follow && logs.logs.length > 0) {
@@ -296,8 +323,17 @@ function LogsButtonContent({ item }: LogsButtonProps) {
           let lastLogLength = 0;
           cleanup = pod.getLogs(
             selectedContainer,
-            ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
+            ({
+              logs: newLogs,
+              hasJsonLogs: newHasJsonLogs,
+            }: {
+              logs: string[];
+              hasJsonLogs?: boolean;
+            }) => {
               if (!isSubscribed) return;
+              if (newHasJsonLogs) {
+                setHasJsonLogs(true);
+              }
 
               setLogs(current => {
                 const terminalRef = xtermRef.current;
@@ -310,10 +346,12 @@ function LogsButtonContent({ item }: LogsButtonProps) {
                   const endIdx = Math.min(startIdx + CHUNK_SIZE, newLogs.length);
 
                   // Process only the new chunk of logs
-                  const newLogContent = newLogs
-                    .slice(startIdx, endIdx)
-                    .join('')
-                    .replaceAll('\n', '\r\n');
+                  const logSlice = newLogs.slice(startIdx, endIdx);
+                  const displaySlice =
+                    prettifyLogs && newHasJsonLogs
+                      ? logSlice.map(log => colorizePrettifiedLog(log))
+                      : logSlice;
+                  const newLogContent = displaySlice.join('').replaceAll('\n', '\r\n');
 
                   terminalRef.write(newLogContent);
                   lastLogLength = endIdx;
@@ -342,6 +380,8 @@ function LogsButtonContent({ item }: LogsButtonProps) {
               showPrevious,
               showTimestamps,
               follow,
+              prettifyLogs,
+              formatJsonValues,
               onReconnectStop: () => {
                 if (isSubscribed) {
                   setShowReconnectButton(true);
@@ -359,7 +399,19 @@ function LogsButtonContent({ item }: LogsButtonProps) {
         cleanup();
       }
     };
-  }, [selectedPodIndex, selectedContainer, lines, showTimestamps, follow, clearLogs, t, pods]);
+  }, [
+    selectedPodIndex,
+    selectedContainer,
+    lines,
+    showTimestamps,
+    follow,
+    clearLogs,
+    t,
+    pods,
+    prettifyLogs,
+    formatJsonValues,
+    showPrevious,
+  ]);
 
   // Effect to process logs when allPodLogs changes - only for "All Pods" mode
   React.useEffect(() => {
@@ -496,6 +548,40 @@ function LogsButtonContent({ item }: LogsButtonProps) {
           disabled={false}
         />
       </LightTooltip>
+
+      {/* Prettify JSON logs switch */}
+      {hasJsonLogs && (
+        <PaddedFormControlLabel
+          label={t('translation|Prettify')}
+          control={
+            <Switch
+              checked={prettifyLogs}
+              onChange={handlePrettifyChange}
+              size="small"
+              sx={{ transform: 'scale(0.8)' }}
+            />
+          }
+        />
+      )}
+
+      {/* Format JSON values switch */}
+      {hasJsonLogs && (
+        <LightTooltip
+          title={t('translation|Show JSON values in plain text by removing escape characters.')}
+        >
+          <PaddedFormControlLabel
+            label={t('translation|Format')}
+            control={
+              <Switch
+                checked={formatJsonValues}
+                onChange={handleFormatJsonValuesChange}
+                size="small"
+                sx={{ transform: 'scale(0.8)' }}
+              />
+            }
+          />
+        </LightTooltip>
+      )}
     </Box>,
   ];
 

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -186,12 +186,51 @@ class Pod extends KubeObject<KubePod> {
         .replace(/\\\\/g, '\\'); // Backslash
     }
 
-    function prettifyLogLine(logLine: string): string {
-      try {
-        const jsonMatch = logLine.match(/(\{.*\})/);
-        if (!jsonMatch) return logLine;
+    function findJsonBounds(line: string): { start: number; end: number } | null {
+      const start = line.indexOf('{');
+      if (start === -1) return null;
 
-        const jsonStr = jsonMatch[1];
+      // Walk from the first '{' tracking brace depth and string context
+      // to find the matching '}', ignoring braces inside quoted strings.
+      let depth = 0;
+      let inString = false;
+      let escapeNext = false;
+
+      for (let i = start; i < line.length; i++) {
+        const ch = line[i];
+
+        if (escapeNext) {
+          escapeNext = false;
+          continue;
+        }
+
+        if (ch === '\\') {
+          escapeNext = true;
+          continue;
+        }
+
+        if (ch === '"') {
+          inString = !inString;
+          continue;
+        }
+
+        if (inString) continue;
+
+        if (ch === '{') {
+          depth++;
+        } else if (ch === '}') {
+          depth--;
+          if (depth === 0) return { start, end: i };
+          if (depth < 0) return null;
+        }
+      }
+
+      return null;
+    }
+
+    function prettifyLogLine(logLine: string, jsonBounds: { start: number; end: number }): string {
+      try {
+        const jsonStr = logLine.substring(jsonBounds.start, jsonBounds.end + 1);
         const jsonObj = JSON.parse(jsonStr);
 
         const valueReplacer = formatJsonValues
@@ -205,7 +244,7 @@ class Pod extends KubeObject<KubePod> {
           : prettyJson;
 
         if (showTimestamps) {
-          const timestamp = logLine.slice(0, jsonMatch.index).trim();
+          const timestamp = logLine.slice(0, jsonBounds.start).trim();
           return timestamp ? `${timestamp}\n${terminalReadyJson}\n` : `${terminalReadyJson}\n`;
         } else {
           return `${terminalReadyJson}\n`;
@@ -221,9 +260,15 @@ class Pod extends KubeObject<KubePod> {
       const decodedLog = Base64.decode(item);
       if (!decodedLog || decodedLog.trim() === '') return;
       const trimmedLog = decodedLog.trim();
-      const jsonMatch = trimmedLog.match(/(\{.*\})/);
-      if (jsonMatch) hasJsonLogs = true;
-      const processedLog = hasJsonLogs && prettifyLogs ? prettifyLogLine(decodedLog) : decodedLog;
+      const jsonBounds = findJsonBounds(trimmedLog);
+
+      const processedLog =
+        !!jsonBounds && prettifyLogs ? prettifyLogLine(trimmedLog, jsonBounds) : decodedLog;
+
+      if (jsonBounds) {
+        hasJsonLogs = true;
+      }
+
       logs.push(processedLog);
       onLogs({ logs, hasJsonLogs });
     }


### PR DESCRIPTION
## Summary

This PR fixes #3421 and adds also the prettify/format switches to the deployments' log viewer.

## Related Issue

Fixes #3421

## Steps to Test

**Pods:**

1. Create a simple pod with JSON logs:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: json-logger
spec:
  containers:
    - name: logger
      image: busybox
      command: ["/bin/sh", "-c"]
      args:
        - |
          i=0;
          while true; do
            echo "{\"level\":\"info\", \"message\":\"hello from pod\", \"count\": $i}";
            i=$((i+1));
            sleep 1;
          done
```
2. Go to the pod's details view and click the logs button: verify there's a prettify/format buttons and they work correctly (maybe the format is not noticeable in this test).

**Deployments:**

1. Create a deployment with JSON logs in its pod:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: json-logger-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: json-logger
  template:
    metadata:
      labels:
        app: json-logger
    spec:
      containers:
        - name: logger
          image: busybox
          command: ["/bin/sh", "-c"]
          args:
            - |
              i=0;
              while true; do
                echo "{\"timestamp\":\"$(date -Iseconds)\", \"level\":\"info\", \"message\":\"hello from deployment\", \"count\": $i}";
                i=$((i+1));
                sleep 1;
              done
```
2. Go to the deployment's details view and click the logs button: verify there's a prettify/format buttons and they work correctly (maybe the format is not noticeable in this test).
