### PR TITLE
fix(PluginSettings): improve chip contrast and enable custom chip styles.

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -103,7 +103,7 @@
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <div
-                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-1m87iv1-MuiPaper-root-MuiAlert-root"
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-st0ufu-MuiPaper-root-MuiAlert-root"
                         role="alert"
                       >
                         <div
@@ -125,7 +125,7 @@
                   </div>
                 </div>
                 <div
-                  class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+                  class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
                   style="opacity: 0; visibility: hidden;"
                 >
                   <p

--- a/frontend/src/components/App/PluginSettings/PluginSettings.themes.stories.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.themes.stories.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Box from '@mui/material/Box';
+import { ThemeProvider } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import { Meta, StoryFn } from '@storybook/react';
+import { AppTheme } from '../../../lib/AppTheme';
+import { createMuiTheme } from '../../../lib/themes';
+import { PluginInfo } from '../../../plugin/pluginsSlice';
+import { TestContext } from '../../../test';
+import defaultAppThemes from '../defaultAppThemes';
+import { PluginSettingsPure } from './PluginSettings';
+
+export default {
+  title: 'Settings/PluginSettings/Themes',
+  component: PluginSettingsPure,
+} as Meta;
+
+const plugins: PluginInfo[] = [
+  {
+    name: 'user-plugin-example',
+    description: 'An example of a user-installed plugin',
+    type: 'user',
+    isEnabled: true,
+    isCompatible: true,
+    isLoaded: true,
+    homepage: 'https://example.com/user-plugin',
+    origin: 'User',
+  },
+  {
+    name: 'dev-plugin-example',
+    description: 'An example of a development plugin',
+    type: 'development',
+    isEnabled: true,
+    isCompatible: true,
+    isLoaded: true,
+    homepage: 'https://example.com/dev-plugin',
+    origin: 'Dev',
+  },
+  {
+    name: 'shipped-plugin-example',
+    description: 'An example of a shipped plugin',
+    type: 'shipped',
+    isEnabled: true,
+    isCompatible: true,
+    isLoaded: true,
+    homepage: 'https://example.com/shipped-plugin',
+    origin: 'Headlamp',
+  },
+];
+
+export const AllThemes: StoryFn = () => (
+  <TestContext>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4, p: 2 }}>
+      <Typography variant="h4" gutterBottom>
+        Theme Verification
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        This story renders the PluginSettings component with each of the default application themes.
+        Use this to verify the contrast of the "User-installed" chips and other UI elements.
+      </Typography>
+
+      {defaultAppThemes.map((theme: AppTheme) => {
+        const muiTheme = createMuiTheme(theme);
+        return (
+          <Box
+            key={theme.name}
+            sx={{
+              border: '1px solid #ccc',
+              borderRadius: 1,
+              overflow: 'hidden',
+            }}
+          >
+            <Box sx={{ p: 1, bgcolor: '#eee', borderBottom: '1px solid #ccc' }}>
+              <Typography variant="subtitle1" component="div" sx={{ color: '#333' }}>
+                Theme: <strong>{theme.name}</strong> ({theme.base || 'light'})
+              </Typography>
+            </Box>
+            <ThemeProvider theme={muiTheme}>
+              <Box
+                sx={{
+                  bgcolor: 'background.default',
+                  color: 'text.primary',
+                  p: 2,
+                }}
+              >
+                <PluginSettingsPure plugins={plugins as any} onSave={() => {}} />
+              </Box>
+            </ThemeProvider>
+          </Box>
+        );
+      })}
+    </Box>
+  </TestContext>
+);

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -16,9 +16,9 @@
 
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
+import Chip, { ChipProps } from '@mui/material/Chip';
 import Link from '@mui/material/Link';
-import { useTheme } from '@mui/material/styles';
+import { SxProps, Theme, useTheme } from '@mui/material/styles';
 import { SwitchProps } from '@mui/material/Switch';
 import Switch from '@mui/material/Switch';
 import Tooltip from '@mui/material/Tooltip';
