### PR TITLE
frontend: resourceMap: Fix glances so they open up into visible space

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -115,3 +115,48 @@ export const BasicExample = () => (
   </TestContext>
 );
 BasicExample.args = {};
+
+/**
+ * Shows a node with its glance card open from first render.
+ * Uses `initialGlanceOpen: true` on the node — no hover interaction required.
+ */
+export const GlanceActive = () => (
+  <TestContext>
+    <GraphView
+      height="600px"
+      defaultSources={[
+        {
+          id: 'glance-source',
+          label: 'Pods',
+          useData() {
+            return {
+              nodes: [
+                { id: 'pod-glance', kubeObject: new Pod(podList[0]), initialGlanceOpen: true },
+              ],
+            };
+          },
+        } satisfies GraphSource,
+      ]}
+    />
+  </TestContext>
+);
+GlanceActive.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get(
+          'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
+          () => HttpResponse.json({ kind: 'List', items: [], metadata: {} })
+        ),
+        http.get(
+          'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+          () => HttpResponse.error()
+        ),
+        // KubeObjectGlance fetches events for the open pod node
+        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
+        ),
+      ],
+    },
+  },
+};

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -273,6 +273,9 @@ function GraphViewContent({
           sx={{
             position: 'relative',
             height: height ?? '800px',
+            // Ensure the canvas stays visible when flex parent is small (e.g. at
+            // 200% browser zoom where the available height may be < 200px).
+            minHeight: height ? undefined : '400px',
             display: 'flex',
             flexDirection: 'row',
             flex: 1,

--- a/frontend/src/components/resourceMap/KubeObjectGlance/NodeGlance.tsx
+++ b/frontend/src/components/resourceMap/KubeObjectGlance/NodeGlance.tsx
@@ -24,7 +24,7 @@ import { KubeObjectGlance } from './KubeObjectGlance';
  * Generic glance component for rendering node previews in Headlamp's graph view.
  * Renders KubeObjectGlance for Kubernetes objects or a plugin-provided glance for other nodes.
  */
-export const NodeGlance = ({ node }: { node: GraphNode }) => {
+export const NodeGlance = ({ node, wrapper }: { node: GraphNode; wrapper?: React.ElementType }) => {
   const glances = useSelector((state: RootState) => state.graphView.glances);
 
   const glanceResults = Object.values(glances).map(glance => {
@@ -49,5 +49,9 @@ export const NodeGlance = ({ node }: { node: GraphNode }) => {
   /**
    * Render all components (custom glances and KubeObjectGlance) within a fragment.
    */
+  if (wrapper) {
+    const WrapperComponent = wrapper;
+    return <WrapperComponent>{results}</WrapperComponent>;
+  }
   return <>{results}</>;
 };

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.GlanceActive.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.GlanceActive.stories.storyshot
@@ -1,0 +1,361 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1yvazsw"
+    >
+      <div
+        class="MuiBox-root css-2gjmrx"
+      >
+        <div
+          class="MuiBox-root css-pb8oes"
+        >
+          <div
+            class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+          >
+            <div
+              class="MuiBox-root css-1dipl1t"
+            >
+              <div
+                class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                style="margin-top: 0px;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-81cxhg-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="true"
+                  for="namespaces-filter"
+                  id="namespaces-filter-label"
+                >
+                  Namespaces
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-b1xigt-MuiInputBase-root-MuiOutlinedInput-root"
+                >
+                  <input
+                    aria-autocomplete="both"
+                    aria-expanded="false"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="namespaces-filter"
+                    placeholder="Filter"
+                    role="combobox"
+                    spellcheck="false"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                  >
+                    <button
+                      aria-label="Open"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-qzbt6i-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        data-testid="ArrowDropDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-14lo706"
+                    >
+                      <span>
+                        Namespaces
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-qsy4j-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1qxw92a-MuiStack-root"
+              >
+                 
+                Pods
+                 
+              </div>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+          <div
+            class="MuiBox-root css-19ideir"
+          >
+            Group By
+          </div>
+          <div
+            class="MuiBox-root css-esugir"
+          >
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-661vdt-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+              >
+                Namespace
+              </span>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+              >
+                Instance
+              </span>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+              >
+                Node
+              </span>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+            >
+              Status: Error or Warning
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-outlined MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-outlinedDefault css-1b73nf-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1jzq0dw-MuiChip-label"
+            >
+              Expand All
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </div>
+        </div>
+        <div
+          style="flex-grow: 1;"
+        >
+          <div
+            class="react-flow light"
+            data-testid="rf__wrapper"
+            style="width: 100%; height: 100%; overflow: hidden; position: relative; z-index: 0;"
+          >
+            <div
+              class="react-flow__renderer"
+              style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px;"
+            >
+              <div
+                class="react-flow__pane draggable"
+                style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px;"
+              >
+                <div
+                  class="react-flow__viewport xyflow__viewport react-flow__container"
+                  style="transform: translate(0px,0px) scale(1);"
+                >
+                  <div
+                    class="react-flow__edges"
+                  />
+                  <div
+                    class="react-flow__edgelabel-renderer"
+                  />
+                  <div
+                    class="react-flow__nodes"
+                    style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px;"
+                  />
+                  <div
+                    class="react-flow__viewport-portal"
+                  />
+                </div>
+              </div>
+            </div>
+            <svg
+              class="react-flow__background"
+              data-testid="rf__background"
+              style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px; --xy-background-pattern-color-props: rgba(0, 0, 0, 0.12);"
+            >
+              <pattern
+                height="20"
+                id="pattern-1"
+                patternTransform="translate(-11,-11)"
+                patternUnits="userSpaceOnUse"
+                width="20"
+                x="0"
+                y="0"
+              >
+                <circle
+                  class="react-flow__background-pattern dots"
+                  cx="1"
+                  cy="1"
+                  r="1"
+                />
+              </pattern>
+              <rect
+                fill="url(#pattern-1)"
+                height="100%"
+                width="100%"
+                x="0"
+                y="0"
+              />
+            </svg>
+            <div
+              aria-label="React Flow controls"
+              class="react-flow__panel react-flow__controls vertical bottom left"
+              data-testid="rf__controls"
+              style="pointer-events: all;"
+            >
+              <div
+                class="MuiBox-root css-1u72um6"
+              >
+                <div
+                  aria-label="Vertical button group"
+                  class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-vertical css-126jwi2-MuiButtonGroup-root"
+                  role="group"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButtonGroup-firstButton css-14951ov-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    title="Zoom in"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedVertical MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedVertical MuiButtonGroup-groupedContainedPrimary MuiButtonGroup-lastButton css-14951ov-MuiButtonBase-root-MuiButton-root"
+                    tabindex="0"
+                    title="Zoom out"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-14951ov-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  title="Fit to screen"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-14951ov-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  title="Zoom to 100%"
+                  type="button"
+                >
+                  100%
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-17ewocx-MuiTypography-root"
+            >
+              No data to be shown. Try to change filters or select a different namespace.
+            </p>
+            <div
+              class="react-flow__panel top left"
+              style="pointer-events: all;"
+            />
+            <div
+              class="react-flow__panel react-flow__attribution bottom right"
+              data-message="Please only hide this attribution when you are subscribed to React Flow Pro: https://pro.reactflow.dev"
+              style="pointer-events: all;"
+            >
+              <a
+                aria-label="React Flow attribution"
+                href="https://reactflow.dev"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                React Flow
+              </a>
+            </div>
+            <div
+              id="react-flow__node-desc-1"
+              style="display: none;"
+            >
+              Press enter or space to select a node.
+              You can then use the arrow keys to move the node around.
+               Press delete to remove it and escape to cancel.
+               
+            </div>
+            <div
+              id="react-flow__edge-desc-1"
+              style="display: none;"
+            >
+              Press enter or space to select an edge. You can then press delete to remove it or escape to cancel.
+            </div>
+            <div
+              aria-atomic="true"
+              aria-live="assertive"
+              id="react-flow__aria-live-1"
+              style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(100%);"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/resourceMap/graph/graphModel.tsx
+++ b/frontend/src/components/resourceMap/graph/graphModel.tsx
@@ -53,6 +53,12 @@ export type GraphNode = {
   data?: any;
   /** CustomResourceDefinition for this node */
   customResourceDefinition?: string;
+  /**
+   * When true the glance card is shown immediately on first render, without
+   * requiring a hover interaction.  Intended for Storybook stories and other
+   * contexts where you want to preview the glance in a static state.
+   */
+  initialGlanceOpen?: boolean;
 };
 
 /**

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -15,11 +15,12 @@
  */
 
 import { Icon } from '@iconify/react';
+import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 import { styled } from '@mui/material/styles';
 import { alpha } from '@mui/system/colorManipulator';
-import { Handle, NodeProps, Position } from '@xyflow/react';
-import { memo, useEffect, useState } from 'react';
+import { Handle, NodeProps, Position, useViewport } from '@xyflow/react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import { Activity } from '../../activity/Activity';
 import { GraphNodeDetails } from '../details/GraphNodeDetails';
 import { getMainNode } from '../graph/graphGrouping';
@@ -139,15 +140,28 @@ const Title = styled('div')({
   whiteSpace: 'nowrap',
 });
 
+import { computeGlanceStyle } from './glancePositioning';
+
 const EXPAND_DELAY = 450;
 
 export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
   const node = useNode(id);
-  const [isHovered, setHovered] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isHovered, setHovered] = useState(() => node?.initialGlanceOpen ?? false);
+  const [isExpanded, setIsExpanded] = useState(() => node?.initialGlanceOpen ?? false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  /**
+   * Computed `position:absolute` style for the glance card in node-local units.
+   * Recalculated on hover, expand, and map-zoom changes so the card is always
+   * clamped inside the browser viewport — even when the node itself is partially
+   * off-screen or the map has been zoomed in.
+   *
+   * Clamps to the .react-flow canvas bounds (and only falls back to
+   * window.innerWidth/innerHeight if the canvas isn’t found).
+   */
+  const [glanceStyle, setGlanceStyle] = useState<React.CSSProperties>({});
   const theme = useTheme();
   const graph = useGraphView();
-
+  const { zoom: mapZoom, x: viewportX, y: viewportY } = useViewport();
   const mainNode = node?.nodes ? getMainNode(node.nodes) : undefined;
   const kubeObject = node?.kubeObject ?? mainNode?.kubeObject;
 
@@ -187,8 +201,25 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
     }
 
     const id = setTimeout(() => setIsExpanded(true), EXPAND_DELAY);
-    return () => clearInterval(id);
+    return () => clearTimeout(id);
   }, [isHovered]);
+
+  /**
+   * Recomputes the glance card position whenever hover state, expand state,
+   * zoom, or viewport pan (x/y) changes so the card stays clamped inside
+   * the ReactFlow canvas at all times.
+   */
+  function updateGlancePosition() {
+    if (!isHovered || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const canvasEl = containerRef.current.closest('.react-flow');
+    const clip = canvasEl
+      ? canvasEl.getBoundingClientRect()
+      : { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight };
+    setGlanceStyle(computeGlanceStyle(rect, clip, mapZoom));
+  }
+
+  useEffect(updateGlancePosition, [isHovered, isExpanded, mapZoom, viewportX, viewportY]);
 
   const icon = kubeObject ? (
     <KubeIcon width="42px" height="42px" kind={kubeObject.kind} apiGroup={apiGroup} />
@@ -232,12 +263,13 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
 
   return (
     <Container
+      ref={containerRef}
       tabIndex={0}
       role="button"
       isFaded={false}
       childrenCount={node.nodes?.length ?? 0}
       isSelected={isSelected}
-      isExpanded={isExpanded}
+      isExpanded={false}
       onClick={openDetails}
       onFocus={() => setHovered(true)}
       onBlur={() => setHovered(false)}
@@ -286,7 +318,66 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
           </Title>
         </LabelContainer>
       </TextContainer>
-      {isExpanded && <NodeGlance node={node} />}
+      {isExpanded && (
+        <NodeGlance
+          node={node}
+          wrapper={({ children }) => (
+            <GlanceWrapper
+              children={children}
+              glanceStyle={glanceStyle}
+              isSelected={isSelected}
+              setHovered={setHovered}
+            />
+          )}
+        />
+      )}
     </Container>
   );
 });
+
+/**
+ * GlanceWrapper is a styled container for the NodeGlance content.
+ */
+function GlanceWrapper({
+  children,
+  glanceStyle,
+  setHovered,
+  isSelected,
+}: {
+  children: React.ReactNode;
+  glanceStyle?: React.CSSProperties;
+  isSelected?: boolean;
+  setHovered: (hovered: boolean) => void;
+}) {
+  const theme = useTheme();
+
+  /*
+    Glance card: rendered as an absolutely-positioned child of the node
+    so it automatically moves and scales with the ReactFlow viewport
+    (panning, map zoom controls).  Position is fully computed in
+    screen-space and converted to node-local units using `mapZoom`, so
+    the card is always clamped inside the browser viewport — including
+    when the map has been zoomed in or the node is near any edge.
+    Guard: only render when node.kubeObject is set — NodeGlance returns
+    null for group/custom nodes without a kubeObject, which would
+    produce an empty card.
+  */
+  return (
+    <Box
+      sx={{
+        ...glanceStyle,
+        zIndex: 1500,
+        background: theme.palette.background.paper,
+        border: '1px solid',
+        borderColor: isSelected ? theme.palette.action.active : theme.palette.divider,
+        borderRadius: '10px',
+        padding: '10px',
+        boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
+      }}
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -246,7 +246,9 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
         setHovered(false);
       }}
       onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === 'Space') {
+        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Space' || e.key === 'Spacebar') {
+          e.preventDefault();
+          e.stopPropagation();
           openDetails();
         }
       }}

--- a/frontend/src/components/resourceMap/nodes/glancePositioning.test.ts
+++ b/frontend/src/components/resourceMap/nodes/glancePositioning.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { computeGlanceStyle } from './glancePositioning';
+
+// Canvas 1200×800, zoom 1, node in the upper part — plenty of space below.
+const defaultClip = { left: 0, top: 0, right: 1200, bottom: 800 };
+const makeRect = (
+  left: number,
+  top: number,
+  width: number,
+  height: number
+): { left: number; top: number; right: number; bottom: number; width: number; height: number } => ({
+  left,
+  top,
+  right: left + width,
+  bottom: top + height,
+  width,
+  height,
+});
+
+describe('computeGlanceStyle', () => {
+  describe('placement below (case 1)', () => {
+    it('places the glance below the node when there is enough space', () => {
+      // Node sits near the top; 630 px of space below — well above FLIP_THRESHOLD 300.
+      const rect = makeRect(100, 100, 220, 70);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+
+      expect(style.position).toBe('absolute');
+      // top = nodeHeight/zoom + GLANCE_GAP = 70/1 + 8 = 78
+      expect(style.top).toBe('78px');
+      expect(style.bottom).toBe('auto');
+    });
+
+    it('positions glance left-aligned with the node (clamped to canvas)', () => {
+      const rect = makeRect(100, 100, 220, 70);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+      // leftAligned = clampLeft(100) = max(4, min(100, 1200-350-4)) = 100
+      // leftNodeLocal = (100 - 100) / 1 = 0
+      expect(style.left).toBe('0px');
+    });
+
+    it('clamps the left position when the node is near the right canvas edge', () => {
+      // Node near the right edge; left-aligned glance would overflow — must clamp.
+      const rect = makeRect(900, 100, 220, 70);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+      // glanceW = min(350, 1192) = 350; clamp ceiling = 1200-350-4 = 846
+      // leftAligned = clampLeft(900) = min(900, 846) = 846
+      // leftNodeLocal = (846 - 900) / 1 = -54
+      expect(style.left).toBe('-54px');
+    });
+
+    it('respects the zoom factor when computing node-local units', () => {
+      const rect = makeRect(100, 100, 440, 140); // zoom-2 equivalent of 220×70 node
+      const style = computeGlanceStyle(rect, defaultClip, 2);
+      // topNodeLocal = rect.height/zoom + GLANCE_GAP = 140/2 + 8 = 78
+      expect(style.top).toBe('78px');
+    });
+  });
+
+  describe('placement above (case 2)', () => {
+    it('flips the glance above when there is not enough space below but enough above', () => {
+      // Node near the bottom: only 100 px below, but 450 px above.
+      const rect = makeRect(100, 630, 220, 70);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+
+      expect(style.position).toBe('absolute');
+      // bottom = nodeHeight/zoom + GLANCE_GAP = 70 + 8 = 78
+      expect(style.bottom).toBe('78px');
+      expect(style.top).toBe('auto');
+    });
+  });
+
+  describe('placement right/left (case 3)', () => {
+    it('places the glance to the right when the node is vertically centred with no room above/below', () => {
+      // Node fills most of the vertical space; space on the right.
+      // spaceBelow = 800-560 = 240 < 300; spaceAbove = 200 < 300
+      // clip.right - rect.right = 1200-270 = 930 ≥ 350+8+4=362 → right placement
+      const rect = makeRect(50, 200, 220, 360);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+
+      expect(style.position).toBe('absolute');
+      // glanceLeftScreen = rect.right + gap = 270 + 8 = 278
+      // leftNodeLocalSide = (clampLeft(278) - 50) / 1 = (278 - 50) / 1 = 228
+      expect(style.left).toBe('228px');
+      expect(style.top).toBe('auto');
+    });
+
+    it('places the glance to the left when there is more room on the left', () => {
+      // Node on the right side; only 80 px to the right, 900 px to the left.
+      const rect = makeRect(900, 200, 220, 360);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+
+      expect(style.position).toBe('absolute');
+      // clip.right-rect.right = 80 < 362; rect.left-clip.left = 900 ≥ 362 → left side
+      // glanceLeftScreen = 900 - 8 - 350 = 542
+      // leftNodeLocalSide = (542 - 900) / 1 = -358
+      expect(style.left).toBe('-358px');
+      expect(style.top).toBe('auto');
+    });
+  });
+
+  describe('overlap placement (case 4)', () => {
+    it('pins the glance to the canvas top-left when the node fills the canvas', () => {
+      // Node covers almost the entire canvas — no room above, below, left, or right.
+      const rect = makeRect(50, 50, 1100, 700);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+
+      expect(style.position).toBe('absolute');
+      // overlapLeftNodeLocal = (clip.left + MARGIN - rect.left) / zoom = (0+4-50)/1 = -46
+      expect(style.left).toBe('-46px');
+      // overlapTopNodeLocal = (clip.top + MARGIN - rect.top) / zoom = (0+4-50)/1 = -46
+      expect(style.top).toBe('-46px');
+      expect(style.bottom).toBe('auto');
+    });
+
+    it('gives the glance the full canvas height as maxHeight in the overlap case', () => {
+      const rect = makeRect(50, 50, 1100, 700);
+      const style = computeGlanceStyle(rect, defaultClip, 1);
+      // maxHeight = (clip.bottom - clip.top - 2*MARGIN) / zoom = (800 - 0 - 8) / 1 = 792
+      expect(style.maxHeight).toBe('792px');
+    });
+
+    it('works at zoom ≠ 1 for overlap placement', () => {
+      const rect = makeRect(100, 100, 2200, 1400); // large node at zoom 2
+      const clip = { left: 0, top: 0, right: 2400, bottom: 1600 };
+      const style = computeGlanceStyle(rect, clip, 2);
+
+      // overlapLeftNodeLocal = (0+4-100)/2 = -48
+      expect(style.left).toBe('-48px');
+      // overlapTopNodeLocal = (0+4-100)/2 = -48
+      expect(style.top).toBe('-48px');
+    });
+  });
+
+  describe('maxHeight floor', () => {
+    it('enforces a 50px minimum maxHeight when available space is tiny', () => {
+      // Use overlap case (node fills canvas) — maxHeight = max(50, 800-0-8) = 792
+      const bigRect = makeRect(50, 50, 1100, 750);
+      const style = computeGlanceStyle(bigRect, { left: 0, top: 0, right: 1200, bottom: 800 }, 1);
+      expect(parseFloat(style.maxHeight as string)).toBeGreaterThanOrEqual(50);
+    });
+  });
+});

--- a/frontend/src/components/resourceMap/nodes/glancePositioning.ts
+++ b/frontend/src/components/resourceMap/nodes/glancePositioning.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CSSProperties } from 'react';
+
+/** Minimum px of space below the node before the glance flips to open upward. */
+export const GLANCE_FLIP_THRESHOLD = 300;
+/** Maximum width of the glance card in pixels — must match the `maxWidth` sx value. */
+export const GLANCE_MAX_WIDTH = 350;
+/** Visual gap between the node edge and the glance card. */
+export const GLANCE_GAP = 8;
+
+/**
+ * Computes the optimal `position:absolute` style for the glance card.
+ *
+ * The glance is rendered as an absolutely-positioned child of the ReactFlow node
+ * element, so its coordinates are in *node-local* units (screen px ÷ zoom).
+ * The canvas element (`.react-flow`, which has `overflow:hidden`) is used as the
+ * clipping boundary — not the browser viewport.
+ *
+ * Placement priority:
+ *  1. BELOW  — preferred when ≥ GLANCE_FLIP_THRESHOLD px below the node.
+ *  2. ABOVE  — when ≥ GLANCE_FLIP_THRESHOLD px above.
+ *  3. LEFT / RIGHT — when neither above nor below fits but there is a side.
+ *  4. OVERLAP — last resort: pin to canvas top-left corner so as much content
+ *     as possible is visible even when the node fills most of the canvas.
+ */
+export function computeGlanceStyle(
+  rect: { left: number; top: number; right: number; bottom: number; width: number; height: number },
+  clip: { left: number; top: number; right: number; bottom: number },
+  zoom: number
+): CSSProperties {
+  const MARGIN = 4; // minimum px from any canvas edge
+  const gap = GLANCE_GAP * zoom; // gap in screen px
+
+  // Effective glance width in screen px — never wider than the canvas.
+  const maxWidthScreen = Math.max(100, clip.right - clip.left - 2 * MARGIN);
+  const glanceW = Math.min(GLANCE_MAX_WIDTH * zoom, maxWidthScreen);
+  const maxWidthNodeLocal = glanceW / zoom;
+
+  // Clamp a proposed screen-space left into the canvas.
+  const clampLeft = (screenLeft: number) =>
+    Math.max(clip.left + MARGIN, Math.min(screenLeft, clip.right - glanceW - MARGIN));
+
+  // Shared horizontal placement: left-aligned with node, clamped to canvas.
+  const leftAligned = clampLeft(rect.left);
+  const leftNodeLocal = (leftAligned - rect.left) / zoom;
+
+  const spaceBelow = clip.bottom - rect.bottom;
+  const spaceAbove = rect.top - clip.top;
+
+  if (spaceBelow >= GLANCE_FLIP_THRESHOLD) {
+    // ---- 1. BELOW the node (preferred) ----
+    const topNodeLocal = rect.height / zoom + GLANCE_GAP;
+    const maxHeight = Math.max(50, (clip.bottom - rect.bottom - gap - MARGIN) / zoom);
+    return {
+      position: 'absolute',
+      left: `${leftNodeLocal}px`,
+      top: `${topNodeLocal}px`,
+      bottom: 'auto',
+      maxWidth: `${maxWidthNodeLocal}px`,
+      maxHeight: `${maxHeight}px`,
+      overflowY: 'auto',
+    };
+  } else if (spaceAbove >= GLANCE_FLIP_THRESHOLD) {
+    // ---- 2. ABOVE the node ----
+    const bottomNodeLocal = rect.height / zoom + GLANCE_GAP;
+    const maxHeight = Math.max(50, (rect.top - clip.top - gap - MARGIN) / zoom);
+    return {
+      position: 'absolute',
+      left: `${leftNodeLocal}px`,
+      bottom: `${bottomNodeLocal}px`,
+      top: 'auto',
+      maxWidth: `${maxWidthNodeLocal}px`,
+      maxHeight: `${maxHeight}px`,
+      overflowY: 'auto',
+    };
+  } else if (
+    clip.right - rect.right >= glanceW + gap + MARGIN ||
+    rect.left - clip.left >= glanceW + gap + MARGIN
+  ) {
+    // ---- 3. LEFT or RIGHT ----
+    let glanceLeftScreen: number;
+    if (
+      clip.right - rect.right < glanceW + gap + MARGIN &&
+      rect.left - clip.left > clip.right - rect.right
+    ) {
+      glanceLeftScreen = rect.left - gap - glanceW; // left of node
+    } else {
+      glanceLeftScreen = rect.right + gap; // right of node
+    }
+    const leftNodeLocalSide = (clampLeft(glanceLeftScreen) - rect.left) / zoom;
+    const maxHeight = Math.max(50, (rect.bottom - clip.top - MARGIN) / zoom);
+    return {
+      position: 'absolute',
+      left: `${leftNodeLocalSide}px`,
+      bottom: 0,
+      top: 'auto',
+      maxWidth: `${maxWidthNodeLocal}px`,
+      maxHeight: `${maxHeight}px`,
+      overflowY: 'auto',
+    };
+  } else {
+    // ---- 4. OVERLAP the node (last resort) ----
+    // Node fills most of the canvas.  Pin the glance to the canvas top-left
+    // corner so as much content as possible is visible.
+    const overlapLeftNodeLocal = (clip.left + MARGIN - rect.left) / zoom;
+    const overlapTopNodeLocal = (clip.top + MARGIN - rect.top) / zoom;
+    const maxHeight = Math.max(50, (clip.bottom - clip.top - 2 * MARGIN) / zoom);
+    return {
+      position: 'absolute',
+      left: `${overlapLeftNodeLocal}px`,
+      top: `${overlapTopNodeLocal}px`,
+      bottom: 'auto',
+      maxWidth: `${maxWidthNodeLocal}px`,
+      maxHeight: `${maxHeight}px`,
+      overflowY: 'auto',
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Some a11y / usability fixes to do with the map / glances.

- **frontend: resourceMap/GraphView: Fix for zoomed in heights**
- **frontend: resourceMap: KubeObjectNode: Fix for glances being cut**
- **frontend: resourceMap: KubeObjectNode: Fix space bar on safari open node**


## Steps to Test

1. Open the app at 200% browser zoom on a 1280×768 display.
2. Navigate to a project → **Map** tab.
3. Confirm graph nodes (e.g. `nginx-test` deployment) are visible — the canvas should not collapse.
4. Hover or tab to a node — the quick-glance popup should open **below** the node, left-aligned, and move with the node when you pan the map.
5. Use the map zoom controls to zoom in until a node fills most of the canvas — hover the node and confirm the glance is still visible (overlapping the node if necessary).
6. Drag the map while a glance is open — the glance should follow the node.
7. move a node on the canvas near the **bottom** edge of the canvas — the glance should flip **above** the node.
8. move a node on the canvas near the **top** edge — the glance should open **below** (sufficient space below).
9. move a node on the canvas where neither above nor below fits — the glance opens to the **right** or **left** of the node.
10. In the basic Storybook example, click on a pod to zoom in, then hover — the glance should appear overlapping the node and fully visible within the canvas.
11. Hover a collapsed group node (e.g. a namespace group) — confirm no empty bordered card appears.
12. Press Space on a focused node — confirm the node activates (keyboard fix).



## Screenshots (if applicable)

### After: (note you can read the "glance" (tooltip).

#### Zoomed in

Rather than popping to the bottom/top/left/right... if it's zoomed in and there's no space it renders overlapping, giving it a chance to be visible.

<img width="1986" height="1168" alt="image" src="https://github.com/user-attachments/assets/e86da662-f528-41ac-9b57-69765fa2a700" />


#### Bottom edge

<img width="719" height="465" alt="Screenshot 2026-02-27 at 16 16 20" src="https://github.com/user-attachments/assets/7f7f6cbc-2d6b-4998-941a-6742622b80a3" />


#### Right edge
<img width="414" height="718" alt="Screenshot 2026-02-27 at 16 19 36" src="https://github.com/user-attachments/assets/b40d911e-ef5f-4d8a-92a0-3db238cdeb7c" />


#### Left edge

<img width="460" height="529" alt="Screenshot 2026-02-27 at 16 18 48" src="https://github.com/user-attachments/assets/225ec1a0-de68-48e9-b968-937faea4b6f8" />

#### Top edge


<img width="670" height="518" alt="Screenshot 2026-02-27 at 16 20 11" src="https://github.com/user-attachments/assets/e1d4642a-2987-4a6a-af19-2fad6dbce87b" />
