### PR TITLE
frontend: Add Storybook stories for ResourceTableColumnChooser

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTableColumnChooser.stories.tsx
+++ b/frontend/src/components/common/Resource/ResourceTableColumnChooser.stories.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Button from '@mui/material/Button';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { TestContext } from '../../../test';
+import { ResourceTableColumn } from './ResourceTable';
+import ColumnsPopup from './ResourceTableColumnChooser';
+
+export default {
+  title: 'Resource/ResourceTableColumnChooser',
+  component: ColumnsPopup,
+  argTypes: {
+    onToggleColumn: { action: 'column toggled' },
+    onClose: { action: 'closed' },
+  },
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+interface ColumnsPopupWithAnchorProps {
+  columns: ResourceTableColumn<any>[];
+  onToggleColumn: (cols: ResourceTableColumn<any>[]) => void;
+  onClose: () => void;
+  startOpen?: boolean;
+}
+
+function ColumnsPopupWithAnchor(props: ColumnsPopupWithAnchorProps) {
+  const { columns: initialColumns, onToggleColumn, onClose, startOpen = true } = props;
+  const [columns, setColumns] = React.useState(initialColumns);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (startOpen && buttonRef.current) {
+      setAnchorEl(buttonRef.current);
+    }
+  }, [startOpen]);
+
+  const handleClose = () => {
+    setAnchorEl(null);
+    onClose();
+  };
+  const handleToggleColumn = (newColumns: ResourceTableColumn<any>[]) => {
+    setColumns(newColumns);
+    onToggleColumn(newColumns);
+  };
+  return (
+    <>
+      <Button ref={buttonRef} variant="outlined" onClick={e => setAnchorEl(e.currentTarget)}>
+        Choose Columns
+      </Button>
+      <ColumnsPopup
+        columns={columns}
+        onToggleColumn={handleToggleColumn}
+        onClose={handleClose}
+        anchorEl={anchorEl}
+      />
+    </>
+  );
+}
+
+const Template: StoryFn<ColumnsPopupWithAnchorProps> = args => <ColumnsPopupWithAnchor {...args} />;
+
+const defaultColumns: ResourceTableColumn<any>[] = [
+  { id: 'name', label: 'Name', show: true, getValue: item => item.name },
+  { id: 'namespace', label: 'Namespace', show: true, getValue: item => item.namespace },
+  { id: 'age', label: 'Age', show: true, getValue: item => item.age },
+  { id: 'status', label: 'Status', show: false, getValue: item => item.status },
+  { id: 'labels', label: 'Labels', show: false, getValue: item => item.labels },
+];
+
+const defaultArgs = {
+  columns: defaultColumns,
+  startOpen: true,
+};
+
+// Column list with checkboxes - some visible, some hidden
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+// All columns selected
+export const AllColumnsVisible = Template.bind({});
+AllColumnsVisible.args = {
+  ...defaultArgs,
+  columns: [
+    { id: 'name', label: 'Name', show: true, getValue: item => item.name },
+    { id: 'namespace', label: 'Namespace', show: true, getValue: item => item.namespace },
+    { id: 'age', label: 'Age', show: true, getValue: item => item.age },
+    { id: 'status', label: 'Status', show: true, getValue: item => item.status },
+    { id: 'labels', label: 'Labels', show: true, getValue: item => item.labels },
+  ],
+};
+
+// All columns deselected
+export const AllColumnsHidden = Template.bind({});
+AllColumnsHidden.args = {
+  ...defaultArgs,
+  columns: [
+    { id: 'name', label: 'Name', show: false, getValue: item => item.name },
+    { id: 'namespace', label: 'Namespace', show: false, getValue: item => item.namespace },
+    { id: 'age', label: 'Age', show: false, getValue: item => item.age },
+    { id: 'status', label: 'Status', show: false, getValue: item => item.status },
+    { id: 'labels', label: 'Labels', show: false, getValue: item => item.labels },
+  ],
+};
+
+// Many columns to allow scrolling
+export const ManyColumns = Template.bind({});
+ManyColumns.args = {
+  ...defaultArgs,
+  columns: [
+    { id: 'name', label: 'Name', show: true, getValue: () => '' },
+    { id: 'namespace', label: 'Namespace', show: true, getValue: () => '' },
+    { id: 'age', label: 'Age', show: true, getValue: () => '' },
+    { id: 'status', label: 'Status', show: true, getValue: () => '' },
+    { id: 'ready', label: 'Ready', show: false, getValue: () => '' },
+    { id: 'restarts', label: 'Restarts', show: false, getValue: () => '' },
+    { id: 'node', label: 'Node', show: false, getValue: () => '' },
+    { id: 'ip', label: 'IP', show: false, getValue: () => '' },
+    { id: 'labels', label: 'Labels', show: false, getValue: () => '' },
+    { id: 'annotations', label: 'Annotations', show: false, getValue: () => '' },
+  ],
+};
+
+// Popover closed state
+export const Closed = Template.bind({});
+Closed.args = {
+  ...defaultArgs,
+  startOpen: false,
+};

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsHidden.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsHidden.stories.storyshot
@@ -1,0 +1,269 @@
+<body>
+  <div
+    aria-hidden="true"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      Choose Columns
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+  <div
+    class="MuiPopover-root MuiModal-root css-1i0e6f3-MuiModal-root-MuiPopover-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop css-g3hgs1-MuiBackdrop-root-MuiModal-backdrop"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiPopover-paper css-qmfbpu-MuiPaper-root-MuiPopover-paper"
+      style="opacity: 1; transform: none; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 16px; left: 16px; transform-origin: -16px -16px;"
+      tabindex="-1"
+    >
+      <ul
+        class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      >
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-0"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-0-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Name
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-1"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-1-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Namespace
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-2"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-2-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Age
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-3"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-3-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Status
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-4"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-4-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Labels
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+      </ul>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsVisible.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.AllColumnsVisible.stories.storyshot
@@ -1,0 +1,274 @@
+<body>
+  <div
+    aria-hidden="true"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      Choose Columns
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+  <div
+    class="MuiPopover-root MuiModal-root css-1i0e6f3-MuiModal-root-MuiPopover-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop css-g3hgs1-MuiBackdrop-root-MuiModal-backdrop"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiPopover-paper css-qmfbpu-MuiPaper-root-MuiPopover-paper"
+      style="opacity: 1; transform: none; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 16px; left: 16px; transform-origin: -16px -16px;"
+      tabindex="-1"
+    >
+      <ul
+        class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      >
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-0"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-0-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Name
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-1"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-1-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Namespace
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-2"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-2-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Age
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-3"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-3-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Status
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-4"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-4-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Labels
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+      </ul>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.Closed.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.Closed.stories.storyshot
@@ -1,0 +1,14 @@
+<body>
+  <div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      Choose Columns
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.Default.stories.storyshot
@@ -1,0 +1,272 @@
+<body>
+  <div
+    aria-hidden="true"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      Choose Columns
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+  <div
+    class="MuiPopover-root MuiModal-root css-1i0e6f3-MuiModal-root-MuiPopover-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop css-g3hgs1-MuiBackdrop-root-MuiModal-backdrop"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiPopover-paper css-qmfbpu-MuiPaper-root-MuiPopover-paper"
+      style="opacity: 1; transform: none; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 16px; left: 16px; transform-origin: -16px -16px;"
+      tabindex="-1"
+    >
+      <ul
+        class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      >
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-0"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-0-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Name
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-1"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-1-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Namespace
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-2"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-2-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Age
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-3"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-3-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Status
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-4"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-4-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Labels
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+      </ul>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.ManyColumns.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTableColumnChooser.ManyColumns.stories.storyshot
@@ -1,0 +1,498 @@
+<body>
+  <div
+    aria-hidden="true"
+  >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      Choose Columns
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+  <div
+    class="MuiPopover-root MuiModal-root css-1i0e6f3-MuiModal-root-MuiPopover-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiBackdrop-invisible MuiModal-backdrop css-g3hgs1-MuiBackdrop-root-MuiModal-backdrop"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiPopover-paper css-qmfbpu-MuiPaper-root-MuiPopover-paper"
+      style="opacity: 1; transform: none; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; top: 16px; left: 16px; transform-origin: -16px -16px;"
+      tabindex="-1"
+    >
+      <ul
+        class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      >
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-0"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-0-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Name
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-1"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-1-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Namespace
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-2"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-2-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Age
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-3"
+                checked=""
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-3-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Status
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-4"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-4-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Ready
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-5"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-5-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Restarts
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-6"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-6-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Node
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-7"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-7-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              IP
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-8"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-8-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Labels
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+        <div
+          class="MuiButtonBase-root MuiListItem-root MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-button css-97b0kf-MuiButtonBase-root-MuiListItem-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorDefault MuiCheckbox-sizeMedium css-1xy1w9p-MuiButtonBase-root-MuiCheckbox-root"
+            >
+              <input
+                aria-labelledby="column-index-9"
+                class="PrivateSwitchBase-input css-1m9pwf3"
+                data-indeterminate="false"
+                tabindex="-1"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="CheckBoxOutlineBlankIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="MuiListItemText-root MuiListItemText-dense css-tlelie-MuiListItemText-root"
+            id="column-index-9-label"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 MuiListItemText-primary css-z2qth0-MuiTypography-root"
+            >
+              Annotations
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </div>
+      </ul>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>


### PR DESCRIPTION
## Summary
This PR adds Storybook stories for the ResourceTableColumnChooser component to improve test coverage and visual documentation.

## Related Issue
Fixes #4692

## Changes
- Created `ResourceTableColumnChooser.stories.tsx` with stories covering:
  - Default state (mix of visible/hidden columns)
  - All columns visible
  - All columns hidden
  - Many columns (scroll behavior)
  - Closed state (popup not open)

## Steps to Test
1. Run `cd frontend && npm run storybook`
2. Navigate to "Resource/ResourceTableColumnChooser" in sidebar
3. Click through each story to verify UI states
4. Test checkbox toggling in Default story

## Notes for the Reviewer
- Coverage increased from 0% to ~50%
- Reset to defaults and save preferences are not included because ResourceTableColumnChooser only handles displaying checkboxes and calling onToggleColumn. That logic is in the parent ResourceTable component (uses localStorage via storeTableSettings/loadTableSettings).