### PR TITLE
headlamp-plugin: Fixes for svg, useClustersConf used in example plugin, testing headlamp-plugin changes in the PR

### DIFF
--- a/plugins/examples/cluster-chooser/src/index.test.tsx
+++ b/plugins/examples/cluster-chooser/src/index.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { describe, expect, it } from 'vitest';
+import { ClusterChooserButton } from './index';
+
+describe('ClusterChooserButton', () => {
+  it('shows 0 clusters when clusters have not been loaded', () => {
+    const store = configureStore({
+      reducer: {
+        config: () => ({
+          clusters: null,
+          allClusters: null,
+          statelessClusters: null,
+          settings: {},
+        }),
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <ClusterChooserButton clickHandler={() => {}} cluster="test" />
+      </Provider>
+    );
+
+    expect(screen.getByText(/0 clusters/)).toBeTruthy();
+  });
+
+  it('shows cluster count from the store', () => {
+    const store = configureStore({
+      reducer: {
+        config: () => ({
+          clusters: {
+            'my-cluster': { name: 'my-cluster' },
+          },
+          allClusters: {},
+          statelessClusters: null,
+          settings: {},
+        }),
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <ClusterChooserButton clickHandler={() => {}} cluster="my-cluster" />
+      </Provider>
+    );
+
+    expect(screen.getByText(/Cluster: my-cluster/)).toBeTruthy();
+    expect(screen.getByText(/1 clusters/)).toBeTruthy();
+  });
+
+  it('includes stateless clusters in the count', () => {
+    const store = configureStore({
+      reducer: {
+        config: () => ({
+          clusters: {
+            'regular-cluster': { name: 'regular-cluster' },
+          },
+          allClusters: {},
+          statelessClusters: {
+            'stateless-cluster': { name: 'stateless-cluster' },
+          },
+          settings: {},
+        }),
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <ClusterChooserButton clickHandler={() => {}} cluster="regular-cluster" />
+      </Provider>
+    );
+
+    expect(screen.getByText(/2 clusters/)).toBeTruthy();
+  });
+});

--- a/plugins/examples/cluster-chooser/src/index.tsx
+++ b/plugins/examples/cluster-chooser/src/index.tsx
@@ -14,9 +14,31 @@
  * limitations under the License.
  */
 
-import { ClusterChooserProps, registerClusterChooser } from '@kinvolk/headlamp-plugin/lib';
+import { ClusterChooserProps, K8s, registerClusterChooser } from '@kinvolk/headlamp-plugin/lib';
 import { Button } from '@mui/material';
 
-registerClusterChooser(({ clickHandler, cluster }: ClusterChooserProps) => {
-  return <Button onClick={clickHandler}>Our Cluster Chooser button. Cluster: {cluster}</Button>;
-});
+/** Props for the ClusterChooserButton component. */
+export interface ClusterChooserButtonProps {
+  /** Handler called when the button is clicked. */
+  clickHandler: ClusterChooserProps['clickHandler'];
+  /** Currently selected cluster name. */
+  cluster: ClusterChooserProps['cluster'];
+}
+
+/** A button that shows the current cluster and total cluster count using useClustersConf. */
+export function ClusterChooserButton({ clickHandler, cluster }: ClusterChooserButtonProps) {
+  const clusters = K8s.useClustersConf();
+  const clusterNames = clusters ? Object.keys(clusters) : [];
+
+  return (
+    <Button onClick={clickHandler}>
+      Our Cluster Chooser button. Cluster: {cluster} ({clusterNames.length} clusters)
+    </Button>
+  );
+}
+
+// Replaces the default cluster chooser in the top bar with a button that shows
+// the current cluster name and total number of configured clusters (e.g. "Cluster: minikube (3 clusters)").
+registerClusterChooser(({ clickHandler, cluster }: ClusterChooserProps) => (
+  <ClusterChooserButton clickHandler={clickHandler} cluster={cluster} />
+));

--- a/plugins/examples/projects/src/index.tsx
+++ b/plugins/examples/projects/src/index.tsx
@@ -185,5 +185,5 @@ registerProjectHeaderAction({
     </button>
   ),
   // Only show this action if the project has multiple clusters
-  isEnabled: ({ project }) => project.clusters.length > 0,
+  isEnabled: async ({ project }) => project.clusters.length > 0,
 });

--- a/plugins/headlamp-plugin/config/plugins-tsconfig.json
+++ b/plugins/headlamp-plugin/config/plugins-tsconfig.json
@@ -41,5 +41,6 @@
     "rootDirs": ["node_modules/@kinvolk/headlamp-plugin/"],
     "skipLibCheck": true
   },
+  "files": ["./svg.d.ts"],
   "include": ["./../../../../src/**/*"]
 }

--- a/plugins/headlamp-plugin/config/svg.d.ts
+++ b/plugins/headlamp-plugin/config/svg.d.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Override vite/client's *.svg module declaration.
+ * vite/client types SVG imports as strings, but headlamp uses vite-plugin-svgr
+ * which transforms SVG imports into React components at build time.
+ */
+declare module '*.svg' {
+  import * as React from 'react';
+  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+  export default content;
+}

--- a/plugins/headlamp-plugin/test-plugins-examples.sh
+++ b/plugins/headlamp-plugin/test-plugins-examples.sh
@@ -6,14 +6,20 @@ set -o xtrace
 
 npm run check-dependencies
 npm run build
+npm run copy-package-lock
 npm pack
 
 cd ../examples
 for i in * ; do
   if [ -d "$i" ]; then
     cd "$i"
-    # Test changes to headlamp-plugin in the PR/repo that released version might not have.
-    npm ci `ls -t ../../headlamp-plugin/kinvolk-headlamp-plugin-*.tgz | head -1`
+    # First, do a fast clean install of all dependencies from the lockfile.
+    npm ci
+    # Then override headlamp-plugin with the locally built tarball so we test
+    # PR/repo changes that the released registry version might not have.
+    # npm ci cannot do this — it ignores positional package arguments and would
+    # silently keep the registry version.
+    npm install `ls -t ../../headlamp-plugin/kinvolk-headlamp-plugin-*.tgz | head -1`
     npm run lint
     npm run format
     npm run build


### PR DESCRIPTION
## Summary

Fixes SVG type declarations and TSC errors across example plugins.

Before:
- there was no way to use useClustersConf used in an example plugin. Now there is one, and it also tests it.
- SVG types were broken when people used new vite packages which overrode our type
- changes to headlamp-plugin in the PRs were not tested in the example plugins as they were in the past

How to use useClustersConf in a plugin so it can also be tested? For now:
```tsx
import { K8s } from '@kinvolk/headlamp-plugin/lib';
// use it like this:
K8s.useClustersConf
```

## Changes

- **New `ClusterChooserButton` component** in `cluster-chooser` example — extracted from the inline `registerClusterChooser` callback so it can be tested
- **Tests** for `ClusterChooserButton` (vitest): null state, loaded clusters, stateless cluster merging
- **SVG type fix**: Added `config/svg.d.ts` referenced via `files` in `plugins-tsconfig.json` to override `vite/client`'s `*.svg → string` declaration with `React.FunctionComponent` (matching vite-plugin-svgr behavior). Fixes `SvgIcon` prop errors in `change-logo` and any external plugin using SVG imports.
- **`test-plugins-examples.sh`**: Now runs `npm ci` first for a fast clean install from the lockfile, then `npm install <tgz>` to override headlamp-plugin with the locally built tarball (`npm ci` silently ignores positional args, so it cannot install the local tarball directly). Added `npm run copy-package-lock` before `npm pack`.
- **`projects` example**: `isEnabled` now returns `Promise<boolean>` via `async` to match `ProjectHeaderAction` type signature

## Commits

- **plugins/examples/projects: Fix missing async on isEnabled**
- **headlamp-plugin: Fix type error for svg imports**
- **headlamp-plugin: test-plugins-examples: Fix test to use in PR changes**
- **plugins/examples/cluster-chooser: Add useClustersConf and test**

## Steps to Test

1. `cd plugins/headlamp-plugin && npm install && npm run build && npm run copy-package-lock && npm pack`
2. `cd ../examples/cluster-chooser && npm ci && npm install ../../headlamp-plugin/kinvolk-headlamp-plugin-*.tgz`
3. `npm run tsc && npm run lint && npm run test && npm start`
4. Run headlamp and see the cluster chooser runs and there's not type error because of useClustersConf



## Notes for the Reviewer

- The test script uses a two-step install: `npm ci` for fast lockfile-based dependency installation, then `npm install <tgz>` to override headlamp-plugin with the local build. `npm ci` cannot do both because it ignores positional package arguments per npm docs. Comments in the script explain this.