@@ -268,7 +268,10 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
               header: t('translation|Type'),
               accessorFn: (plugin: PluginInfo) => plugin.type || 'unknown',
               Cell: ({ row: { original: plugin } }: { row: MRT_Row<PluginInfo> }) => {
-                const typeLabels: Record<string, { label: string; color: any }> = {
+                const typeLabels: Record<
+                  string,
+                  { label: string; color: ChipProps['color']; sx?: SxProps<Theme> }
+                > = {
                   development: {
                     label: t('translation|Development'),
                     color: 'primary',
@@ -276,6 +279,11 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                   user: {
                     label: t('translation|User-installed'),
                     color: 'info',
+                    sx: {
+                      backgroundColor: (theme: Theme) => theme.palette.info.main,
+                      color: (theme: Theme) =>
+                        theme.palette.getContrastText(theme.palette.info.main),
+                    },
                   },
                   shipped: {
                     label: t('translation|Shipped'),
@@ -283,7 +291,14 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                   },
                 };
                 const typeInfo = typeLabels[plugin.type || 'shipped'];
-                return <Chip label={typeInfo.label} size="small" color={typeInfo.color} />;
+                return (
+                  <Chip
+                    label={typeInfo.label}
+                    size="small"
+                    color={typeInfo.color}
+                    sx={typeInfo.sx}
+                  />
+                );
               },
             },
             {

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -43,7 +43,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -64,7 +64,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -43,7 +43,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -64,7 +64,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -43,7 +43,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -64,7 +64,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -43,7 +43,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -64,7 +64,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
@@ -43,7 +43,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -64,7 +64,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p
@@ -410,7 +410,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-2ayyqd-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -473,7 +473,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-2ayyqd-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -43,7 +43,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -64,7 +64,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
@@ -43,7 +43,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -64,7 +64,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p
@@ -491,7 +491,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-2ayyqd-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -639,7 +639,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-2ayyqd-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -839,7 +839,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-2ayyqd-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -1046,7 +1046,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-2ayyqd-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.themes.AllThemes.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.themes.AllThemes.stories.storyshot
@@ -1,0 +1,3043 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-15eplcb"
+    >
+      <h4
+        class="MuiTypography-root MuiTypography-h4 MuiTypography-gutterBottom css-1pb18xt-MuiTypography-root"
+      >
+        Theme Verification
+      </h4>
+      <p
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-9vf8gf-MuiTypography-root"
+      >
+        This story renders the PluginSettings component with each of the default application themes. Use this to verify the contrast of the "User-installed" chips and other UI elements.
+      </p>
+      <div
+        class="MuiBox-root css-11y0tqg"
+      >
+        <div
+          class="MuiBox-root css-u522hp"
+        >
+          <div
+            class="MuiTypography-root MuiTypography-subtitle1 css-bs2adw-MuiTypography-root"
+          >
+            Theme: 
+            <strong>
+              light
+            </strong>
+             (
+            light
+            )
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-g7ofe5"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Plugins
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1ipmh7v"
+              >
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                        >
+                          <div
+                            class="MuiStack-root css-5kul5x-MuiStack-root"
+                          >
+                            <div
+                              class="MuiBox-root css-k008qs"
+                            >
+                               
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
+                  style="opacity: 0; visibility: hidden;"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+                  >
+                    Drop to group by 
+                  </p>
+                </div>
+                <div
+                  class="MuiBox-root css-zrlv9q"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-1p0wbhh"
+                  >
+                    <div
+                      class="MuiBox-root css-di3982"
+                    >
+                      <button
+                        aria-label="Show/Hide search"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide filters"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="FilterListIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide columns"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ViewColumnIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="MuiTable-root css-j5wd0t-MuiTable-root"
+              >
+                <thead
+                  class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+                >
+                  <tr
+                    class="css-1lqh5un"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-542uyz-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Name
+                          </div>
+                          <span
+                            aria-label="Sort by Name ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Name ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-11ihby4-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Description
+                          </div>
+                          <span
+                            aria-label="Sort by Description ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Description ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-9s5e2s-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Type
+                          </div>
+                          <span
+                            aria-label="Sort by Type ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Type ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1os7eds-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Origin
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1m1rn7x-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Status
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="css-1obf64m"
+                >
+                  <tr
+                    class="css-1ospngb"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-12snkzy-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/user-plugin-example/user"
+                        >
+                          user-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a user-installed plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-2ayyqd-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          User-installed
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/user-plugin"
+                      >
+                        User
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-xfrc9u-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1ospngb"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-12snkzy-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/dev-plugin-example/development"
+                        >
+                          dev-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a development plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-filledPrimary css-zjbtey-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Development
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/dev-plugin"
+                      >
+                        Dev
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-xfrc9u-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1ospngb"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-12snkzy-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/shipped-plugin-example/shipped"
+                        >
+                          shipped-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a shipped plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-148jm2l-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Shipped
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/shipped-plugin"
+                      >
+                        Headlamp
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-xfrc9u-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="MuiBox-root css-1bxknjp"
+              >
+                <div
+                  class="MuiBox-root css-1llu0od"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-qpxlqp"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-11y0tqg"
+      >
+        <div
+          class="MuiBox-root css-u522hp"
+        >
+          <div
+            class="MuiTypography-root MuiTypography-subtitle1 css-bs2adw-MuiTypography-root"
+          >
+            Theme: 
+            <strong>
+              dark
+            </strong>
+             (
+            dark
+            )
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-4div0l"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Plugins
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1ipmh7v"
+              >
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-mxpy5l-MuiPaper-root-MuiAlert-root"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                        >
+                          <div
+                            class="MuiStack-root css-5kul5x-MuiStack-root"
+                          >
+                            <div
+                              class="MuiBox-root css-k008qs"
+                            >
+                               
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
+                  style="opacity: 0; visibility: hidden;"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+                  >
+                    Drop to group by 
+                  </p>
+                </div>
+                <div
+                  class="MuiBox-root css-zrlv9q"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-1p0wbhh"
+                  >
+                    <div
+                      class="MuiBox-root css-di3982"
+                    >
+                      <button
+                        aria-label="Show/Hide search"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1fm49pm-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide filters"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1fm49pm-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="FilterListIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide columns"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1fm49pm-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ViewColumnIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="MuiTable-root css-6geeki-MuiTable-root"
+              >
+                <thead
+                  class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+                >
+                  <tr
+                    class="css-wxofb2"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-x68q68-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Name
+                          </div>
+                          <span
+                            aria-label="Sort by Name ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Name ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-nb79r7-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fdxqho-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Description
+                          </div>
+                          <span
+                            aria-label="Sort by Description ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Description ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-nb79r7-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qvhph8-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Type
+                          </div>
+                          <span
+                            aria-label="Sort by Type ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Type ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-nb79r7-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ut48l2-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Origin
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-umeihi-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Status
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="css-1obf64m"
+                >
+                  <tr
+                    class="css-u9mgsa"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lrgyxe-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-18mmjzc-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/user-plugin-example/user"
+                        >
+                          user-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-z2erbi-MuiTableCell-root"
+                    >
+                      An example of a user-installed plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-j33fml-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-7nrh78-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          User-installed
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-h11tap-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1f50ofn-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/user-plugin"
+                      >
+                        User
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1f4flmb-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-mpq89t-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-u9mgsa"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lrgyxe-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-18mmjzc-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/dev-plugin-example/development"
+                        >
+                          dev-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-z2erbi-MuiTableCell-root"
+                    >
+                      An example of a development plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-j33fml-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-filledPrimary css-8pypdg-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Development
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-h11tap-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1f50ofn-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/dev-plugin"
+                      >
+                        Dev
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1f4flmb-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-mpq89t-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-u9mgsa"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lrgyxe-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-18mmjzc-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/shipped-plugin-example/shipped"
+                        >
+                          shipped-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-z2erbi-MuiTableCell-root"
+                    >
+                      An example of a shipped plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-j33fml-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1l9gf7d-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Shipped
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-h11tap-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1f50ofn-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/shipped-plugin"
+                      >
+                        Headlamp
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1f4flmb-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-mpq89t-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="MuiBox-root css-1bxknjp"
+              >
+                <div
+                  class="MuiBox-root css-1llu0od"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-qpxlqp"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-11y0tqg"
+      >
+        <div
+          class="MuiBox-root css-u522hp"
+        >
+          <div
+            class="MuiTypography-root MuiTypography-subtitle1 css-bs2adw-MuiTypography-root"
+          >
+            Theme: 
+            <strong>
+              Headlamp Classic
+            </strong>
+             (
+            light
+            )
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-k6r8if"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Plugins
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1ipmh7v"
+              >
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-yxe1uh-MuiPaper-root-MuiAlert-root"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                        >
+                          <div
+                            class="MuiStack-root css-5kul5x-MuiStack-root"
+                          >
+                            <div
+                              class="MuiBox-root css-k008qs"
+                            >
+                               
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
+                  style="opacity: 0; visibility: hidden;"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+                  >
+                    Drop to group by 
+                  </p>
+                </div>
+                <div
+                  class="MuiBox-root css-zrlv9q"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-1p0wbhh"
+                  >
+                    <div
+                      class="MuiBox-root css-di3982"
+                    >
+                      <button
+                        aria-label="Show/Hide search"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide filters"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="FilterListIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide columns"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ViewColumnIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="MuiTable-root css-13kw34t-MuiTable-root"
+              >
+                <thead
+                  class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+                >
+                  <tr
+                    class="css-12nvjnd"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-jqods2-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Name
+                          </div>
+                          <span
+                            aria-label="Sort by Name ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Name ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-118d58w-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-dsqwo-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Description
+                          </div>
+                          <span
+                            aria-label="Sort by Description ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Description ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-118d58w-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1jyxr9-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Type
+                          </div>
+                          <span
+                            aria-label="Sort by Type ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Type ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-118d58w-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1hrbq8u-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Origin
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1d4w7te-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Status
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="css-1obf64m"
+                >
+                  <tr
+                    class="css-iaw4rz"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-hf1w1v-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/user-plugin-example/user"
+                        >
+                          user-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a user-installed plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-omr55x-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          User-installed
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1lglz53-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/user-plugin"
+                      >
+                        User
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-ox608-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-iaw4rz"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-hf1w1v-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/dev-plugin-example/development"
+                        >
+                          dev-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a development plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-filledPrimary css-ix3znj-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Development
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1lglz53-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/dev-plugin"
+                      >
+                        Dev
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-ox608-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-iaw4rz"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-hf1w1v-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/shipped-plugin-example/shipped"
+                        >
+                          shipped-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a shipped plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-8egqs4-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Shipped
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1lglz53-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/shipped-plugin"
+                      >
+                        Headlamp
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-ox608-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="MuiBox-root css-1bxknjp"
+              >
+                <div
+                  class="MuiBox-root css-1llu0od"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-qpxlqp"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-11y0tqg"
+      >
+        <div
+          class="MuiBox-root css-u522hp"
+        >
+          <div
+            class="MuiTypography-root MuiTypography-subtitle1 css-bs2adw-MuiTypography-root"
+          >
+            Theme: 
+            <strong>
+              Lights Out
+            </strong>
+             (
+            dark
+            )
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1d9eukt"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Plugins
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1ipmh7v"
+              >
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-dj4wsp-MuiPaper-root-MuiAlert-root"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                        >
+                          <div
+                            class="MuiStack-root css-5kul5x-MuiStack-root"
+                          >
+                            <div
+                              class="MuiBox-root css-k008qs"
+                            >
+                               
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
+                  style="opacity: 0; visibility: hidden;"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+                  >
+                    Drop to group by 
+                  </p>
+                </div>
+                <div
+                  class="MuiBox-root css-zrlv9q"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-1p0wbhh"
+                  >
+                    <div
+                      class="MuiBox-root css-di3982"
+                    >
+                      <button
+                        aria-label="Show/Hide search"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1fm49pm-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide filters"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1fm49pm-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="FilterListIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide columns"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1fm49pm-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ViewColumnIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="MuiTable-root css-6geeki-MuiTable-root"
+              >
+                <thead
+                  class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+                >
+                  <tr
+                    class="css-1lgxin5"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-mugi43-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Name
+                          </div>
+                          <span
+                            aria-label="Sort by Name ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Name ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-z1n2do-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-13ei9ps-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Description
+                          </div>
+                          <span
+                            aria-label="Sort by Description ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Description ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-z1n2do-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wrrnr6-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Type
+                          </div>
+                          <span
+                            aria-label="Sort by Type ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Type ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-z1n2do-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1jm6dwe-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Origin
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1mqkw8t-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Status
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="css-1obf64m"
+                >
+                  <tr
+                    class="css-1hnlad4"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lrgyxe-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-1upvvd-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/user-plugin-example/user"
+                        >
+                          user-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-z2erbi-MuiTableCell-root"
+                    >
+                      An example of a user-installed plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-j33fml-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-13s4tjg-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          User-installed
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-h11tap-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-9pggim-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/user-plugin"
+                      >
+                        User
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1f4flmb-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-1bwwjse-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1hnlad4"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lrgyxe-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-1upvvd-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/dev-plugin-example/development"
+                        >
+                          dev-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-z2erbi-MuiTableCell-root"
+                    >
+                      An example of a development plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-j33fml-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-filledPrimary css-1c8ron0-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Development
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-h11tap-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-9pggim-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/dev-plugin"
+                      >
+                        Dev
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1f4flmb-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-1bwwjse-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1hnlad4"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-lrgyxe-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-1upvvd-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/shipped-plugin-example/shipped"
+                        >
+                          shipped-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-z2erbi-MuiTableCell-root"
+                    >
+                      An example of a shipped plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-j33fml-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1jyumwp-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Shipped
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-h11tap-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-9pggim-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/shipped-plugin"
+                      >
+                        Headlamp
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1f4flmb-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-1bwwjse-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="MuiBox-root css-1bxknjp"
+              >
+                <div
+                  class="MuiBox-root css-1llu0od"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-qpxlqp"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-11y0tqg"
+      >
+        <div
+          class="MuiBox-root css-u522hp"
+        >
+          <div
+            class="MuiTypography-root MuiTypography-subtitle1 css-bs2adw-MuiTypography-root"
+          >
+            Theme: 
+            <strong>
+              Monochrome Light
+            </strong>
+             (
+            light
+            )
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1rhcry3"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Plugins
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1ipmh7v"
+              >
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-gp1048-MuiPaper-root-MuiAlert-root"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                        >
+                          <div
+                            class="MuiStack-root css-5kul5x-MuiStack-root"
+                          >
+                            <div
+                              class="MuiBox-root css-k008qs"
+                            >
+                               
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
+                  style="opacity: 0; visibility: hidden;"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+                  >
+                    Drop to group by 
+                  </p>
+                </div>
+                <div
+                  class="MuiBox-root css-zrlv9q"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-1p0wbhh"
+                  >
+                    <div
+                      class="MuiBox-root css-di3982"
+                    >
+                      <button
+                        aria-label="Show/Hide search"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide filters"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="FilterListIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide columns"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ViewColumnIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="MuiTable-root css-j5wd0t-MuiTable-root"
+              >
+                <thead
+                  class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+                >
+                  <tr
+                    class="css-orobyx"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1pqmuwf-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Name
+                          </div>
+                          <span
+                            aria-label="Sort by Name ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Name ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1yq7j2g-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-rrh68r-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Description
+                          </div>
+                          <span
+                            aria-label="Sort by Description ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Description ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1yq7j2g-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-okvt6d-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Type
+                          </div>
+                          <span
+                            aria-label="Sort by Type ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Type ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1yq7j2g-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-f4um5e-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Origin
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-6m55co-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Status
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="css-1obf64m"
+                >
+                  <tr
+                    class="css-1guigkd"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-35r211-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/user-plugin-example/user"
+                        >
+                          user-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a user-installed plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-16m1ezg-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          User-installed
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-10el08t-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/user-plugin"
+                      >
+                        User
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-1w52w35-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1guigkd"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-35r211-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/dev-plugin-example/development"
+                        >
+                          dev-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a development plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-filledPrimary css-1umycb5-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Development
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-10el08t-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/dev-plugin"
+                      >
+                        Dev
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-1w52w35-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1guigkd"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-subtitle1 css-1t3dwd5-MuiTypography-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiTypography-alignRight MuiLink-root MuiLink-underlineHover css-35r211-MuiTypography-root-MuiLink-root"
+                          href="/settings/plugins/shipped-plugin-example/shipped"
+                        >
+                          shipped-plugin-example
+                        </a>
+                      </div>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1yjsbnr-MuiTypography-root"
+                      />
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
+                    >
+                      An example of a shipped plugin
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-9jadv7-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Shipped
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
+                    >
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-10el08t-MuiTypography-root-MuiLink-root"
+                        href="https://example.com/shipped-plugin"
+                      >
+                        Headlamp
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-i01a7i-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-1w52w35-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                        >
+                          Loaded
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="MuiBox-root css-1bxknjp"
+              >
+                <div
+                  class="MuiBox-root css-1llu0od"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-qpxlqp"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
+++ b/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
@@ -48,7 +48,7 @@
               class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
             >
               <div
-                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                 role="alert"
               >
                 <div
@@ -69,7 +69,7 @@
           </div>
         </div>
         <div
-          class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+          class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
           style="opacity: 0; visibility: hidden;"
         >
           <p

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -40,7 +40,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -61,7 +61,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
@@ -123,7 +123,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
@@ -123,7 +123,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
@@ -123,7 +123,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
@@ -161,7 +161,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -182,7 +182,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
@@ -123,7 +123,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
@@ -123,7 +123,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
@@ -31,7 +31,7 @@
               class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
             >
               <div
-                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                 role="alert"
               >
                 <div
@@ -52,7 +52,7 @@
           </div>
         </div>
         <div
-          class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+          class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
           style="opacity: 0; visibility: hidden;"
         >
           <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
@@ -31,7 +31,7 @@
               class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
             >
               <div
-                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                 role="alert"
               >
                 <div
@@ -52,7 +52,7 @@
           </div>
         </div>
         <div
-          class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+          class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
           style="opacity: 0; visibility: hidden;"
         >
           <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
@@ -123,7 +123,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
@@ -14,7 +14,7 @@
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
               role="alert"
             >
               <div
@@ -35,7 +35,7 @@
         </div>
       </div>
       <div
-        class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+        class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
         style="opacity: 0; visibility: hidden;"
       >
         <p

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -620,7 +620,7 @@
                       class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
                       <div
-                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                         role="alert"
                       >
                         <div
@@ -641,7 +641,7 @@
                   </div>
                 </div>
                 <div
-                  class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+                  class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
                   style="opacity: 0; visibility: hidden;"
                 >
                   <p

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -40,7 +40,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -61,7 +61,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -151,7 +151,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -172,7 +172,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -144,7 +144,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -165,7 +165,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -144,7 +144,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -165,7 +165,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -52,7 +52,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -52,7 +52,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -52,7 +52,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -55,7 +55,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -76,7 +76,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -52,7 +52,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -144,7 +144,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -165,7 +165,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -52,7 +52,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -172,7 +172,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -193,7 +193,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -52,7 +52,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -52,7 +52,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -141,7 +141,7 @@
                 class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                   role="alert"
                 >
                   <div
@@ -162,7 +162,7 @@
             </div>
           </div>
           <div
-            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
             style="opacity: 0; visibility: hidden;"
           >
             <p

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -55,7 +55,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -76,7 +76,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -55,7 +55,7 @@
                   class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                    class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                     role="alert"
                   >
                     <div
@@ -76,7 +76,7 @@
               </div>
             </div>
             <div
-              class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+              class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
               style="opacity: 0; visibility: hidden;"
             >
               <p

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1022,7 +1022,7 @@
                         class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-9hz0j4-MuiPaper-root-MuiAlert-root"
                           role="alert"
                         >
                           <div
@@ -1043,7 +1043,7 @@
                     </div>
                   </div>
                   <div
-                    class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+                    class="Mui-ToolbarDropZone MuiBox-root css-xad10n"
                     style="opacity: 0; visibility: hidden;"
                   >
                     <p

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -249,6 +249,9 @@ export function createMuiTheme(currentTheme: AppTheme) {
         main: red['800'],
         light: red['50'],
       },
+      info: {
+        main: '#015493',
+      },
       resourceToolTip: {
         color: 'rgba(0, 0, 0, 0.87)',
       },
@@ -434,6 +437,7 @@ export function createMuiTheme(currentTheme: AppTheme) {
         resourceToolTip: {
           color: 'rgba(255, 255, 255, 0.87)',
         },
+
         clusterChooser: {
           button: {
             color: '#fff',


### PR DESCRIPTION
## Summary

This PR fixes the color contrast issue for the "User-installed" chip in the Plugin Settings. The previous color combination (#ffffff on #0288d1) had a contrast ratio of 3.85:1, which failed the WCAG AA requirement of 4.5:1. This change updates the background color to `#015493` to meet accessibility standards.

## Related Issue

Fixes #4592

## Changes

- Updated [PluginSettings.tsx] to allow [sx] prop in `typeLabels` definition.
- Changed "User-installed" chip background color to `#015493`.
- Applied [sx] prop to the `Chip` component for custom styling.


## Screenshots

Before:
<img width="576" height="444" alt="Screenshot 2026-02-15 201303" src="https://github.com/user-attachments/assets/0ff93353-031f-4bb3-a434-035f483fca9e" />
After:
<img width="584" height="446" alt="_2" src="https://github.com/user-attachments/assets/367c49fd-c6b9-4d4c-88e0-dc385cd2da08" />

Before:

<img width="695" height="38" alt="lights-out-dark-old" src="https://github.com/user-attachments/assets/11758d78-ea0f-478c-9466-5b4907dccc29" />
<img width="703" height="40" alt="dark-theme-old" src="https://github.com/user-attachments/assets/f3d7e0f2-393e-431c-a745-151390c5c18d" />
<img width="709" height="44" alt="light-theme-old" src="https://github.com/user-attachments/assets/d88ca2b3-bd7b-443f-8739-5ab2c6e628f3" />

After:

<img width="736" height="37" alt="lights-out-dark-new" src="https://github.com/user-attachments/assets/1abf7627-447f-4fcb-9c52-e39feac69dde" />
<img width="734" height="38" alt="dark-new" src="https://github.com/user-attachments/assets/c187f2e0-89e3-475b-832b-6517013bd373" />
<img width="707" height="38" alt="light-theme-new" src="https://github.com/user-attachments/assets/59e9d84d-ea67-4bc9-909c-6f81e4eb4b43" />



## Notes for the Reviewer

- Checked against [WCAG AA contrast guidelines](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=01579B).
