### PR TITLE
Backend cluster rename bug clusters with special characters

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -34,6 +34,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -63,6 +64,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -2099,8 +2101,8 @@ func (c *HeadlampConfig) handleStatelessClusterRename(w http.ResponseWriter, r *
 	}, nil, "Completed stateless cluster rename")
 }
 
-// customNameToExtenstions writes the custom name to the Extensions map in the kubeconfig.
-func customNameToExtenstions(config *api.Config, contextName, newClusterName, path string) error {
+// customNameToExtensions writes the custom name to the Extensions map in the kubeconfig.
+func customNameToExtensions(config *api.Config, contextName, newClusterName, path string) error {
 	var err error
 
 	// Get the context with the given cluster name
@@ -2119,7 +2121,13 @@ func customNameToExtenstions(config *api.Config, contextName, newClusterName, pa
 		CustomName: newClusterName,
 	}
 
-	// Assign the CustomObject to the Extensions map
+	// Assign the CustomObject to the Extensions map.
+	// Extensions is nil for contexts that have never had extensions set; initialize
+	// it before writing to avoid a nil-map panic.
+	if contextConfig.Extensions == nil {
+		contextConfig.Extensions = make(map[string]k8sruntime.Object)
+	}
+
 	contextConfig.Extensions["headlamp_info"] = customObj
 
 	if err := clientcmd.WriteToFile(*config, path); err != nil {
@@ -2249,7 +2257,7 @@ func (c *HeadlampConfig) handleClusterRename(w http.ResponseWriter, r *http.Requ
 
 	contextName := findMatchingContextName(config, clusterName)
 
-	if err := customNameToExtenstions(config, contextName, reqBody.NewClusterName, path); err != nil {
+	if err := customNameToExtensions(config, contextName, reqBody.NewClusterName, path); err != nil {
 		c.handleError(w, ctx, span, err, "failed to write custom extension", http.StatusInternalServerError)
 		return err
 	}
@@ -2266,27 +2274,66 @@ func (c *HeadlampConfig) handleClusterRename(w http.ResponseWriter, r *http.Requ
 }
 
 // findMatchingContextName checks all contexts, returning the key for whichever
-// has a matching customObj.CustomName, if any.
+// has a matching customObj.CustomName, if any. It also handles the case where
+// the clusterName is a DNS-friendly version of the original context key
+// (e.g. slashes replaced with double dashes by MakeDNSFriendly).
+//
+// Resolution order:
+//  1. Custom name match (headlamp_info extension) — highest priority, returns immediately.
+//  2. Exact key match — avoids DNS-friendly ambiguity when the name already exists verbatim.
+//  3. DNS-friendly match — collects all candidates; warns and picks the
+//     lexicographically first one when multiple keys map to the same form.
 func findMatchingContextName(config *api.Config, clusterName string) string {
-	contextName := clusterName
-
+	// 1. Custom name takes priority: return the real context key immediately.
 	for k, v := range config.Contexts {
 		info := v.Extensions["headlamp_info"]
-		if info != nil {
-			customObj, err := MarshalCustomObject(info, contextName)
-			if err != nil {
-				logger.Log(logger.LevelError, map[string]string{"cluster": contextName},
-					err, "marshaling custom object")
-				continue
-			}
+		if info == nil {
+			continue
+		}
 
-			if customObj.CustomName != "" && customObj.CustomName == clusterName {
-				contextName = k
-			}
+		customObj, err := MarshalCustomObject(info, k)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": k},
+				err, "marshaling custom object")
+			continue
+		}
+
+		if customObj.CustomName != "" && customObj.CustomName == clusterName {
+			return k
 		}
 	}
 
-	return contextName
+	// 2. Exact key match: clusterName is already a verbatim context key.
+	if _, ok := config.Contexts[clusterName]; ok {
+		return clusterName
+	}
+
+	// 3. DNS-friendly match: collect all keys whose DNS-friendly form matches.
+	// Sorting makes the selection deterministic when multiple keys collide.
+	var matches []string
+
+	for k := range config.Contexts {
+		if kubeconfig.MakeDNSFriendly(k) == clusterName {
+			matches = append(matches, k)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0]
+	case 0:
+		return clusterName
+	default:
+		sort.Strings(matches)
+		logger.Log(logger.LevelWarn,
+			map[string]string{"clusterName": clusterName},
+			nil,
+			fmt.Sprintf("ambiguous DNS-friendly cluster name %q matches multiple context keys %v; using %q",
+				clusterName, matches, matches[0]),
+		)
+
+		return matches[0]
+	}
 }
 
 // checkUniqueName returns false if 'newName' is already in 'names', otherwise returns true.

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -277,7 +278,7 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 	req := ClusterReq{
 		KubeConfig: &kubeConfig,
 	}
-	cache := cache.New[interface{}]()
+	newCache := cache.New[interface{}]()
 	kubeConfigStore := kubeconfig.NewContextStore()
 
 	c := HeadlampConfig{
@@ -288,7 +289,7 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 				EnableDynamicClusters: true,
 				KubeConfigStore:       kubeConfigStore,
 			},
-			Cache:            cache,
+			Cache:            newCache,
 			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
 			TelemetryHandler: &telemetry.RequestHandler{},
 		},
@@ -303,28 +304,23 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 	clusters := c.getClusters()
 
 	assert.Equal(t, http.StatusCreated, r.Code)
-	assert.Equal(t, 2, len(clusters))
 
-	var contextWithoutNamespace *Cluster
-
-	var minikubeCluster *Cluster
-
-	for i, cluster := range clusters {
-		if cluster.Name == minikubeName {
-			// Using the slice addressing here to avoid the
-			// implicit memory aliasing in the loop.
-			minikubeCluster = &clusters[i]
-		} else if cluster.Name == "docker-desktop" {
-			contextWithoutNamespace = &clusters[i]
-		}
+	clustersByName := map[string]Cluster{}
+	for _, cl := range clusters {
+		clustersByName[cl.Name] = cl
 	}
 
-	assert.NotNil(t, contextWithoutNamespace)
-	assert.Equal(t, "", contextWithoutNamespace.Metadata["namespace"])
+	assert.Contains(t, clustersByName, minikubeName, "expected minikube cluster to exist")
+	assert.Contains(t, clustersByName, "docker-desktop", "expected docker-desktop cluster to exist")
 
-	assert.NotNil(t, minikubeCluster)
-	assert.Equal(t, minikubeName, minikubeCluster.Name)
-	assert.Equal(t, "default", minikubeCluster.Metadata["namespace"])
+	if contextWithoutNamespace, ok := clustersByName["docker-desktop"]; ok {
+		assert.Equal(t, "", contextWithoutNamespace.Metadata["namespace"])
+	}
+
+	if minikubeCluster, ok := clustersByName[minikubeName]; ok {
+		assert.Equal(t, minikubeName, minikubeCluster.Name)
+		assert.Equal(t, "default", minikubeCluster.Metadata["namespace"])
+	}
 }
 
 func TestInvalidKubeConfig(t *testing.T) {
@@ -703,6 +699,142 @@ func TestCheckUniqueName(t *testing.T) {
 	}
 }
 
+// TestFindMatchingContextName tests that findMatchingContextName resolves context keys correctly,
+// including DNS-friendly ARN names and headlamp_info custom name extensions.
+//
+//nolint:funlen
+func TestFindMatchingContextName(t *testing.T) {
+	cases := []struct {
+		label       string
+		contexts    map[string]*api.Context
+		clusterName string
+		expected    string
+	}{
+		{
+			label:       "plain name returns itself",
+			contexts:    map[string]*api.Context{"minikube": {}},
+			clusterName: "minikube",
+			expected:    "minikube",
+		},
+		{
+			// This covers the fix for ARN-like names: slashes in the original context key
+			// are converted to -- by MakeDNSFriendly when stored, so the rename request
+			// arrives with the -- form and must be mapped back to the original key.
+			label: "DNS-friendly ARN resolves to original slash form",
+			contexts: map[string]*api.Context{
+				"arn:aws:eks:us-east-1:123456789012:cluster/my-eks-cluster": {},
+			},
+			clusterName: "arn:aws:eks:us-east-1:123456789012:cluster--my-eks-cluster",
+			expected:    "arn:aws:eks:us-east-1:123456789012:cluster/my-eks-cluster",
+		},
+		{
+			label: "headlamp_info custom name takes priority over key matching",
+			contexts: map[string]*api.Context{
+				"original-context": {
+					Extensions: map[string]k8sruntime.Object{
+						"headlamp_info": &kubeconfig.CustomObject{
+							CustomName: "my-custom-name",
+						},
+					},
+				},
+			},
+			clusterName: "my-custom-name",
+			expected:    "original-context",
+		},
+		{
+			// When a verbatim key and a DNS-friendly alias of another key both match,
+			// the exact key match must win (priority 2 beats priority 3).
+			// This prevents nondeterminism when e.g. "a--b" exists alongside "a/b"
+			// (MakeDNSFriendly("a/b") == "a--b").
+			label: "exact key wins over DNS-friendly collision",
+			contexts: map[string]*api.Context{
+				"a--b": {},
+				"a/b":  {},
+			},
+			clusterName: "a--b",
+			expected:    "a--b",
+		},
+		{
+			// When two keys share the same DNS-friendly form and neither is an exact
+			// match, the lexicographically first key is returned deterministically.
+			// MakeDNSFriendly("a--b/c") == "a--b--c"
+			// MakeDNSFriendly("a/b--c") == "a--b--c"
+			// Neither key equals "a--b--c" verbatim, so DNS-friendly matching applies
+			// and the lexicographically smaller "a--b/c" must win.
+			label: "ambiguous DNS-friendly match returns lexicographically first key",
+			contexts: map[string]*api.Context{
+				"a--b/c": {},
+				"a/b--c": {},
+			},
+			clusterName: "a--b--c",
+			expected:    "a--b/c",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			config := &api.Config{Contexts: tc.contexts}
+			got := findMatchingContextName(config, tc.clusterName)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestCustomNameToExtensions verifies that customNameToExtensions writes the
+// custom name correctly in both the common case (Extensions already initialized)
+// and the panic-prone case (Extensions is nil, as happens for fresh kubeconfig
+// contexts that have never had extensions set).
+func TestCustomNameToExtensions(t *testing.T) {
+	cases := []struct {
+		label      string
+		extensions map[string]k8sruntime.Object // nil simulates a fresh context
+	}{
+		{
+			label:      "nil Extensions map is initialized before write",
+			extensions: nil,
+		},
+		{
+			label:      "existing Extensions map is preserved and updated",
+			extensions: map[string]k8sruntime.Object{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			// Write the config to a temp file so customNameToExtensions can persist it.
+			tmpFile, err := os.CreateTemp(t.TempDir(), "kubeconfig-*.yaml")
+			require.NoError(t, err)
+			tmpFile.Close()
+
+			config := &api.Config{
+				Contexts: map[string]*api.Context{
+					"my-cluster": {Extensions: tc.extensions},
+				},
+			}
+
+			require.NoError(t, clientcmd.WriteToFile(*config, tmpFile.Name()))
+
+			// Must not panic when Extensions is nil.
+			err = customNameToExtensions(config, "my-cluster", "my-custom-name", tmpFile.Name())
+			require.NoError(t, err)
+
+			// Reload from disk and verify the custom name was written.
+			// Extensions round-trip through the kubeconfig serializer as
+			// *runtime.Unknown, so use MarshalCustomObject to decode them.
+			saved, err := clientcmd.LoadFromFile(tmpFile.Name())
+			require.NoError(t, err)
+
+			ctx, ok := saved.Contexts["my-cluster"]
+			require.True(t, ok)
+			require.NotNil(t, ctx.Extensions["headlamp_info"])
+
+			customObj, err := MarshalCustomObject(ctx.Extensions["headlamp_info"], "my-cluster")
+			require.NoError(t, err)
+			assert.Equal(t, "my-custom-name", customObj.CustomName)
+		})
+	}
+}
+
 // runClusterRenameTests used to run the cluster rename tests.
 func runClusterRenameTests(
 	t *testing.T,
@@ -793,7 +925,20 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 	require.NoError(t, remErrNonDy, "Failed to remove context: minikubetestworkskubeconfig")
 
 	clusters := c.getClusters()
-	assert.Equal(t, 2, len(clusters))
+	clustersByName := map[string]Cluster{}
+
+	for _, cl := range clusters {
+		clustersByName[cl.Name] = cl
+	}
+
+	// The stateless rename removes the original from the store; the new name is frontend-only.
+	// The kubeconfig rename context was explicitly removed above.
+	assert.NotContains(t, clustersByName, "minikubetest", "expected stateless cluster to be removed from store")
+	assert.NotContains(t, clustersByName, "minikubetestworkskubeconfig",
+		"expected kubeconfig-renamed cluster to be removed from store")
+	// The clusters added via POST should still be present.
+	assert.Contains(t, clustersByName, minikubeName, "expected minikube cluster to still exist")
+	assert.Contains(t, clustersByName, "docker-desktop", "expected docker-desktop cluster to still exist")
 }
 
 func TestFileExists(t *testing.T) {

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -932,7 +932,7 @@ func convertToContext(contextName string, clientConfig *api.Config, source int, 
 	authInfo := clientConfig.AuthInfos[context.AuthInfo]
 
 	// Make contextName DNS friendly.
-	contextName = makeDNSFriendly(contextName)
+	contextName = MakeDNSFriendly(contextName)
 
 	newContext := Context{
 		Name:        contextName,
@@ -968,7 +968,7 @@ func LoadContextsFromAPIConfig(config *api.Config, skipProxySetup bool) ([]Conte
 		authInfo := config.AuthInfos[context.AuthInfo]
 
 		// Make contextName DNS friendly.
-		contextName = makeDNSFriendly(contextName)
+		contextName = MakeDNSFriendly(contextName)
 
 		context := Context{
 			Name:        contextName,
@@ -1029,7 +1029,7 @@ func GetInClusterContext(
 		Cluster:  contextName,
 		AuthInfo: contextName,
 	}
-	contextName = makeDNSFriendly(contextName)
+	contextName = MakeDNSFriendly(contextName)
 
 	inClusterAuthInfo := &api.AuthInfo{}
 
@@ -1123,8 +1123,8 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 	return errors.Join(errs...)
 }
 
-// makeDNSFriendly converts a string to a DNS-friendly format.
-func makeDNSFriendly(name string) string {
+// MakeDNSFriendly converts a string to a DNS-friendly format.
+func MakeDNSFriendly(name string) string {
 	name = strings.ReplaceAll(name, "/", "--")
 	name = strings.ReplaceAll(name, " ", "__")
 


### PR DESCRIPTION
## Summary

This PR adds/fixes #4813 by checking the dns-friendly version of a context key alongside the existing custom name check when retrieving cluster contexts. Previously, when renaming a cluster with a special character, the character was replaced. This new dns-friendly cluster key was then never matched.

This resulted in clusters with a dns-unfriendly special character in the name to be removed from the list of contexts after a rename was performed.

This was visible by simply reviewing the kubeconfig retrieved from the backend. The renamed cluster was simply no longer included in the kubeconfig response.

## Related Issue

Fixes #4813 

## Changes

- Fixed backend/cmd/headlamp.go to 
  - additionally check the DNS friendly version of a given context against the incoming findMatchingContextName parameter
  - Fixed a typo in the function customNameToExtensions
  - defensively handle when extensions are nil
- Updated backend/cmd/headlamp_test.go to 
  - verify updated findMatchingContextName supports special characters in a deterministic way (as recommended by Copilot)
  - updated variable that was shadowing a package name
  - verify expected clusters exist instead of checking overall cluster contexts, avoiding issues with drift
- Updated backend/pkg/kubeconfig/kubeconfig.go to change makeDNSFriendly to MakeDNSFriendly so it is exported and callable in backend/cmd/headlamp.go to validate findMatchingContextName parameter

## Steps to Test

1. Add an AWS EKS or other cluster with a / in the name
2. Open the cluster from the Home page
3. Select the Settings gear in the top right
4. Update the name to a valid name
5. Click Apply
6. Validate that the cluster is still available in the Home list, with its newly updated custom cluster name

## Screenshots (if applicable)

Before rename:
<img width="332" height="101" alt="image" src="https://github.com/user-attachments/assets/91e8b164-3cae-471e-a187-70d26a17ec51" />
After rename before fix with identical filter:
<img width="337" height="101" alt="image" src="https://github.com/user-attachments/assets/2376c0f6-1700-4260-a8eb-44bbd4a5a214" />

AFTER FIX:
Before rename:
<img width="309" height="139" alt="image" src="https://github.com/user-attachments/assets/9ef7691a-465e-4807-bd3b-0424b56043ac" />
After rename after fix with identical filter:
<img width="300" height="130" alt="image" src="https://github.com/user-attachments/assets/c8827220-6ca7-4c58-94f8-1319ce61f2de" />

Additional Notes:

I was unable to get clean test runs on a machine that was being actively used for kubernetes via kubectl, headlamp and other tooling. It seems like the tests expect a certain configuration of $HOME/.kube/config and the headlamp kubeconfig file. After manually resetting the files, I could only get one test execution until the files were altered.

In case this wasn't intended, I updated the RenameCluster tests to simply verify the updated cluster contexts are present, rather than the layout of the whole file.

Also I apologize for the churn in the PR, I was testing at too high of a level along with the issue I mentioned in these additional notes that sent me down the wrong track.
