### PR TITLE
frontend: cascade delete Pods when deleting Jobs

### DIFF
--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -489,10 +489,12 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     }
     const params: DeleteParameters = {};
 
-    console.log(force);
+    if (this._class().kind === 'Job') {
+      params.propagationPolicy = 'Background';
+    }
+
     if (force) {
       params.gracePeriodSeconds = 0;
-      console.log(params);
     }
 
     // @ts-ignore

--- a/frontend/src/lib/k8s/api/v1/deleteParameters.ts
+++ b/frontend/src/lib/k8s/api/v1/deleteParameters.ts
@@ -29,4 +29,5 @@ export interface DeleteParameters {
    * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#dry-run
    */
   dryRun?: string;
+  propagationPolicy?: 'Foreground' | 'Background' | 'Orphan';
 }


### PR DESCRIPTION
## Summary

Deleting a Job in Headlamp currently leaves the Pod created by the Job
orphaned because `propagationPolicy` is not included in the delete
request.

This change ensures Job deletions include
`propagationPolicy=Background`, allowing Kubernetes to cascade the
deletion to Pods owned by the Job.

Fixes #4834.

## Changes

- Add `propagationPolicy` to `DeleteParameters`
- Ensure Job deletions set `propagationPolicy=Background` in
  `KubeObject.delete()`

## Implementation Details

Headlamp serializes delete parameters using `asQuery(deleteParams)`.
By exposing `propagationPolicy` in `DeleteParameters` and setting it
for Job deletions, the resulting request becomes:

DELETE /apis/batch/v1/namespaces/<ns>/jobs/<name>?propagationPolicy=Background


This allows Kubernetes to perform background garbage collection and
delete Pods owned by the Job.

## Testing

- Ran `npm run frontend:lint`
- Ran `npm run frontend:test`
- Verified cascading delete behavior on a local Kubernetes cluster
  created with `kind`