### PR TITLE
WIP frontend:SettingsCluster: Fix narration for change icon & change color

### DIFF
--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -313,7 +313,11 @@ export default function SettingsCluster() {
                         size="small"
                         onClick={() => setColorPickerOpen(true)}
                         startIcon={<Icon icon="mdi:palette" />}
-                        aria-labelledby={`${appearanceLabelID} ${colorButtonID}`}
+                        aria-label={`${t('translation|Appearance')}, ${
+                          appearanceAccentColor
+                            ? t('translation|Change Color')
+                            : t('translation|Choose Color')
+                        }`}
                       >
                         {appearanceAccentColor
                           ? t('translation|Change Color')
@@ -349,7 +353,11 @@ export default function SettingsCluster() {
                         size="small"
                         onClick={() => setIconPickerOpen(true)}
                         startIcon={<Icon icon="mdi:emoticon-outline" />}
-                        aria-labelledby={`${appearanceLabelID} ${iconButtonID}`}
+                        aria-label={`${t('translation|Appearance')}, ${
+                          appearanceIcon
+                            ? t('translation|Change Icon')
+                            : t('translation|Choose Icon')
+                        }`}
                       >
                         {appearanceIcon
                           ? t('translation|Change Icon')


### PR DESCRIPTION
## Summary



## Related Issue



## Changes

- Fixed screen reader narration for appearance section

## Steps to Test

- Navigate to home view
- Open cluster settings of any cluster
- Use screen reader to tab through settings 
- Notice the appearance section should now narrate "appearance" before choose color / choose icon


## Screenshots (if applicable)

