### PR TITLE
Add GCP OAuth authentication support for GKE clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 plugins/headlamp-plugin/headlamp-myfancy/
 plugins/examples/*/dist/
 .DS_Store
+scripts/backend/headlamp

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -47,6 +47,7 @@ import (
 	auth "github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/gcp"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/serviceproxy"
 
 	headlampcfg "github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
@@ -453,6 +454,16 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 		}
 
 		context.Source = kubeconfig.InCluster
+
+		// When GCP OAuth is enabled, clear the in-cluster auth info (service account token) so
+		// that requests are not automatically authenticated as the pod's service account.
+		// This ensures all Kubernetes API calls go through GCP OAuth, preserving each user's
+		// identity for proper attribution and RBAC enforcement based on their Google account.
+		if config.GCPOAuthEnabled {
+			context.AuthInfo = &api.AuthInfo{}
+
+			logger.Log(logger.LevelInfo, nil, nil, "Added in-cluster context without service account auth (GCP OAuth enabled)")
+		}
 
 		err = context.SetupProxy()
 		if err != nil {
@@ -878,6 +889,36 @@ func createHeadlampHandler(config *HeadlampConfig) http.Handler {
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	})
+
+	// GCP OAuth routes for GKE authentication
+	if config.GCPOAuthEnabled {
+		gcpAuth := gcp.NewGCPAuthenticator(
+			config.GCPClientID,
+			config.GCPClientSecret,
+			config.GCPRedirectURL,
+			config.Cache,
+		)
+
+		r.HandleFunc("/gcp-auth/login", auth.HandleGCPAuthLogin(gcpAuth)).Methods("GET")
+		r.HandleFunc("/gcp-auth/callback", auth.HandleGCPAuthCallback(gcpAuth, config.BaseURL, config.SessionTTL)).Methods("GET")
+		r.HandleFunc("/gcp-auth/refresh", auth.HandleGCPTokenRefresh(gcpAuth, config.BaseURL, config.SessionTTL)).Methods("POST")
+
+		logger.Log(logger.LevelInfo, nil, nil, "GCP OAuth authentication enabled for GKE clusters")
+	}
+
+	// Endpoint to check if GCP OAuth is enabled.
+	// This is intentionally outside the gcpOAuthEnabled conditional block so the frontend
+	// can always query this endpoint to determine whether to show the GCP OAuth login button.
+	r.HandleFunc("/gcp-auth/enabled", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if config.GCPOAuthEnabled {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"enabled": true}`))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"enabled": false}`))
+		}
+	}).Methods("GET")
 
 	// Serve the frontend if needed
 	if spa.UseEmbeddedFiles {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -144,6 +144,11 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		Cache:                     cache,
 		Multiplexer:               multiplexer,
 		TelemetryConfig:           buildTelemetryConfig(conf),
+		// GCP OAuth fields
+		GCPOAuthEnabled: conf.GCPOAuthEnabled,
+		GCPClientID:     conf.GCPClientID,
+		GCPClientSecret: conf.GCPClientSecret,
+		GCPRedirectURL:  conf.GCPRedirectURL,
 	}
 
 	if conf.OidcCAFile != "" {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -50,6 +50,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240716105424-66b64c4bb379 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=

--- a/backend/pkg/auth/gcp.go
+++ b/backend/pkg/auth/gcp.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/gcp"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+// validClusterNamePattern matches valid Kubernetes cluster names.
+// Allows alphanumeric characters, hyphens, underscores, and dots.
+var validClusterNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+const (
+	// Cookie names for OAuth flow state.
+	gcpOAuthStateCookie    = "gcp_oauth_state"
+	gcpOAuthClusterCookie  = "gcp_oauth_cluster"
+	gcpOAuthVerifierCookie = "gcp_oauth_verifier"
+
+	// OAuth flow timeout.
+	oauthFlowTimeout = 10 * time.Minute
+)
+
+// HandleGCPAuthLogin initiates the GCP OAuth login flow for GKE clusters.
+func HandleGCPAuthLogin(gcpAuth *gcp.GCPAuthenticator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cluster := r.URL.Query().Get("cluster")
+		if cluster == "" {
+			http.Error(w, "cluster parameter required", http.StatusBadRequest)
+			return
+		}
+
+		// Validate cluster name format to prevent injection attacks
+		if !validClusterNamePattern.MatchString(cluster) {
+			http.Error(w, "invalid cluster name format", http.StatusBadRequest)
+			return
+		}
+
+		// Generate state token for CSRF protection
+		state, err := gcp.GenerateRandomState()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to generate state")
+			http.Error(w, "failed to generate state", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Generate PKCE code verifier and challenge for enhanced security
+		codeVerifier, err := gcp.GenerateCodeVerifier()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to generate code verifier")
+			http.Error(w, "failed to generate code verifier", http.StatusInternalServerError)
+
+			return
+		}
+
+		codeChallenge := gcp.GenerateCodeChallenge(codeVerifier)
+
+		secure := IsSecureContext(r)
+
+		// Store state, cluster, and PKCE verifier in cookies for validation in callback
+		setOAuthCookie(w, gcpOAuthStateCookie, state, secure)
+		setOAuthCookie(w, gcpOAuthClusterCookie, cluster, secure)
+		setOAuthCookie(w, gcpOAuthVerifierCookie, codeVerifier, secure)
+
+		// Redirect to Google OAuth
+		authURL := gcpAuth.GetAuthCodeURL(state, codeChallenge)
+
+		logger.Log(logger.LevelInfo, map[string]string{
+			"cluster": cluster,
+		}, nil, "initiating GCP OAuth flow")
+
+		http.Redirect(w, r, authURL, http.StatusFound)
+	}
+}
+
+// gcpCallbackData holds validated data from the OAuth callback.
+type gcpCallbackData struct {
+	cluster      string
+	codeVerifier string
+	code         string
+}
+
+// validateGCPCallback validates the OAuth callback request and returns extracted data.
+func validateGCPCallback(r *http.Request) (*gcpCallbackData, error) {
+	// Validate state token (CSRF protection)
+	stateCookie, err := r.Cookie(gcpOAuthStateCookie)
+	if err != nil {
+		return nil, fmt.Errorf("state cookie not found: %w", err)
+	}
+
+	stateParam := r.URL.Query().Get("state")
+	if stateCookie.Value != stateParam {
+		return nil, fmt.Errorf("OAuth state mismatch")
+	}
+
+	// Get cluster from cookie
+	clusterCookie, err := r.Cookie(gcpOAuthClusterCookie)
+	if err != nil {
+		return nil, fmt.Errorf("cluster cookie not found: %w", err)
+	}
+
+	cluster := clusterCookie.Value
+	if !validClusterNamePattern.MatchString(cluster) {
+		return nil, fmt.Errorf("invalid cluster name format: %s", cluster)
+	}
+
+	// Check for OAuth errors
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		errDesc := r.URL.Query().Get("error_description")
+		logger.Log(logger.LevelError, map[string]string{
+			"error":       errParam,
+			"description": errDesc,
+		}, nil, "OAuth provider returned an error")
+
+		return nil, fmt.Errorf("OAuth authentication failed")
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		return nil, fmt.Errorf("no code in request")
+	}
+
+	// Get PKCE code verifier (optional)
+	codeVerifier := ""
+	if verifierCookie, err := r.Cookie(gcpOAuthVerifierCookie); err == nil {
+		codeVerifier = verifierCookie.Value
+	}
+
+	return &gcpCallbackData{
+		cluster:      cluster,
+		codeVerifier: codeVerifier,
+		code:         code,
+	}, nil
+}
+
+// HandleGCPAuthCallback handles the OAuth callback from Google.
+func HandleGCPAuthCallback(gcpAuth *gcp.GCPAuthenticator, baseURL string, sessionTTL int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		data, err := validateGCPCallback(r)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "OAuth callback validation failed")
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		token, err := gcpAuth.Exchange(ctx, data.code, data.codeVerifier)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": data.cluster}, err, "failed to exchange code")
+			http.Error(w, "failed to exchange token", http.StatusInternalServerError)
+
+			return
+		}
+
+		gkeToken, err := gcpAuth.GetGKEAccessToken(ctx, token)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": data.cluster}, err, "failed to get GKE token")
+			http.Error(w, "failed to get GKE token", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Cache the refresh token (non-fatal if it fails)
+		if token.RefreshToken != "" {
+			if cacheErr := gcpAuth.CacheRefreshToken(ctx, data.cluster, gkeToken, token.RefreshToken); cacheErr != nil {
+				logger.Log(logger.LevelError, map[string]string{"cluster": data.cluster}, cacheErr, "failed to cache refresh token")
+			}
+		}
+
+		SetTokenCookie(w, r, data.cluster, gkeToken, baseURL, sessionTTL)
+
+		secure := IsSecureContext(r)
+		clearOAuthCookie(w, gcpOAuthStateCookie, secure)
+		clearOAuthCookie(w, gcpOAuthClusterCookie, secure)
+		clearOAuthCookie(w, gcpOAuthVerifierCookie, secure)
+
+		logger.Log(logger.LevelInfo, map[string]string{"cluster": data.cluster}, nil, "GCP OAuth flow completed")
+
+		redirectURL := fmt.Sprintf("/#/c/%s", data.cluster)
+		if baseURL != "" {
+			trimmedBase := strings.Trim(baseURL, "/")
+			redirectURL = "/" + trimmedBase + redirectURL
+		}
+
+		http.Redirect(w, r, redirectURL, http.StatusFound)
+	}
+}
+
+// HandleGCPTokenRefresh handles token refresh requests for GKE clusters.
+// The cluster name and current access token are provided via query parameters
+// since this endpoint is not registered under the /clusters/{clusterName}/ path.
+func HandleGCPTokenRefresh(gcpAuth *gcp.GCPAuthenticator, baseURL string, sessionTTL int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		cluster := r.URL.Query().Get("cluster")
+		if cluster == "" {
+			http.Error(w, "cluster parameter required", http.StatusBadRequest)
+			return
+		}
+
+		if !validClusterNamePattern.MatchString(cluster) {
+			http.Error(w, "invalid cluster name format", http.StatusBadRequest)
+			return
+		}
+
+		// Get the current access token from the cluster cookie
+		token, err := GetTokenFromCookie(r, cluster)
+		if err != nil || token == "" {
+			http.Error(w, "valid token cookie required", http.StatusBadRequest)
+			return
+		}
+
+		// Get cached refresh token
+		refreshToken, err := gcpAuth.GetCachedRefreshToken(ctx, cluster, token)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{
+				"cluster": cluster,
+			}, err, "failed to get cached refresh token")
+			http.Error(w, "no refresh token available", http.StatusUnauthorized)
+
+			return
+		}
+
+		// Refresh the token
+		newToken, err := gcpAuth.RefreshToken(ctx, refreshToken)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{
+				"cluster": cluster,
+			}, err, "failed to refresh token")
+			http.Error(w, "failed to refresh token", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Get new GKE access token
+		newGKEToken, err := gcpAuth.GetGKEAccessToken(ctx, newToken)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{
+				"cluster": cluster,
+			}, err, "failed to get new GKE access token")
+			http.Error(w, "failed to get new GKE token", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Cache the new refresh token if we got one (non-fatal if it fails)
+		if newToken.RefreshToken != "" {
+			if cacheErr := gcpAuth.CacheRefreshToken(ctx, cluster, newGKEToken, newToken.RefreshToken); cacheErr != nil {
+				logger.Log(logger.LevelError, map[string]string{"cluster": cluster}, cacheErr, "failed to cache new refresh token")
+			}
+		}
+
+		// Set new token in cookie
+		SetTokenCookie(w, r, cluster, newGKEToken, baseURL, sessionTTL)
+
+		logger.Log(logger.LevelInfo, map[string]string{
+			"cluster": cluster,
+		}, nil, "token refreshed successfully")
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("token refreshed"))
+	}
+}
+
+// setOAuthCookie sets a temporary cookie for OAuth flow state.
+func setOAuthCookie(w http.ResponseWriter, name, value string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   int(oauthFlowTimeout.Seconds()),
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearOAuthCookie clears a cookie by setting it to expire immediately.
+func clearOAuthCookie(w http.ResponseWriter, name string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/backend/pkg/auth/gcp_test.go
+++ b/backend/pkg/auth/gcp_test.go
@@ -1,0 +1,481 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/gcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockGCPCache implements the cache interface for testing.
+type mockGCPCache struct {
+	data map[string]interface{}
+}
+
+func newMockGCPCache() *mockGCPCache {
+	return &mockGCPCache{
+		data: make(map[string]interface{}),
+	}
+}
+
+func (m *mockGCPCache) Get(ctx context.Context, key string) (interface{}, error) {
+	val, ok := m.data[key]
+	if !ok {
+		return nil, assert.AnError
+	}
+
+	return val, nil
+}
+
+func (m *mockGCPCache) Set(ctx context.Context, key string, value interface{}) error {
+	m.data[key] = value
+	return nil
+}
+
+func (m *mockGCPCache) SetWithTTL(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	m.data[key] = value
+	return nil
+}
+
+func (m *mockGCPCache) Delete(ctx context.Context, key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *mockGCPCache) GetAll(ctx context.Context, selectFunc cache.Matcher) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+
+	for k, v := range m.data {
+		if selectFunc == nil || selectFunc(k) {
+			result[k] = v
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockGCPCache) UpdateTTL(ctx context.Context, key string, ttl time.Duration) error {
+	return nil
+}
+
+func TestHandleGCPAuthLogin_MissingCluster(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthLogin(gcpAuth)
+
+	req := httptest.NewRequest(http.MethodGet, "/gcp-auth/login", nil)
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "cluster parameter required")
+}
+
+func TestHandleGCPAuthLogin_InvalidClusterName(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthLogin(gcpAuth)
+
+	tests := []struct {
+		name        string
+		cluster     string
+		errContains string
+	}{
+		{
+			name:        "cluster name starting with hyphen",
+			cluster:     "-invalid-cluster",
+			errContains: "invalid cluster name format",
+		},
+		{
+			name:        "cluster name starting with dot",
+			cluster:     ".invalid-cluster",
+			errContains: "invalid cluster name format",
+		},
+		{
+			name:        "cluster name starting with underscore",
+			cluster:     "_invalid-cluster",
+			errContains: "invalid cluster name format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/gcp-auth/login?cluster="+url.QueryEscape(tt.cluster), nil)
+			rr := httptest.NewRecorder()
+
+			handler(rr, req)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.errContains)
+		})
+	}
+}
+
+func TestHandleGCPAuthLogin_ValidClusterName(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthLogin(gcpAuth)
+
+	tests := []struct {
+		name    string
+		cluster string
+	}{
+		{
+			name:    "simple cluster name",
+			cluster: "my-cluster",
+		},
+		{
+			name:    "cluster name with underscore",
+			cluster: "my_cluster",
+		},
+		{
+			name:    "cluster name with dots",
+			cluster: "my.cluster.name",
+		},
+		{
+			name:    "alphanumeric cluster name",
+			cluster: "cluster123",
+		},
+		{
+			name:    "GKE style cluster name",
+			cluster: "gke_project-id_us-central1_cluster-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/gcp-auth/login?cluster="+tt.cluster, nil)
+			rr := httptest.NewRecorder()
+
+			handler(rr, req)
+
+			// Should redirect to Google OAuth
+			assert.Equal(t, http.StatusFound, rr.Code)
+
+			// Should set OAuth cookies
+			cookies := rr.Result().Cookies()
+			require.GreaterOrEqual(t, len(cookies), 3)
+
+			// Verify cookie names
+			cookieNames := make(map[string]bool)
+			for _, c := range cookies {
+				cookieNames[c.Name] = true
+			}
+
+			assert.True(t, cookieNames["gcp_oauth_state"], "should have state cookie")
+			assert.True(t, cookieNames["gcp_oauth_cluster"], "should have cluster cookie")
+			assert.True(t, cookieNames["gcp_oauth_verifier"], "should have verifier cookie")
+
+			// Verify redirect URL contains Google OAuth
+			location := rr.Header().Get("Location")
+			assert.Contains(t, location, "accounts.google.com")
+			assert.Contains(t, location, "client_id=test-client-id")
+		})
+	}
+}
+
+func TestHandleGCPAuthLogin_CookieAttributes(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthLogin(gcpAuth)
+
+	req := httptest.NewRequest(http.MethodGet, "/gcp-auth/login?cluster=test-cluster", nil)
+	req.Host = "localhost"
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+
+	// Check cookie attributes
+	cookies := rr.Result().Cookies()
+
+	for _, cookie := range cookies {
+		// All OAuth cookies should be HttpOnly
+		assert.True(t, cookie.HttpOnly, "cookie %s should be HttpOnly", cookie.Name)
+		// Should have SameSite=Lax for OAuth flow
+		assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite, "cookie %s should have SameSite=Lax", cookie.Name)
+		// Path should be root
+		assert.Equal(t, "/", cookie.Path, "cookie %s should have path=/", cookie.Name)
+	}
+}
+
+func TestHandleGCPAuthLogin_WithBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/headlamp/callback", cache)
+
+	handler := auth.HandleGCPAuthLogin(gcpAuth)
+
+	req := httptest.NewRequest(http.MethodGet, "/headlamp/gcp-auth/login?cluster=test-cluster", nil)
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	// Should still redirect successfully
+	assert.Equal(t, http.StatusFound, rr.Code)
+}
+
+func TestHandleGCPAuthCallback_MissingStateCookie(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthCallback(gcpAuth, "", 86400)
+
+	req := httptest.NewRequest(http.MethodGet, "/gcp-auth/callback?code=test-code&state=test-state", nil)
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "state cookie not found")
+}
+
+func TestHandleGCPAuthCallback_StateMismatch(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthCallback(gcpAuth, "", 86400)
+
+	req := httptest.NewRequest(http.MethodGet, "/gcp-auth/callback?code=test-code&state=different-state", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_state",
+		Value: "test-state",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_cluster",
+		Value: "test-cluster",
+	})
+
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "OAuth state mismatch")
+}
+
+func TestHandleGCPAuthCallback_MissingClusterCookie(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthCallback(gcpAuth, "", 86400)
+
+	req := httptest.NewRequest(http.MethodGet, "/gcp-auth/callback?code=test-code&state=test-state", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_state",
+		Value: "test-state",
+	})
+
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "cluster cookie not found")
+}
+
+func TestHandleGCPAuthCallback_InvalidClusterInCookie(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthCallback(gcpAuth, "", 86400)
+
+	req := httptest.NewRequest(http.MethodGet, "/gcp-auth/callback?code=test-code&state=test-state", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_state",
+		Value: "test-state",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_cluster",
+		Value: "-invalid-cluster",
+	})
+
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid cluster name format")
+}
+
+func TestHandleGCPAuthCallback_OAuthError(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthCallback(gcpAuth, "", 86400)
+
+	callbackURL := "/gcp-auth/callback?error=access_denied&error_description=User+denied+access&state=test-state"
+	req := httptest.NewRequest(http.MethodGet, callbackURL, nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_state",
+		Value: "test-state",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_cluster",
+		Value: "test-cluster",
+	})
+
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "OAuth authentication failed")
+}
+
+func TestHandleGCPAuthCallback_MissingCode(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPAuthCallback(gcpAuth, "", 86400)
+
+	req := httptest.NewRequest(http.MethodGet, "/gcp-auth/callback?state=test-state", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_state",
+		Value: "test-state",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "gcp_oauth_cluster",
+		Value: "test-cluster",
+	})
+
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no code in request")
+}
+
+func TestHandleGCPTokenRefresh_MissingCluster(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPTokenRefresh(gcpAuth, "", 86400)
+
+	req := httptest.NewRequest(http.MethodPost, "/gcp-auth/refresh", nil)
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "cluster parameter required")
+}
+
+func TestHandleGCPTokenRefresh_NoCachedRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	handler := auth.HandleGCPTokenRefresh(gcpAuth, "", 86400)
+
+	req := httptest.NewRequest(http.MethodPost, "/gcp-auth/refresh?cluster=test-cluster", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "headlamp-auth-test-cluster.0",
+		Value: "test-token",
+	})
+
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), "no refresh token available")
+}
+
+func TestValidClusterNamePattern(t *testing.T) {
+	t.Parallel()
+
+	// Test the pattern that's used for cluster name validation
+	tests := []struct {
+		name    string
+		cluster string
+		valid   bool
+	}{
+		{"simple name", "cluster", true},
+		{"with hyphen", "my-cluster", true},
+		{"with underscore", "my_cluster", true},
+		{"with dot", "my.cluster", true},
+		{"with numbers", "cluster123", true},
+		{"GKE format", "gke_project_zone_name", true},
+		{"starts with number", "123cluster", true},
+		{"starts with hyphen", "-cluster", false},
+		{"starts with dot", ".cluster", false},
+		{"starts with underscore", "_cluster", false},
+	}
+
+	cache := newMockGCPCache()
+	gcpAuth := gcp.NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+	handler := auth.HandleGCPAuthLogin(gcpAuth)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/gcp-auth/login?cluster="+url.QueryEscape(tt.cluster), nil)
+			rr := httptest.NewRecorder()
+
+			handler(rr, req)
+
+			if tt.valid {
+				// Valid cluster names should redirect (302)
+				assert.Equal(t, http.StatusFound, rr.Code, "cluster %q should be valid", tt.cluster)
+			} else {
+				// Invalid cluster names should return 400
+				assert.Equal(t, http.StatusBadRequest, rr.Code, "cluster %q should be invalid", tt.cluster)
+			}
+		})
+	}
+}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -73,6 +73,20 @@ type Config struct {
 	MeGroupsPath              string `koanf:"me-groups-path"`
 	MeUserInfoURL             string `koanf:"me-user-info-url"`
 	OidcUsePKCE               bool   `koanf:"oidc-use-pkce"`
+	// GCPOAuthEnabled enables GCP OAuth 2.0 authentication for GKE clusters.
+	// When true, users authenticate via Google OAuth instead of service account tokens,
+	// enabling proper user identity attribution and RBAC enforcement.
+	GCPOAuthEnabled bool `koanf:"gcp-oauth-enabled"`
+	// GCPClientID is the OAuth 2.0 Client ID obtained from Google Cloud Console.
+	// Required when GCPOAuthEnabled is true.
+	GCPClientID string `koanf:"gcp-client-id"`
+	// GCPClientSecret is the OAuth 2.0 Client Secret obtained from Google Cloud Console.
+	// Required when GCPOAuthEnabled is true.
+	GCPClientSecret string `koanf:"gcp-client-secret"`
+	// GCPRedirectURL is the callback URL registered in Google Cloud Console for the OAuth flow.
+	// Must exactly match one of the authorized redirect URIs configured for the OAuth client.
+	// Required when GCPOAuthEnabled is true.
+	GCPRedirectURL string `koanf:"gcp-redirect-url"`
 	// telemetry configs
 	ServiceName        string   `koanf:"service-name"`
 	ServiceVersion     *string  `koanf:"service-version"`
@@ -128,6 +142,11 @@ func (c *Config) Validate() error {
 		return errors.New("session-ttl cannot be greater than 1 year")
 	}
 
+	// GCP OAuth validation
+	if err := c.validateGCPOAuth(); err != nil {
+		return err
+	}
+
 	if c.TracingEnabled != nil && *c.TracingEnabled {
 		if c.ServiceName == "" {
 			return errors.New("service-name is required when tracing is enabled")
@@ -143,6 +162,27 @@ func (c *Config) Validate() error {
 			(c.OTLPEndpoint == nil || *c.OTLPEndpoint == "") {
 			return errors.New("otlp-endpoint must be configured when use-otlp-http is enabled")
 		}
+	}
+
+	return nil
+}
+
+// validateGCPOAuth validates GCP OAuth configuration.
+func (c *Config) validateGCPOAuth() error {
+	if !c.GCPOAuthEnabled {
+		return nil
+	}
+
+	if c.GCPClientID == "" {
+		return errors.New("gcp-client-id is required when gcp-oauth-enabled is true")
+	}
+
+	if c.GCPClientSecret == "" {
+		return errors.New("gcp-client-secret is required when gcp-oauth-enabled is true")
+	}
+
+	if c.GCPRedirectURL == "" {
+		return errors.New("gcp-redirect-url is required when gcp-oauth-enabled is true")
 	}
 
 	return nil

--- a/backend/pkg/gcp/auth.go
+++ b/backend/pkg/gcp/auth.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	// refreshTokenTTL is the TTL for cached refresh tokens.
+	// Aligned with typical OAuth refresh token lifetimes.
+	refreshTokenTTL = 24 * time.Hour
+)
+
+const (
+	// GCP OAuth scopes required for GKE authentication.
+	scopeOpenID        = "openid"
+	scopeEmail         = "email"
+	scopeProfile       = "profile"
+	scopeCloudPlatform = "https://www.googleapis.com/auth/cloud-platform"
+	scopeUserInfoEmail = "https://www.googleapis.com/auth/userinfo.email"
+
+	// Cache key prefix for refresh tokens.
+	refreshTokenCachePrefix = "gcp-refresh-" //nolint:gosec // G101: This is a cache key prefix, not a credential
+)
+
+// GCPAuthenticator handles GCP-specific OAuth authentication for GKE clusters.
+type GCPAuthenticator struct {
+	clientID     string
+	clientSecret string
+	oauth2Config *oauth2.Config
+	cache        cache.Cache[interface{}]
+}
+
+// NewGCPAuthenticator creates a new GCP authenticator for OAuth flows.
+func NewGCPAuthenticator(clientID, clientSecret, redirectURL string, cache cache.Cache[interface{}]) *GCPAuthenticator {
+	return &GCPAuthenticator{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		cache:        cache,
+		oauth2Config: &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			RedirectURL:  redirectURL,
+			Scopes: []string{
+				scopeOpenID,
+				scopeEmail,
+				scopeProfile,
+				scopeCloudPlatform,
+				scopeUserInfoEmail,
+			},
+			Endpoint: google.Endpoint,
+		},
+	}
+}
+
+// GetAuthCodeURL returns the URL for OAuth authorization with PKCE support.
+func (g *GCPAuthenticator) GetAuthCodeURL(state string, codeChallenge string) string {
+	opts := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("access_type", "offline"),
+		oauth2.SetAuthURLParam("prompt", "consent"),
+	}
+
+	if codeChallenge != "" {
+		// PKCE support for enhanced security
+		opts = append(opts,
+			oauth2.SetAuthURLParam("code_challenge", codeChallenge),
+			oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		)
+	}
+
+	return g.oauth2Config.AuthCodeURL(state, opts...)
+}
+
+// Exchange exchanges an authorization code for an OAuth token.
+func (g *GCPAuthenticator) Exchange(ctx context.Context, code string, codeVerifier string) (*oauth2.Token, error) {
+	opts := []oauth2.AuthCodeOption{}
+
+	if codeVerifier != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
+	}
+
+	token, err := g.oauth2Config.Exchange(ctx, code, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
+	}
+
+	return token, nil
+}
+
+// GetGKEAccessToken returns the access token suitable for GKE authentication.
+// This mimics what gke-gcloud-auth-plugin does internally.
+func (g *GCPAuthenticator) GetGKEAccessToken(ctx context.Context, oauth2Token *oauth2.Token) (string, error) {
+	if oauth2Token == nil {
+		return "", fmt.Errorf("oauth2 token is nil")
+	}
+
+	if !oauth2Token.Valid() {
+		return "", fmt.Errorf("oauth2 token is invalid or expired")
+	}
+
+	// The OAuth token with cloud-platform scope is what GKE accepts directly!
+	// This is exactly what gke-gcloud-auth-plugin does internally.
+	return oauth2Token.AccessToken, nil
+}
+
+// RefreshToken refreshes an expired token using the refresh token.
+func (g *GCPAuthenticator) RefreshToken(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
+	if refreshToken == "" {
+		return nil, fmt.Errorf("refresh token is empty")
+	}
+
+	token := &oauth2.Token{
+		RefreshToken: refreshToken,
+	}
+
+	tokenSource := g.oauth2Config.TokenSource(ctx, token)
+
+	newToken, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	return newToken, nil
+}
+
+// CacheRefreshToken stores the refresh token in the cache for later use.
+func (g *GCPAuthenticator) CacheRefreshToken(ctx context.Context, cluster, accessToken, refreshToken string) error {
+	if refreshToken == "" {
+		logger.Log(logger.LevelInfo, map[string]string{"cluster": cluster}, nil, "no refresh token to cache")
+		return nil
+	}
+
+	cacheKey := g.getRefreshTokenCacheKey(cluster, accessToken)
+	if err := g.cache.SetWithTTL(ctx, cacheKey, refreshToken, refreshTokenTTL); err != nil {
+		return fmt.Errorf("failed to cache refresh token: %w", err)
+	}
+
+	logger.Log(logger.LevelInfo, map[string]string{"cluster": cluster}, nil, "cached refresh token")
+
+	return nil
+}
+
+// GetCachedRefreshToken retrieves the refresh token from cache.
+func (g *GCPAuthenticator) GetCachedRefreshToken(ctx context.Context, cluster, accessToken string) (string, error) {
+	cacheKey := g.getRefreshTokenCacheKey(cluster, accessToken)
+
+	refreshToken, err := g.cache.Get(ctx, cacheKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to get cached refresh token: %w", err)
+	}
+
+	refreshTokenStr, ok := refreshToken.(string)
+	if !ok {
+		return "", fmt.Errorf("cached refresh token is not a string")
+	}
+
+	return refreshTokenStr, nil
+}
+
+// getRefreshTokenCacheKey generates a cache key for storing refresh tokens.
+func (g *GCPAuthenticator) getRefreshTokenCacheKey(cluster, accessToken string) string {
+	return fmt.Sprintf("%s%s-%s", refreshTokenCachePrefix, cluster, hashToken(accessToken))
+}
+
+// hashToken creates a short hash of the token for cache key purposes.
+func hashToken(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return base64.URLEncoding.EncodeToString(hash[:])[:16]
+}
+
+// GenerateRandomState generates a cryptographically secure random state for CSRF protection.
+func GenerateRandomState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate random state: %w", err)
+	}
+
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// GenerateCodeVerifier generates a PKCE code verifier.
+func GenerateCodeVerifier() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate code verifier: %w", err)
+	}
+
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// GenerateCodeChallenge generates a PKCE code challenge from a verifier.
+func GenerateCodeChallenge(verifier string) string {
+	hash := sha256.Sum256([]byte(verifier))
+	// Use RawURLEncoding (no padding) as per RFC 7636 PKCE specification
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// IsGKECluster detects if a cluster URL is a GKE cluster.
+func IsGKECluster(clusterURL string) bool {
+	if clusterURL == "" {
+		return false
+	}
+
+	clusterURL = strings.ToLower(clusterURL)
+
+	return strings.Contains(clusterURL, ".googleapis.com") ||
+		strings.Contains(clusterURL, "container.cloud.google.com")
+}

--- a/backend/pkg/gcp/auth_test.go
+++ b/backend/pkg/gcp/auth_test.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcp //nolint:testpackage // Tests access internal functions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// mockCache is a simple in-memory cache for testing.
+type mockCache struct {
+	data map[string]interface{}
+}
+
+func newMockCache() *mockCache {
+	return &mockCache{
+		data: make(map[string]interface{}),
+	}
+}
+
+func (m *mockCache) Get(ctx context.Context, key string) (interface{}, error) {
+	val, ok := m.data[key]
+	if !ok {
+		return nil, assert.AnError
+	}
+
+	return val, nil
+}
+
+func (m *mockCache) Set(ctx context.Context, key string, value interface{}) error {
+	m.data[key] = value
+	return nil
+}
+
+func (m *mockCache) SetWithTTL(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	m.data[key] = value
+	return nil
+}
+
+func (m *mockCache) Delete(ctx context.Context, key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *mockCache) GetAll(ctx context.Context, selectFunc cache.Matcher) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+
+	for k, v := range m.data {
+		if selectFunc == nil || selectFunc(k) {
+			result[k] = v
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockCache) UpdateTTL(ctx context.Context, key string, ttl time.Duration) error {
+	// No-op for mock
+	return nil
+}
+
+func TestNewGCPAuthenticator(t *testing.T) {
+	cache := newMockCache()
+	auth := NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	assert.NotNil(t, auth)
+	assert.Equal(t, "test-client-id", auth.clientID)
+	assert.Equal(t, "test-secret", auth.clientSecret)
+	assert.NotNil(t, auth.oauth2Config)
+	assert.NotNil(t, auth.cache)
+}
+
+func TestGetAuthCodeURL(t *testing.T) {
+	cache := newMockCache()
+	auth := NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	tests := []struct {
+		name          string
+		state         string
+		codeChallenge string
+		wantContains  []string
+	}{
+		{
+			name:         "without PKCE",
+			state:        "test-state",
+			wantContains: []string{"test-state", "access_type=offline", "prompt=consent"},
+		},
+		{
+			name:          "with PKCE",
+			state:         "test-state",
+			codeChallenge: "test-challenge",
+			wantContains:  []string{"test-state", "code_challenge=test-challenge", "code_challenge_method=S256"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := auth.GetAuthCodeURL(tt.state, tt.codeChallenge)
+			assert.NotEmpty(t, url)
+
+			for _, want := range tt.wantContains {
+				assert.Contains(t, url, want)
+			}
+		})
+	}
+}
+
+func TestGetGKEAccessToken(t *testing.T) {
+	cache := newMockCache()
+	auth := NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	tests := []struct {
+		name       string
+		token      *oauth2.Token
+		wantErr    bool
+		wantErrMsg string
+		wantToken  string
+	}{
+		{
+			name:       "nil token",
+			token:      nil,
+			wantErr:    true,
+			wantErrMsg: "oauth2 token is nil",
+		},
+		{
+			name: "expired token",
+			token: &oauth2.Token{
+				AccessToken: "test-token",
+				Expiry:      time.Now().Add(-1 * time.Hour),
+			},
+			wantErr:    true,
+			wantErrMsg: "oauth2 token is invalid or expired",
+		},
+		{
+			name: "valid token",
+			token: &oauth2.Token{
+				AccessToken: "test-access-token",
+				Expiry:      time.Now().Add(1 * time.Hour),
+			},
+			wantErr:   false,
+			wantToken: "test-access-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := auth.GetGKEAccessToken(context.Background(), tt.token)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantToken, token)
+			}
+		})
+	}
+}
+
+func TestCacheRefreshToken(t *testing.T) {
+	cache := newMockCache()
+	auth := NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	ctx := context.Background()
+	cluster := "test-cluster"
+	accessToken := "test-access-token"
+	refreshToken := "test-refresh-token"
+
+	err := auth.CacheRefreshToken(ctx, cluster, accessToken, refreshToken)
+	assert.NoError(t, err)
+
+	// Verify token was cached
+	cachedToken, err := auth.GetCachedRefreshToken(ctx, cluster, accessToken)
+	assert.NoError(t, err)
+	assert.Equal(t, refreshToken, cachedToken)
+}
+
+func TestGetCachedRefreshToken(t *testing.T) {
+	cache := newMockCache()
+	auth := NewGCPAuthenticator("test-client-id", "test-secret", "http://localhost/callback", cache)
+
+	ctx := context.Background()
+	cluster := "test-cluster"
+	accessToken := "test-access-token"
+
+	// No cached token
+	_, err := auth.GetCachedRefreshToken(ctx, cluster, accessToken)
+	assert.Error(t, err)
+
+	// Cache a token
+	refreshToken := "test-refresh-token"
+	err = auth.CacheRefreshToken(ctx, cluster, accessToken, refreshToken)
+	require.NoError(t, err)
+
+	// Retrieve it
+	cachedToken, err := auth.GetCachedRefreshToken(ctx, cluster, accessToken)
+	assert.NoError(t, err)
+	assert.Equal(t, refreshToken, cachedToken)
+}
+
+func TestGenerateRandomState(t *testing.T) {
+	state1, err := GenerateRandomState()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, state1)
+
+	state2, err := GenerateRandomState()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, state2)
+
+	// States should be different
+	assert.NotEqual(t, state1, state2)
+}
+
+func TestGenerateCodeVerifier(t *testing.T) {
+	verifier1, err := GenerateCodeVerifier()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, verifier1)
+
+	verifier2, err := GenerateCodeVerifier()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, verifier2)
+
+	// Verifiers should be different
+	assert.NotEqual(t, verifier1, verifier2)
+}
+
+func TestGenerateCodeChallenge(t *testing.T) {
+	verifier := "test-verifier"
+	challenge := GenerateCodeChallenge(verifier)
+
+	assert.NotEmpty(t, challenge)
+	// Challenge should be deterministic for same verifier
+	challenge2 := GenerateCodeChallenge(verifier)
+	assert.Equal(t, challenge, challenge2)
+}
+
+func TestIsGKECluster(t *testing.T) {
+	tests := []struct {
+		name       string
+		clusterURL string
+		want       bool
+	}{
+		{
+			name:       "GKE cluster with googleapis.com",
+			clusterURL: "https://35.123.45.67.gke.googleapis.com",
+			want:       true,
+		},
+		{
+			name:       "GKE cluster with container.cloud.google.com",
+			clusterURL: "https://container.cloud.google.com/v1/projects/...",
+			want:       true,
+		},
+		{
+			name:       "non-GKE cluster",
+			clusterURL: "https://kubernetes.default.svc",
+			want:       false,
+		},
+		{
+			name:       "empty URL",
+			clusterURL: "",
+			want:       false,
+		},
+		{
+			name:       "EKS cluster",
+			clusterURL: "https://ABC123.gr7.us-west-2.eks.amazonaws.com",
+			want:       false,
+		},
+		{
+			name:       "AKS cluster",
+			clusterURL: "https://myaks-dns-12345678.hcp.westus.azmk8s.io",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsGKECluster(tt.clusterURL)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHashToken(t *testing.T) {
+	token := "test-token"
+	hash1 := hashToken(token)
+
+	assert.NotEmpty(t, hash1)
+	assert.Len(t, hash1, 16) // Should be truncated to 16 characters
+
+	// Hash should be deterministic
+	hash2 := hashToken(token)
+	assert.Equal(t, hash1, hash2)
+
+	// Different tokens should produce different hashes
+	hash3 := hashToken("different-token")
+	assert.NotEqual(t, hash1, hash3)
+}

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -36,6 +36,11 @@ type HeadlampConfig struct {
 	MeEmailPaths              string
 	MeGroupsPaths             string
 	MeUserInfoURL             string
+	// GCP OAuth fields for GKE authentication
+	GCPOAuthEnabled bool
+	GCPClientID     string
+	GCPClientSecret string
+	GCPRedirectURL  string
 }
 
 type HeadlampCFG struct {

--- a/docs/GCP_OAUTH_GKE_SETUP.md
+++ b/docs/GCP_OAUTH_GKE_SETUP.md
@@ -1,0 +1,612 @@
+# GCP OAuth Setup for GKE Deployments
+
+This guide covers how to configure GCP OAuth authentication for Headlamp when deploying to Google Kubernetes Engine (GKE).
+
+## Overview
+
+This implementation adds GCP OAuth 2.0 authentication support to Headlamp, replacing the deprecated Identity Service for GKE. Users authenticate with their Google Cloud account, and the authentication tokens are used to access Kubernetes resources with proper RBAC.
+
+## Architecture
+
+### Authentication Flow
+
+1. **User Login**: User clicks "Sign in with Google" in Headlamp UI
+2. **OAuth Redirect**: User is redirected to Google's OAuth consent screen
+3. **Authorization**: User authorizes Headlamp to access their GCP account
+4. **Callback**: Google redirects back to Headlamp with authorization code
+5. **Token Exchange**: Headlamp exchanges code for access/refresh tokens
+6. **K8s API Access**: Tokens are used to authenticate with Kubernetes API
+7. **RBAC Authorization**: Kubernetes RBAC evaluates permissions based on user's GCP identity
+
+### Components
+
+#### Backend Changes
+
+1. **GCP Authenticator** (`backend/pkg/gcp/auth.go`)
+   - Implements OAuth 2.0 flow with Google
+   - PKCE (Proof Key for Code Exchange) support for enhanced security
+   - Token refresh and caching mechanisms
+   - GKE cluster detection
+
+2. **Route Handlers** (`backend/pkg/auth/gcp.go`)
+   - `/gcp-auth/login`: Initiates OAuth flow
+   - `/gcp-auth/callback`: Handles OAuth callback
+   - `/gcp-auth/refresh`: Refreshes expired tokens
+   - `/gcp-auth/enabled`: Check if GCP OAuth is enabled
+
+3. **Configuration** (`backend/pkg/config/config.go`)
+   - `GCPOAuthEnabled`: Enable/disable GCP OAuth
+   - `GCPClientID`: OAuth 2.0 Client ID
+   - `GCPClientSecret`: OAuth 2.0 Client Secret
+   - `GCPRedirectURL`: Callback URL for OAuth flow
+
+#### Frontend Changes
+
+1. **GCP Login Button** (`frontend/src/components/cluster/GCPLoginButton.tsx`)
+   - React component that renders "Sign in with Google" button
+   - Automatically shown for GKE clusters or when backend OAuth is enabled
+
+2. **Auth Chooser** (`frontend/src/components/authchooser/index.tsx`)
+   - Shows authentication options including GCP OAuth
+   - Prevents auto-redirect to token page to allow users to choose auth method
+
+## Prerequisites
+
+1. GKE cluster up and running
+2. `kubectl` configured to access your cluster
+3. Google Cloud Console access with permissions to create OAuth credentials
+
+## Step 1: Create OAuth 2.0 Credentials
+
+1. Go to [Google Cloud Console - Credentials](https://console.cloud.google.com/apis/credentials)
+2. Select your project (can be different from your GKE cluster project)
+3. Click **"Create Credentials"** → **"OAuth client ID"**
+4. Choose **"Web application"**
+5. Configure the OAuth client:
+   - **Name**: `headlamp-gke-auth` (or your preferred name)
+   - **Authorized JavaScript origins**: Leave empty (not needed)
+   - **Authorized redirect URIs**: Add your deployment URL(s):
+     - For LoadBalancer with IP: `http://<EXTERNAL_IP>/gcp-auth/callback`
+     - For custom domain: `http://your-domain.com/gcp-auth/callback`
+     - For HTTPS (if configured): `https://your-domain.com/gcp-auth/callback`
+     - For local testing: `http://localhost:4466/gcp-auth/callback`
+     - If using a base URL (e.g. `--base-url /headlamp`): include it in the path, e.g. `http://your-domain.com/headlamp/gcp-auth/callback`
+6. Click **"Create"**
+7. **Save the Client ID and Client Secret** - you'll need these for the next step
+
+## Step 2: Create Kubernetes Secret
+
+Store your OAuth credentials securely in a Kubernetes Secret:
+
+```bash
+# Replace with your actual credentials
+kubectl create secret generic gcp-oauth-credentials \
+  --from-literal=client-id='YOUR_CLIENT_ID.apps.googleusercontent.com' \
+  --from-literal=client-secret='YOUR_CLIENT_SECRET' \
+  -n headlamp
+```
+
+**Important**: Never commit these credentials to version control or hardcode them in deployment files.
+
+## Step 3: Configure Headlamp Deployment
+
+Update your Headlamp deployment to enable GCP OAuth:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headlamp
+  template:
+    metadata:
+      labels:
+        app: headlamp
+    spec:
+      containers:
+      - name: headlamp
+        image: ghcr.io/kubernetes-sigs/headlamp:latest  # Or a specific version tag
+        ports:
+        - containerPort: 4466
+        env:
+        # Enable GCP OAuth
+        - name: HEADLAMP_CONFIG_GCP_OAUTH_ENABLED
+          value: "true"
+
+        # OAuth Client ID (from Secret)
+        - name: HEADLAMP_CONFIG_GCP_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: gcp-oauth-credentials
+              key: client-id
+
+        # OAuth Client Secret (from Secret)
+        - name: HEADLAMP_CONFIG_GCP_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: gcp-oauth-credentials
+              key: client-secret
+
+        # Redirect URL - MUST match what you configured in Google Cloud Console
+        - name: HEADLAMP_CONFIG_GCP_REDIRECT_URL
+          value: "http://YOUR_DOMAIN/gcp-auth/callback"
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+```
+
+## Step 4: Expose Headlamp with LoadBalancer
+
+Create a LoadBalancer service to expose Headlamp:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  type: LoadBalancer
+  selector:
+    app: headlamp
+  ports:
+  - port: 80
+    targetPort: 4466
+    protocol: TCP
+```
+
+Apply the service:
+
+```bash
+kubectl apply -f headlamp-service.yaml
+```
+
+Get the external IP:
+
+```bash
+kubectl get svc headlamp -n headlamp
+```
+
+Wait for `EXTERNAL-IP` to be assigned (not `<pending>`).
+
+## Step 5: Update Redirect URL
+
+Once you have the external IP, update your deployment's redirect URL:
+
+### Option A: Using External IP Directly
+
+**Note**: Google OAuth doesn't allow IP addresses as redirect URIs. You'll need to use a domain name service like nip.io:
+
+```bash
+# Get your LoadBalancer IP
+EXTERNAL_IP=$(kubectl get svc headlamp -n headlamp -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+# Update the redirect URL to use nip.io
+kubectl set env deployment/headlamp \
+  HEADLAMP_CONFIG_GCP_REDIRECT_URL="http://headlamp.${EXTERNAL_IP}.nip.io/gcp-auth/callback" \
+  -n headlamp
+```
+
+Then add this redirect URI to your OAuth client in Google Cloud Console:
+- `http://headlamp.<EXTERNAL_IP>.nip.io/gcp-auth/callback`
+
+### Option B: Using Custom Domain
+
+If you have a custom domain pointing to your LoadBalancer IP:
+
+```bash
+kubectl set env deployment/headlamp \
+  HEADLAMP_CONFIG_GCP_REDIRECT_URL="http://your-domain.com/gcp-auth/callback" \
+  -n headlamp
+```
+
+Then add this redirect URI to your OAuth client:
+- `http://your-domain.com/gcp-auth/callback`
+
+## Step 6: Verify Configuration
+
+Check that all environment variables are set correctly:
+
+```bash
+kubectl get deployment headlamp -n headlamp -o jsonpath='{.spec.template.spec.containers[0].env}' | jq
+```
+
+You should see:
+- `HEADLAMP_CONFIG_GCP_OAUTH_ENABLED=true`
+- `HEADLAMP_CONFIG_GCP_CLIENT_ID` (from secret)
+- `HEADLAMP_CONFIG_GCP_CLIENT_SECRET` (from secret)
+- `HEADLAMP_CONFIG_GCP_REDIRECT_URL` (your configured URL)
+
+Check that the pod is running:
+
+```bash
+kubectl get pods -n headlamp
+kubectl logs -n headlamp -l app=headlamp --tail=20
+```
+
+## Step 7: Configure RBAC for GCP Users
+
+After OAuth is configured, you need to grant Kubernetes permissions to your GCP users. When users authenticate via GCP OAuth, their Google email becomes their Kubernetes username.
+
+### Example 1: Grant Cluster Admin to a Single User
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-user-admin
+subjects:
+- kind: User
+  name: alice@example.com  # User's Google email
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Apply it:
+```bash
+kubectl apply -f gcp-user-admin.yaml
+```
+
+### Example 2: Grant Read-Only Access to Multiple Users
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-users-view
+subjects:
+- kind: User
+  name: bob@example.com
+  apiGroup: rbac.authorization.k8s.io
+- kind: User
+  name: charlie@example.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: view  # Built-in read-only role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### Example 3: Namespace-Specific Permissions
+
+Grant a user edit permissions only in specific namespaces:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gcp-user-dev-edit
+  namespace: development
+subjects:
+- kind: User
+  name: developer@example.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: edit  # Built-in edit role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### Example 4: Custom Role for Specific Resources
+
+Create a custom role for limited access:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-user-pod-reader
+subjects:
+- kind: User
+  name: auditor@example.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### Example 5: Group-Based Permissions (Google Groups)
+
+If using Google Workspace, you can grant permissions to entire groups:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-group-admins
+subjects:
+- kind: Group
+  name: admins@example.com  # Google Group email
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### Built-in Kubernetes Roles
+
+Common built-in ClusterRoles you can use:
+
+| Role | Permissions | Use Case |
+|------|-------------|----------|
+| `cluster-admin` | Full access to all resources | Cluster administrators |
+| `admin` | Full access within a namespace | Namespace administrators |
+| `edit` | Read/write access to most resources | Developers |
+| `view` | Read-only access to most resources | Auditors, viewers |
+
+### Verify User Permissions
+
+After setting up RBAC, verify that users have the correct permissions:
+
+```bash
+# Check what user can do
+kubectl auth can-i list pods --as=alice@example.com
+kubectl auth can-i create deployments --as=alice@example.com --namespace=production
+
+# List all permissions for a user
+kubectl auth can-i --list --as=alice@example.com
+```
+
+### Important RBAC Notes
+
+1. **User Identification**: The `name` field in RBAC must match the user's Google email exactly
+2. **Case Sensitive**: Email addresses are case-sensitive in Kubernetes RBAC
+3. **Minimum Permissions**: Start with minimal permissions and add more as needed
+4. **Service Accounts**: The Headlamp pod itself still needs a ServiceAccount for cluster operations
+5. **Testing**: Always test permissions after creating RBAC rules
+
+## Step 8: Test the OAuth Flow
+
+1. Navigate to your Headlamp deployment:
+   - With nip.io: `http://headlamp.<EXTERNAL_IP>.nip.io`
+   - With custom domain: `http://your-domain.com`
+
+2. You should see the authentication page with:
+   - "Sign in with Google" button
+   - "Use A Token" button (fallback option)
+
+3. Click **"Sign in with Google"**
+
+4. Authorize the application with your Google account
+
+5. You should be redirected back to Headlamp and authenticated
+
+## Configuration Reference
+
+### Required Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `HEADLAMP_CONFIG_GCP_OAUTH_ENABLED` | Enable GCP OAuth feature | `"true"` |
+| `HEADLAMP_CONFIG_GCP_CLIENT_ID` | OAuth 2.0 Client ID from Google Cloud Console | `"123456789-abc.apps.googleusercontent.com"` |
+| `HEADLAMP_CONFIG_GCP_CLIENT_SECRET` | OAuth 2.0 Client Secret from Google Cloud Console | `"GOCSPX-xxxxxxxxxxxxx"` |
+| `HEADLAMP_CONFIG_GCP_REDIRECT_URL` | Callback URL for OAuth flow | `"http://headlamp.35.232.228.61.nip.io/gcp-auth/callback"` |
+
+### Important Notes
+
+1. **Redirect URL Must Match Exactly**
+   - The `HEADLAMP_CONFIG_GCP_REDIRECT_URL` must match what you configured in Google Cloud Console
+   - Include the protocol (`http://` or `https://`)
+   - Include the full path: `/gcp-auth/callback`
+
+2. **IP Address Limitation**
+   - Google OAuth doesn't allow bare IP addresses as redirect URIs
+   - Use a service like nip.io for IP-based access: `http://headlamp.<IP>.nip.io`
+   - Or configure a proper DNS domain
+
+3. **HTTPS Considerations**
+   - The example uses HTTP for simplicity
+   - For production, configure HTTPS with proper TLS certificates
+   - Update redirect URL to `https://` when HTTPS is enabled
+
+4. **Secrets Management**
+   - Always store OAuth credentials in Kubernetes Secrets
+   - Never commit credentials to version control
+   - Rotate credentials periodically
+
+## Troubleshooting
+
+### "Sign in with Google" Button Not Appearing
+
+**Check:**
+1. Environment variable is set: `HEADLAMP_CONFIG_GCP_OAUTH_ENABLED=true`
+2. Pod has restarted after configuration changes
+3. Backend logs for any errors:
+   ```bash
+   kubectl logs -n headlamp -l app=headlamp | grep -i "gcp\|oauth"
+   ```
+
+**Test the endpoint:**
+```bash
+curl http://<YOUR_URL>/gcp-auth/enabled
+# Should return: {"enabled":true}
+```
+
+### redirect_uri_mismatch Error
+
+**Problem**: OAuth fails with "Error 400: redirect_uri_mismatch"
+
+**Solution**:
+1. Check the exact redirect URI being sent (look at browser URL when error occurs)
+2. Go to Google Cloud Console → Credentials → Your OAuth Client
+3. Add the **exact** redirect URI (including protocol and path)
+4. Wait a few minutes for Google's changes to propagate
+
+### Authentication Succeeds But Can't Access Kubernetes API
+
+**Problem**: Login works but you see permission errors in Headlamp
+
+**Solution**: Configure Kubernetes RBAC for your GCP user:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-user-admin
+subjects:
+- kind: User
+  name: your-email@gmail.com  # Your GCP account email
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin  # Or a more restrictive role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Apply it:
+```bash
+kubectl apply -f rbac.yaml
+```
+
+### Browser HSTS Issues (Domain Redirects to HTTPS)
+
+**Problem**: Custom domain redirects to HTTPS but only HTTP is available
+
+**Solution**:
+1. Clear browser HSTS cache:
+   - Chrome: `chrome://net-internals/#hsts` → Delete domain
+   - Firefox: Clear all browsing data
+2. Use a different domain without HSTS cached
+3. Or configure HTTPS on your LoadBalancer
+
+### Pod Crashes or Restarts
+
+**Check logs:**
+```bash
+kubectl logs -n headlamp -l app=headlamp --previous
+kubectl describe pod -n headlamp -l app=headlamp
+```
+
+**Common issues:**
+- Invalid OAuth credentials
+- Missing environment variables
+- Memory/CPU resource constraints
+
+## Security Best Practices
+
+1. **Use Kubernetes Secrets** for OAuth credentials
+2. **Enable HTTPS** in production with valid TLS certificates
+3. **Restrict RBAC** - don't give all users cluster-admin
+4. **Rotate credentials** periodically
+5. **Use Private GKE clusters** when possible
+6. **Enable Workload Identity** for enhanced security
+7. **Monitor OAuth usage** through Google Cloud Console
+
+## Example: Complete Deployment
+
+Here's a complete example combining all components:
+
+```bash
+# 1. Create namespace
+kubectl create namespace headlamp
+
+# 2. Create OAuth credentials secret
+kubectl create secret generic gcp-oauth-credentials \
+  --from-literal=client-id='YOUR_CLIENT_ID.apps.googleusercontent.com' \
+  --from-literal=client-secret='YOUR_CLIENT_SECRET' \
+  -n headlamp
+
+# 3. Apply deployment (save as headlamp-deployment.yaml)
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: headlamp
+  template:
+    metadata:
+      labels:
+        app: headlamp
+    spec:
+      containers:
+      - name: headlamp
+        image: ghcr.io/kubernetes-sigs/headlamp:latest
+        ports:
+        - containerPort: 4466
+        env:
+        - name: HEADLAMP_CONFIG_GCP_OAUTH_ENABLED
+          value: "true"
+        - name: HEADLAMP_CONFIG_GCP_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: gcp-oauth-credentials
+              key: client-id
+        - name: HEADLAMP_CONFIG_GCP_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: gcp-oauth-credentials
+              key: client-secret
+        - name: HEADLAMP_CONFIG_GCP_REDIRECT_URL
+          value: "http://REPLACE_WITH_YOUR_URL/gcp-auth/callback"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  type: LoadBalancer
+  selector:
+    app: headlamp
+  ports:
+  - port: 80
+    targetPort: 4466
+EOF
+
+# 4. Wait for LoadBalancer IP
+kubectl get svc headlamp -n headlamp -w
+
+# 5. Get the IP and update redirect URL
+EXTERNAL_IP=$(kubectl get svc headlamp -n headlamp -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo "Your Headlamp URL: http://headlamp.${EXTERNAL_IP}.nip.io"
+
+# 6. Update redirect URL
+kubectl set env deployment/headlamp \
+  HEADLAMP_CONFIG_GCP_REDIRECT_URL="http://headlamp.${EXTERNAL_IP}.nip.io/gcp-auth/callback" \
+  -n headlamp
+
+# 7. Add this URL to Google Cloud Console OAuth client:
+echo "Add this redirect URI to Google Cloud Console:"
+echo "http://headlamp.${EXTERNAL_IP}.nip.io/gcp-auth/callback"
+```
+
+## Related Documentation
+
+- [Google OAuth 2.0 Documentation](https://developers.google.com/identity/protocols/oauth2)
+- [GKE Authentication](https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication)

--- a/frontend/.storybook/baseMocks.ts
+++ b/frontend/.storybook/baseMocks.ts
@@ -25,6 +25,8 @@ import { NODE_DUMMY_DATA } from '../src/components/node/storyHelper';
  *
  */
 export const baseMocks = [
+  http.get('http://localhost:4466/gcp-auth/enabled', () => HttpResponse.json({ enabled: false })),
+  http.get('http://localhost:3000/gcp-auth/enabled', () => HttpResponse.json({ enabled: false })),
   http.get('http://localhost:4466/wsMultiplexer', () => HttpResponse.error()),
   http.get('https://api.iconify.design/mdi.json', () => HttpResponse.json({})),
   http.post('http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', () =>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1134,9 +1134,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1177,9 +1177,9 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1297,9 +1297,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.1.tgz",
+      "integrity": "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw==",
       "cpu": [
         "arm"
       ],
@@ -2284,9 +2284,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.1.tgz",
+      "integrity": "sha512-PPkxTOisoNC6TpnDKatjKkjRMsdaWIhyuMkA4UsBXT9WEZY4uHezBTjs6Vl4PbqQQeu6oION1w2voYZv9yquCw==",
       "cpu": [
         "arm64"
       ],
@@ -2297,9 +2297,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.1.tgz",
+      "integrity": "sha512-VWXGISWFY18v/0JyNUy4A46KCFCb9NVsH+1100XP31lud+TzlezBbz24CYzbnA4x6w4hx+NYCXDfnvDVO6lcAA==",
       "cpu": [
         "arm64"
       ],
@@ -2310,9 +2310,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.1.tgz",
+      "integrity": "sha512-nIwkXafAI1/QCS7pxSpv/ZtFW6TXcNUEHAIA9EIyw5OzxJZQ1YDrX+CL6JAIQgZ33CInl1R6mHet9Y/UZTg2Bw==",
       "cpu": [
         "x64"
       ],
@@ -2323,9 +2323,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.1.tgz",
+      "integrity": "sha512-BdrLJ2mHTrIYdaS2I99mriyJfGGenSaP+UwGi1kB9BLOCu9SR8ZpbkmmalKIALnRw24kM7qCN0IOm6L0S44iWw==",
       "cpu": [
         "arm64"
       ],
@@ -2336,9 +2336,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.1.tgz",
+      "integrity": "sha512-VXeo/puqvCG8JBPNZXZf5Dqq7BzElNJzHRRw3vjBE27WujdzuOPecDPc/+1DcdcTptNBep3861jNq0mYkT8Z6Q==",
       "cpu": [
         "x64"
       ],
@@ -2349,9 +2349,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.1.tgz",
+      "integrity": "sha512-ehSKrewwsESPt1TgSE/na9nIhWCosfGSFqv7vwEtjyAqZcvbGIg4JAcV7ZEh2tfj/IlfBeZjgOXm35iOOjadcg==",
       "cpu": [
         "arm"
       ],
@@ -2362,9 +2362,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.1.tgz",
+      "integrity": "sha512-m39iO/aaurh5FVIu/F4/Zsl8xppd76S4qoID8E+dSRQvTyZTOI2gVk3T4oqzfq1PtcvOfAVlwLMK3KRQMaR8lg==",
       "cpu": [
         "arm"
       ],
@@ -2375,9 +2375,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.1.tgz",
+      "integrity": "sha512-Y+GHnGaku4aVLSgrT0uWe2o2Rq8te9hi+MwqGF9r9ORgXhmHK5Q71N757u0F8yU1OIwUIFy6YiJtKjtyktk5hg==",
       "cpu": [
         "arm64"
       ],
@@ -2388,9 +2388,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.1.tgz",
+      "integrity": "sha512-jEwjn3jCA+tQGswK3aEWcD09/7M5wGwc6+flhva7dsQNRZZTe30vkalgIzV4tjkopsTS9Jd7Y1Bsj6a4lzz8gQ==",
       "cpu": [
         "arm64"
       ],
@@ -2400,10 +2400,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.1.tgz",
+      "integrity": "sha512-ySyWikVhNzv+BV/IDCsrraOAZ3UaC8SZB67FZlqVwXwnFhPihOso9rPOxzZbjp81suB1O2Topw+6Ug3JNegejQ==",
       "cpu": [
         "loong64"
       ],
@@ -2413,36 +2413,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.1.tgz",
+      "integrity": "sha512-BvvA64QxZlh7WZWqDPPdt0GH4bznuL6uOO1pmgPnnv86rpUpc8ZxgZwcEgXvo02GRIZX1hQ0j0pAnhwkhwPqWg==",
       "cpu": [
         "ppc64"
       ],
@@ -2453,9 +2427,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.1.tgz",
+      "integrity": "sha512-EQSP+8+1VuSulm9RKSMKitTav89fKbHymTf25n5+Yr6gAPZxYWpj3DzAsQqoaHAk9YX2lwEyAf9S4W8F4l3VBQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2466,9 +2440,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.1.tgz",
+      "integrity": "sha512-n/vQ4xRZXKuIpqukkMXZt9RWdl+2zgGNx7Uda8NtmLJ06NL8jiHxUawbwC+hdSq1rrw/9CghCpEONor+l1e2gA==",
       "cpu": [
         "riscv64"
       ],
@@ -2479,9 +2453,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.1.tgz",
+      "integrity": "sha512-h8d28xzYb98fMQKUz0w2fMc1XuGzLLjdyxVIbhbil4ELfk5/orZlSTpF/xdI9C8K0I8lCkq+1En2RJsawZekkg==",
       "cpu": [
         "s390x"
       ],
@@ -2492,9 +2466,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.1.tgz",
+      "integrity": "sha512-XiK5z70PEFEFqcNj3/zRSz/qX4bp4QIraTy9QjwJAb/Z8GM7kVUsD0Uk8maIPeTyPCP03ChdI+VVmJriKYbRHQ==",
       "cpu": [
         "x64"
       ],
@@ -2505,9 +2479,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.1.tgz",
+      "integrity": "sha512-2BRORitq5rQ4Da9blVovzNCMaUlyKrzMSvkVR0D4qPuOy/+pMCrh1d7o01RATwVy+6Fa1WBw+da7QPeLWU/1mQ==",
       "cpu": [
         "x64"
       ],
@@ -2517,36 +2491,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.1.tgz",
+      "integrity": "sha512-b2bcNm9Kbde03H+q+Jjw9tSfhYkzrDUf2d5MAd1bOJuVplXvFhWz7tRtWvD8/ORZi7qSCy0idW6tf2HgxSXQSg==",
       "cpu": [
         "arm64"
       ],
@@ -2557,9 +2505,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.1.tgz",
+      "integrity": "sha512-DfcogW8N7Zg7llVEfpqWMZcaErKfsj9VvmfSyRjCyo4BI3wPEfrzTtJkZG6gKP/Z92wFm6rz2aDO7/JfiR/whA==",
       "cpu": [
         "ia32"
       ],
@@ -2569,23 +2517,10 @@
         "win32"
       ]
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.1.tgz",
+      "integrity": "sha512-ECyOuDeH3C1I8jH2MK1RtBJW+YPMvSfT0a5NN0nHfQYnDSJ6tUiZH3gzwVP5/Kfh/+Tt7tpWVF9LXNTnhTJ3kA==",
       "cpu": [
         "x64"
       ],
@@ -2996,16 +2931,16 @@
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.19.tgz",
-      "integrity": "sha512-kRK3oIq4wlyH5Zr7Dpr44zzk3nhJdegKSNe6b4wi0a1vnIhnuuxgJc0KXqgiyP2jb1GfUTB/1IRfDqUsQEw+vg==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.20.tgz",
+      "integrity": "sha512-eUIOd4u/p9994Nkv8Avn6r/xmS7D+RNmhmu6KGROefN3myLe3JfhSdimal2wDFe/h/OUNZ/LVVKMZrya9oEfKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.19",
+        "@storybook/csf-plugin": "9.1.20",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.19",
+        "@storybook/react-dom-shim": "9.1.20",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -3015,13 +2950,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.19"
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.19.tgz",
-      "integrity": "sha512-elFv6OjJEW+5cbEUComCZOkoHQ/a8Faq3M8JLK8MGQBzhN0SWwIjYE/3m/U+FKmnuny3Idm18CMlhFXgbIVxgA==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.20.tgz",
+      "integrity": "sha512-/fFOqTZQ0Q5JmSAVlyfEFRa0W3hAh2u7kg+OQRLVxvNZVVuW50mOxE3853tAqisw9UX8TOCN6ZflFBeeoGLYfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3033,7 +2968,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.19"
+        "storybook": "^9.1.20"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -3042,13 +2977,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.19.tgz",
-      "integrity": "sha512-NidYsvbLig1zQjhSammTsbwc8KzYQ6vC07uZjfzarwSmTdhFp7j2II0nek8iMNMPnfP9sxugJL990UyV5Wbhug==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.20.tgz",
+      "integrity": "sha512-cdU3Q2/wEaT8h+mApFToRiF/0hYKH1eAkD0scQn67aODgp7xnkr0YHcdA+8w0Uxd2V7U8crV/cmT/HD0ELVOGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.19",
+        "@storybook/csf-plugin": "9.1.20",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -3056,14 +2991,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.19",
+        "storybook": "^9.1.20",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.19.tgz",
-      "integrity": "sha512-jQN9JAbyDxjcQ5r48/t/rb4RMow5V/WB7LUir1Sp5GSMMSg5QD2XlfVuSnxsUk2VjhKVZNmwCa8jMCTjBR3L9Q==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.20.tgz",
+      "integrity": "sha512-HHgk50YQhML7mT01Mzf9N7lNMFHWN4HwwRP90kPT9Ct+Jhx7h3LBDbdmWjI96HwujcpY7eoYdTfpB1Sw8Z7nBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3074,7 +3009,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.19"
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/global": {
@@ -3098,14 +3033,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.19.tgz",
-      "integrity": "sha512-UuTGumzQ1/Nffm1rWjrfFefL1a7uZlJEk34Cjp8N5uA9qPEX68e1OEeFnHX3nBk+8yEadPfs77vJox76aeTC6g==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.20.tgz",
+      "integrity": "sha512-TJhqzggs7HCvLhTXKfx8HodnVq9YizsB2J31s9v6olU0UCxbCY+FYaCF+XdE8qUCyefGRZgHKzGBIczJ/q9e2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.19"
+        "@storybook/react-dom-shim": "9.1.20"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3117,7 +3052,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.19",
+        "storybook": "^9.1.20",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -3127,9 +3062,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.19.tgz",
-      "integrity": "sha512-raIZEhHFQANSPBikc1Zn6cEHHnj+MbrUD3bbxj/abQHi/bqRIAf20ALOAfIuKk1oFD7lSP6J22h4FXYZm/TtFA==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.20.tgz",
+      "integrity": "sha512-UYdZavfPwHEqCKMqPssUOlyFVZiJExLxnSHwkICSZBmw3gxXJcp1aXWs7PvoZdWz2K4ztl3IcKErXXHeiY6w+A==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3139,20 +3074,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.19"
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.19.tgz",
-      "integrity": "sha512-J7ikh6oWy+GMgEBuNkZ1uhrozHMUu2cQclmMivhm1kJSix9FsjcflFAaO9rzzBbtOVyX1afu+JStNpyOjfj5NQ==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.20.tgz",
+      "integrity": "sha512-buXeNvEJ9kp4FKbGYV7zW4sh/KS01EAjeq8Z6AVxaXOh4W2CIRTKM9maWGz+Rr+YyqQIq/Gl+RqNwxctpxeuHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.1.19",
-        "@storybook/react": "9.1.19",
+        "@storybook/builder-vite": "9.1.20",
+        "@storybook/react": "9.1.20",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -3169,7 +3104,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.19",
+        "storybook": "^9.1.20",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
@@ -3862,6 +3797,16 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -4043,9 +3988,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -4841,9 +4786,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5090,9 +5035,9 @@
       }
     },
     "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -5271,9 +5216,9 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
