### PR TITLE
fix: Update Terminal snapshots which causes failed test while checks

### DIFF
--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalAttachEmptyFirstOutput.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalAttachEmptyFirstOutput.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Attach: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectedAndReady.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectedAndReady.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectionFailed.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectionFailed.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectionLoading.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectionLoading.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalDefaultNodeSelector.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalDefaultNodeSelector.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalDisconnected.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalDisconnected.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalInitAndEphemeralContainers.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalInitAndEphemeralContainers.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalShellNotFoundTryNext.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalShellNotFoundTryNext.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsNodeSelector.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsNodeSelector.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsShellNotFound.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsShellNotFound.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalWithCommandOutput.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalWithCommandOutput.stories.storyshot
@@ -39,6 +39,7 @@
             >
               <h1
                 class="MuiTypography-root MuiTypography-h1 css-1kazmbo-MuiTypography-root"
+                id=":mock-test-id:"
                 style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
               >
                 Terminal: mock-pod


### PR DESCRIPTION
## Summary
This PR updates the Terminal component snapshots to include the new `id` attribute that was added in a previous PR.

## Related Issue
Fixes failing CI tests on main branch

## Changes
- Updated 11 Terminal snapshot files to include `id=":mock-test-id:"` attribute

## Steps to Test
1. Run `cd frontend && npm run test`
2. All Terminal snapshot tests should pass

