### PR TITLE
frontend: Add JobSet as a first-class workload resource

### DIFF
--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -366,6 +366,29 @@
                               />
                             </a>
                           </li>
+                          <li
+                            class="css-1gktw5r"
+                          >
+                            <a
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              href="/"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                              >
+                                <span
+                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                                >
+                                  Job Sets
+                                </span>
+                              </div>
+                              <span
+                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                              />
+                            </a>
+                          </li>
                         </ul>
                       </div>
                     </div>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -390,6 +390,29 @@
                               />
                             </a>
                           </li>
+                          <li
+                            class="css-1gktw5r"
+                          >
+                            <a
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              href="/"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                              >
+                                <span
+                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                                >
+                                  Job Sets
+                                </span>
+                              </div>
+                              <span
+                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                              />
+                            </a>
+                          </li>
                         </ul>
                       </div>
                     </div>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -390,6 +390,29 @@
                               />
                             </a>
                           </li>
+                          <li
+                            class="css-1gktw5r"
+                          >
+                            <a
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              href="/"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+                              >
+                                <span
+                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                                >
+                                  Job Sets
+                                </span>
+                              </div>
+                              <span
+                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                              />
+                            </a>
+                          </li>
                         </ul>
                       </div>
                     </div>

--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -244,6 +244,10 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
             name: 'CronJobs',
             label: t('glossary|CronJobs'),
           },
+          {
+            name: 'JobSets',
+            label: t('glossary|Job Sets'),
+          },
         ],
       },
       {

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -41,6 +41,7 @@ import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
 import { KubeCondition, KubeContainer, KubeContainerStatus } from '../../../lib/k8s/cluster';
 import ConfigMap from '../../../lib/k8s/configMap';
 import { KubeEvent } from '../../../lib/k8s/event';
+import Job from '../../../lib/k8s/job';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { KubeObjectInterface } from '../../../lib/k8s/KubeObject';
 import { KubeObjectClass } from '../../../lib/k8s/KubeObject';
@@ -61,6 +62,7 @@ import {
   DefaultDetailsViewSection,
   DetailsViewSection,
 } from '../../DetailsViewSection/detailsViewSectionSlice';
+import { JobsListRenderer } from '../../job/List';
 import { PodListProps, PodListRenderer } from '../../pod/List';
 import { LightTooltip, Loader, ObjectEventList } from '..';
 import BackLink from '../BackLink';
@@ -1708,11 +1710,16 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   } else {
     namespace = resource.metadata.namespace;
   }
+  let labelSelector = '';
+  if (resource?.jsonData?.spec?.selector) {
+    labelSelector = labelSelectorToQuery(resource?.jsonData?.spec?.selector);
+  } else if (resource.kind === 'JobSet') {
+    labelSelector = `jobset.sigs.k8s.io/jobset-name=${resource.metadata.name}`;
+  }
+
   const queryData = {
     namespace,
-    labelSelector: resource?.jsonData?.spec?.selector
-      ? labelSelectorToQuery(resource?.jsonData?.spec?.selector)
-      : '',
+    labelSelector,
     fieldSelector: resource.kind === 'Node' ? `spec.nodeName=${resource.metadata.name}` : undefined,
     cluster: resource.cluster,
   };
@@ -1737,6 +1744,42 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
       errors={errors}
       metrics={podMetrics}
       noNamespaceFilter={hideNamespaceFilter}
+      hideCreateButton
+      enableRowActions={resource.kind === 'JobSet' ? false : undefined}
+      enableRowSelection={resource.kind === 'JobSet' ? false : undefined}
+    />
+  );
+}
+
+export interface OwnedJobsSectionProps {
+  resource: KubeObject;
+}
+
+export function OwnedJobsSection(props: OwnedJobsSectionProps) {
+  const { resource } = props;
+
+  if (resource.kind !== 'JobSet') {
+    return null;
+  }
+
+  return <OwnedJobsSectionContent resource={resource} />;
+}
+
+function OwnedJobsSectionContent({ resource }: OwnedJobsSectionProps) {
+  const { items: jobs, errors } = Job.useList({
+    namespace: resource.metadata.namespace,
+    labelSelector: `jobset.sigs.k8s.io/jobset-name=${resource.metadata.name}`,
+    cluster: resource.cluster,
+  });
+
+  return (
+    <JobsListRenderer
+      jobs={jobs}
+      errors={errors}
+      hideColumns={['namespace']}
+      noNamespaceFilter
+      enableRowActions={false}
+      enableRowSelection={false}
       hideCreateButton
     />
   );

--- a/frontend/src/components/common/Resource/ResourceListView.tsx
+++ b/frontend/src/components/common/Resource/ResourceListView.tsx
@@ -73,7 +73,11 @@ export default function ResourceListView(
         )
       }
     >
-      <ResourceTable enableRowActions enableRowSelection {...tableProps} />
+      <ResourceTable
+        {...tableProps}
+        enableRowActions={tableProps.enableRowActions ?? true}
+        enableRowSelection={tableProps.enableRowSelection ?? true}
+      />
       {children}
     </SectionBox>
   );

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -41,6 +41,7 @@ import Endpoints from '../../lib/k8s/endpoints';
 import EndpointSlice from '../../lib/k8s/endpointSlices';
 import Ingress from '../../lib/k8s/ingress';
 import Job from '../../lib/k8s/job';
