### PR TITLE
frontend: SettingsClusters stories for cluster list states

### DIFF
--- a/frontend/src/components/App/Settings/SettingsClusters.stories.tsx
+++ b/frontend/src/components/App/Settings/SettingsClusters.stories.tsx
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Storybook stories for SettingsClusters component.
+ * Demonstrates various cluster configuration states including
+ * normal cluster lists, empty states, single cluster, and many clusters.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { Meta, StoryFn } from '@storybook/react';
+import { Cluster } from '../../../lib/k8s/cluster';
+import { initialState } from '../../../redux/configSlice';
+import { TestContext } from '../../../test';
+import SettingsClusters from './SettingsClusters';
+
+/**
+ * Helper to convert Cluster array to a name->cluster record.
+ * @param clusters - Array of cluster objects
+ * @returns Record mapping cluster names to cluster objects
+ */
+const clustersToRecord = (clusters: Cluster[]): Record<string, Cluster> =>
+  clusters.reduce((acc, cluster) => {
+    acc[cluster.name] = cluster;
+    return acc;
+  }, {} as Record<string, Cluster>);
+
+/**
+ * Creates mock state with cluster configuration.
+ * @param clusters - Array of cluster objects to include in the state
+ * @returns Mock Redux state object
+ */
+const getMockState = (clusters?: Cluster[] | null) => {
+  const clusterRecord = clusters === null ? null : clusters ? clustersToRecord(clusters) : {};
+
+  return {
+    config: {
+      ...initialState,
+      clusters: clusterRecord,
+      allClusters: clusterRecord,
+    },
+    filter: {
+      search: '',
+    },
+    plugins: {
+      loaded: true,
+    },
+    ui: {
+      clusterChooserButtonComponent: null,
+    },
+    theme: {
+      logo: null,
+      name: 'light',
+    },
+  };
+};
+
+export default {
+  title: 'Settings/SettingsClusters',
+  component: SettingsClusters,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a table of configured clusters with their names and server URLs. ' +
+          'Each cluster name is a clickable link to the cluster settings page.',
+      },
+    },
+  },
+} as Meta<typeof SettingsClusters>;
+
+/**
+ * Args type for story template.
+ */
+interface StoryArgs {
+  clusters: Cluster[] | null;
+}
+
+/**
+ * Story template with Redux Provider and TestContext.
+ */
+const Template: StoryFn<StoryArgs> = args => {
+  const { clusters } = args;
+
+  return (
+    <TestContext
+      store={configureStore({
+        reducer: (state = getMockState()) => state,
+        preloadedState: getMockState(clusters),
+      })}
+    >
+      <SettingsClusters />
+    </TestContext>
+  );
+};
+
+/**
+ * Default story showing a typical cluster list with multiple clusters.
+ * Displays three clusters with different server URLs.
+ */
+export const ClusterListDisplay = Template.bind({});
+ClusterListDisplay.args = {
+  clusters: [
+    {
+      name: 'production',
+      server: 'https://prod-k8s.example.com:6443',
+      auth_type: 'token',
+    },
+    {
+      name: 'staging',
+      server: 'https://staging-k8s.example.com:6443',
+      auth_type: 'oidc',
+    },
+    {
+      name: 'development',
+      server: 'https://dev-k8s.example.com:6443',
+      auth_type: 'token',
+    },
+  ],
+};
+
+/**
+ * Empty state story showing when no clusters are configured.
+ * This demonstrates the empty table state.
+ */
+export const EmptyClusterList = Template.bind({});
+EmptyClusterList.args = {
+  clusters: [],
+};
+EmptyClusterList.parameters = {
+  docs: {
+    description: {
+      story: 'Shows the component state when no clusters are configured.',
+    },
+  },
+};
+
+/**
+ * Single cluster story showing minimal configuration.
+ * Useful for testing single-cluster environments.
+ */
+export const SingleCluster = Template.bind({});
+SingleCluster.args = {
+  clusters: [
+    {
+      name: 'my-cluster',
+      server: 'https://kubernetes.default.svc.cluster.local:6443',
+      auth_type: 'serviceAccount',
+    },
+  ],
+};
+SingleCluster.parameters = {
+  docs: {
+    description: {
+      story: 'Displays a single cluster configuration.',
+    },
+  },
+};
+
+/**
+ * Many clusters story for testing scrolling and performance.
+ * Shows 15 clusters to demonstrate table behavior with many entries.
+ */
+export const ManyClusters = Template.bind({});
+ManyClusters.args = {
+  clusters: Array(15)
+    .fill(0)
+    .map((_, i) => ({
+      name: `cluster-${i + 1}`,
+      server: `https://cluster-${i + 1}.k8s.example.com:6443`,
+      auth_type: i % 3 === 0 ? 'token' : i % 3 === 1 ? 'oidc' : 'serviceAccount',
+    })),
+};
+ManyClusters.parameters = {
+  docs: {
+    description: {
+      story: 'Demonstrates the component with many clusters to test scrolling and table behavior.',
+    },
+  },
+};
+
+/**
+ * Clusters with various configurations and metadata.
+ * Shows different auth types and server URL formats.
+ */
+export const VariousConfigurations = Template.bind({});
+VariousConfigurations.args = {
+  clusters: [
+    {
+      name: 'local-kind',
+      server: 'https://127.0.0.1:6443',
+      auth_type: 'token',
+    },
+    {
+      name: 'minikube',
+      server: 'https://192.168.49.2:8443',
+      auth_type: 'certificate',
+    },
+    {
+      name: 'eks-cluster',
+      server: 'https://ABC123DEF456.gr7.us-west-2.eks.amazonaws.com',
+      auth_type: 'oidc',
+    },
+    {
+      name: 'gke-cluster',
+      server: 'https://34.123.45.67',
+      auth_type: 'oidc',
+    },
+    {
+      name: 'aks-cluster',
+      server: 'https://myaks-dns-12345678.hcp.eastus.azmk8s.io:443',
+      auth_type: 'oidc',
+    },
+  ],
+};
+VariousConfigurations.parameters = {
+  docs: {
+    description: {
+      story:
+        'Shows clusters with various configurations including local development clusters ' +
+        'and managed Kubernetes services (EKS, GKE, AKS).',
+    },
+  },
+};
+
+/**
+ * Clusters with long names and URLs for testing text overflow.
+ * Verifies that the component handles long strings gracefully.
+ */
+export const LongNamesAndURLs = Template.bind({});
+LongNamesAndURLs.args = {
+  clusters: [
+    {
+      name: 'very-long-production-cluster-name-for-enterprise-deployment',
+      server:
+        'https://very-long-subdomain-name-for-kubernetes-api-server.production.enterprise.example.com:6443',
+      auth_type: 'oidc',
+    },
+    {
+      name: 'another-extremely-long-cluster-identifier-with-multiple-hyphens',
+      server: 'https://another-very-long-server-url.staging.corporate.example.org:8443',
+      auth_type: 'token',
+    },
+  ],
+};
+LongNamesAndURLs.parameters = {
+  docs: {
+    description: {
+      story:
+        'Tests the component with very long cluster names and server URLs to verify proper text handling.',
+    },
+  },
+};
+
+/**
+ * Null cluster state - equivalent to empty cluster list.
+ * When clusters are null, SettingsClusters renders Object.values(clusterConf || {}),
+ * which produces an empty array, resulting in the same display as EmptyClusterList.
+ */
+export const NullClusterState = Template.bind({});
+NullClusterState.args = {
+  clusters: null,
+};
+NullClusterState.parameters = {
+  docs: {
+    description: {
+      story:
+        'Shows the component when clusters are null. Note: This renders identically to EmptyClusterList ' +
+        'because the component converts null to an empty array via Object.values(clusterConf || {}).',
+    },
+  },
+};

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ClusterListDisplay.stories.storyshot
@@ -1,0 +1,122 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Cluster Settings
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+          tabindex="0"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Name
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Server
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=production"
+                  >
+                    production
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://prod-k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=staging"
+                  >
+                    staging
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://staging-k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=development"
+                  >
+                    development
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://dev-k8s.example.com:6443
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.EmptyClusterList.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.EmptyClusterList.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Cluster Settings
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.LongNamesAndURLs.stories.storyshot
@@ -1,0 +1,103 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Cluster Settings
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+          tabindex="0"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Name
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Server
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=very-long-production-cluster-name-for-enterprise-deployment"
+                  >
+                    very-long-production-cluster-name-for-enterprise-deployment
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://very-long-subdomain-name-for-kubernetes-api-server.production.enterprise.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=another-extremely-long-cluster-identifier-with-multiple-hyphens"
+                  >
+                    another-extremely-long-cluster-identifier-with-multiple-hyphens
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://another-very-long-server-url.staging.corporate.example.org:8443
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.ManyClusters.stories.storyshot
@@ -1,0 +1,350 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Cluster Settings
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+          tabindex="0"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Name
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Server
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-1"
+                  >
+                    cluster-1
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-1.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-2"
+                  >
+                    cluster-2
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-2.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-3"
+                  >
+                    cluster-3
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-3.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-4"
+                  >
+                    cluster-4
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-4.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-5"
+                  >
+                    cluster-5
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-5.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-6"
+                  >
+                    cluster-6
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-6.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-7"
+                  >
+                    cluster-7
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-7.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-8"
+                  >
+                    cluster-8
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-8.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-9"
+                  >
+                    cluster-9
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-9.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-10"
+                  >
+                    cluster-10
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-10.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-11"
+                  >
+                    cluster-11
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-11.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-12"
+                  >
+                    cluster-12
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-12.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-13"
+                  >
+                    cluster-13
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-13.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-14"
+                  >
+                    cluster-14
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-14.k8s.example.com:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=cluster-15"
+                  >
+                    cluster-15
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://cluster-15.k8s.example.com:6443
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.NullClusterState.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.NullClusterState.stories.storyshot
@@ -1,0 +1,45 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Cluster Settings
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.SingleCluster.stories.storyshot
@@ -1,0 +1,84 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Cluster Settings
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+          tabindex="0"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Name
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Server
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=my-cluster"
+                  >
+                    my-cluster
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://kubernetes.default.svc.cluster.local:6443
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsClusters.VariousConfigurations.stories.storyshot
@@ -1,0 +1,160 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Cluster Settings
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+          tabindex="0"
+        >
+          <table
+            class="MuiTable-root css-1ml9dpn-MuiTable-root"
+          >
+            <thead
+              class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+            >
+              <tr
+                class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+              >
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Name
+                </th>
+                <th
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                  scope="col"
+                >
+                  Server
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+            >
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=local-kind"
+                  >
+                    local-kind
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://127.0.0.1:6443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=minikube"
+                  >
+                    minikube
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://192.168.49.2:8443
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=eks-cluster"
+                  >
+                    eks-cluster
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://ABC123DEF456.gr7.us-west-2.eks.amazonaws.com
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=gke-cluster"
+                  >
+                    gke-cluster
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://34.123.45.67
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                    href="/settings/cluster?c=aks-cluster"
+                  >
+                    aks-cluster
+                  </a>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  https://myaks-dns-12345678.hcp.eastus.azmk8s.io:443
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary
This PR adds comprehensive Storybook coverage for the SettingsClusters, increasing test coverage from 0% to full visual documentation across all component states.

## Related Issue
Fixes #4683 

## Steps to Test
- npm run frontend:storybook
- Go to Settings > SettingsClusters in the sidebar
- Test each story