### PR TITLE
frontend: Terminal: useTerminalStream: Focus terminal when showing it

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -78,6 +78,7 @@ export default function Terminal(props: TerminalProps) {
     }
 
     xterm.open(containerRef);
+    xterm.focus();
 
     let lastKeyPressEvent: KeyboardEvent | null = null;
     xterm.onData(data => {

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalAttachEmptyFirstOutput.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalAttachEmptyFirstOutput.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -228,7 +228,9 @@
                     <div
                       style="width: 0px; height: 0px; line-height: 0px; overflow: hidden;"
                     >
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectedAndReady.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectedAndReady.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -217,7 +217,9 @@
                       <span>
                         user@mock-pod:~$ 
                       </span>
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectionFailed.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalConnectionFailed.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -231,7 +231,9 @@
                     <div
                       style="width: 0px; height: 0px; line-height: 0px; overflow: hidden;"
                     >
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalDefaultNodeSelector.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalDefaultNodeSelector.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -217,7 +217,9 @@
                       <span>
                         user@mock-pod:~$ 
                       </span>
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalDisconnected.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalDisconnected.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -217,7 +217,9 @@
                       <span>
                         user@mock-pod:~$ 
                       </span>
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalInitAndEphemeralContainers.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalInitAndEphemeralContainers.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -217,7 +217,9 @@
                       <span>
                         user@mock-pod:~$ 
                       </span>
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalNoDialog.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalNoDialog.stories.storyshot
@@ -60,7 +60,7 @@
           style="flex: 1; display: flex; flex-direction: column-reverse;"
         >
           <div
-            class="terminal xterm xterm-dom-renderer-owner"
+            class="terminal xterm xterm-dom-renderer-owner focus"
             dir="ltr"
           >
             <div
@@ -131,7 +131,7 @@
               </style>
               <div
                 aria-hidden="true"
-                class="xterm-rows"
+                class="xterm-rows xterm-focus"
                 style="line-height: normal; letter-spacing: 0px;"
               >
                 <div
@@ -140,7 +140,9 @@
                   <span>
                     user@mock-pod:~$ 
                   </span>
-                  <span>
+                  <span
+                    class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                  >
                      
                   </span>
                 </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalShellNotFoundTryNext.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalShellNotFoundTryNext.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -217,7 +217,9 @@
                       <span>
                         user@mock-pod:~$ 
                       </span>
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsNodeSelector.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsNodeSelector.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -217,7 +217,9 @@
                       <span>
                         PS C:\&gt; 
                       </span>
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsShellNotFound.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalWindowsShellNotFound.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -231,7 +231,9 @@
                     <div
                       style="width: 0px; height: 0px; line-height: 0px; overflow: hidden;"
                     >
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/components/common/__snapshots__/Terminal.TerminalWithCommandOutput.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Terminal.TerminalWithCommandOutput.stories.storyshot
@@ -137,7 +137,7 @@
               style="flex: 1; display: flex; flex-direction: column-reverse;"
             >
               <div
-                class="terminal xterm xterm-dom-renderer-owner"
+                class="terminal xterm xterm-dom-renderer-owner focus"
                 dir="ltr"
               >
                 <div
@@ -208,7 +208,7 @@
                   </style>
                   <div
                     aria-hidden="true"
-                    class="xterm-rows"
+                    class="xterm-rows xterm-focus"
                     style="line-height: normal; letter-spacing: 0px;"
                   >
                     <div
@@ -259,7 +259,9 @@
                       <span>
                         user@mock-pod:~$ 
                       </span>
-                      <span>
+                      <span
+                        class="xterm-cursor xterm-cursor-blink xterm-cursor-underline"
+                      >
                          
                       </span>
                     </div>

--- a/frontend/src/lib/k8s/useTerminalStream.ts
+++ b/frontend/src/lib/k8s/useTerminalStream.ts
@@ -182,6 +182,7 @@ export function useTerminalStream(options: TerminalStreamOptions) {
       }
 
       xterm.open(containerEl);
+      xterm.focus();
 
       let lastKeyPressEvent: KeyboardEvent | null = null;
       xterm.onData(data => {


### PR DESCRIPTION
## Summary

Users had to click inside the terminal window before typing — this PR auto-focuses the xterm terminal immediately after it mounts.

Fixes #4754

## Related Issue

- #4754

## Changes

- Added `xterm.focus()` after `xterm.open()` in `Terminal.tsx` (pod exec terminal) and `useTerminalStream.ts` (used by `PodDebugTerminal` and `NodeShellTerminal`)

## Steps to Test

1. Open a pod's terminal (Exec tab)
2. Without clicking, type a command
3. Characters should appear immediately — no click required

Also verify with:
- Node shell terminal
- Pod debug/ephemeral container terminal
