### PR TITLE
Update French translation for 'Sign In'

### DIFF
--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -201,7 +201,7 @@
   "Getting auth info": "Obtenir des informations d'authentification",
   "Testing auth": "Test d'authentification",
   "Headlamp Cluster Authentication": "Authentification du cluster HeadLamp",
-  "Sign In": "S'inscrire",
+  "Sign In": "Se connecter",
   "Use A Token": "Utiliser un jeton",
   "Failed to connect. Please make sure the Kubernetes cluster is running and accessible. Error: {{ errorMessage }}": "Impossible de se connecter. Veuillez vous assurer que le cluster Kubernetes est en cours d'exécution et accessible. Erreur : {{ errorMessage }}",
   "Failed to get authentication information: {{ errorMessage }}": "Impossible d'obtenir les informations d'authentification : {{ errorMessage }}",


### PR DESCRIPTION
## Summary

This PR fixes a French translation. "Sign in" was translated as "S'inscrire" which actually means "Sign up". This confused some of our users who were connecting via SSO and already have an account.

## Changes

- Updated the french i8n file
