### PR TITLE
cloudbuild: Use correct staging repo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
       - DOCKER_CMD= # Because we are using a custom entrypoint, we need to set DOCKER_CMD to empty
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - DOCKER_PUSH=true
-      - DOCKER_REPO=gcr.io/k8s-staging-headlamp
+      - DOCKER_REPO=gcr.io/k8s-staging-images
       - DOCKER_IMAGE_NAME=headlamp
       - DOCKER_IMAGE_VERSION=$_PULL_BASE_REF
 substitutions:


### PR DESCRIPTION
## Summary

This PR fixes the Kubernetes SIGs repo name for Headlamp's container image.
It's part of the effort of having images in the official Kubernetes registry.