-      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -6102,9 +6047,9 @@
       }
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -6771,9 +6716,9 @@
       }
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -6917,9 +6862,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -7413,9 +7358,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7489,9 +7434,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7572,9 +7517,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7655,9 +7600,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7735,9 +7680,9 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7932,9 +7877,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
-      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
       "dev": true,
       "funding": [
         {
@@ -7948,7 +7893,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "pure-rand": "^7.0.0"
+        "pure-rand": "^8.0.0"
       },
       "engines": {
         "node": ">=12.17.0"
@@ -10292,7 +10237,8 @@
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -10575,9 +10521,9 @@
       }
     },
     "node_modules/matcher-collection/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11348,9 +11294,9 @@
       }
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -11402,11 +11348,11 @@
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11837,9 +11783,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -12497,9 +12443,9 @@
       }
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -12528,9 +12474,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
-      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.2.0.tgz",
+      "integrity": "sha512-KHnUjm68KSO/hqpWlVwagMDPrIjnDNY9r0DbKN79xEa5RU2MLUe0lICBGpWDF8cwmhUiN8r9A8DLGPVcFB62/A==",
       "dev": true,
       "funding": [
         {
@@ -12545,11 +12491,11 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -12640,9 +12586,9 @@
       }
     },
     "node_modules/quick-temp/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -13424,9 +13370,9 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -13444,12 +13390,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.1.tgz",
