### PR TITLE
app: Makefile: .github/app: Add Windows Arm64 builds

### DIFF
--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -21,7 +21,14 @@ jobs:
       id-token: write # For fetching an OpenID Connect (OIDC) token
       contents: read
       actions: write # needed to upload artifacts
-    runs-on: windows-2022
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-2022
+          - arch: arm64
+            runner: windows-11-arm
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
@@ -75,7 +82,23 @@ jobs:
         nuget.exe sources add -name esrp -source ${{ secrets.ESRP_NUGET_INDEX_URL }} -username headlamp -password ${{ secrets.AZ_DEVOPS_TOKEN }}
         nuget.exe install Microsoft.EsrpClient -Version 1.2.80 -source  ${{ secrets.ESRP_NUGET_INDEX_URL }} | out-null
 
-    - name: App Windows
+    - name: Build Frontend
+      shell: pwsh
+      working-directory: headlamp
+      run: |
+        cd frontend
+        npm ci
+        npm run build
+
+    - name: Install App Dependencies and Setup Plugins
+      shell: pwsh
+      working-directory: headlamp
+      run: |
+        cd app
+        npm ci
+        node scripts/setup-plugins.js
+
+    - name: Build Windows ${{ matrix.arch }} App
       shell: pwsh
       working-directory: headlamp
       run: |
@@ -86,12 +109,23 @@ jobs:
         } else {
           echo "Not signing binaries"
         }
-        make app-win
+        cd app
+        npm run package -- --win --${{ matrix.arch }}
+
+    - name: Create MSI for ${{ matrix.arch }}
+      if: ${{ matrix.arch == 'x64' }}
+      shell: pwsh
+      working-directory: headlamp
+      env:
+        MSI_ARCH: ${{ matrix.arch }}
+      run: |
+        cd app
+        node windows/msi/build.js
 
     - name: Upload artifact
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: Win exes
-        path: ./headlamp/app/dist/Headlamp*.*
+        name: Win-${{ matrix.arch }}-exes
+        path: ./headlamp/app/dist/Headlamp*${{ matrix.arch }}*.*
         if-no-files-found: error
         retention-days: 2

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -50,10 +50,16 @@ jobs:
     - name: Verify Linux build
       run: npm run app:verify-build-linux
   build-windows:
-    runs-on: windows-2025
     strategy:
       matrix:
-        node-version: [22.x]
+        include:
+          - arch: x64
+            runner: windows-2022
+            node-version: 22.x
+          - arch: arm64
+            runner: windows-11-arm
+            node-version: 22.x
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Use Node.js ${{ matrix.node-version }}
@@ -71,8 +77,8 @@ jobs:
       run: make app-test
     - name: Run tsc type checker
       run: make app-tsc
-    - name: App Windows
-      run: make app-win
+    - name: App Windows ${{ matrix.arch }}
+      run: make app-build && cd app && npm run package -- --win --${{ matrix.arch }}
     - name: Verify Windows build
       shell: pwsh
       run: npm run app:verify-build-windows

--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,18 @@ app-build: frontend/build
 app: app-build
 	cd app && npm run package -- --win --linux --mac
 app-win: app-build
-	cd app && npm run package -- --win
-app-win-msi: app-build
-	cd app && npm run package-msi
+	cd app && npm run package -- --win --x64 --arm64
+app-win-x64: app-build
+	cd app && npm run package -- --win --x64
+app-win-arm64: app-build
+	cd app && npm run package -- --win --arm64
+app-win-msi: app-win-msi-x64
+app-win-msi-x64: app-build
+	cd app && npm run package -- --win --x64
+	cd app && MSI_ARCH="x64" node windows/msi/build.js
+app-win-msi-arm64: app-build
+	cd app && npm run package -- --win --arm64
+	cd app && MSI_ARCH="arm64" node windows/msi/build.js
 app-linux: app-build
 	cd app && npm run package -- --linux
 app-mac: app-build

--- a/app/scripts/build-backend.js
+++ b/app/scripts/build-backend.js
@@ -2,13 +2,36 @@
 
 const { execSync } = require('child_process');
 
