### PR TITLE
bump headlamp chart version to 0.40.1

### DIFF
--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.40.0
-appVersion: 0.40.0
+version: 0.40.1
+appVersion: 0.40.1
 annotations:
   artifacthub.io/signKey: |
     fingerprint: 2956B7F7167769370C93730C7264DA7B85D08A37

--- a/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
+++ b/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -18,10 +18,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,10 +39,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -66,10 +66,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -95,7 +95,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -44,10 +44,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -65,10 +65,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -92,10 +92,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -121,7 +121,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/host-users-override.yaml
+++ b/charts/headlamp/tests/expected_templates/host-users-override.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
+++ b/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:
@@ -136,10 +136,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingress
   annotations:

--- a/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -28,10 +28,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49,10 +49,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -76,10 +76,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -105,7 +105,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: mynamespace2
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -31,10 +31,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52,10 +52,10 @@ metadata:
   name: headlamp
   namespace: mynamespace2
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -79,10 +79,10 @@ metadata:
   name: headlamp
   namespace: mynamespace2
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -108,7 +108,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/namespace-override.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: mynamespace
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: mynamespace
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: mynamespace
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
+++ b/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -18,10 +18,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,10 +39,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -66,10 +66,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -95,7 +95,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -31,10 +31,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52,10 +52,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -79,10 +79,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -108,7 +108,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -18,10 +18,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,10 +39,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -66,10 +66,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -95,7 +95,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -18,10 +18,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,10 +39,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -66,10 +66,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -95,7 +95,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           # Check if externalSecret is enabled

--- a/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -18,10 +18,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,10 +39,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -66,10 +66,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -95,7 +95,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
@@ -18,10 +18,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,10 +39,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -66,10 +66,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -95,7 +95,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/pod-disruption.yaml
+++ b/charts/headlamp/tests/expected_templates/pod-disruption.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   maxUnavailable: 1
@@ -26,10 +26,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -47,10 +47,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -68,10 +68,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -95,10 +95,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -124,7 +124,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -28,10 +28,10 @@ metadata:
   name: headlamp-plugin-config
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 data:
   plugin.yml: |
@@ -42,10 +42,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -63,10 +63,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -90,10 +90,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -130,7 +130,7 @@ spec:
             runAsUser: 100
             seccompProfile:
               type: RuntimeDefault
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/tls-added.yaml
+++ b/charts/headlamp/tests/expected_templates/tls-added.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -6,10 +6,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: headlamp/templates/secret.yaml
@@ -27,10 +27,10 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,10 +48,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -75,10 +75,10 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.40.0
+    helm.sh/chart: headlamp-0.40.1
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.40.0"
+    app.kubernetes.io/version: "0.40.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -104,7 +104,7 @@ spec:
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.0"
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.40.1"
           imagePullPolicy: IfNotPresent
           
           env:


### PR DESCRIPTION
## Summary

This PR bumps to chart version to match the current latest release, 0.40.1.

## Related Issue

#4847

## Changes

- Bump chart version to 0.40.1
- Bump chart test fixtures to 0.40.1

## Steps to Test

N/A

## Screenshots (if applicable)


## Notes for the Reviewer

- First PR here so let me know if I missed anything but seems pretty straight forward.