+      "integrity": "sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.7"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -13459,31 +13405,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@rollup/rollup-android-arm-eabi": "4.40.1",
+        "@rollup/rollup-android-arm64": "4.40.1",
+        "@rollup/rollup-darwin-arm64": "4.40.1",
+        "@rollup/rollup-darwin-x64": "4.40.1",
+        "@rollup/rollup-freebsd-arm64": "4.40.1",
+        "@rollup/rollup-freebsd-x64": "4.40.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.40.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.40.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.40.1",
+        "@rollup/rollup-linux-arm64-musl": "4.40.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.40.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.40.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.40.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.40.1",
+        "@rollup/rollup-linux-x64-gnu": "4.40.1",
+        "@rollup/rollup-linux-x64-musl": "4.40.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.40.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.40.1",
+        "@rollup/rollup-win32-x64-msvc": "4.40.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -13590,15 +13531,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=11.0.0"
-      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -13878,65 +13810,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dependencies": {
+        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14131,9 +14012,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.19",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.19.tgz",
-      "integrity": "sha512-P7K/b+Pn1sXJzwYCF6hH5Zjdrg4ZlA5Bz9rdOJEdvm6ev27XESDGI+Ql+dfUfUcGOym3Aud4MssJIDEF2ocsyQ==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.20.tgz",
+      "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14628,19 +14509,19 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.3.1",
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0",
-        "sax": "^1.5.0"
+        "picocolors": "^1.0.0"
       },
       "bin": {
         "svgo": "bin/svgo"
@@ -15926,9 +15807,9 @@
       }
     },
     "node_modules/walk-sync/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -26,12 +26,14 @@ import { getAppUrl } from '../../helpers/getAppUrl';
 import { getCluster, getClusterPrefixedPath } from '../../lib/cluster';
 import { useClustersConf } from '../../lib/k8s';
 import { testAuth } from '../../lib/k8s/api/v1/clusterApi';
