### PR TITLE
frontend: stories: add test for LogsButton.tsx file

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.stories.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.stories.tsx
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React, { useEffect } from 'react';
+import { userEvent, waitFor } from 'storybook/test';
+import Deployment from '../../../lib/k8s/deployment';
+import { KubeObject } from '../../../lib/k8s/KubeObject';
+import Pod from '../../../lib/k8s/pod';
+import { TestContext } from '../../../test';
+import { ActivitiesRenderer } from '../../activity/Activity';
+import { LogsButton } from './LogsButton';
+
+export default {
+  title: 'common/Resource/LogsButton',
+  component: LogsButton,
+  argTypes: {},
+  decorators: [
+    Story => (
+      <TestContext>
+        <Box
+          sx={{
+            display: 'grid',
+            overflow: 'hidden',
+            position: 'relative',
+            gridTemplateRows: '1fr min-content',
+            gridTemplateColumns: 'min-content 1fr',
+            width: '100%',
+            height: '90vh',
+          }}
+        >
+          <Box
+            id="main"
+            sx={{
+              overflow: 'auto',
+              position: 'relative',
+              minHeight: '0',
+              gridColumn: '2/3',
+              gridRow: '1/2',
+              padding: 2,
+            }}
+          >
+            <Story />
+          </Box>
+          <ActivitiesRenderer />
+        </Box>
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<{ item: KubeObject | null }> = args => <LogsButton {...args} />;
+
+// --- Mock Data ---
+
+const mockNamespace = 'default';
+const mockContainerName = 'nginx';
+
+const mockDeployment = new Deployment({
+  kind: 'Deployment',
+  metadata: {
+    name: 'test-deployment',
+    namespace: mockNamespace,
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'dep-123',
+  },
+  spec: {
+    selector: {
+      matchLabels: {
+        app: 'test-app',
+      },
+    },
+    template: {
+      spec: {
+        nodeName: 'mock-node',
+        containers: [
+          {
+            name: mockContainerName,
+            image: 'nginx:latest',
+            imagePullPolicy: 'Always',
+          },
+        ],
+      },
+    },
+  },
+  status: {},
+});
+
+const mockPodJSON = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'test-pod-1',
+    namespace: mockNamespace,
+    uid: 'pod-123',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+  },
+  spec: {
+    containers: [
+      {
+        name: mockContainerName,
+        image: 'nginx:latest',
+        imagePullPolicy: 'Always',
+      },
+    ],
+    nodeName: 'docker-desktop',
+  },
+  status: {
+    phase: 'Running',
+  },
+};
+
+const standardHandlers = [
+  http.get('*/api/v1/namespaces/:namespace/pods', () => {
+    return HttpResponse.json({
+      kind: 'PodList',
+      apiVersion: 'v1',
+      metadata: {},
+      items: [mockPodJSON],
+    });
+  }),
+];
+
+// --- Stories ---
+
+/**
+ * Button enabled state — the logs button is rendered and clickable
+ * for a Deployment that has running pods available.
+ */
+export const Enabled = Template.bind({});
+Enabled.args = {
+  item: mockDeployment,
+};
+Enabled.parameters = {
+  msw: {
+    handlers: standardHandlers,
+  },
+};
+
+/**
+ * Button disabled state — no pods are available for this workload.
+ * The API returns an empty pod list, so clicking would show no logs.
+ */
+export const NoLogsAvailable = Template.bind({});
+NoLogsAvailable.args = {
+  item: mockDeployment,
+};
+NoLogsAvailable.parameters = {
+  msw: {
+    handlers: [
+      http.get('*/api/v1/namespaces/:namespace/pods', () => {
+        return HttpResponse.json({
+          kind: 'PodList',
+          apiVersion: 'v1',
+          metadata: {},
+          items: [],
+        });
+      }),
+    ],
+  },
+};
+
+/**
+ * Loading logs spinner state — pods exist but getLogs never delivers data,
+ * simulating an indefinite loading state in the log viewer.
+ */
+export const LoadingLogs = Template.bind({});
+LoadingLogs.args = {
+  item: mockDeployment,
+};
+LoadingLogs.parameters = {
+  msw: {
+    handlers: standardHandlers,
+  },
+  storyshots: {
+    disable: true,
+  },
+};
+LoadingLogs.decorators = [
+  (Story: StoryFn) => {
+    useEffect(() => {
+      const originalGetLogs = Pod.prototype.getLogs;
+      Pod.prototype.getLogs = function () {
+        // Never deliver logs — simulates loading
+        return () => {};
+      };
+      return () => {
+        Pod.prototype.getLogs = originalGetLogs;
+      };
+    }, []);
+    return <Story />;
+  },
+];
+LoadingLogs.play = async () => {
+  await userEvent.click(screen.getByLabelText('Show logs'));
+  await waitFor(() => screen.getByText(/Select Pod/i), { timeout: 5000 });
+};
+
+/**
+ * Logs viewer opened state — pods are available and getLogs streams
+ * sample log lines, simulating a fully loaded log viewer.
+ */
+export const LogsViewerOpened = Template.bind({});
+LogsViewerOpened.args = {
+  item: mockDeployment,
+};
+LogsViewerOpened.parameters = {
+  msw: {
+    handlers: standardHandlers,
+  },
+  storyshots: {
+    disable: true,
+  },
+};
+LogsViewerOpened.decorators = [
+  (Story: StoryFn) => {
+    useEffect(() => {
+      const originalGetLogs = Pod.prototype.getLogs;
+      Pod.prototype.getLogs = function (...args: any[]) {
+        const onLogs = args[1];
+        const mockLogs = [
+          `2023-01-01T00:00:01Z Starting container...\n`,
+          `2023-01-01T00:00:02Z Initializing application...\n`,
+          `2023-01-01T00:00:03Z Server listening on port 80\n`,
+        ];
+        const timeout = setTimeout(() => {
+          onLogs({ logs: mockLogs, hasJsonLogs: false });
+        }, 100);
+        return () => clearTimeout(timeout);
+      };
+      return () => {
+        Pod.prototype.getLogs = originalGetLogs;
+      };
+    }, []);
+    return <Story />;
+  },
+];
+LogsViewerOpened.play = async () => {
+  await userEvent.click(screen.getByLabelText('Show logs'));
+  await waitFor(() => screen.getByText(/Select Pod/i), { timeout: 5000 });
+};

--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'vitest-canvas-mock';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Deployment from '../../../lib/k8s/deployment';
+import Pod from '../../../lib/k8s/pod';
+import { TestContext } from '../../../test';
+import { LogsButton } from './LogsButton';
+
+// vi.hoisted runs before imports, making values available to vi.mock factories
+const { MockKubeObject, mockClusterFetch, mockEnqueueSnackbar, mockActivityLaunch } = vi.hoisted(
+  () => {
+    class MockKubeObject {
+      jsonData: any;
+      constructor(data: any) {
+        this.jsonData = data;
+      }
+      get metadata() {
+        return this.jsonData?.metadata;
+      }
+      get spec() {
+        return this.jsonData?.spec;
+      }
+      get status() {
+        return this.jsonData?.status;
+      }
+      get cluster() {
+        return '';
+      }
+      getName() {
+        return this.jsonData?.metadata?.name ?? '';
+      }
+      getNamespace() {
+        return this.jsonData?.metadata?.namespace ?? '';
+      }
+    }
+    return {
+      MockKubeObject,
+      mockClusterFetch: vi.fn(),
+      mockEnqueueSnackbar: vi.fn(),
+      mockActivityLaunch: vi.fn(),
+    };
+  }
+);
+
+// --- K8s module mocks ---
+
+vi.mock('../../../lib/k8s/KubeObject', () => ({
+  KubeObject: MockKubeObject,
+}));
+
+vi.mock('../../../lib/k8s/deployment', () => ({
+  default: class Deployment extends MockKubeObject {},
+  __esModule: true,
+}));
+
+vi.mock('../../../lib/k8s/pod', () => ({
+  default: class Pod extends MockKubeObject {
+    getLogs() {
+      return () => {};
+    }
+  },
+  __esModule: true,
+}));
+
+vi.mock('../../../lib/k8s/daemonSet', () => ({
+  default: class DaemonSet extends MockKubeObject {},
+  __esModule: true,
+}));
+
+vi.mock('../../../lib/k8s/replicaSet', () => ({
+  default: class ReplicaSet extends MockKubeObject {},
+  __esModule: true,
+}));
+
+vi.mock('../../../lib/k8s', () => ({}));
+
+vi.mock('../../../lib/k8s/api/v2/fetch', () => ({
+  clusterFetch: (...args: any[]) => mockClusterFetch(...args),
+}));
+
+vi.mock('notistack', () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
+}));
+
+vi.mock('../../activity/Activity', () => ({
+  Activity: {
+    launch: (...args: any[]) => mockActivityLaunch(...args),
+    close: vi.fn(),
+  },
+  ActivitiesRenderer: () => null,
+}));
+
+// --- Mock Data ---
+
+const deploymentData = {
+  kind: 'Deployment',
+  metadata: {
+    name: 'test-deployment',
+    namespace: 'default',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'dep-123',
+  },
+  spec: {
+    selector: { matchLabels: { app: 'test-app' } },
+    template: {
+      spec: {
+        nodeName: 'test-node',
+        containers: [{ name: 'nginx', image: 'nginx:latest', imagePullPolicy: 'Always' }],
+      },
+    },
+  },
+  status: {},
+};
+
+const mockPodData = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'test-pod-1',
+    namespace: 'default',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    uid: 'pod-123',
+  },
+  spec: {
+    containers: [{ name: 'nginx', image: 'nginx:latest', imagePullPolicy: 'Always' }],
+    nodeName: 'test-node',
+  },
+  status: { phase: 'Running' },
+};
+
+// --- Tests ---
+
+describe('LogsButton', () => {
+  let originalGetLogs: typeof Pod.prototype.getLogs;
+
+  beforeEach(() => {
+    originalGetLogs = Pod.prototype.getLogs;
+    mockClusterFetch.mockReset();
+    mockEnqueueSnackbar.mockReset();
+    mockActivityLaunch.mockReset();
+  });
+
+  afterEach(() => {
+    Pod.prototype.getLogs = originalGetLogs;
+  });
+
+  it('renders the logs button for a Deployment', () => {
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData)} />
+      </TestContext>
+    );
+
+    expect(screen.getByLabelText('translation|Show logs')).toBeInTheDocument();
+  });
+
+  it('does not render the button for null item', () => {
+    render(
+      <TestContext>
+        <LogsButton item={null} />
+      </TestContext>
+    );
+
+    expect(screen.queryByLabelText('Show logs')).not.toBeInTheDocument();
+  });
+
+  it('launches Activity with correct metadata on click', () => {
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData)} />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+
+    expect(mockActivityLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'logs-dep-123',
+        title: 'Logs: test-deployment',
+      })
+    );
+  });
+
+  it('shows warning snackbar when no pods are available', async () => {
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({ kind: 'PodList', apiVersion: 'v1', metadata: {}, items: [] }),
+    });
+
+    const { rerender } = render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData)} />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+
+    // Render the LogsButtonContent
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    rerender(
+      <TestContext>
+        <div id="main" />
+        {activityContent}
+      </TestContext>
+    );
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        expect.stringMatching(/No pods found/i),
+        expect.objectContaining({ variant: 'warning' })
+      );
+    });
+  });
+
+  it('opens log viewer in loading state when getLogs never delivers data', async () => {
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({
+        kind: 'PodList',
+        apiVersion: 'v1',
+        metadata: {},
+        items: [mockPodData],
+      }),
+    });
+
+    Pod.prototype.getLogs = function () {
+      // Never deliver logs — simulates loading
+      return () => {};
+    };
+
+    const { rerender } = render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData)} />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    rerender(
+      <TestContext>
+        <div id="main" />
+        {activityContent}
+      </TestContext>
+    );
+
+    // LogsButtonContent mounts and fetches pods
+    await waitFor(() => {
+      expect(mockClusterFetch).toHaveBeenCalled();
+    });
+  });
+
+  it('opens log viewer and streams logs successfully', async () => {
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({
+        kind: 'PodList',
+        apiVersion: 'v1',
+        metadata: {},
+        items: [mockPodData],
+      }),
+    });
+
+    Pod.prototype.getLogs = function (...args: any[]) {
+      const onLogs = args[1];
+      const mockLogs = [
+        '2023-01-01T00:00:01Z Starting container...\n',
+        '2023-01-01T00:00:02Z Initializing application...\n',
+        '2023-01-01T00:00:03Z Server listening on port 80\n',
+      ];
+      const timeout = setTimeout(() => onLogs({ logs: mockLogs, hasJsonLogs: false }), 50);
+      return () => clearTimeout(timeout);
+    };
+
+    const { rerender } = render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData)} />
+      </TestContext>
+    );
+
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    rerender(
+      <TestContext>
+        <div id="main" />
+        {activityContent}
+      </TestContext>
+    );
+
+    // LogsButtonContent mounts and fetches pods
+    await waitFor(() => {
+      expect(mockClusterFetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/common/Resource/__snapshots__/LogsButton.Enabled.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/LogsButton.Enabled.stories.storyshot
@@ -1,0 +1,27 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-llgzss"
+    >
+      <div
+        class="MuiBox-root css-vi298g"
+        id="main"
+      >
+        <button
+          aria-label="Show logs"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="MuiBox-root css-11hh78l"
+      />
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/LogsButton.LoadingLogs.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/LogsButton.LoadingLogs.stories.storyshot
@@ -1,0 +1,15 @@
+<body>
+  <div>
+    <button
+      aria-label="Show logs"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/LogsButton.LogsViewerOpened.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/LogsButton.LogsViewerOpened.stories.storyshot
@@ -1,0 +1,15 @@
+<body>
+  <div>
+    <button
+      aria-label="Show logs"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/LogsButton.NoLogsAvailable.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/LogsButton.NoLogsAvailable.stories.storyshot
@@ -1,0 +1,27 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-llgzss"
+    >
+      <div
+        class="MuiBox-root css-vi298g"
+        id="main"
+      >
+        <button
+          aria-label="Show logs"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="MuiBox-root css-11hh78l"
+      />
+    </div>
+  </div>
+</body>


### PR DESCRIPTION


## Summary
Add Storybook stories for the LogsButton component to improve coverage and document UI states.

## Related Issue

Fixes #4688

## Changes

- **New file:** `frontend/src/components/common/Resource/LogsButton.stories.tsx`
- **New file:** `frontend/src/components/common/Resource/LogsButton.test.tsx`

<img width="1332" height="19" alt="logsButton" src="https://github.com/user-attachments/assets/a459e28a-2d39-4a31-80eb-207ee6bb665b" />



## Notes for the Reviewer

The tests require `vi.mock` chains for K8s classes (`Deployment`, `Pod`,
`ReplicaSet`, `DaemonSet`) because [LogsButton.tsx](cci:7://file://wsl.localhost/Ubuntu/home/ara/open/headlamp/frontend/src/components/common/Resource/LogsButton.tsx:0:0-0:0) uses `instanceof`
checks internally. A future improvement could replace `instanceof` with
`item.kind`-based checks, which would make testing significantly simpler
(similar to how `Terminal.test.tsx` uses plain mock objects).
