### PR TITLE
github: Fix picking the hash for chocolatey version bump

### DIFF
--- a/.github/workflows/pr-to-update-choco.yml
+++ b/.github/workflows/pr-to-update-choco.yml
@@ -66,7 +66,13 @@ jobs:
             exit 1
           fi
           echo "Setting hash and checksum"
-          read -r hash win_file_name <<< $(grep 'win-x64' ./checksums.txt)
+          expected_win_file_name="Headlamp-${LATEST_HEADLAMP_TAG}-win-x64.exe"
+          mapfile -t matches < <(grep -F "  $expected_win_file_name" ./checksums.txt || true)
+          if [ "${#matches[@]}" -ne 1 ]; then
+            echo "Error: Expected exactly one checksum entry for $expected_win_file_name, found ${#matches[@]}"
+            exit 1
+          fi
+          read -r hash win_file_name <<<"${matches[0]}"
           echo "Hash: $hash"
           echo "Win file name: $win_file_name"
           echo "WIN_FILE_NAME=$win_file_name" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

The logic to update the chocolatey version was checking for the hash
of the Headlamp file by checking for the right architecture only.
If, for some reason, we have more than one Headlamp version in a file,
it could pick up the wrong file for the bump. So this change makes
sure we choose the hash corresponding to the right architecture and
version.

## Steps to Test

This can only be tested next time we release. But it's an easy, logical change.
