### PR TITLE
fix(a11y) : remove empty h1 from ClusterDialog

### DIFF
--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -48,6 +48,11 @@
                 <div
                   class="MuiBox-root css-19midj6"
                 />
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -71,6 +71,11 @@
                 <div
                   class="MuiBox-root css-19midj6"
                 />
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -44,6 +44,11 @@
                 <div
                   class="MuiBox-root css-19midj6"
                 />
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -44,6 +44,11 @@
                 <div
                   class="MuiBox-root css-19midj6"
                 />
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -44,6 +44,11 @@
                 <div
                   class="MuiBox-root css-19midj6"
                 />
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -44,6 +44,11 @@
                 <div
                   class="MuiBox-root css-19midj6"
                 />
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
@@ -44,6 +44,11 @@
                 <div
                   class="MuiBox-root css-19midj6"
                 />
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -31,6 +31,7 @@ import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { visuallyHidden } from '@mui/utils';
 import _ from 'lodash';
 import React, { isValidElement, PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -340,6 +341,9 @@ export function ClusterDialog(props: ClusterDialogProps) {
             width: 'auto',
           }}
         />
+        <Box component="span" sx={visuallyHidden}>
+          Headlamp
+        </Box>
       </DialogTitle>
       <DialogContent
         dividers

--- a/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
@@ -97,6 +97,11 @@
                     fill="#1B1A19"
                   />
                 </svg>
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.NoClusters.stories.storyshot
@@ -97,6 +97,11 @@
                     fill="#1B1A19"
                   />
                 </svg>
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
@@ -97,6 +97,11 @@
                     fill="#1B1A19"
                   />
                 </svg>
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div

--- a/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
@@ -97,6 +97,11 @@
                     fill="#1B1A19"
                   />
                 </svg>
+                <span
+                  class="MuiBox-root css-ty8jgw"
+                >
+                  Headlamp
+                </span>
               </h1>
             </div>
             <div


### PR DESCRIPTION
## Summary
This PR fixes accessibility violations across multiple dialog components where the header rendered an empty `<h1>` containing only an SVG logo. 

The implementation ensures that `ClusterDialog` maintains a semantic `<h1>` structure for screen readers while preventing visual layout shifts, resolving WCAG "Empty Heading" errors.

## Related Issues
Fixes #4594, #4595, #4596, #4597, #4598, #4599, #4600, #4601, #4602, #4603, #4604

## Changes
* **Semantic Heading Fix**: Updated `ClusterDialog` in `frontend/src/components/cluster/Chooser.tsx` to include visually hidden text ("Headlamp") within the `<h1>`.


## Steps to Test
1. Run Storybook: `npm run storybook`
2. Open any of the following stories:
   - `AuthToken` -> `ShowActions`
   - `AuthChooser` -> `BasicAuthChooser`
   - `Cluster` -> `Chooser`
3. **Inspect the DOM**:
   - Verify the logo container remains an **`<h1>`**.
   - Verify the `<h1>` now contains a span with the text **"Headlamp"** that is visually hidden.

## Notes for the Reviewer

This single change in ClusterDialog fixes the issue for all components that use it as a wrapper (AuthToken, AuthChooser, ClusterChooser).