### PR TITLE
frontend: ClusterTable/ResourceTable: Lift up tableSettings helpers and add localStorage to ClusterTable

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -329,7 +329,7 @@
                     </th>
                     <th
                       aria-sort="none"
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-11ihby4-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-4ks04s-MuiTableCell-root"
                       colspan="1"
                       data-can-sort="true"
                       data-index="-1"
@@ -384,7 +384,7 @@
                     </th>
                     <th
                       aria-sort="none"
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-9s5e2s-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-13c0hsi-MuiTableCell-root"
                       colspan="1"
                       data-can-sort="true"
                       data-index="-1"
@@ -439,7 +439,7 @@
                     </th>
                     <th
                       aria-sort="none"
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-usbwln-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-rymsnu-MuiTableCell-root"
                       colspan="1"
                       data-can-sort="true"
                       data-index="-1"
@@ -494,7 +494,7 @@
                     </th>
                     <th
                       aria-sort="none"
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-19o1a0j-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1bc3cd9-MuiTableCell-root"
                       colspan="1"
                       data-can-sort="true"
                       data-index="-1"
@@ -629,7 +629,7 @@
                       </a>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
@@ -638,7 +638,7 @@
                       </p>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1n4xkg0-MuiTableCell-root"
                     >
                       <div
                         class="MuiBox-root css-1gtanqs"
@@ -656,12 +656,12 @@
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17iljsw-MuiTableCell-root"
                     >
                       0
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
                     >
                       ⋯
                     </td>
@@ -737,7 +737,7 @@
                       </a>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
@@ -746,7 +746,7 @@
                       </p>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1n4xkg0-MuiTableCell-root"
                     >
                       <div
                         class="MuiBox-root css-1gtanqs"
@@ -764,12 +764,12 @@
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17iljsw-MuiTableCell-root"
                     >
                       0
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
                     >
                       ⋯
                     </td>
@@ -845,7 +845,7 @@
                       </a>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
                     >
                       <p
                         class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
@@ -854,7 +854,7 @@
                       </p>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1n4xkg0-MuiTableCell-root"
                     >
                       <div
                         class="MuiBox-root css-1gtanqs"
@@ -872,12 +872,12 @@
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17iljsw-MuiTableCell-root"
                     >
                       0
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
                     >
                       ⋯
                     </td>

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -36,6 +36,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { loadTableSettings, storeTableSettings } from '../../../helpers/tableSettings';
 import { useSelectedClusters } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
@@ -207,44 +208,6 @@ function TableFromResourceClass<KubeClass extends KubeObjectClass>(
       data={throttledItems}
     />
   );
