### PR TITLE
docs: Fix typo 'shoud' to 'should' in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ Use **atomic commits** to keep each commit focused on a single change. Follow th
 
 `<area>: <description of changes>`
 
-- Both the title and the body of the commit message shoud not exceed
+- Both the title and the body of the commit message should not exceed
   72 characters in length.
   i.e. Please keep the title length under 72
   characters, and the wrap the body of the message at 72 characters.


### PR DESCRIPTION
## Summary

This PR fixes a small documentation typo in the contributing guide by replacing "shoud" with "should".

## Related Issue

Fixes #4848 

## Changes

- Updated documentation in /docs/latest/contributing/
- Fixed typo: **shoud** with **should**

## Steps to Test

1. Navigate to the contributing documentation page.

2. Locate the sentence which has the typo.

3. Verify that "shoud" has been changed to "should".

## Screenshots (if applicable)


## Notes for the Reviewer

- This is a small documentation improvement identified while reading the docs.