### PR TITLE
Remove duplicate word 'the the'

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -763,7 +763,7 @@ async function startServer(flags: string[] = []): Promise<ChildProcessWithoutNul
   // Pass a token to the backend that can be used for auth on some routes
   process.env.HEADLAMP_BACKEND_TOKEN = backendToken;
 
-  // Set the bundled plugins in addition to the the user's plugins.
+  // Set the bundled plugins in addition to the user's plugins.
   try {
     const stat = await fsPromises.stat(bundledPlugins);
     if (stat.isDirectory()) {

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,7 +74,7 @@ Use **atomic commits** to keep each commit focused on a single change. Follow th
   characters, and the wrap the body of the message at 72 characters.
 
 - Commits should be atomic and self-contained. Divide logically separate changes
-  to separate commits. This principle is best explained in the the Linux Kernel
+  to separate commits. This principle is best explained in the Linux Kernel
   [submitting patches](https://www.kernel.org/doc/html/v4.17/process/submitting-patches.html#separate-your-changes) guide.
 
 - Commit messages should explain the intention, _why_ something is done. This,


### PR DESCRIPTION
## Summary

This PR fixes a small documentation issue in the contributing guide and `/app/electron/main.ts` in by removing a duplicate word.

## Related Issue

Fixes #4864 

## Changes

* Updated documentation in `/docs/latest/contributing/`
* Updated comment in `/app/electron/main.ts`
* Replaced duplicate word **"the the" to "the"**

## Steps to Test

1. Navigate to the contributing documentation page.
2. Locate the sentence where the duplicate word appeared.
3. Verify that the duplicate word has been removed.