-}
-
-/**
- * Store the table settings in local storage.
- *
- * @param tableId - The ID of the table.
- * @param columns - The columns to store.
- * @returns void
- */
-function storeTableSettings(tableId: string, columns: { id?: string; show: boolean }[]) {
-  if (!tableId) {
-    console.debug('storeTableSettings: tableId is empty!', new Error().stack);
-    return;
-  }
-
-  const columnsWithIds = columns.map((c, i) => ({ id: i.toString(), ...c }));
-  // Delete the entry if there are no settings to store.
-  if (columnsWithIds.length === 0) {
-    localStorage.removeItem(`table_settings.${tableId}`);
-    return;
-  }
-  localStorage.setItem(`table_settings.${tableId}`, JSON.stringify(columnsWithIds));
-}
-
-/**
- * Load the table settings from local storage for a given table ID.
- *
- * @param tableId - The ID of the table.
- * @returns The table settings for the given table ID.
- */
-function loadTableSettings(tableId: string): { id: string; show: boolean }[] {
-  if (!tableId) {
-    console.debug('loadTableSettings: tableId is empty!', new Error().stack);
-    return [];
-  }
-
-  const settings = JSON.parse(localStorage.getItem(`table_settings.${tableId}`) || '[]');
-  return settings;
 }
 
 /**

--- a/frontend/src/helpers/tableSettings.test.ts
+++ b/frontend/src/helpers/tableSettings.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { loadTableSettings, storeTableSettings } from './tableSettings';
+
+describe('tableSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('storeTableSettings', () => {
+    it('stores column visibility settings in localStorage', () => {
+      const columns = [
+        { id: 'name', show: true },
+        { id: 'status', show: false },
+      ];
+
+      storeTableSettings('test-table', columns);
+
+      const stored = JSON.parse(localStorage.getItem('table_settings.test-table') || '[]');
+      expect(stored).toEqual([
+        { id: 'name', show: true },
+        { id: 'status', show: false },
+      ]);
+    });
+
+    it('assigns numeric IDs to columns without IDs', () => {
+      const columns = [{ show: true }, { show: false }];
+
+      storeTableSettings('test-table', columns);
+
+      const stored = JSON.parse(localStorage.getItem('table_settings.test-table') || '[]');
+      expect(stored).toEqual([
+        { id: '0', show: true },
+        { id: '1', show: false },
+      ]);
+    });
+
+    it('removes the entry when columns array is empty', () => {
+      localStorage.setItem('table_settings.test-table', JSON.stringify([{ id: '0', show: true }]));
+
+      storeTableSettings('test-table', []);
+
+      expect(localStorage.getItem('table_settings.test-table')).toBeNull();
+    });
+
+    it('does nothing when tableId is empty', () => {
+      storeTableSettings('', [{ id: 'name', show: true }]);
+
+      // No key should have been written for an empty tableId
+      expect(localStorage.getItem('table_settings.')).toBeNull();
+    });
+  });
+
+  describe('loadTableSettings', () => {
+    it('returns stored settings', () => {
+      const settings = [
+        { id: 'name', show: true },
+        { id: 'status', show: false },
+      ];
+      localStorage.setItem('table_settings.test-table', JSON.stringify(settings));
+
+      const result = loadTableSettings('test-table');
+
+      expect(result).toEqual(settings);
+    });
+
+    it('returns empty array when no settings exist', () => {
+      const result = loadTableSettings('nonexistent-table');
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when tableId is empty', () => {
+      const result = loadTableSettings('');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/helpers/tableSettings.ts
+++ b/frontend/src/helpers/tableSettings.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Store the table column visibility settings in local storage.
+ *
+ * @param tableId - The ID of the table.
+ * @param columns - The columns to store.
+ */
+export function storeTableSettings(tableId: string, columns: { id?: string; show: boolean }[]) {
+  if (!tableId) {
+    console.debug('storeTableSettings: tableId is empty!', new Error().stack);
+    return;
+  }
+
+  const columnsWithIds = columns.map((c, i) => ({ id: i.toString(), ...c }));
+  // Delete the entry if there are no settings to store.
+  if (columnsWithIds.length === 0) {
+    localStorage.removeItem(`table_settings.${tableId}`);
+    return;
+  }
+  localStorage.setItem(`table_settings.${tableId}`, JSON.stringify(columnsWithIds));
+}
+
+/**
+ * Load the table column visibility settings from local storage for a given table ID.
+ *
+ * @param tableId - The ID of the table.
+ * @returns The table settings for the given table ID.
+ */
+export function loadTableSettings(tableId: string): { id: string; show: boolean }[] {
+  if (!tableId) {
+    console.debug('loadTableSettings: tableId is empty!', new Error().stack);
+    return [];
+  }
+
+  const settings = JSON.parse(localStorage.getItem(`table_settings.${tableId}`) || '[]');
+  return settings;
+}


### PR DESCRIPTION
## Summary

This PR fixes #4711 by persisting column visibility, sorting, and column filter settings on the home page's ClusterTable to localStorage, so users' table customizations survive page navigations and browser refreshes.

## Related Issue

Fixes #4711 

## Changes

- Lifted tableSettings from ResourceTable.tsx into a shared helper
- Updated ResourceTable.tsx to use new shared helper
- Updated ClusterTable.tsx by adding columnIds and localStorage persistence for visibility, sorting and filters
- Added shared helper tests in tableSettings.test.ts

## Steps to Test

1. Update a filter in the cluster table
2. Select and open a cluster. 
3. Navigate around the cluster for any length of time
4. Click `Home` in the top left
5. Review that the filter is still present in the table
6. Update the columns by toggling Origin and Warnings invisible (for example)
7. Select and open a cluster
8. Navigate around the cluster for any length of time
9. Click `Home` in the top left
10. Review that the column that were toggled invisible are still not present

## Screenshots (if applicable)

<img width="1438" height="970" alt="easy-to-read-cluster-edited" src="https://github.com/user-attachments/assets/b9dbf2d8-514c-403d-b686-7a367165ef3b" />

## Notes for the Reviewer

Before this changed, if you set filters or column settings, when you enter and then leave a cluster, the cluster table is reset.