+/**
+ * Convert electron-builder architecture names to Go GOARCH values.
+ *
+ * Why this exists:
+ * electron-builder and Go use different architecture identifiers for some targets
+ * (for example, electron uses "x64" while Go expects "amd64"). We normalize here
+ * so `make backend` receives a valid GOARCH.
+ *
+ * Known mappings:
+ * - x64 -> amd64
+ * - armv7l -> arm
+ * - arm64 -> (passthrough; already valid for GOARCH)
+ *
+ * Unknown values are passed through unchanged so existing/custom workflows do not
+ * break unexpectedly.
+ *
+ * @param {string} electronArch
+ * @returns {string}
+ */
+function mapElectronArchToGoArch(electronArch) {
+  const archMap = {
+    x64: 'amd64',
+    armv7l: 'arm',
+  };
+
+  return archMap[electronArch] || electronArch;
+}
+
 exports.default = async context => {
-  let arch = context.arch;
-  if (arch === 'x64') {
-    arch = 'amd64';
-  } else if (arch === 'armv7l') {
-    arch = 'arm';
-  }
+  const arch = mapElectronArchToGoArch(context.arch);
 
   let osName = '';
   let goos = '';

--- a/app/scripts/start.js
+++ b/app/scripts/start.js
@@ -5,7 +5,7 @@
  * Assumes being run from within the app/ folder
  */
 const { spawn } = require('child_process');
-const { statSync, existsSync } = require('fs');
+const { statSync, existsSync, openSync, readSync, closeSync } = require('fs');
 const { join } = require('path');
 const { execSync } = require('child_process');
 const { spawnSync } = require('child_process');
@@ -56,8 +56,43 @@ function getLastCommitDateMs(backendDir) {
  */
 function isSameArch(headlampServerPath) {
   if (process.platform === 'win32') {
-    // we only have x64 build at the moment
-    return true;
+    // Add .exe extension if not present
+    const exePath = headlampServerPath.endsWith('.exe')
+      ? headlampServerPath
+      : `${headlampServerPath}.exe`;
+
+    // Read PE header to determine binary architecture
+    try {
+      const fd = openSync(exePath, 'r');
+      try {
+        // Read PE offset (at 0x3C, 4 bytes)
+        const peOffsetBuffer = Buffer.alloc(4);
+        readSync(fd, peOffsetBuffer, 0, 4, 0x3c);
+        const peOffset = peOffsetBuffer.readUInt32LE(0);
+
+        // Read machine type (2 bytes at peOffset + 4)
+        const machineTypeBuffer = Buffer.alloc(2);
+        readSync(fd, machineTypeBuffer, 0, 2, peOffset + 4);
+        const machineType = machineTypeBuffer.readUInt16LE(0);
+
+        const binaryIsX64 = machineType === 0x8664;
+        const binaryIsArm64 = machineType === 0xaa64;
+
+        if (process.arch === 'x64') return binaryIsX64;
+        if (process.arch === 'arm64') return binaryIsArm64;
+        // Unknown host arch; be conservative and trigger rebuild
+        return false;
+      } finally {
+        closeSync(fd);
+      }
+    } catch (err) {
+      const fileExists = existsSync(exePath);
+      console.warn(
+        `Could not determine binary architecture for "${exePath}" (exists=${fileExists}): ${err.message}`
+      );
+      // If we can't check, be conservative and trigger rebuild
+      return false;
+    }
   }
 
   const unameRes = spawnSync('uname', ['-m'], { stdio: ['ignore', 'pipe', 'pipe'] });

--- a/app/windows/msi/build.js
+++ b/app/windows/msi/build.js
@@ -4,10 +4,93 @@ const fs = require('fs');
 const path = require('path');
 const info = require('../../package.json');
 
-const APP_DIR = path.resolve(__dirname, '../../dist/win-unpacked');
+// Detect the architecture from the dist directory
+// electron-builder creates win-unpacked for x64 and win-arm64-unpacked for arm64
+const x64Dir = path.resolve(__dirname, '../../dist/win-unpacked');
+const arm64Dir = path.resolve(__dirname, '../../dist/win-arm64-unpacked');
+
+/**
+ * Resolves the MSI target architecture and matching electron-builder output directory.
+ *
+ * Selection order:
+ * 1. Explicit environment variable (`MSI_ARCH`, `ARCH`, or `npm_config_arch`).
+ * 2. Auto-detection from available dist folders.
+ *
+ * Cases where architecture is NOT explicitly set:
+ * - Running this script directly, e.g. `node app/windows/msi/build.js`.
+ * - Invoking the script from tooling that does not pass `MSI_ARCH`, `ARCH`,
+ *   or `npm_config_arch`.
+ * - Older/custom workflows that package Windows binaries first and run MSI
+ *   creation separately without exporting an arch variable.
+ *
+ * Note: `make app-win-msi-x64` and `make app-win-msi-arm64` set `MSI_ARCH`
+ * explicitly, and `make app-win-msi` invokes both of those targets.
+ *
+ * This function terminates the process with a clear error message for invalid or
+ * ambiguous inputs (unsupported architecture, missing dist directory, both dist
+ * directories present without explicit selection, or no dist directories found).
+ *
+ * @returns {{ arch: 'x64' | 'arm64', appDir: string }}
+ */
+function resolveBuildArchitecture() {
+  const explicitArch =
+    process.env.MSI_ARCH || process.env.ARCH || process.env.npm_config_arch || '';
+
+  if (explicitArch) {
+    const normalizedArch = explicitArch.toLowerCase();
+    if (normalizedArch !== 'x64' && normalizedArch !== 'arm64') {
+      console.error(`Unsupported architecture "${explicitArch}". Expected "x64" or "arm64".`);
+      process.exit(1);
+    }
+
+    const appDir = normalizedArch === 'arm64' ? arm64Dir : x64Dir;
+    if (!fs.existsSync(appDir)) {
+      console.error(
+        `Explicit architecture "${normalizedArch}" selected, but directory "${appDir}" does not exist. ` +
+          'Please run electron-builder for this architecture first.'
+      );
+      process.exit(1);
+    }
+
+    console.log(`Using explicitly selected architecture: ${normalizedArch}`);
+    return { arch: normalizedArch, appDir };
+  }
+
+  const hasX64 = fs.existsSync(x64Dir);
+  const hasArm64 = fs.existsSync(arm64Dir);
+
+  if (hasX64 && hasArm64) {
+    console.error(
+      'Both x64 and ARM64 builds were found. ' +
+        'Please specify which architecture to package by setting one of MSI_ARCH, ARCH, or npm_config_arch (x64 or arm64).'
+    );
+    process.exit(1);
+  }
+
+  if (hasArm64) {
+    console.log('Detected ARM64 build');
+    return { arch: 'arm64', appDir: arm64Dir };
+  }
+
+  if (hasX64) {
+    console.log('Detected x64 build');
+    return { arch: 'x64', appDir: x64Dir };
+  }
+
+  console.error('No unpacked Windows build found. Please run electron-builder first.');
+  process.exit(1);
+}
+
+const { arch: ARCH, appDir: APP_DIR } = resolveBuildArchitecture();
+
 const OUT_DIR = path.resolve(__dirname, '../../dist');
-const ARCH = 'x64';
-const APP_UUID = 'b5678886-26a5-4a15-8513-17d67aaeaf68';
+
+// Use different UUIDs for different architectures to allow side-by-side installation
+const APP_UUIDS = {
+  x64: 'b5678886-26a5-4a15-8513-17d67aaeaf68',
+  arm64: 'c6789997-37b6-5b26-9624-28e78bbfbf79',
+};
+const APP_UUID = APP_UUIDS[ARCH];
 
 const nameOptions = {
   productName: info.productName,


### PR DESCRIPTION
Makes windows arm64 builds.

Fixes #4162
- https://github.com/kubernetes-sigs/headlamp/issues/4162

### Screenshot of Windows Arm64 Headlamp running

<img width="768" height="889" alt="image" src="https://github.com/user-attachments/assets/89b9fcfc-5036-4d9a-a0f1-599893818b0b" />

### Changes

- Added ARM64 architecture mapping in app/scripts/build-backend.js (maps arm64 to Go's GOARCH=arm64).
- Updated Windows architecture detection in app/scripts/start.js to support ARM64 with PE header-based binary architecture verification using pure JavaScript (reads PE header from binary file, extracts machine type, and compares with process.arch).
- Implemented explicit architecture selection in app/windows/msi/build.js via environment variables (MSI_ARCH, ARCH, or npm_config_arch) with auto-detection when only one build exists; errors when both x64 and ARM64 builds are present without explicit selection; uses separate UUIDs per architecture to allow side-by-side installation.
- Refactored .github/workflows/app-artifacts-win.yml to use matrix strategy with a single job definition (build-windows) that creates two parallel job runs (one for x64, one for arm64) on architecture-specific runners (windows-2022 for x64, windows-11-arm for ARM64)
- Updated .github/workflows/app.yml to build both Windows architectures using matrix strategy with architecture-specific runners (windows-2022 for x64, windows-11-arm for ARM64). Tests run on both architectures.

Updated Makefile with 4 new Windows build targets:
- app-win-x64 (builds x64 only)
- and app-win-arm64 (builds ARM64 only)
- app-win-msi-x64
- app-win-msi-arm64

Now app-win (builds both x64 and ARM64).
Now app-win-msi (builds both x64 and ARM64).




### Testing

See the commands make the installers (for the right architectures).

- make app-win-x64
- make app-win-arm64
- make app-win-msi-x64
- make app-win-msi-arm64
- make app-win
- make app-win-msi

---

See that there is an extra CI job for windows arm64, that builds and runs tests on arm64.

<img width="503" height="299" alt="Screenshot 2026-02-19 at 19 57 40" src="https://github.com/user-attachments/assets/64dcfc07-3ba4-4914-9570-4f3a22312003" />

---

The app start script detects the backend binary is arm64 and behaves correctly (making sure to rebuild it if it's the wrong one). 

On an x64 machine you can make the arm64 backend binary, and have the start script rebuild it for you in x64 and have the start script start.

```
make app-win-arm64
cd app; npm run star
```

### Passes windows 11 ARM64 tests in CI

Note: there is a test which runs the compiled app and then checks it is running, and then closes it, and checks that the headlamp-server is also closed. This completes successfully in ARM64 in GitHub CI.

<img width="781" height="545" alt="image" src="https://github.com/user-attachments/assets/46a2a1de-709e-457c-b4f1-96823058d949" />


You can test manually either on a real ARM64 device, or with parallels on a silicon Mac, or in azure with a VM. See https://learn.microsoft.com/en-us/windows/arm/iso
