### PR TITLE
app: i18next: Fix translations by using fs-backend with frontend locales path

### DIFF
--- a/app/electron/i18next.config.ts
+++ b/app/electron/i18next.config.ts
@@ -15,50 +15,31 @@
  */
 
 import i18next from 'i18next';
-import { CURRENT_LOCALES } from './i18n-helper';
+import * as path from 'path';
+import { CURRENT_LOCALES, LOCALES_DIR } from './i18n-helper';
 const i18nextBackend = require('i18next-fs-backend');
 
-const en = {}; // To keep TS happy.
-
-i18next
-  // Use dynamic imports (webpack code splitting) to load javascript bundles.
-  // @see https://www.i18next.com/misc/creating-own-plugins#backend
-  // @see https://webpack.js.org/guides/code-splitting/
-  .use(i18nextBackend)
-  .use({
-    type: 'backend',
-    read<Namespace extends keyof typeof en>(
-      language: string | any,
-      namespace: Namespace,
-      callback: (errorValue: unknown, translations: null | (typeof en)[Namespace]) => void
-    ) {
-      import(`./locales/${language}/${namespace}.json`)
-        .then(resources => {
-          callback(null, resources);
-        })
-        .catch(error => {
-          callback(error, null);
-        });
+i18next.use(i18nextBackend).init({
+  debug: process.env.NODE_ENV === 'development',
+  fallbackLng: 'en',
+  supportedLngs: CURRENT_LOCALES,
+  ns: ['app'],
+  defaultNS: 'app',
+  backend: {
+    loadPath: path.join(LOCALES_DIR, '{{lng}}/{{ns}}.json'),
+  },
+  interpolation: {
+    escapeValue: false, // not needed for react as it escapes by default
+    format: function (value, format, lng) {
+      // https://www.i18next.com/translation-function/formatting
+      if (format === 'number') return new Intl.NumberFormat(lng).format(value);
+      if (format === 'date') return new Intl.DateTimeFormat(lng).format(value);
+      return value;
     },
-  })
-  .init({
-    debug: process.env.NODE_ENV === 'development',
-    fallbackLng: 'en',
-    supportedLngs: CURRENT_LOCALES,
-    ns: ['app'],
-    defaultNS: 'app',
-    interpolation: {
-      escapeValue: false, // not needed for react as it escapes by default
-      format: function (value, format, lng) {
-        // https://www.i18next.com/translation-function/formatting
-        if (format === 'number') return new Intl.NumberFormat(lng).format(value);
-        if (format === 'date') return new Intl.DateTimeFormat(lng).format(value);
-        return value;
-      },
-    },
-    returnEmptyString: false,
-    nsSeparator: '|',
-    keySeparator: false,
-  });
+  },
+  returnEmptyString: false,
+  nsSeparator: '|',
+  keySeparator: false,
+});
 
 export default i18next;

--- a/app/package.json
+++ b/app/package.json
@@ -137,6 +137,10 @@
         "to": "frontend"
       },
       {
+        "from": "../frontend/src/i18n/locales",
+        "to": "frontend/i18n/locales"
+      },
+      {
         "from": "../.plugins",
         "to": ".plugins"
       },


### PR DESCRIPTION
Fixes #4732

The Electron main process translations stopped working because i18next.config.ts still used a custom dynamic-import backend loading from a non-existent app/electron/locales/ directory.

Changes:
Configured i18next-fs-backend with loadPath pointing to LOCALES_DIR from i18n-helper.ts, which resolves to the correct frontend locales directory
Removed the broken custom backend that attempted import('./locales/...')
Added extraResources entry in package.json to copy locales into the packaged app at frontend/i18n/locales, where i18n-helper.ts expects them at runtime


How to test:
Run the app in dev mode, verify menu items and dialogs are translated when switching locale
Build the app (npm run build) and run the packaged binary, verify translations still work  

<img width="535" height="393" alt="image" src="https://github.com/user-attachments/assets/5d792ec4-9f97-4f97-a3ec-c50e6703c062" />
