### PR TITLE
feat: add visual indicator for resources pending deletion

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -56,6 +56,7 @@ import { DateLabel } from '../Label';
 import Link from '../Link';
 import Table, { TableColumn } from '../Table';
 import { getA8RMetadata } from './A8RInfo';
+import { LightTooltip } from '../Tooltip';
 import DeleteButton from './DeleteButton';
 import DownloadButton from './DownloadButton';
 import EditButton from './EditButton';
@@ -449,8 +450,31 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
               header: t('translation|Name'),
               gridTemplate: 'auto',
               accessorFn: (item: RowItem) => item.metadata.name,
-              Cell: ({ row }: { row: MRT_Row<RowItem> }) =>
-                row.original && <Link kubeObject={row.original} />,
+              Cell: ({ row }: { row: MRT_Row<RowItem> }) => {
+                if (!row.original) {
+                  return null;
+                }
+
+                const isDeleting = !!row.original.metadata?.deletionTimestamp;
+
+                return (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {isDeleting && (
+                      <LightTooltip title={t('translation|Deleting')}>
+                        <Box component="span" sx={{ display: 'flex', color: 'text.secondary' }}>
+                          <Icon
+                            icon="mdi:trash-can-outline"
+                            width="1rem"
+                            height="1rem"
+                            color={theme.palette.error.main}
+                          />
+                        </Box>
+                      </LightTooltip>
+                    )}
+                    <Link kubeObject={row.original} />
+                  </Box>
+                );
+              },
             };
           case 'age':
             return {


### PR DESCRIPTION
## Summary

This PR adds a visual indicator for resources that are pending deletion. A red trash icon is shown next to resources that have a deletionTimestamp, making it clear they are in the process of being deleted.

## Related Issue

Fixes #4573 

## Changes

- Updated ResourceTable to detect deletionTimestamp
- Added a red trash icon next to resources pending deletion
- Ensured visibility works in both light and dark themes

## Steps to Test

1. Create a resource (e.g., a Service).
2. Delete it while it has a finalizer (or simulate a delayed deletion).
3. Return to the list view.
4. Verify that a red trash icon appears next to the resource name while it is pending deletion.

## Screenshots (if applicable)
<img width="1824" height="960" alt="image" src="https://github.com/user-attachments/assets/f4b71d4b-3c66-4599-acaa-6f79e0827d5e" />
<img width="1824" height="960" alt="image" src="https://github.com/user-attachments/assets/374f68e4-be45-4c80-914c-a3cd5ca10c2e" />


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