+import { isGCPOAuthEnabled } from '../../lib/k8s/gke';
 import { queryClient } from '../../lib/queryClient';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { getRoute } from '../../lib/router/getRoute';
 import { getRoutePath } from '../../lib/router/getRoutePath';
 import { setConfig } from '../../redux/configSlice';
 import { ClusterDialog } from '../cluster/Chooser';
+import GCPLoginButton from '../cluster/GCPLoginButton';
 import { DialogTitle } from '../common/Dialog';
 import Empty from '../common/EmptyContent';
 import Link from '../common/Link';
@@ -159,22 +161,42 @@ function AuthChooser({ children }: AuthChooserProps) {
               if (cluster.useToken === false) {
                 history.replace(from);
               } else if (!clusterAuthType) {
-                // we know that it requires token and also doesn't have oidc configured
-                // so let's redirect to token page
-                history.replace({
-                  pathname: generatePath(getClusterPrefixedPath('token'), {
-                    cluster: clusterName as string,
-                  }),
-                });
+                // Check if GCP OAuth is enabled before auto-redirecting to token page.
+                // If GCP OAuth is enabled, we want to show the auth chooser so users can
+                // choose between Google Sign In and token authentication.
+                isGCPOAuthEnabled()
+                  .then(gcpEnabled => {
+                    if (!gcpEnabled && !cancelledRef.current) {
+                      // GCP OAuth not enabled, so redirect to token page
+                      history.replace({
+                        pathname: generatePath(getClusterPrefixedPath('token'), {
+                          cluster: clusterName as string,
+                        }),
+                      });
+                    }
+                    // If GCP OAuth is enabled, stay on auth chooser to show both options
+                  })
+                  .catch(err => {
+                    console.warn('Failed to check GCP OAuth status:', err);
+                  });
               }
             }
           });
       } else if (cluster.useToken) {
-        history.replace({
-          pathname: generatePath(getClusterPrefixedPath('token'), {
-            cluster: clusterName as string,
-          }),
-        });
+        // Check if GCP OAuth is enabled before auto-redirecting
+        isGCPOAuthEnabled()
+          .then(gcpEnabled => {
+            if (!gcpEnabled && !cancelledRef.current) {
+              history.replace({
+                pathname: generatePath(getClusterPrefixedPath('token'), {
+                  cluster: clusterName as string,
+                }),
+              });
+            }
+          })
+          .catch(err => {
+            console.warn('Failed to check GCP OAuth status:', err);
+          });
       }
     },
     // eslint-disable-next-line
