### PR TITLE
chocolatey: Bump Headlamp version to 0.40.1

### DIFF
--- a/app/windows/chocolatey/tools/chocolateyinstall.ps1
+++ b/app/windows/chocolatey/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $headlampVersion = '0.40.1'
 $url = "https://github.com/kubernetes-sigs/headlamp/releases/download/v${headlampVersion}/Headlamp-${headlampVersion}-win-x64.exe"
-$checksum = 'e180221f477381dafb81b5d538a00623f78dbeacd4218772bd3160a2eda39ffe'
+$checksum = 'ea8172a5d5902b75019319d86891135295c18366e0148ddabe12917232748f2c'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
The Chocolatey had the wrong checksum because somehow the checksums.txt file had both the 0.40.0 and the 0.41.1 checksums. The script that updates chocolatey looks only for the arch, not the version, as the file is supposed to only have one version displayed there. We should update the script for the extra match.