### PR TITLE
frontend: NavigationTabs: Refactor component so it doesn't require cloning

### DIFF
--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -18,8 +18,7 @@ import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import cloneDeep from 'lodash/cloneDeep';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useHistory } from 'react-router';
 import { getCluster, getClusterPrefixedPath } from '../../lib/cluster';
@@ -31,152 +30,55 @@ import { SidebarItemProps } from '../Sidebar';
 import { getFullURLOnRoute } from './SidebarItem';
 import { useSidebarItems } from './useSidebarItems';
 
-function searchNameInSubList(sublist: SidebarItemProps['subList'], name: string): boolean {
-  if (!sublist) {
-    return false;
-  }
-  for (let i = 0; i < sublist.length; i++) {
-    if (sublist[i].name === name) {
-      return true;
-    }
-    if (
-      sublist[i].isCR &&
-      sublist[i].name.startsWith('group-') &&
-      searchNameInSubList(sublist[i].subList, name)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function findIndexNameInSubList(sublist: SidebarItemProps['subList'], name: string | null): number {
-  if (!name) {
-    return -1;
-  }
-  if (!sublist) {
-    return -1;
-  }
-  for (let i = 0; i < sublist.length; i++) {
-    if (sublist[i].name === name) {
-      return i;
-    }
-    if (
-      sublist[i].isCR &&
-      sublist[i].name.startsWith('group-') &&
-      searchNameInSubList(sublist[i].subList, name)
-    ) {
-      return i;
-    }
-  }
-  return -1;
-}
-
-function findParentOfSubList(
-  list: SidebarItemProps[],
-  name: string | null
-): SidebarItemProps | null {
-  if (!name) {
-    return null;
-  }
-
-  let parent = null;
-  for (let i = 0; i < list.length; i++) {
-    if (searchNameInSubList(list[i].subList, name)) {
-      parent = list[i];
-    }
-  }
-  return parent;
-}
-
-function findIndexParentOfSubList(list: SidebarItemProps[], name: string | null): number {
-  if (!name) {
-    return -1;
-  }
-
-  for (let i = 0; i < list.length; i++) {
-    const k = findIndexNameInSubList(list[i].subList, name);
-    if (k !== -1) {
-      return k;
-    }
-  }
-  return -1;
-}
-
-// todo open second level tabs on reload
-
 export default function NavigationTabs() {
   const history = useHistory();
-  const sidebar = useTypedSelector(state => state.sidebar);
+  const { item, sidebar } = useTypedSelector(state => state.sidebar.selected);
+  const isSidebarOpen = useTypedSelector(state => state.sidebar.isSidebarOpen);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
   const isSmallSideBar = useMediaQuery(theme.breakpoints.only('sm'));
   const { t } = useTranslation();
-  const [secondLevelSidebarItems, setSecondLevelTabRoutes] = useState<SidebarItemProps[]>([]);
 
-  const listItemsOriginal = useSidebarItems(sidebar.selected.sidebar ?? undefined);
-  const [navigationItem, subList] = useMemo(() => {
-    // Making a copy because we're going to mutate it later in here
-    const listItems = cloneDeep(listItemsOriginal);
+  const sidebarItems = useSidebarItems(sidebar ?? undefined);
 
-    let item = listItems.find(item => item.name === sidebar.selected.item);
-    if (!item) {
-      const parent = findParentOfSubList(listItems, sidebar.selected.item);
-      if (!parent) {
-        return [null, []];
-      }
-      item = parent;
-    }
-    const list = item.subList;
+  // Root sidebar entry that contains selected item
+  const rootSelectedItem = useMemo(
+    () =>
+      sidebarItems.findLast(
+        it =>
+          it.name === item ||
+          it?.subList?.find(it => it.name === item || it?.subList?.find(it => it.name === item))
+      ),
+    [sidebarItems, item]
+  );
 
-    if (!list) {
-      return [null, null];
-    }
+  const level1Tabs = useMemo(
+    () =>
+      [
+        // If there's a route for the root entry then it should be a Tab
+        getRoute(rootSelectedItem?.name ?? undefined)
+          ? // we remove subList here because those items are already included in level 1
+            { ...rootSelectedItem, subList: [] }
+          : undefined,
+        ...(rootSelectedItem?.subList ?? []),
+      ].filter(Boolean) as Omit<SidebarItemProps, 'sidebar'>[],
+    [rootSelectedItem]
+  );
+  const level1SelectedItem = useMemo(
+    () => level1Tabs?.find(it => it.name === item || it.subList?.find(it => it.name === item)),
+    [level1Tabs, item]
+  );
 
-    if (getRoute(item.name)) {
-      list.unshift(item);
-    }
+  const level2Tabs = useMemo(() => level1SelectedItem?.subList, [level1SelectedItem]);
 
-    return [item, list];
-  }, [listItemsOriginal, sidebar]);
-
-  useEffect(() => {
-    if (!subList) {
-      return;
-    }
-
-    const index = findIndexNameInSubList(subList, sidebar.selected.item) ?? null;
-    if (index === undefined || index === null || index === -1) {
-      return;
-    }
-
-    if (getRoute(navigationItem?.name ?? '') && index === 0) {
-      setSecondLevelTabRoutes([]);
-    } else if (
-      subList[index] !== undefined &&
-      subList[index].subList !== undefined &&
-      subList[index].subList.length !== 0
-    ) {
-      setSecondLevelTabRoutes(subList[index].subList);
-    } else {
-      setSecondLevelTabRoutes([]);
-    }
-  }, [subList, navigationItem, sidebar.selected.item]);
+  const level2SelectedItem = useMemo(
+    () => level2Tabs?.find(it => it.name === item),
+    [level2Tabs, item]
+  );
 
   const tabChangeHandler = useCallback(
     (index: number) => {
-      if (subList === undefined || subList === null) {
-        return;
-      }
-      if (getRoute(navigationItem?.name ?? '') && index === 0) {
-        setSecondLevelTabRoutes([]);
-      } else if (subList[index].subList !== undefined && subList[index].subList.length !== 0) {
-        setSecondLevelTabRoutes(subList[index].subList);
-      } else {
-        setSecondLevelTabRoutes([]);
-      }
-
-      const item = subList[index];
+      const item = level1Tabs[index];
       if (item.url && item.useClusterURL && getCluster()) {
         history.push({
           pathname: generatePath(getClusterPrefixedPath(item.url), { cluster: getCluster()! }),
@@ -187,16 +89,17 @@ export default function NavigationTabs() {
         history.push({ pathname: getFullURLOnRoute(item.name, item.isCR, item.subList ?? []) });
       }
     },
-    [setSecondLevelTabRoutes, subList, navigationItem]
+    [level1Tabs]
   );
 
   const tabSecondLevelChangeHandler = useCallback(
     (index: number) => {
-      if (!secondLevelTabRoutes) {
+      if (!level2Tabs) {
         return;
       }
-      const url = secondLevelSidebarItems[index].url;
-      const useClusterURL = !!secondLevelSidebarItems[index].useClusterURL;
+      const tab = level2Tabs[index];
+      const url = tab.url;
+      const useClusterURL = !!tab.useClusterURL;
       if (url && useClusterURL && getCluster()) {
         history.push({
           pathname: generatePath(getClusterPrefixedPath(url), { cluster: getCluster()! }),
@@ -204,52 +107,43 @@ export default function NavigationTabs() {
       } else if (url) {
         history.push(url);
       } else {
-        if (secondLevelSidebarItems[index].isCR) {
+        if (tab.isCR) {
           history.push({
             pathname: createRouteURL('customresources', {
-              crd: secondLevelSidebarItems[index].name,
+              crd: tab.name,
             }),
           });
         } else {
-          history.push({ pathname: createRouteURL(secondLevelSidebarItems[index].name) });
+          history.push({ pathname: createRouteURL(tab.name) });
         }
       }
     },
-    [secondLevelSidebarItems]
+    [level2Tabs]
   );
 
   // Always show the navigation tabs when the sidebar is the small version
-  if (!isSmallSideBar && (sidebar.isSidebarOpen || isMobile)) {
+  if (!isSmallSideBar && (isSidebarOpen || isMobile)) {
     return null;
   }
 
-  if (!subList) {
+  if (!level1Tabs.length) {
     return null;
   }
 
-  const tabRoutes = subList
+  const level1TabRoutes = level1Tabs
     .filter(item => !item.hide)
-    .map((item: SidebarItemProps) => {
-      return { label: item.label, component: <></> };
-    });
+    .map((item: SidebarItemProps) => ({ label: item.label, component: <></> }));
 
-  const defaultIndex = findIndexParentOfSubList(subList, sidebar.selected.item) ?? null;
-  const secondLevelIndex =
-    secondLevelSidebarItems.findIndex(item => item.name === sidebar.selected.item) ?? null;
-
-  const secondLevelTabRoutes = secondLevelSidebarItems
+  const level2TabRoutes = level2Tabs
     ?.filter(item => !item.hide)
-    ?.map((item: SidebarItemProps) => {
-      return { label: item.label, component: <></> };
-    });
+    ?.map((item: SidebarItemProps) => ({ label: item.label, component: <></> }));
+
   return (
     <Box mb={2} component="nav" aria-label={t('translation|Main Navigation')}>
       <Tabs
-        tabs={tabRoutes}
-        onTabChanged={index => {
-          tabChangeHandler(index);
-        }}
-        defaultIndex={defaultIndex !== -1 ? defaultIndex : 0}
+        tabs={level1TabRoutes}
+        onTabChanged={tabChangeHandler}
+        defaultIndex={level1SelectedItem ? level1Tabs.indexOf(level1SelectedItem) : 0}
         sx={{
           maxWidth: '85vw',
           [theme.breakpoints.down('sm')]: {
@@ -259,14 +153,14 @@ export default function NavigationTabs() {
         ariaLabel={t('translation|Navigation Tabs')}
       />
       <Divider role="separator" />
-      {secondLevelTabRoutes !== undefined && secondLevelTabRoutes.length !== 0 && (
+      {level2TabRoutes && level2TabRoutes.length !== 0 && (
         <>
           <Tabs
-            tabs={secondLevelTabRoutes!!}
-            defaultIndex={secondLevelIndex !== -1 ? secondLevelIndex : 0}
-            onTabChanged={index => {
-              tabSecondLevelChangeHandler(index);
-            }}
+            tabs={level2TabRoutes!!}
+            defaultIndex={
+              level2Tabs && level2SelectedItem ? level2Tabs?.indexOf(level2SelectedItem) : 0
+            }
+            onTabChanged={tabSecondLevelChangeHandler}
             ariaLabel={t('translation|Navigation Tabs')}
           />
           <Divider role="separator" />

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
@@ -65,20 +65,6 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
-              <button
-                aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
-                aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
-                id="full-width-tab-3-NavigationTabs-tabs-id"
-                role="tab"
-                tabindex="-1"
-                type="button"
-              >
-                Advanced Search (Beta)
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
             </div>
             <span
               class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
@@ -104,13 +90,6 @@
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
-          role="tabpanel"
-        />
-        <div
-          aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
-          hidden=""
-          id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
         />
         <hr

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
@@ -65,20 +65,6 @@
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
               </button>
-              <button
-                aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
-                aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
-                id="full-width-tab-3-NavigationTabs-tabs-id"
-                role="tab"
-                tabindex="-1"
-                type="button"
-              >
-                Cluster
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
             </div>
             <span
               class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
@@ -104,13 +90,6 @@
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
-          role="tabpanel"
-        />
-        <div
-          aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
-          hidden=""
-          id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
         />
         <hr

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
@@ -26,7 +26,7 @@
               <button
                 aria-controls="full-width-tabpanel-0-NavigationTabs-tabs-id"
                 aria-selected="true"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-0-NavigationTabs-tabs-id"
                 role="tab"
                 tabindex="0"
@@ -40,7 +40,7 @@
               <button
                 aria-controls="full-width-tabpanel-1-NavigationTabs-tabs-id"
                 aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-1-NavigationTabs-tabs-id"
                 role="tab"
                 tabindex="-1"
@@ -54,7 +54,7 @@
               <button
                 aria-controls="full-width-tabpanel-2-NavigationTabs-tabs-id"
                 aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-2-NavigationTabs-tabs-id"
                 role="tab"
                 tabindex="-1"
@@ -68,69 +68,13 @@
               <button
                 aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
                 aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
                 id="full-width-tab-3-NavigationTabs-tabs-id"
                 role="tab"
                 tabindex="-1"
                 type="button"
               >
-                Stateful Sets
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
-              <button
-                aria-controls="full-width-tabpanel-4-NavigationTabs-tabs-id"
-                aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
-                id="full-width-tab-4-NavigationTabs-tabs-id"
-                role="tab"
-                tabindex="-1"
-                type="button"
-              >
-                Daemon Sets
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
-              <button
-                aria-controls="full-width-tabpanel-5-NavigationTabs-tabs-id"
-                aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
-                id="full-width-tab-5-NavigationTabs-tabs-id"
-                role="tab"
-                tabindex="-1"
-                type="button"
-              >
-                Replica Sets
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
-              <button
-                aria-controls="full-width-tabpanel-6-NavigationTabs-tabs-id"
-                aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
-                id="full-width-tab-6-NavigationTabs-tabs-id"
-                role="tab"
-                tabindex="-1"
-                type="button"
-              >
-                Jobs
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
-              <button
-                aria-controls="full-width-tabpanel-7-NavigationTabs-tabs-id"
-                aria-selected="false"
-                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1ao1q84-MuiButtonBase-root-MuiTab-root"
-                id="full-width-tab-7-NavigationTabs-tabs-id"
-                role="tab"
-                tabindex="-1"
-                type="button"
-              >
-                CronJobs
+                Item Without URL
                 <span
                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                 />
@@ -167,34 +111,6 @@
           class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
-          role="tabpanel"
-        />
-        <div
-          aria-labelledby="full-width-tab-4-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
-          hidden=""
-          id="full-width-tabpanel-4-NavigationTabs-tabs-id"
-          role="tabpanel"
-        />
-        <div
-          aria-labelledby="full-width-tab-5-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
-          hidden=""
-          id="full-width-tabpanel-5-NavigationTabs-tabs-id"
-          role="tabpanel"
-        />
-        <div
-          aria-labelledby="full-width-tab-6-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
-          hidden=""
-          id="full-width-tabpanel-6-NavigationTabs-tabs-id"
-          role="tabpanel"
-        />
-        <div
-          aria-labelledby="full-width-tab-7-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
-          hidden=""
-          id="full-width-tabpanel-7-NavigationTabs-tabs-id"
           role="tabpanel"
         />
         <hr

--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -519,8 +519,8 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
     sidebars[sidebarName === '' ? DefaultSidebars.IN_CLUSTER : sidebarName] ?? [];
 
   const sortedItems = useMemo(() => {
-    // Make a deep copy so that we always start from the original (unsorted) order.
-    const itemsCopy = _.cloneDeep(unsortedItems);
+    // Make a copy so that we always start from the original (unsorted) order.
+    const itemsCopy = [...unsortedItems];
     return settings?.sidebarSortAlphabetically ? sortSidebarItems(itemsCopy) : itemsCopy;
   }, [unsortedItems, settings.sidebarSortAlphabetically]);
 


### PR DESCRIPTION
We recently had a regression with tabs. Sidebar items can now have jsx and cluster has jsx element defined, tabs are incredibly slow in development because the NavigationTabs implementation is deepcloning the items (which in development have `window`).

This PR refactors the implementation to not require cloning at all

You'll also notice that the storybook snapshots changed quite drastically, because they now use correct mocked store. For example checkout the "WorkloadsParentSelected" story, in the previous snapshot it has items like "stateful sets", "daemon sets" which are not present [in the mocked store ](https://github.com/sniok/headlamp-o/blob/62831987b6f82e69c46846ddb5935131c8dda3ee/frontend/src/components/Sidebar/NavigationTabs.stories.tsx#L55). So there was a bug somewhere in the previous implementation which is now fixed. 

To reproduce:

start headlamp in development mode
click on different sidebar items
it will be slow, you can record performance trace in devtools to see that it spends a lot of time cloning items