### PR TITLE
frontend: UploadDialog: Add Storybook stories for UploadDialog

### DIFF
--- a/frontend/src/components/common/Resource/UploadDialog.stories.tsx
+++ b/frontend/src/components/common/Resource/UploadDialog.stories.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { userEvent, waitFor, within } from 'storybook/test';
+import { UploadDialog } from './UploadDialog';
+
+export default {
+  title: 'Resource/UploadDialog',
+  component: UploadDialog,
+  argTypes: {
+    setUploadFiles: { action: 'setUploadFiles' },
+    setCode: { action: 'setCode' },
+  },
+} as Meta;
+
+const Template: StoryFn<typeof UploadDialog> = args => <UploadDialog {...args} />;
+
+/**
+ * Empty upload dialog in its default state with the Upload File tab active.
+ */
+export const Default = Template.bind({});
+
+/**
+ * Upload dialog with a file selected, showing the filename.
+ */
+export const FileSelected = Template.bind({});
+FileSelected.parameters = {
+  storyshots: { disable: true },
+};
+FileSelected.play = async ({ canvasElement }) => {
+  const file = new File(['apiVersion: v1\nkind: Pod'], 'test.yaml', {
+    type: 'application/yaml',
+  });
+  const input = canvasElement.querySelector('input[type="file"]') as HTMLInputElement;
+  await userEvent.upload(input, file);
+};
+
+/**
+ * Upload dialog after successfully loading a file.
+ * The setCode and setUploadFiles actions are invoked on success.
+ */
+export const UploadSuccess = Template.bind({});
+UploadSuccess.parameters = {
+  storyshots: { disable: true },
+};
+UploadSuccess.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const file = new File(['apiVersion: v1\nkind: Pod'], 'test.yaml', {
+    type: 'application/yaml',
+  });
+  const input = canvasElement.querySelector('input[type="file"]') as HTMLInputElement;
+  await userEvent.upload(input, file);
+  const loadButton = canvas.getByRole('button', { name: /^Load$/i });
+  await userEvent.click(loadButton);
+};
+
+/**
+ * Upload dialog showing an error when all selected files are empty (file size error).
+ */
+export const EmptyFileError = Template.bind({});
+EmptyFileError.parameters = {
+  storyshots: { disable: true },
+};
+EmptyFileError.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const emptyFile = new File([''], 'empty.yaml', { type: 'application/yaml' });
+  const input = canvasElement.querySelector('input[type="file"]') as HTMLInputElement;
+  await userEvent.upload(input, emptyFile);
+  const loadButton = canvas.getByRole('button', { name: /^Load$/i });
+  await userEvent.click(loadButton);
+  await waitFor(() => canvas.getByText(/Error: All of the files are empty/i));
+};
+
+/**
+ * Upload dialog showing a validation error for an invalid URL format.
+ */
+export const URLValidationError = Template.bind({});
+URLValidationError.parameters = {
+  storyshots: { disable: true },
+};
+URLValidationError.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const urlTab = canvas.getByRole('tab', { name: /Load from URL/i });
+  await userEvent.click(urlTab);
+  const urlInput = await canvas.findByLabelText(/Enter URL/i);
+  await userEvent.type(urlInput, 'not-a-valid-url');
+  const loadButton = canvas.getByRole('button', { name: /^Load$/i });
+  await userEvent.click(loadButton);
+  await waitFor(() => canvas.getByText(/Please enter a valid URL/i));
+};
+
+/**
+ * Upload dialog showing a network error when fetching from a URL fails.
+ */
+export const URLNetworkError = Template.bind({});
+URLNetworkError.parameters = {
+  storyshots: { disable: true },
+  msw: {
+    handlers: {
+      base: null,
+      story: [
+        http.get('https://example.com/test.yaml', () => {
+          return HttpResponse.error();
+        }),
+      ],
+    },
+  },
+};
+URLNetworkError.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const urlTab = canvas.getByRole('tab', { name: /Load from URL/i });
+  await userEvent.click(urlTab);
+  const urlInput = await canvas.findByLabelText(/Enter URL/i);
+  await userEvent.type(urlInput, 'https://example.com/test.yaml');
+  const loadButton = canvas.getByRole('button', { name: /^Load$/i });
+  await userEvent.click(loadButton);
+  await waitFor(() => canvas.getByText(/Failed to fetch|Unexpected error while fetching/i));
+};

