### PR TITLE
app: electron: Change zoom in shortcut

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1001,7 +1001,7 @@ function getDefaultAppMenu(): AppMenu[] {
         {
           label: i18n.t('Zoom In'),
           id: 'original-zoom-in',
-          accelerator: 'CmdOrCtrl+Plus',
+          accelerator: 'CmdOrCtrl+=',
           click: () => adjustZoom(0.1),
         },
         {


### PR DESCRIPTION
This change updates the Zoom in accelerator from CmdOrCtrl+Plus (requires Shift) to CmdOrCtrl+=.

### Testing

- [x] Open Headlamp and verify that Zoom In works with Ctrl+= (no Shift required)