@@ -299,6 +321,7 @@ export function PureAuthChooser({
                   </OauthPopup>
                 </Box>
               ) : null}
+              <GCPLoginButton cluster={clusterName} />
               <Box m={2}>
                 <ColorButton onClick={handleTokenAuth}>{t('Use A Token')}</ColorButton>
               </Box>

--- a/frontend/src/components/cluster/GCPLoginButton.test.tsx
+++ b/frontend/src/components/cluster/GCPLoginButton.test.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type MockInstance, vi } from 'vitest';
+import { Cluster } from '../../lib/k8s/cluster';
+import * as gke from '../../lib/k8s/gke';
+import { GCPLoginButton } from './GCPLoginButton';
+
+// Mock the translation hook
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'translation|Sign in with Google') {
+        return 'Sign in with Google';
+      }
+      return key;
+    },
+  }),
+}));
+
+describe('GCPLoginButton', () => {
+  let initiateGCPLoginSpy: MockInstance;
+  let isGCPOAuthEnabledSpy: MockInstance;
+
+  beforeEach(() => {
+    // Create spies for GKE functions
+    initiateGCPLoginSpy = vi.spyOn(gke, 'initiateGCPLogin').mockImplementation(() => {});
+    // Mock isGCPOAuthEnabled - default to true so button renders
+    isGCPOAuthEnabledSpy = vi.spyOn(gke, 'isGCPOAuthEnabled').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render button when GCP OAuth is enabled', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      render(<GCPLoginButton cluster={cluster} />);
+
+      await waitFor(() => {
+        const button = screen.getByText('Sign in with Google');
+        expect(button).toBeDefined();
+      });
+    });
+
+    it('should not render button when GCP OAuth is disabled', async () => {
+      const cluster: Cluster = {
+        name: 'eks-cluster',
+        server: 'https://ABCD1234.gr7.us-west-2.eks.amazonaws.com',
+        auth_type: '',
+      };
+
+      isGCPOAuthEnabledSpy.mockResolvedValue(false);
+
+      const { container } = render(<GCPLoginButton cluster={cluster} />);
+
+      await waitFor(() => {
+        expect(container.firstChild).toBeNull();
+      });
+    });
+
+    it('should not render button when cluster name is empty', async () => {
+      const cluster: Cluster = {
+        name: '',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      const { container } = render(<GCPLoginButton cluster={cluster} />);
+
+      await waitFor(() => {
+        expect(container.firstChild).toBeNull();
+      });
+    });
+
+    it('should render button for string cluster name when GCP OAuth enabled', async () => {
+      render(<GCPLoginButton cluster="my-cluster" />);
+
+      await waitFor(() => {
+        const button = screen.getByText('Sign in with Google');
+        expect(button).toBeDefined();
+      });
+    });
+
+    it('should render custom button text', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      render(<GCPLoginButton cluster={cluster}>Custom Login Text</GCPLoginButton>);
+
+      await waitFor(() => {
+        const button = screen.getByText('Custom Login Text');
+        expect(button).toBeDefined();
+      });
+    });
+  });
+
+  describe('Button interaction', () => {
+    it('should call initiateGCPLogin when clicked', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      render(<GCPLoginButton cluster={cluster} />);
+
+      await waitFor(() => {
+        const button = screen.getByText('Sign in with Google');
+        fireEvent.click(button);
+      });
+
+      expect(initiateGCPLoginSpy).toHaveBeenCalledWith('gke-cluster');
+      expect(initiateGCPLoginSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call initiateGCPLogin with correct cluster name for string cluster', async () => {
+      render(<GCPLoginButton cluster="my-gke-cluster" />);
+
+      await waitFor(() => {
+        const button = screen.getByText('Sign in with Google');
+        fireEvent.click(button);
+      });
+
+      expect(initiateGCPLoginSpy).toHaveBeenCalledWith('my-gke-cluster');
+    });
+  });
+
+  describe('Button props', () => {
+    it('should apply custom variant', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      const { container } = render(<GCPLoginButton cluster={cluster} variant="outlined" />);
+
+      await waitFor(() => {
+        const button = container.querySelector('button');
+        expect(button?.className).toContain('MuiButton-outlined');
+      });
+    });
+
+    it('should apply custom color', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      const { container } = render(<GCPLoginButton cluster={cluster} color="secondary" />);
+
+      await waitFor(() => {
+        const button = container.querySelector('button');
+        expect(button?.className).toContain('MuiButton-colorSecondary');
+      });
+    });
+
+    it('should apply custom size', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      const { container } = render(<GCPLoginButton cluster={cluster} size="small" />);
+
+      await waitFor(() => {
+        const button = container.querySelector('button');
+        expect(button?.className).toContain('MuiButton-sizeSmall');
+      });
+    });
+
+    it('should apply fullWidth prop', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      const { container } = render(<GCPLoginButton cluster={cluster} fullWidth />);
+
+      await waitFor(() => {
+        const button = container.querySelector('button');
+        expect(button?.className).toContain('MuiButton-fullWidth');
+      });
+    });
+
+    it('should not apply fullWidth when false', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      const { container } = render(<GCPLoginButton cluster={cluster} fullWidth={false} />);
+
+      await waitFor(() => {
+        const button = container.querySelector('button');
+        expect(button?.className).not.toContain('MuiButton-fullWidth');
+      });
+    });
+  });
+
+  describe('Google logo', () => {
+    it('should render Google logo SVG', async () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+
+      const { container } = render(<GCPLoginButton cluster={cluster} />);
+
+      await waitFor(() => {
+        const svg = container.querySelector('svg');
+        expect(svg).toBeDefined();
+        expect(svg?.getAttribute('width')).toBe('18');
+        expect(svg?.getAttribute('height')).toBe('18');
+      });
+    });
+  });
+});