--- a/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
@@ -1,0 +1,225 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-ytwq1q-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-1ehm288-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <div
+          class="MuiDialogContent-root css-1ovoic6-MuiDialogContent-root"
+        >
+          <div
+            class="MuiTabs-root css-1ujnqem-MuiTabs-root"
+          >
+            <div
+              class="MuiTabs-scrollableX MuiTabs-hideScrollbar css-oqr85h"
+              style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+            />
+            <div
+              class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX css-69z67c-MuiTabs-scroller"
+              style="margin-bottom: 0px;"
+            >
+              <div
+                aria-label="Upload File/URL"
+                class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+                role="tablist"
+              >
+                <button
+                  aria-controls="full-width-tabpanel-0-UploadFile/URL-tabs-id"
+                  aria-selected="true"
+                  class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                  id="full-width-tab-0-UploadFile/URL-tabs-id"
+                  role="tab"
+                  tabindex="0"
+                  type="button"
+                >
+                  Upload File
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-controls="full-width-tabpanel-1-UploadFile/URL-tabs-id"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                  id="full-width-tab-1-UploadFile/URL-tabs-id"
+                  role="tab"
+                  tabindex="-1"
+                  type="button"
+                >
+                  Load from URL
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <span
+                class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+                style="left: 0px; width: 0px;"
+              />
+            </div>
+          </div>
+          <div
+            aria-labelledby="full-width-tab-0-UploadFile/URL-tabs-id"
+            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            id="full-width-tabpanel-0-UploadFile/URL-tabs-id"
+            role="tabpanel"
+          >
+            <div
+              class="MuiBox-root css-1v3caum"
+            >
+              <div
+                class="MuiBox-root css-1mcn8zw"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-3o8n1d-MuiTypography-root"
+                >
+                  Select a file or drag and drop here
+                </p>
+                <input
+                  accept=".yaml,.yml,application/yaml"
+                  hidden=""
+                  multiple=""
+                  type="file"
+                />
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-17g4n8r-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+                  />
+                  Select File
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <div
+                class="MuiBox-root css-lg51ys"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorInherit MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorInherit MuiButton-disableElevation css-1m4efiz-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Back
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit MuiButton-disableElevation css-1nmqcac-MuiButtonBase-root-MuiButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  Load
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-labelledby="full-width-tab-1-UploadFile/URL-tabs-id"
+            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            hidden=""
+            id="full-width-tabpanel-1-UploadFile/URL-tabs-id"
+            role="tabpanel"
+          >
+            <div
+              class="MuiBox-root css-1v3caum"
+            >
+              <div
+                class="MuiBox-root css-zoser8"
+              >
+                <div
+                  class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1j5gcdd-MuiFormControl-root-MuiTextField-root"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1213p86-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="false"
+                    for=":mock-test-id:"
+                    id=":mock-test-id:"
+                  >
+                    Enter URL
+                  </label>
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-u775sc-MuiInputBase-root-MuiOutlinedInput-root"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+                      id=":mock-test-id:"
+                      type="text"
+                      value=""
+                    />
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-njhac4-MuiNotchedOutlined-root"
+                      >
+                        <span>
+                          Enter URL
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-lg51ys"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorInherit MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedInherit MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorInherit MuiButton-disableElevation css-1m4efiz-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Back
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit MuiButton-disableElevation css-1nmqcac-MuiButtonBase-root-MuiButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  Load
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>


### PR DESCRIPTION
## Summary

Adds Storybook stories for `UploadDialog` to increase coverage from 3.89%.

## Related Issue

Fixes #4690

## Changes

- `Default` — empty dialog with Upload File tab active
- `FileSelected` — a YAML file picked via the file input, filename shown
- `UploadSuccess` — file loaded successfully, `setCode`/`setUploadFiles` callbacks fired
- `EmptyFileError` — file selected is empty, shows "Error: All of the files are empty"
- `URLValidationError` — invalid URL entered, shows "Please enter a valid URL"
- `URLNetworkError` — MSW simulates a network failure on URL fetch, shows fetch error


## Steps to Test

1. `cd frontend && npm install`
2. `npm run frontend:storybook`





## Notes for the Reviewer

- The issue title mentions an "upload progress loading bar" story but the  current `UploadDialog` component has no loading or progress state, it reads files synchronously and calls `onLoaded` directly. There is nothing to show a loading bar for without modifying the component itself, which was not part of this issue. 