+import JobSet from '../../lib/k8s/jobSet';
 import { KubeObject, KubeObjectClass } from '../../lib/k8s/KubeObject';
 import Namespace from '../../lib/k8s/namespace';
 import Node from '../../lib/k8s/node';
@@ -104,6 +105,7 @@ const classes: KubeObjectClass[] = [
   Ingress,
   ServiceAccount,
   Node,
+  JobSet,
 ];
 
 /**

--- a/frontend/src/components/job/List.tsx
+++ b/frontend/src/components/job/List.tsx
@@ -103,10 +103,22 @@ export interface JobsListRendererProps {
   hideColumns?: 'namespace'[];
   reflectTableInURL?: SimpleTableProps['reflectInURL'];
   noNamespaceFilter?: boolean;
+  enableRowActions?: boolean;
+  enableRowSelection?: boolean;
+  hideCreateButton?: boolean;
 }
 
 export function JobsListRenderer(props: JobsListRendererProps) {
-  const { jobs, errors, hideColumns = [], reflectTableInURL = 'jobs', noNamespaceFilter } = props;
+  const {
+    jobs,
+    errors,
+    hideColumns = [],
+    reflectTableInURL = 'jobs',
+    noNamespaceFilter,
+    enableRowActions,
+    enableRowSelection,
+    hideCreateButton,
+  } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
   function getCompletions(job: Job) {
@@ -126,7 +138,9 @@ export function JobsListRenderer(props: JobsListRendererProps) {
       title={t('Jobs')}
       headerProps={{
         noNamespaceFilter,
-        titleSideActions: [<CreateResourceButton resourceClass={Job} key="create-job-button" />],
+        titleSideActions: hideCreateButton
+          ? []
+          : [<CreateResourceButton resourceClass={Job} key="create-job-button" />],
       }}
       hideColumns={hideColumns}
       errors={errors}
@@ -208,6 +222,8 @@ export function JobsListRenderer(props: JobsListRendererProps) {
       data={jobs}
       reflectInURL={reflectTableInURL}
       id="headlamp-jobs"
+      enableRowActions={enableRowActions}
+      enableRowSelection={enableRowSelection}
     />
   );
 }

--- a/frontend/src/components/jobset/JobSetList.stories.tsx
+++ b/frontend/src/components/jobset/JobSetList.stories.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { TestContext } from '../../test';
+import { generateK8sResourceList } from '../../test/mocker';
+import List from './List';
+import { jobSets } from './storyHelper';
+
+const jobSetList = generateK8sResourceList(jobSets[0], { numResults: 4 });
+
+const failedJobSet = jobSetList[1];
+failedJobSet.status = {
+  ...failedJobSet.status,
+  conditions: [
+    {
+      type: 'Failed',
+      status: 'True',
+      lastTransitionTime: '2023-07-28T08:01:00Z',
+    },
+  ],
+};
+
+const suspendedJobSet = jobSetList[2];
+suspendedJobSet.status = {
+  ...suspendedJobSet.status,
+  conditions: [
+    {
+      type: 'Suspended',
+      status: 'True',
+      lastTransitionTime: '2023-07-28T08:01:00Z',
+    },
+  ],
+};
+
+const startupPolicyJobSet = jobSetList[3];
+startupPolicyJobSet.status = {
+  ...startupPolicyJobSet.status,
+  conditions: [
+    {
+      type: 'StartupPolicyCompleted',
+      status: 'True',
+      lastTransitionTime: '2023-07-28T08:01:00Z',
+    },
+    {
+      type: 'Completed',
+      status: 'True',
+      lastTransitionTime: '2023-07-28T08:02:00Z',
+    },
+  ],
+};
+
+export default {
+  title: 'JobSet/List',
+  component: List,
+  argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <TestContext>
+          <Story />
+        </TestContext>
+      );
+    },
+  ],
+  parameters: {
+    msw: {
+      handlers: {
+        story: [
+          http.get('http://localhost:4466/apis/jobset.x-k8s.io/v1alpha2/jobsets', () =>
+            HttpResponse.json({
+              kind: 'JobSetList',
+              metadata: {},
+              items: jobSetList,
+            })
+          ),
+        ],
+      },
+    },
+  },
+} as Meta;
+
+const Template: StoryFn = () => {
+  return <List />;
+};
+
+export const Items = Template.bind({});

--- a/frontend/src/components/jobset/List.tsx
+++ b/frontend/src/components/jobset/List.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import JobSet from '../../lib/k8s/jobSet';
+import ResourceListView from '../common/Resource/ResourceListView';
+
+// Explicit priority to make the rendered condition stable and meaningful.
+const conditionPriority = ['Failed', 'Completed', 'Suspended', 'StartupPolicyCompleted'];
+
+function getJobSetCondition(jobSet: JobSet): string {
+  const conditions = jobSet.status?.conditions;
+  if (!conditions) return '-';
+
+  const trueConditions = conditions.filter(c => c.status === 'True');
+  if (trueConditions.length === 0) {
+    return '-';
+  }
+
+  let selected = trueConditions[0];
+  let bestPriorityIndex = conditionPriority.length;
+
+  for (const cond of trueConditions) {
+    const idx = conditionPriority.indexOf(cond.type);
+    if (idx !== -1 && idx < bestPriorityIndex) {
+      bestPriorityIndex = idx;
+      selected = cond;
+    }
+  }
+
+  return selected.type ?? '-';
+}
+
+export default function JobSetList() {
+  const { t } = useTranslation(['glossary', 'translation']);
+
+  return (
+    <ResourceListView
+      title={t('glossary|Job Sets')}
+      resourceClass={JobSet}
+      columns={[
+        'name',
+        'namespace',
+        'cluster',
+        {
+          id: 'conditions',
+          label: t('translation|Conditions'),
+          gridTemplate: 'min-content',
+          getValue: (jobSet: JobSet) => getJobSetCondition(jobSet),
+        },
+        'age',
+      ]}
+      reflectInURL="jobsets"
+      id="headlamp-jobsets"
+    />
+  );
+}

--- a/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
+++ b/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
@@ -106,10 +106,10 @@
                       </div>
                       <fieldset
                         aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                        class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="css-14lo706"
+                          class="css-sl37lx-MuiNotchedOutlined-root"
                         >
                           <span>
                             Namespaces
@@ -278,12 +278,12 @@
                     >
                       <span
                         aria-label="Toggle select all"
-                        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                         data-mui-internal-clone-element="true"
                       >
                         <input
                           aria-label="Toggle select all"
-                          class="PrivateSwitchBase-input css-1m9pwf3"
+                          class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                           data-indeterminate="false"
                           type="checkbox"
                         />
@@ -567,12 +567,12 @@
               >
                 <span
                   aria-label="Toggle select row"
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-mui-internal-clone-element="true"
                 >
                   <input
                     aria-label="Toggle select row"
-                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
@@ -625,7 +625,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -638,17 +638,6 @@
                   tabindex="0"
                   type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                    data-testid="MoreVertIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-                    />
-                  </svg>
                   <span
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
@@ -664,12 +653,12 @@
               >
                 <span
                   aria-label="Toggle select row"
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-mui-internal-clone-element="true"
                 >
                   <input
                     aria-label="Toggle select row"
-                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
@@ -722,7 +711,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -735,17 +724,6 @@
                   tabindex="0"
                   type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                    data-testid="MoreVertIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-                    />
-                  </svg>
                   <span
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
@@ -761,12 +739,12 @@
               >
                 <span
                   aria-label="Toggle select row"
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-mui-internal-clone-element="true"
                 >
                   <input
                     aria-label="Toggle select row"
-                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
@@ -819,7 +797,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -832,17 +810,6 @@
                   tabindex="0"
                   type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                    data-testid="MoreVertIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-                    />
-                  </svg>
                   <span
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
@@ -858,12 +825,12 @@
               >
                 <span
                   aria-label="Toggle select row"
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-mui-internal-clone-element="true"
                 >
                   <input
                     aria-label="Toggle select row"
-                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
@@ -916,7 +883,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -929,17 +896,6 @@
                   tabindex="0"
                   type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                    data-testid="MoreVertIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-                    />
-                  </svg>
                   <span
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />

--- a/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
+++ b/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
@@ -1,0 +1,966 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+            >
+              Job Sets
+            </h1>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            >
+              <button
+                aria-label="Create JobSet"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+              >
+                <div
+                  class="MuiBox-root css-1dipl1t"
+                >
+                  <div
+                    class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                    style="margin-top: 0px;"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                      data-shrink="true"
+                      for="namespaces-filter"
+                      id="namespaces-filter-label"
+                    >
+                      Namespaces
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1xjtaff-MuiInputBase-root-MuiOutlinedInput-root"
+                    >
+                      <input
+                        aria-autocomplete="both"
+                        aria-expanded="false"
+                        aria-invalid="false"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                        id="namespaces-filter"
+                        placeholder="Filter"
+                        role="combobox"
+                        spellcheck="false"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                      >
+                        <button
+                          aria-label="Open"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1aav1nn-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                          tabindex="-1"
+                          title="Open"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                            data-testid="ArrowDropDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7 10l5 5 5-5z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                      >
+                        <legend
+                          class="css-14lo706"
+                        >
+                          <span>
+                            Namespaces
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          class="MuiBox-root css-1ipmh7v"
+        >
+          <div
+            class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+            style="min-height: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+            >
+              <div
+                class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                >
+                  <div
+                    class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                  >
+                    <div
+                      class="MuiStack-root css-5kul5x-MuiStack-root"
+                    >
+                      <div
+                        class="MuiBox-root css-k008qs"
+                      >
+                         
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            style="opacity: 0; visibility: hidden;"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+            >
+              Drop to group by 
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-zrlv9q"
+          >
+            <span />
+            <div
+              class="MuiBox-root css-1p0wbhh"
+            >
+              <div
+                class="MuiBox-root css-di3982"
+              >
+                <button
+                  aria-label="Show/Hide search"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Show/Hide filters"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="FilterListIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Show/Hide columns"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="ViewColumnIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <table
+          class="MuiTable-root css-xsr5nr-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+          >
+            <tr
+              class="css-1lqh5un"
+            >
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-199xzek-MuiTableCell-root"
+                colspan="1"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-4ng264"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-bbxzxe"
+                    >
+                      <span
+                        aria-label="Toggle select all"
+                        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        <input
+                          aria-label="Toggle select all"
+                          class="PrivateSwitchBase-input css-1m9pwf3"
+                          data-indeterminate="false"
+                          type="checkbox"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="CheckBoxOutlineBlankIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pksupb-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Name
+                    </div>
+                    <span
+                      aria-label="Sort by Name ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Name ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1r8sxpv-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Namespace
+                    </div>
+                    <span
+                      aria-label="Sort by Namespace ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Namespace ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-8t6h3-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Conditions
+                    </div>
+                    <span
+                      aria-label="Sort by Conditions ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Conditions ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="ascending"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-7mz8xn-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                data-sort="asc"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-chb057"
+                    >
+                      Age
+                    </div>
+                    <span
+                      aria-label="Sorted by Age ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sorted by Age ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-kfi25q-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="ArrowDownwardIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-nv4ey6-MuiTableCell-root"
+                colspan="1"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-4ng264"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-bbxzxe"
+                    >
+                      Actions
+                    </div>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="css-1obf64m"
+          >
+            <tr
+              class="css-1ospngb"
+              data-selected="false"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+              >
+                <span
+                  aria-label="Toggle select row"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  <input
+                    aria-label="Toggle select row"
+                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    data-indeterminate="false"
+                    type="checkbox"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="CheckBoxOutlineBlankIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  jobset-0
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  default
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qjul6g-MuiTableCell-root"
+              >
+                Completed
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+              >
+                <p
+                  aria-label="2020-01-01T00:00:00.000Z"
+                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  3mo
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+              >
+                <button
+                  aria-label="Row Actions"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="MoreVertIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="css-1ospngb"
+              data-selected="false"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+              >
+                <span
+                  aria-label="Toggle select row"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  <input
+                    aria-label="Toggle select row"
+                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    data-indeterminate="false"
+                    type="checkbox"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="CheckBoxOutlineBlankIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  jobset-1
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  default
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qjul6g-MuiTableCell-root"
+              >
+                Failed
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+              >
+                <p
+                  aria-label="2020-01-01T00:00:00.000Z"
+                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  3mo
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+              >
+                <button
+                  aria-label="Row Actions"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="MoreVertIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="css-1ospngb"
+              data-selected="false"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+              >
+                <span
+                  aria-label="Toggle select row"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  <input
+                    aria-label="Toggle select row"
+                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    data-indeterminate="false"
+                    type="checkbox"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="CheckBoxOutlineBlankIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  jobset-2
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  default
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qjul6g-MuiTableCell-root"
+              >
+                Suspended
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+              >
+                <p
+                  aria-label="2020-01-01T00:00:00.000Z"
+                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  3mo
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+              >
+                <button
+                  aria-label="Row Actions"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="MoreVertIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="css-1ospngb"
+              data-selected="false"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+              >
+                <span
+                  aria-label="Toggle select row"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1li6ni2-MuiButtonBase-root-MuiCheckbox-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  <input
+                    aria-label="Toggle select row"
+                    class="PrivateSwitchBase-input css-1m9pwf3"
+                    data-indeterminate="false"
+                    type="checkbox"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="CheckBoxOutlineBlankIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  jobset-3
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  default
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qjul6g-MuiTableCell-root"
+              >
+                Completed
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+              >
+                <p
+                  aria-label="2020-01-01T00:00:00.000Z"
+                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  3mo
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+              >
+                <button
+                  aria-label="Row Actions"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="MoreVertIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2m0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div
+          class="MuiBox-root css-1bxknjp"
+        >
+          <div
+            class="MuiBox-root css-1llu0od"
+          >
+            <span />
+            <div
+              class="MuiBox-root css-qpxlqp"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/jobset/storyHelper.ts
+++ b/frontend/src/components/jobset/storyHelper.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubeObjectInterface } from '../../lib/k8s/KubeObject';
+
+export const jobSets: KubeObjectInterface[] = [
+  {
+    apiVersion: 'jobset.x-k8s.io/v1alpha2',
+    kind: 'JobSet',
+    metadata: {
+      name: '',
+      creationTimestamp: '2023-07-28T08:00:00Z',
+      generation: 1,
+      labels: {
+        app: 'my-jobset',
+      },
+      namespace: 'default',
+      resourceVersion: '123456',
+      uid: 'abc123',
+    },
+    spec: {
+      replicatedJobs: [
+        {
+          name: 'workers',
+          replicas: 2,
+          template: {
+            spec: {
+              parallelism: 1,
+              completions: 1,
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: 'worker',
+                      image: 'busybox:1.28',
+                      command: ['/bin/sh', '-c', 'echo Hello'],
+                    },
+                  ],
+                  restartPolicy: 'Never',
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+    status: {
+      conditions: [
+        {
+          type: 'Completed',
+          status: 'True',
+          lastTransitionTime: '2023-07-28T08:01:00Z',
+        },
+      ],
+    },
+  },
+];

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -187,6 +187,8 @@ export interface PodListProps {
   noNamespaceFilter?: boolean;
   errors?: ApiError[] | null;
   hideCreateButton?: boolean;
+  enableRowActions?: boolean;
+  enableRowSelection?: boolean;
 }
 
 export function PodListRenderer(props: PodListProps) {
@@ -198,6 +200,8 @@ export function PodListRenderer(props: PodListProps) {
     noNamespaceFilter,
     errors,
     hideCreateButton,
+    enableRowActions,
+    enableRowSelection,
   } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
@@ -493,6 +497,8 @@ export function PodListRenderer(props: PodListProps) {
       data={pods}
       reflectInURL={reflectTableInURL}
       id="headlamp-pods"
+      enableRowActions={enableRowActions}
+      enableRowSelection={enableRowSelection}
     />
   );
 }

--- a/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
@@ -18,6 +18,7 @@ import { Box } from '@mui/system';
 import { memo, ReactElement, useEffect } from 'react';
 import Deployment from '../../../lib/k8s/deployment';
 import Job from '../../../lib/k8s/job';
+import JobSet from '../../../lib/k8s/jobSet';
 import ReplicaSet from '../../../lib/k8s/replicaSet';
 import ConfigDetails from '../../configmap/Details';
 import { CustomResourceDetails } from '../../crd/CustomResourceDetails';
@@ -68,6 +69,7 @@ const kindComponentMap: Record<
   Deployment: props => <WorkloadDetails {...props} workloadKind={Deployment} />,
   ReplicaSet: props => <WorkloadDetails {...props} workloadKind={ReplicaSet} />,
   Job: props => <WorkloadDetails {...props} workloadKind={Job} />,
+  JobSet: props => <WorkloadDetails {...props} workloadKind={JobSet} />,
   Service: ServiceDetails,
   CronJob: CronJobDetails,
   DaemonSet: DaemonSetDetails,

--- a/frontend/src/components/resourceMap/graph/graphModel.tsx
+++ b/frontend/src/components/resourceMap/graph/graphModel.tsx
@@ -139,6 +139,7 @@ const DEFAULT_NODE_WEIGHTS = {
 
   // Tier 3: Job-based Workloads
   CronJob: 960,
+  JobSet: 960,
   Job: 920,
 
   // Tier 4: Intermediate Controllers

--- a/frontend/src/components/resourceMap/kubeIcon/KubeIcon.tsx
+++ b/frontend/src/components/resourceMap/kubeIcon/KubeIcon.tsx
@@ -78,6 +78,9 @@ const kindToIcon: Record<string, React.FC<any>> = {
   'batch/Job': JobIcon,
   'batch/CronJob': CronjobIcon,
 
+  // jobset
+  'jobset.x-k8s.io/JobSet': JobIcon,
+
   // rbac
   'rbac.authorization.k8s.io/Role': RoleIcon,
   'rbac.authorization.k8s.io/RoleBinding': RbIcon,
@@ -108,6 +111,7 @@ const kindGroups = {
     'ReplicaSet',
     'Job',
     'CronJob',
+    'JobSet',
   ]),
   storage: new Set(['PersistentVolumeClaim']),
   network: new Set([

--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -30,6 +30,7 @@ import HPA from '../../../../lib/k8s/hpa';
 import HTTPRoute from '../../../../lib/k8s/httpRoute';
 import Ingress from '../../../../lib/k8s/ingress';
 import Job from '../../../../lib/k8s/job';
+import JobSet from '../../../../lib/k8s/jobSet';
 import { KubeObject, KubeObjectClass } from '../../../../lib/k8s/KubeObject';
 import MutatingWebhookConfiguration from '../../../../lib/k8s/mutatingWebhookConfiguration';
 import NetworkPolicy from '../../../../lib/k8s/networkpolicy';
@@ -243,6 +244,10 @@ const jobToCronJob = makeRelation(Job, CronJob, (job, cronJob) =>
   job.metadata.ownerReferences?.find(owner => owner.uid === cronJob.metadata.uid)
 );
 
+const jobToJobSet = makeRelation(Job, JobSet, (job, jobSet) =>
+  job.metadata.ownerReferences?.find(owner => owner.uid === jobSet.metadata.uid)
+);
+
 const gatewayToGatewayClass = makeRelation(
   Gateway,
   GatewayClass,
@@ -298,6 +303,7 @@ const staticRelations = [
   podToOwner,
   repliaceSetToOwner,
   jobToCronJob,
+  jobToJobSet,
   gatewayToGatewayClass,
   httpRouteToGateway,
   httpRouteToService,

--- a/frontend/src/components/resourceMap/sources/definitions/sources.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/sources.tsx
@@ -34,6 +34,7 @@ import HTTPRoute from '../../../../lib/k8s/httpRoute';
 import Ingress from '../../../../lib/k8s/ingress';
 import IngressClass from '../../../../lib/k8s/ingressClass';
 import Job from '../../../../lib/k8s/job';
+import JobSet from '../../../../lib/k8s/jobSet';
 import { KubeObjectClass } from '../../../../lib/k8s/KubeObject';
 import { Lease } from '../../../../lib/k8s/lease';
 import { LimitRange } from '../../../../lib/k8s/limitRange';
@@ -164,6 +165,7 @@ export function useGetAllSources(): GraphSource[] {
           makeKubeSource(ReplicaSet),
           makeKubeSource(Job),
           makeKubeSource(CronJob),
+          makeKubeSource(JobSet),
         ],
       },
       {

--- a/frontend/src/components/workload/Details.tsx
+++ b/frontend/src/components/workload/Details.tsx
@@ -24,6 +24,7 @@ import {
   DetailsGrid,
   LogsButton,
   MetadataDictGrid,
+  OwnedJobsSection,
   OwnedPodsSection,
   RevisionHistorySection,
   RollbackButton,
@@ -167,6 +168,14 @@ export default function WorkloadDetails<T extends WorkloadClass>(props: Workload
             id: 'headlamp.workload-conditions',
             section: <ConditionsSection resource={item?.jsonData} />,
           },
+          ...(workloadKind.kind === 'JobSet'
+            ? [
+                {
+                  id: 'headlamp.workload-owned-jobs',
+                  section: <OwnedJobsSection resource={item} />,
+                },
+              ]
+            : []),
           {
             id: 'headlamp.workload-owned-pods',
             section: <OwnedPodsSection resource={item} />,

--- a/frontend/src/components/workload/Overview.stories.tsx
+++ b/frontend/src/components/workload/Overview.stories.tsx
@@ -206,6 +206,14 @@ export default {
               ],
             })
           ),
+          http.get('http://localhost:4466/apis/jobset.x-k8s.io/v1alpha2/jobsets', () =>
+            HttpResponse.json({
+              kind: 'JobSetList',
+              apiVersion: 'jobset.x-k8s.io/v1alpha2',
+              metadata: {},
+              items: [],
+            })
+          ),
         ],
       },
     },

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -21,6 +21,7 @@ import CronJob from '../../lib/k8s/cronJob';
 import DaemonSet from '../../lib/k8s/daemonSet';
 import Deployment from '../../lib/k8s/deployment';
 import Job from '../../lib/k8s/job';
+import JobSet from '../../lib/k8s/jobSet';
 import Pod from '../../lib/k8s/pod';
 import ReplicaSet from '../../lib/k8s/replicaSet';
 import StatefulSet from '../../lib/k8s/statefulSet';
@@ -44,6 +45,7 @@ export default function Overview() {
   const [replicaSets] = ReplicaSet.useList();
   const [jobs] = Job.useList();
   const [cronJobs] = CronJob.useList();
+  const [jobSets] = JobSet.useList();
 
   const workloadsData: WorkloadDict = useMemo(
     () => ({
@@ -54,8 +56,9 @@ export default function Overview() {
       ReplicaSet: replicaSets ?? [],
       Job: jobs ?? [],
       CronJob: cronJobs ?? [],
+      JobSet: jobSets ?? [],
     }),
-    [pods, deployments, statefulSets, daemonSets, replicaSets, jobs, cronJobs]
+    [pods, deployments, statefulSets, daemonSets, replicaSets, jobs, cronJobs, jobSets]
   );
 
   const { t } = useTranslation('glossary');
@@ -103,6 +106,7 @@ export default function Overview() {
     ReplicaSet,
     Job,
     CronJob,
+    JobSet,
   ];
 
   const workloadLabel = {
@@ -113,6 +117,7 @@ export default function Overview() {
     [ReplicaSet.className]: t('glossary|Replica Sets'),
     [Job.className]: t('glossary|Jobs'),
     [CronJob.className]: t('glossary|Cron Jobs'),
+    [JobSet.className]: t('glossary|Job Sets'),
   };
 
   function ChartLink({ workload }: { workload: WorkloadClass }) {

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -889,6 +889,128 @@
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              <a
+                                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                                href="/"
+                              >
+                                Job Sets
+                              </a>
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            0 Running
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="0%"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99921809249515,16.20000000682343
+  L 60.999410078712856,27.200000005148027
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    />
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "Hosts",
   "Jobs": "Jobs",
   "Completions": "Abschlüsse",
+  "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "Hosts",
   "Jobs": "Jobs",
   "Completions": "Completions",
+  "Job Sets": "Job Sets",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "Hosts",
   "Jobs": "Jobs",
   "Completions": "Completions",
+  "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "Hôtes",
   "Jobs": "Jobs",
   "Completions": "Achevés",
+  "Job Sets": "",
   "Lease": "Bail",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "होस्ट्स",
   "Jobs": "जॉब्स",
   "Completions": "कम्प्लीशन्स",
+  "Job Sets": "",
   "Lease": "लीज़",
   "LimitRange": "लिमिट रेंज",
   "Ingress": "इंग्रेस",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "Host",
   "Jobs": "Job",
   "Completions": "Completamenti",
+  "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "ホスト",
   "Jobs": "ジョブ",
   "Completions": "完了",
+  "Job Sets": "",
   "Lease": "リース",
   "LimitRange": "制限範囲",
   "Ingress": "イングレス",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "호스트",
   "Jobs": "잡",
   "Completions": "완료 수",
+  "Job Sets": "",
   "Lease": "리스",
   "LimitRange": "리미트 레인지",
   "Ingress": "인그레스",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "Hosts",
   "Jobs": "Jobs",
   "Completions": "Completions",
+  "Job Sets": "",
   "Lease": "Lease",
   "LimitRange": "LimitRange",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "ஹோஸ்ட்கள்",
   "Jobs": "ஜாப்ஸ்",
   "Completions": "நிறைவுகள்",
+  "Job Sets": "",
   "Lease": "லீஸ்",
   "LimitRange": "லிமிட்ரேஞ்ச்",
   "Ingress": "இன்க்ரெஸ்",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "主機",
   "Jobs": "工作",
   "Completions": "完成",
+  "Job Sets": "",
   "Lease": "租約",
   "LimitRange": "限制範圍",
   "Ingress": "Ingress",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -105,6 +105,7 @@
   "Hosts": "主机",
   "Jobs": "Jobs",
   "Completions": "完成",
+  "Job Sets": "",
   "Lease": "租约",
   "LimitRange": "限制范围",
   "Ingress": "Ingress",

--- a/frontend/src/lib/k8s/ResourceCategory.tsx
+++ b/frontend/src/lib/k8s/ResourceCategory.tsx
@@ -42,7 +42,7 @@ export const categoriesConfig: ResourceCategory[] = [
     label: 'Workloads',
     icon: 'mdi:circle-slice-2',
     description: 'Applications and compute resources',
-    apiGroups: ['apps', 'batch'],
+    apiGroups: ['apps', 'batch', 'jobset.x-k8s.io'],
     coreKinds: ['Pod'],
     excludeKinds: ['ControllerRevision'],
   },

--- a/frontend/src/lib/k8s/Workload.ts
+++ b/frontend/src/lib/k8s/Workload.ts
@@ -18,11 +18,20 @@ import type CronJob from './cronJob';
 import type DaemonSet from './daemonSet';
 import type Deployment from './deployment';
 import type Job from './job';
+import type JobSet from './jobSet';
 import type Pod from './pod';
 import type ReplicaSet from './replicaSet';
 import type StatefulSet from './statefulSet';
 
-export type Workload = Pod | DaemonSet | ReplicaSet | StatefulSet | Job | CronJob | Deployment;
+export type Workload =
+  | Pod
+  | DaemonSet
+  | ReplicaSet
+  | StatefulSet
+  | Job
+  | CronJob
+  | Deployment
+  | JobSet;
 export type WorkloadClass =
   | typeof Pod
   | typeof DaemonSet
@@ -30,4 +39,5 @@ export type WorkloadClass =
   | typeof StatefulSet
   | typeof Job
   | typeof CronJob
-  | typeof Deployment;
+  | typeof Deployment
+  | typeof JobSet;

--- a/frontend/src/lib/k8s/index.test.ts
+++ b/frontend/src/lib/k8s/index.test.ts
@@ -252,6 +252,7 @@ const namespacedClasses = [
   'HTTPRoute',
   'Ingress',
   'Job',
+  'JobSet',
   'Lease',
   'LimitRange',
   'NetworkPolicy',

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -41,6 +41,7 @@ import HTTPRoute from './httpRoute';
 import Ingress from './ingress';
 import IngressClass from './ingressClass';
 import Job from './job';
+import JobSet from './jobSet';
 import { Lease } from './lease';
 import { LimitRange } from './limitRange';
 import Namespace from './namespace';
@@ -85,6 +86,7 @@ export const ResourceClasses = {
   Ingress,
   IngressClass,
   Job,
+  JobSet,
   Namespace,
   NetworkPolicy,
   Node,
@@ -471,6 +473,7 @@ export * as event from './event';
 export * as ingress from './ingress';
 export * as ingressClass from './ingressClass';
 export * as job from './job';
+export * as jobSet from './jobSet';
 export * as namespace from './namespace';
 export * as node from './node';
 export * as persistentVolume from './persistentVolume';

--- a/frontend/src/lib/k8s/jobSet.ts
+++ b/frontend/src/lib/k8s/jobSet.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+
+export interface KubeJobSet extends KubeObjectInterface {
+  spec: {
+    [otherProps: string]: any;
+  };
+  status: {
+    conditions?: {
+      type: string;
+      status: string;
+      [otherProps: string]: any;
+    }[];
+    [otherProps: string]: any;
+  };
+}
+
+class JobSet extends KubeObject<KubeJobSet> {
+  static kind = 'JobSet';
+  static apiName = 'jobsets';
+  static apiVersion = 'jobset.x-k8s.io/v1alpha2';
+  static isNamespaced = true;
+
+  get spec() {
+    return this.jsonData.spec;
+  }
+
+  get status() {
+    return this.jsonData.status;
+  }
+
+  static getBaseObject(): KubeJobSet {
+    const baseObject = super.getBaseObject() as KubeJobSet;
+    baseObject.metadata = {
+      ...baseObject.metadata,
+      namespace: '',
+      labels: { app: 'headlamp' },
+    };
+    baseObject.spec = {
+      replicatedJobs: [
+        {
+          name: 'workers',
+          replicas: 1,
+          template: {
+            spec: {
+              parallelism: 1,
+              completions: 1,
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: '',
+                      image: '',
+                      command: [],
+                      imagePullPolicy: 'Always',
+                    },
+                  ],
+                  restartPolicy: 'Never',
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+    return baseObject;
+  }
+}
+
+export default JobSet;

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -66,6 +66,7 @@ import IngressClassList from '../../components/ingress/ClassList';
 import IngressDetails from '../../components/ingress/Details';
 import IngressList from '../../components/ingress/List';
 import JobsList from '../../components/job/List';
+import JobSetList from '../../components/jobset/List';
 import { LeaseDetails } from '../../components/lease/Details';
 import { LeaseList } from '../../components/lease/List';
 import { LimitRangeDetails } from '../../components/limitRange/Details';
@@ -123,6 +124,7 @@ import { useCluster } from '..//k8s';
 import DaemonSet from '../k8s/daemonSet';
 import Deployment from '../k8s/deployment';
 import Job from '../k8s/job';
+import JobSet from '../k8s/jobSet';
 import ReplicaSet from '../k8s/replicaSet';
 import StatefulSet from '../k8s/statefulSet';
 import type { RouteURLProps } from './createRouteURL';
@@ -533,6 +535,19 @@ const defaultRoutes: { [routeName: string]: Route } = {
     sidebar: 'CronJobs',
     name: 'CronJobs',
     component: () => <CronJobList />,
+  },
+  JobSets: {
+    path: '/jobsets',
+    exact: true,
+    sidebar: 'JobSets',
+    name: 'JobSets',
+    component: () => <JobSetList />,
+  },
+  JobSet: {
+    path: '/jobsets/:namespace/:name',
+    exact: true,
+    sidebar: 'JobSets',
+    component: () => <WorkloadDetails workloadKind={JobSet} />,
   },
   Deployments: {
     path: '/deployments',

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -91,6 +91,7 @@
     "NamespaceTextField": [Function],
     "NamespacesAutocomplete": [Function],
     "ObjectEventList": [Function],
+    "OwnedJobsSection": [Function],
     "OwnedPodsSection": [Function],
     "PORT_FORWARDS_STORAGE_KEY": "portforwards",
     "PORT_FORWARD_RUNNING_STATUS": "Running",
@@ -139,6 +140,7 @@
       "MetadataDictGrid": [Function],
       "MetadataDisplay": [Function],
       "NamespaceTextField": [Function],
+      "OwnedJobsSection": [Function],
       "OwnedPodsSection": [Function],
       "PORT_FORWARDS_STORAGE_KEY": "portforwards",
       "PORT_FORWARD_RUNNING_STATUS": "Running",
@@ -343,6 +345,7 @@
       "Ingress": [Function],
       "IngressClass": [Function],
       "Job": [Function],
+      "JobSet": [Function],
       "Lease": [Function],
       "LimitRange": [Function],
       "Namespace": [Function],
@@ -408,6 +411,9 @@
       "default": [Function],
     },
     "job": {
+      "default": [Function],
+    },
+    "jobSet": {
       "default": [Function],
     },
     "labelSelectorToQuery": [Function],


### PR DESCRIPTION
## Summary

This PR adds JobSet (from `jobset.x-k8s.io/v1alpha2`) as a first-class workload resource in Headlamp. JobSet is a Kubernetes-native API for managing a group of Jobs as a unit, commonly used for ML/AI training workloads, HPC, and batch processing.

## Related Issue

N/A

## Changes

- Added `JobSet` KubeObject class (`frontend/src/lib/k8s/jobSet.ts`) with proper API group, version, and type definitions
- Added JobSet list view with conditions column (`frontend/src/components/jobset/List.tsx`)
- Added JobSet detail view reusing the workload details pattern with owned Jobs and Pods sections
- Added sidebar entry under Workloads for "Job Sets"
- Added routes for `/jobsets` (list) and `/jobsets/:namespace/:name` (detail)
- Integrated JobSet into global search, resource map (graph model, relations, sources, icons), and workload overview
- Added Storybook stories for the JobSet list component
- Fixed pod listing for JobSet to filter by `jobset.sigs.k8s.io/jobset-name` label
- Added `jobset.x-k8s.io` to the Workloads resource category API groups
- Added i18n glossary entry for "Job Sets"

## Steps to Test

1. Install the JobSet CRD on a cluster (`kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/latest/download/manifests.yaml`)
2. Create a JobSet resource in a namespace
3. Navigate to the Workloads section in the sidebar — "Job Sets" should appear
4. Click "Job Sets" to see the list view with name, namespace, conditions, and age columns
5. Click a JobSet to see the detail view with owned Jobs and Pods sections
6. Verify JobSet appears in global search results
7. Verify JobSet appears in the resource map with correct relations to Jobs

## Screenshots (if applicable)

<img width="1452" height="804" alt="Screenshot From 2026-03-02 20-16-48" src="https://github.com/user-attachments/assets/bbf9e4c6-a1eb-4e44-8cdc-070910718c26" />
<img width="1416" height="1200" alt="Screenshot From 2026-03-02 20-17-26" src="https://github.com/user-attachments/assets/955131fa-1d12-4aae-88c9-3f41bd041706" />


## Notes for the Reviewer

- JobSet uses the `jobset.x-k8s.io/v1alpha2` API version which is the current stable alpha release
- The owned pods section uses the `jobset.sigs.k8s.io/jobset-name` label selector since JobSets don't have a standard `spec.selector`
- An `OwnedJobsSection` was added to show Jobs belonging to a JobSet in the detail view
- This follows the same patterns used by other workload resources (Jobs, CronJobs, Deployments, etc.)