### PR TITLE
frontend: add tests and stories for AuthToken Component

### DIFF
--- a/frontend/src/components/account/Auth.test.tsx
+++ b/frontend/src/components/account/Auth.test.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { TestContext } from '../../test';
+import AuthToken, { PureAuthToken, PureAuthTokenProps } from './Auth';
+
+// vi.hoisted runs before imports, making values available to vi.mock factories
+const { MockKubeObject, mockSetToken, mockTestAuth, mockGetCluster } = vi.hoisted(() => {
+  class MockKubeObject {
+    jsonData: any;
+    constructor(data: any) {
+      this.jsonData = data;
+    }
+  }
+  return {
+    MockKubeObject,
+    mockSetToken: vi.fn(),
+    mockTestAuth: vi.fn(),
+    mockGetCluster: vi.fn(() => 'test-cluster'),
+  };
+});
+
+// --- K8s module mocks ---
+
+vi.mock('../../lib/k8s/KubeObject', () => ({
+  KubeObject: MockKubeObject,
+}));
+
+vi.mock('../../lib/k8s/deployment', () => ({
+  default: class Deployment extends MockKubeObject {},
+  __esModule: true,
+}));
+
+vi.mock('../../lib/k8s/pod', () => ({
+  default: class Pod extends MockKubeObject {},
+  __esModule: true,
+}));
+
+vi.mock('../../lib/k8s/daemonSet', () => ({
+  default: class DaemonSet extends MockKubeObject {},
+  __esModule: true,
+}));
+
+vi.mock('../../lib/k8s/replicaSet', () => ({
+  default: class ReplicaSet extends MockKubeObject {},
+  __esModule: true,
+}));
+
+vi.mock('../../lib/k8s', () => ({
+  useClustersConf: () => ({ 'test-cluster': {} }),
+}));
+
+// --- Theme mock (AppLogo → useNavBarMode reads theme.palette.navbar, which is undefined without a ThemeProvider) ---
+
+vi.mock('../../lib/themes', () => ({
+  useNavBarMode: () => 'light',
+  getThemeName: () => 'light',
+}));
+
+// --- Auth-specific mocks ---
+
+vi.mock('../../lib/auth', () => ({
+  setToken: (...args: any[]) => mockSetToken(...args),
+}));
+
+vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({
+  testAuth: (...args: any[]) => mockTestAuth(...args),
+}));
+
+vi.mock('../../lib/cluster', async importOriginal => ({
+  ...(await importOriginal()),
+  getCluster: () => mockGetCluster(),
+  getClusterPrefixedPath: () => '/c/:cluster',
+}));
+
+// --- Helpers ---
+
+/** Returns default props for PureAuthToken, with vi.fn() callbacks. */
+function defaultProps(overrides: Partial<PureAuthTokenProps> = {}): PureAuthTokenProps {
+  return {
+    title: 'Authentication',
+    token: '',
+    showError: false,
+    showActions: false,
+    onCancel: vi.fn(),
+    onChangeToken: vi.fn(),
+    onAuthClicked: vi.fn(),
+    onCloseError: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderPure(overrides: Partial<PureAuthTokenProps> = {}) {
+  const props = defaultProps(overrides);
+  const result = render(
+    <TestContext>
+      <PureAuthToken {...props} />
+    </TestContext>
+  );
+  return { ...result, props };
+}
+
+// --- Tests ---
+
+describe('PureAuthToken', () => {
+  it('renders the dialog title', () => {
+    renderPure({ title: 'Authentication: my-cluster' });
+
+    expect(screen.getByText('Authentication: my-cluster')).toBeInTheDocument();
+  });
+
+  it('renders the token input field', () => {
+    renderPure();
+
+    expect(screen.getByLabelText('ID token')).toBeInTheDocument();
+  });
+
+  it('renders the "Please paste your authentication token" prompt', () => {
+    renderPure();
+
+    expect(screen.getByText('Please paste your authentication token.')).toBeInTheDocument();
+  });
+
+  it('renders the Authenticate button', () => {
+    renderPure();
+
+    expect(screen.getByRole('button', { name: /Authenticate/i })).toBeInTheDocument();
+  });
+
+  it('renders the service account token docs link', () => {
+    renderPure();
+
+    const link = screen.getByRole('link', { name: /service account token/i });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('shows error snackbar when showError is true', () => {
+    renderPure({ showError: true });
+
+    expect(screen.getByText('Error authenticating')).toBeInTheDocument();
+  });
+
+  it('does not show error snackbar when showError is false', () => {
+    renderPure({ showError: false });
+
+    expect(screen.queryByText('Error authenticating')).not.toBeInTheDocument();
+  });
+
+  it('shows Cancel button when showActions is true', () => {
+    renderPure({ showActions: true });
+
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+  });
+
+  it('does not show Cancel button when showActions is false', () => {
+    renderPure({ showActions: false });
+
+    expect(screen.queryByRole('button', { name: /Cancel/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onChangeToken when typing in the token field', () => {
+    const { props } = renderPure();
+
+    const tokenField = screen.getByLabelText('ID token');
+    fireEvent.change(tokenField, { target: { value: 'my-token' } });
+
+    expect(props.onChangeToken).toHaveBeenCalled();
+  });
+
+  it('calls onAuthClicked when Authenticate button is clicked', () => {
+    const { props } = renderPure();
+
+    fireEvent.click(screen.getByRole('button', { name: /Authenticate/i }));
+
+    expect(props.onAuthClicked).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel button is clicked', () => {
+    const { props } = renderPure({ showActions: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AuthToken (stateful)', () => {
+  beforeEach(() => {
+    mockSetToken.mockReset();
+    mockTestAuth.mockReset();
+    mockGetCluster.mockReturnValue('test-cluster');
+  });
+
+  it('shows error snackbar after authentication failure', async () => {
+    mockSetToken.mockResolvedValue(undefined);
+    mockTestAuth.mockRejectedValue({ status: 401, message: 'Unauthorized' });
+
+    render(
+      <TestContext>
+        <AuthToken />
+      </TestContext>
+    );
+
+    const tokenField = screen.getByLabelText('ID token');
+    fireEvent.change(tokenField, { target: { value: 'bad-token' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Authenticate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Error authenticating')).toBeInTheDocument();
+    });
+  });
+
+  it('clears the token field after authentication failure', async () => {
+    mockSetToken.mockResolvedValue(undefined);
+    mockTestAuth.mockRejectedValue({ status: 401, message: 'Unauthorized' });
+
+    render(
+      <TestContext>
+        <AuthToken />
+      </TestContext>
+    );
+
+    const tokenField = screen.getByLabelText('ID token');
+    fireEvent.change(tokenField, { target: { value: 'bad-token' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Authenticate/i }));
+
+    await waitFor(() => {
+      expect(tokenField).toHaveValue('');
+    });
+  });
+});

--- a/frontend/src/components/account/AuthToken.stories.tsx
+++ b/frontend/src/components/account/AuthToken.stories.tsx
@@ -15,8 +15,18 @@
  */
 
 import { Meta, StoryFn } from '@storybook/react';
+import { delay, http, HttpResponse } from 'msw';
+import { useEffect } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { TestContext } from '../../test';
-import { PureAuthToken, PureAuthTokenProps } from './Auth';
+import AuthToken, { PureAuthToken, PureAuthTokenProps } from './Auth';
+
+// --- Constants for stateful AuthToken stories ---
+const CLUSTER_NAME = 'test-cluster';
+const MOCK_PATH = `/c/${CLUSTER_NAME}`;
+const INITIAL_PATH = window.location.pathname;
+const SET_TOKEN_URL = `*/clusters/${CLUSTER_NAME}/set-token`;
+const AUTH_URL = `*/clusters/${CLUSTER_NAME}/apis/authorization.k8s.io/v1/selfsubjectrulesreviews`;
 
 export default {
   title: 'AuthToken',
@@ -38,8 +48,14 @@ export default {
   ],
 } as Meta;
 
+// --- PureAuthToken stories (presentational, no MSW) ---
+
 const Template: StoryFn<PureAuthTokenProps> = args => <PureAuthToken {...args} />;
 
+/**
+ * Error state — the error snackbar is visible, indicating
+ * an authentication failure.
+ */
 export const ShowError = Template.bind({});
 ShowError.args = {
   title: 'a title',
@@ -48,10 +64,195 @@ ShowError.args = {
   showActions: false,
 };
 
+/**
+ * Actions visible — the Cancel button is shown, used when
+ * multiple clusters are configured.
+ */
 export const ShowActions = Template.bind({});
 ShowActions.args = {
   title: 'a title',
   token: 'a token',
   showError: false,
   showActions: true,
+};
+
+/**
+ * Default empty form — the token input field is empty and ready
+ * for the user to paste an authentication token.
+ */
+export const TokenInputForm = Template.bind({});
+TokenInputForm.args = {
+  title: 'Authentication',
+  token: '',
+  showError: false,
+  showActions: false,
+};
+TokenInputForm.parameters = {
+  storyshots: { disable: true },
+};
+TokenInputForm.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  const tokenField = canvas.getByLabelText('ID token');
+  await userEvent.type(tokenField, 'my-test-token');
+
+  await waitFor(() => {
+    expect(tokenField).toHaveValue('my-test-token');
+  });
+};
+
+/**
+ * Invalid token error — the error snackbar is shown upon
+ * authentication failure with an invalid token.
+ */
+export const InvalidTokenError = Template.bind({});
+InvalidTokenError.args = {
+  title: 'Authentication',
+  token: '',
+  showError: true,
+  showActions: false,
+};
+InvalidTokenError.parameters = {
+  storyshots: { disable: true },
+};
+InvalidTokenError.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  await waitFor(() => {
+    expect(canvas.getByText('Error authenticating')).toBeInTheDocument();
+  });
+};
+
+/**
+ * Cancel button visible — multiple clusters are configured,
+ * so the user can cancel and return to cluster selection.
+ */
+export const WithCancelButton = Template.bind({});
+WithCancelButton.args = {
+  title: 'Authentication: production-cluster',
+  token: '',
+  showError: false,
+  showActions: true,
+};
+WithCancelButton.parameters = {
+  storyshots: { disable: true },
+};
+WithCancelButton.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  const cancelButton = canvas.getByRole('button', { name: /Cancel/i });
+  expect(cancelButton).toBeInTheDocument();
+  await userEvent.click(cancelButton);
+};
+
+// --- Stateful AuthToken stories (with MSW) ---
+
+const StatefulTemplate: StoryFn = () => <AuthToken />;
+
+const statefulDecorator = (Story: StoryFn) => {
+  const Wrapper = () => {
+    useEffect(() => {
+      // Set URL so getCluster() returns our cluster name
+      window.history.replaceState({}, '', MOCK_PATH);
+
+      return () => {
+        window.history.replaceState({}, '', INITIAL_PATH);
+      };
+    }, []);
+
+    return <Story />;
+  };
+
+  return (
+    <TestContext routerMap={{ cluster: CLUSTER_NAME }} urlPrefix="/c">
+      <Wrapper />
+    </TestContext>
+  );
+};
+
+/**
+ * Successful authentication — the token is accepted and the
+ * user is redirected to the cluster dashboard.
+ */
+export const SuccessRedirect = StatefulTemplate.bind({});
+SuccessRedirect.decorators = [statefulDecorator];
+SuccessRedirect.parameters = {
+  storyshots: { disable: true },
+  msw: {
+    handlers: [
+      http.post(SET_TOKEN_URL, () => HttpResponse.json({ ok: true })),
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+      ),
+    ],
+  },
+};
+SuccessRedirect.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  const tokenField = canvas.getByLabelText('ID token');
+  await userEvent.type(tokenField, 'valid-token-12345');
+
+  const authButton = canvas.getByRole('button', { name: /Authenticate/i });
+  await userEvent.click(authButton);
+};
+
+/**
+ * Network error — the API returns a 401 Unauthorized response,
+ * triggering the error snackbar.
+ */
+export const NetworkError = StatefulTemplate.bind({});
+NetworkError.decorators = [statefulDecorator];
+NetworkError.parameters = {
+  storyshots: { disable: true },
+  msw: {
+    handlers: [
+      http.post(SET_TOKEN_URL, () => HttpResponse.json({ ok: true })),
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ message: 'Unauthorized', status: 401 }, { status: 401 })
+      ),
+    ],
+  },
+};
+NetworkError.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  const tokenField = canvas.getByLabelText('ID token');
+  await userEvent.type(tokenField, 'invalid-token');
+
+  const authButton = canvas.getByRole('button', { name: /Authenticate/i });
+  await userEvent.click(authButton);
+
+  await waitFor(() => {
+    expect(canvas.getByText('Error authenticating')).toBeInTheDocument();
+  });
+};
+
+/**
+ * Timeout error — the API never responds, simulating a request
+ * that hangs indefinitely.
+ */
+export const TimeoutError = StatefulTemplate.bind({});
+TimeoutError.decorators = [statefulDecorator];
+TimeoutError.parameters = {
+  storyshots: { disable: true },
+  msw: {
+    handlers: [
+      http.post(SET_TOKEN_URL, () => HttpResponse.json({ ok: true })),
+      http.post(AUTH_URL, async () => {
+        // Simulate a request that never completes (times out)
+        await delay('infinite');
+        return HttpResponse.json({});
+      }),
+    ],
+  },
+};
+TimeoutError.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  const tokenField = canvas.getByLabelText('ID token');
+  await userEvent.type(tokenField, 'timeout-token');
+
+  const authButton = canvas.getByRole('button', { name: /Authenticate/i });
+  await userEvent.click(authButton);
 };


### PR DESCRIPTION
## Summary

Add Storybook stories for the Auth.tsx component to improve coverage and document UI states.

## Related Issue

Fixes #4684

## Changes

- **New file:** `frontend/src/components/account/Auth.test.tsx`
- **New file:** `frontend/src/components/account/AuthToken.stories.tsx`

<img width="830" height="20" alt="AuthToken-test" src="https://github.com/user-attachments/assets/25b3220d-5932-45c7-a586-1b8ed9a9cc87" />

## Notes for the Reviewer

- The tests require vi.mock chains for K8s classes (Deployment, Pod, ReplicaSet) to prevent a circular dependency during import  when vitest loads Auth.tsx, the k8s module graph triggers class ReplicaSet extends KubeObject before KubeObject finishes loading. The mocks break this chain by providing stub classes. 
- Additionally, useNavBarMode is mocked because TestContext does not provide a MUI ThemeProvider, so theme.palette.navbar is undefined.