### PR TITLE
frontend: PureNamespaceAutocomplete: disable close on select

### DIFF
--- a/frontend/src/components/common/NamespacesAutocomplete.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.tsx
@@ -110,6 +110,7 @@ export function PureNamespacesAutocomplete({
       id="namespaces-filter"
       autoComplete
       openOnFocus
+      disableCloseOnSelect
       options={namespaceNames}
       onChange={onChange}
       onInputChange={onInputChange}


### PR DESCRIPTION
## Summary

This pull request introduces a minor improvement to the `PureNamespacesAutocomplete` component by updating its autocomplete behavior. Now, the dropdown will remain open after selecting an option, allowing users to make multiple selections or replace one namespace with another more efficiently.

## Changes

  * Added the `disableCloseOnSelect` prop to the `PureNamespacesAutocomplete` component so the dropdown stays open after a selection.
