### PR TITLE
Fix empty DialogTitle h1 in ManyClusters story

### DIFF
--- a/frontend/src/components/cluster/Chooser.stories.tsx
+++ b/frontend/src/components/cluster/Chooser.stories.tsx
@@ -130,8 +130,8 @@ ManyClusters.args = {
       auth_type: '',
     })),
   open: true,
+  title: 'Choose Cluster',
 };
-
 export const NoClusters = Template.bind({});
 NoClusters.args = {
   clusters: [],


### PR DESCRIPTION
## Description

Fixes an accessibility issue in the ManyClusters Storybook story where an empty `<h1>` element was rendered due to a missing `title` prop.

## Changes

* Added the required `title` prop to the `ManyClusters` story in `Chooser.stories.tsx`
* Ensures proper heading structure for accessibility compliance

## Issue

Fixes #4603

## Testing

* Ran Storybook locally
* Verified that the dialog now displays a proper title instead of an empty heading
* Confirmed no visual regressions in related stories
