### PR TITLE
app: build-backend: Fix make app on mac

### DIFF
--- a/app/scripts/build-backend.js
+++ b/app/scripts/build-backend.js
@@ -11,14 +11,21 @@ exports.default = async context => {
   }
 
   let osName = '';
+  let goos = '';
   if (context.platform.name === 'windows') {
     osName = 'Windows_NT';
+    goos = 'windows';
+  } else if (context.platform.name === 'mac') {
+    goos = 'darwin';
+  } else if (context.platform.name === 'linux') {
+    goos = 'linux';
   }
 
   execSync('make backend', {
     env: {
       ...process.env, // needed otherwise important vars like PATH and GOROOT are not set
       GOARCH: arch,
+      GOOS: goos,
       OS: osName,
     },
     cwd: '..',


### PR DESCRIPTION
Was failing with go: unsupported GOOS/GOARCH pair darwin/arm

### Testing


"make app" builds without error on a silicon mac.x