--- a/frontend/src/components/cluster/GCPLoginButton.tsx
+++ b/frontend/src/components/cluster/GCPLoginButton.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box, Button, ButtonProps } from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Cluster } from '../../lib/k8s/cluster';
+import { initiateGCPLogin, isGCPOAuthEnabled } from '../../lib/k8s/gke';
+
+export interface GCPLoginButtonProps {
+  /** The cluster to authenticate to */
+  cluster: Cluster | string;
+  /** Optional button variant */
+  variant?: ButtonProps['variant'];
+  /** Optional button color */
+  color?: ButtonProps['color'];
+  /** Optional button size */
+  size?: ButtonProps['size'];
+  /** Whether to show the button in full width */
+  fullWidth?: boolean;
+  /** Custom button text */
+  children?: React.ReactNode;
+}
+
+/**
+ * A button component that initiates Google OAuth login for GKE clusters.
+ * Only renders if GCP OAuth is enabled in the backend via the HEADLAMP_CONFIG_GCP_OAUTH_ENABLED
+ * environment variable.
+ */
+export function GCPLoginButton({
+  cluster,
+  variant = 'contained',
+  color = 'primary',
+  size = 'large',
+  fullWidth = true,
+  children,
+}: GCPLoginButtonProps) {
+  const { t } = useTranslation(['translation']);
+  const [gcpOAuthEnabled, setGcpOAuthEnabled] = React.useState<boolean | null>(null);
+
+  // Get cluster name
+  const clusterName = typeof cluster === 'string' ? cluster : cluster?.name;
+
+  // Check if GCP OAuth is enabled on component mount
+  React.useEffect(() => {
+    let cancelled = false;
+
+    isGCPOAuthEnabled()
+      .then(enabled => {
+        if (!cancelled) {
+          setGcpOAuthEnabled(enabled);
+        }
+      })
+      .catch(error => {
+        if (!cancelled) {
+          console.warn('Failed to check GCP OAuth status:', error);
+          setGcpOAuthEnabled(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Only show button if GCP OAuth is enabled via environment variable
+  const shouldShowButton = gcpOAuthEnabled === true;
+
+  if (!shouldShowButton) {
+    return null;
+  }
+
+  if (!clusterName) {
+    return null;
+  }
+
+  const handleClick = () => {
+    initiateGCPLogin(clusterName);
+  };
+
+  return (
+    <Box m={2}>
+      <Button
+        variant={variant}
+        color={color}
+        size={size}
+        fullWidth={fullWidth}
+        onClick={handleClick}
+        startIcon={
+          <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+            <path
+              fill="#EA4335"
+              d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+            />
+            <path
+              fill="#4285F4"
+              d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+            />
+            <path
+              fill="#34A853"
+              d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+            />
+            <path fill="none" d="M0 0h48v48H0z" />
+          </svg>
+        }
+      >
+        {children || t('translation|Sign in with Google')}
+      </Button>
+    </Box>
+  );
+}
+
+export default GCPLoginButton;

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "",
   "Hide details": "",
   "Show details": "",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "",
   "Error setting up clusters, please load a valid kubeconfig file": "Fehler beim Einrichten der Cluster. Bitte laden Sie eine korrekte kubeconfig-Datei",
   "Couldn't read kubeconfig file": "Konnte die kubeconfig-Datei nicht lesen",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "Resource not found",
   "Hide details": "Hide details",
   "Show details": "Show details",
+  "Sign in with Google": "Sign in with Google",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.",
   "Error setting up clusters, please load a valid kubeconfig file": "Error setting up clusters, please load a valid kubeconfig file",
   "Couldn't read kubeconfig file": "Couldn't read kubeconfig file",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "Recurso no encontrado",
   "Hide details": "Ocultar detalles",
   "Show details": "Mostrar detalles",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "Cluster duplicado: {{ clusterNames }} en la lista. Por favor edite el nombre del contexto.",
   "Error setting up clusters, please load a valid kubeconfig file": "Error al configurar los clusters, por favor cargue un archivo kubeconfig válido",
   "Couldn't read kubeconfig file": "No se pudo leer el archivo kubeconfig",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "Ressource non trouvée",
   "Hide details": "Masquer les détails",
   "Show details": "Afficher les détails",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "Cluster dupliqué : {{ clusterNames }} dans la liste. Veuillez modifier le nom du contexte.",
   "Error setting up clusters, please load a valid kubeconfig file": "Erreur lors de la configuration des clusters, veuillez charger un fichier kubeconfig valide",
   "Couldn't read kubeconfig file": "Impossible de lire le fichier kubeconfig",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "संसाधन नहीं मिला",
   "Hide details": "विवरण छिपाएँ",
   "Show details": "विवरण दिखाएँ",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "डुप्लिकेट क्लस्टर: सूची में {{ clusterNames }}। कृपया संदर्भ नाम संपादित करें।",
   "Error setting up clusters, please load a valid kubeconfig file": "क्लस्टर सेट अप करने में त्रुटि, कृपया वैध kubeconfig फ़ाइल लोड करें",
   "Couldn't read kubeconfig file": "kubeconfig फ़ाइल पढ़ नहीं सका",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "Risorsa non trovata",
   "Hide details": "Nascondi dettagli",
   "Show details": "Mostra dettagli",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "Cluster duplicato: {{ clusterNames }} nella lista. Per favore modifica il nome del contesto.",
   "Error setting up clusters, please load a valid kubeconfig file": "Errore nella configurazione dei cluster, carica un file kubeconfig valido",
   "Couldn't read kubeconfig file": "Impossibile leggere il file kubeconfig",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "リソースが見つかりません",
   "Hide details": "詳細を隠す",
   "Show details": "詳細を表示",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "クラスターの重複: {{ clusterNames }} はリストにあります。コンテキスト名を編集してください。",
   "Error setting up clusters, please load a valid kubeconfig file": "クラスターの設定中にエラーが発生しました。有効な kubeconfig ファイルを読み込んでください",
   "Couldn't read kubeconfig file": "kubeconfig ファイルを読み取れませんでした",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "리소스를 찾을 수 없습니다",
   "Hide details": "세부정보 숨기기",
   "Show details": "세부정보 보기",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "중복된 클러스터: {{ clusterNames }}. 컨텍스트 이름을 수정하세요.",
   "Error setting up clusters, please load a valid kubeconfig file": "클러스터 설정 중 오류 발생, 유효한 kubeconfig 파일을 불러오세요",
   "Couldn't read kubeconfig file": "kubeconfig 파일을 읽을 수 없습니다",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "Recurso não encontrado",
   "Hide details": "Ocultar detalhes",
   "Show details": "Mostrar detalhes",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "Cluster duplicado: {{ clusterNames }} na lista. Por favor edite o nome do contexto.",
   "Error setting up clusters, please load a valid kubeconfig file": "Erro ao configurar clusters, por favor carregue um ficheiro kubeconfig válido",
   "Couldn't read kubeconfig file": "Não foi possível ler o ficheiro kubeconfig",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "ரிசோர்ஸ் கிடைக்கவில்லை",
   "Hide details": "விவரங்களை மறை",
   "Show details": "விவரங்களைக் காட்டு",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "நகல் க்ளஸ்டர்: பட்டியலில் {{ clusterNames }}. கான்டெக்ஸ்ட் பெயரைத் திருத்தவும்.",
   "Error setting up clusters, please load a valid kubeconfig file": "க்ளஸ்டர்களை அமைப்பதில் பிழை, தயவுசெய்து சரியான கியூப்கான்ஃபிக் கோப்பை ஏற்றவும்",
   "Couldn't read kubeconfig file": "கியூப்கான்ஃபிக் கோப்பைப் படிக்க முடியவில்லை",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "資源未找到",
   "Hide details": "隱藏詳情",
   "Show details": "顯示詳情",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "列表中有重複的叢集：{{ clusterNames }}。請編輯上下文名稱。",
   "Error setting up clusters, please load a valid kubeconfig file": "設定叢集時出錯，請讀取有效的 kubeconfig 檔案",
   "Couldn't read kubeconfig file": "無法讀取 kubeconfig 檔案",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -229,6 +229,7 @@
   "Resource not found": "资源未找到",
   "Hide details": "隐藏详情",
   "Show details": "显示详情",
+  "Sign in with Google": "",
   "Duplicate cluster: {{ clusterNames }} in the list. Please edit the context name.": "列表中有重复的集群：{{ clusterNames }}。请编辑上下文名称。",
   "Error setting up clusters, please load a valid kubeconfig file": "设置集群时出错，请读取有效的 kubeconfig 文件",
   "Couldn't read kubeconfig file": "无法读取 kubeconfig 文件",

--- a/frontend/src/lib/k8s/cluster.ts
+++ b/frontend/src/lib/k8s/cluster.ts
@@ -58,6 +58,7 @@ export function getAllowedNamespaces(cluster: string | null = getCluster()): str
 
 export interface Cluster {
   name: string;
+  server?: string;
   useToken?: boolean;
   /**
    * Either 'oidc' or ''. '' means unknown.

--- a/frontend/src/lib/k8s/gke.test.ts
+++ b/frontend/src/lib/k8s/gke.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type MockInstance, vi } from 'vitest';
+import { Cluster } from './cluster';
+import { initiateGCPLogin, isGCPOAuthEnabled, isGKECluster } from './gke';
+
+// Mock getAppUrl to return a predictable base URL
+vi.mock('../../helpers/getAppUrl', () => ({
+  getAppUrl: () => 'http://localhost:4466/',
+}));
+
+describe('GKE utilities', () => {
+  describe('isGKECluster', () => {
+    it('should return false for null cluster', () => {
+      expect(isGKECluster(null)).toBe(false);
+    });
+
+    it('should return false for string cluster name', () => {
+      expect(isGKECluster('my-cluster')).toBe(false);
+    });
+
+    it('should return false for cluster without server property', () => {
+      const cluster: Cluster = {
+        name: 'my-cluster',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(false);
+    });
+
+    it('should return false for cluster with empty server', () => {
+      const cluster: Cluster = {
+        name: 'my-cluster',
+        server: '',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(false);
+    });
+
+    it('should return true for cluster with googleapis.com server', () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.googleapis.com',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(true);
+    });
+
+    it('should return true for cluster with container.cloud.google.com server', () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server:
+          'https://container.cloud.google.com/v1/projects/my-project/zones/us-central1-a/clusters/my-cluster',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(true);
+    });
+
+    it('should be case insensitive', () => {
+      const cluster: Cluster = {
+        name: 'gke-cluster',
+        server: 'https://35.123.45.67.GOOGLEAPIS.COM',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(true);
+    });
+
+    it('should return false for non-GKE cluster', () => {
+      const cluster: Cluster = {
+        name: 'eks-cluster',
+        server: 'https://ABCD1234.gr7.us-west-2.eks.amazonaws.com',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(false);
+    });
+
+    it('should return false for on-prem cluster', () => {
+      const cluster: Cluster = {
+        name: 'on-prem',
+        server: 'https://kubernetes.mycompany.com:6443',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(false);
+    });
+
+    it('should return false for localhost cluster', () => {
+      const cluster: Cluster = {
+        name: 'local',
+        server: 'https://localhost:6443',
+        auth_type: '',
+      };
+      expect(isGKECluster(cluster)).toBe(false);
+    });
+  });
+
+  describe('initiateGCPLogin', () => {
+    let originalLocation: Location;
+
+    beforeEach(() => {
+      // Save the original location
+      originalLocation = window.location;
+      // Mock window.location
+      delete (window as any).location;
+      window.location = { href: '' } as Location;
+    });
+
+    afterEach(() => {
+      // Restore the original location
+      window.location = originalLocation;
+    });
+
+    it('should redirect to GCP auth login URL', () => {
+      initiateGCPLogin('my-gke-cluster');
+      expect(window.location.href).toBe(
+        'http://localhost:4466/gcp-auth/login?cluster=my-gke-cluster'
+      );
+    });
+
+    it('should encode cluster name with special characters', () => {
+      initiateGCPLogin('my-cluster-123_test');
+      expect(window.location.href).toBe(
+        'http://localhost:4466/gcp-auth/login?cluster=my-cluster-123_test'
+      );
+    });
+
+    it('should encode cluster name with spaces', () => {
+      initiateGCPLogin('my cluster');
+      expect(window.location.href).toBe(
+        'http://localhost:4466/gcp-auth/login?cluster=my%20cluster'
+      );
+    });
+
+    it('should encode cluster name with special URL characters', () => {
+      initiateGCPLogin('my&cluster=test');
+      expect(window.location.href).toBe(
+        'http://localhost:4466/gcp-auth/login?cluster=my%26cluster%3Dtest'
+      );
+    });
+  });
+
+  describe('isGCPOAuthEnabled', () => {
+    let fetchSpy: MockInstance;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('should return true when backend returns enabled: true', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ enabled: true }),
+      } as Response);
+
+      const result = await isGCPOAuthEnabled();
+      expect(result).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledWith('http://localhost:4466/gcp-auth/enabled');
+    });
+
+    it('should return false when backend returns enabled: false', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ enabled: false }),
+      } as Response);
+
+      const result = await isGCPOAuthEnabled();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when response is not ok', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const result = await isGCPOAuthEnabled();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when fetch throws an error', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      fetchSpy.mockRejectedValue(new Error('Network error'));
+
+      const result = await isGCPOAuthEnabled();
+      expect(result).toBe(false);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to check GCP OAuth status:',
+        expect.any(Error)
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return false when JSON parsing fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new Error('Invalid JSON')),
+      } as Response);
+
+      const result = await isGCPOAuthEnabled();
+      expect(result).toBe(false);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return false when enabled field is missing', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response);
+
+      const result = await isGCPOAuthEnabled();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when enabled is not a boolean true', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ enabled: 'true' }),
+      } as Response);
+
+      const result = await isGCPOAuthEnabled();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/frontend/src/lib/k8s/gke.ts
+++ b/frontend/src/lib/k8s/gke.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getAppUrl } from '../../helpers/getAppUrl';
+import { Cluster } from './cluster';
+
+/**
+ * Determines if a cluster is a GKE (Google Kubernetes Engine) cluster
+ * based on its server URL.
+ *
+ * @param cluster - The cluster object or cluster name
+ * @returns true if the cluster appears to be a GKE cluster
+ */
+export function isGKECluster(cluster: Cluster | string | null): boolean {
+  if (!cluster) {
+    return false;
+  }
+
+  // If cluster is a string (cluster name), we can't determine from name alone
+  if (typeof cluster === 'string') {
+    return false;
+  }
+
+  // Check if cluster has a server property
+  const serverUrl = cluster.server || '';
+
+  if (!serverUrl) {
+    return false;
+  }
+
+  const lowerUrl = serverUrl.toLowerCase();
+
+  // GKE clusters have servers at *.googleapis.com or container.cloud.google.com
+  return lowerUrl.includes('.googleapis.com') || lowerUrl.includes('container.cloud.google.com');
+}
+
+/**
+ * Initiates the GCP OAuth login flow for a GKE cluster.
+ *
+ * @param clusterName - The name of the cluster to authenticate to
+ */
+export function initiateGCPLogin(clusterName: string): void {
+  const baseUrl = getAppUrl();
+  const loginUrl = `${baseUrl}gcp-auth/login?cluster=${encodeURIComponent(clusterName)}`;
+  window.location.href = loginUrl;
+}
+
+/**
+ * Checks if GCP OAuth is enabled in the backend.
+ *
+ * @returns Promise that resolves to true if GCP OAuth is enabled
+ */
+export async function isGCPOAuthEnabled(): Promise<boolean> {
+  try {
+    const baseUrl = getAppUrl();
+    const response = await fetch(`${baseUrl}gcp-auth/enabled`);
+    if (!response.ok) {
+      return false;
+    }
+    const data = await response.json();
+    return data.enabled === true;
+  } catch (error) {
+    console.warn('Failed to check GCP OAuth status:', error);
+    return false;
+  }
+}

--- a/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
+++ b/plugins/headlamp-plugin/config/.storybook/baseMocks.ts
@@ -98,6 +98,8 @@ export const NODE_DUMMY_DATA = [
  *
  */
 export const baseMocks = [
+  http.get('http://localhost:4466/gcp-auth/enabled', () => HttpResponse.json({ enabled: false })),
+  http.get('http://localhost:3000/gcp-auth/enabled', () => HttpResponse.json({ enabled: false })),
   http.get('http://localhost:4466/wsMultiplexer', () => HttpResponse.error()),
   http.get('https://api.iconify.design/mdi.json', () => HttpResponse.json({})),
   http.post('http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', () =>


### PR DESCRIPTION
This implementation adds Google Cloud Platform OAuth 2.0 authentication to Headlamp, providing a replacement for the deprecated Identity Service for GKE. Users can now authenticate with their Google Cloud accounts when accessing Headlamp deployed on GKE clusters.

## Backend Changes

- Add GCP OAuth configuration system (backend/pkg/config/config.go)
- Implement GCP authenticator with PKCE support (backend/pkg/gcp/auth.go)
- Add OAuth HTTP handlers for login, callback, and feature detection (backend/pkg/auth/gcp.go)
- Register OAuth routes: /gcp-auth/login, /gcp-auth/callback, /gcp-auth/enabled
- Support for token refresh and caching
- Environment variable configuration for OAuth credentials

## Frontend Changes

- Add GCPLoginButton component for Google sign-in (frontend/src/components/cluster/GCPLoginButton.tsx)
- Implement GKE cluster detection (frontend/src/lib/k8s/gke.ts)
- Integrate OAuth flow into AuthChooser component
- Add backend feature detection to conditionally show GCP login option
- Disable auto-redirect to token page to allow users to see authentication options

## Key Features

- RFC 7636 compliant PKCE (Proof Key for Code Exchange) implementation
- Base64url encoding without padding for code challenge
- OAuth state parameter for CSRF protection
- Automatic token refresh handling
- GKE cluster detection based on server URL patterns
- Comprehensive error handling and logging

## Documentation

- Comprehensive setup guide (docs/GCP_OAUTH_SETUP.md)
- Implementation status and troubleshooting (docs/GCP_OAUTH_IMPLEMENTATION_STATUS.md)
- Deployment instructions for GKE
- RBAC configuration examples

## Testing

- Unit tests for GCP authenticator functions
- Unit tests for GKE cluster detection
- Component tests for GCPLoginButton

This implementation has been tested and verified to work with GKE clusters, including successful OAuth flow initiation and PKCE code challenge generation.