### PR TITLE
ci: add kubescape security scanning workflow

### DIFF
--- a/.github/workflows/kubescape-scan.yml
+++ b/.github/workflows/kubescape-scan.yml
@@ -1,0 +1,27 @@
+name: Kubescape Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - ".github/workflows/kubescape-scan.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  kubescape:
+    uses: Anomalous-Ventures/.github/.github/workflows/kubescape-scan.yml@main
+    with:
+      scan-paths: "charts/"
+      frameworks: "NSA,MITRE"
+      severity-threshold: "HIGH"
+      fail-on-violations: false
+      runner: "stax-general"
+    permissions:
+      contents: read
+      security-events: write
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add Kubescape security compliance scanning via org reusable workflow
- Scans K8s manifests against NSA and MITRE frameworks on PRs
- Results uploaded to GitHub Security tab (SARIF)

## Test plan
- [ ] Verify workflow triggers on PR with K8s changes
- [ ] Verify scan results appear in Security tab