### PR TITLE
fix: preserve original URL after OIDC authentication

### DIFF
--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -209,11 +209,7 @@ function AuthChooser({ children }: AuthChooserProps) {
       handleTryAgain={runTestAuthAgain}
       handleOidcAuth={() => {
         queryClient.invalidateQueries({ queryKey: ['clusterMe', clusterName], exact: true });
-        history.replace({
-          pathname: generatePath(getClusterPrefixedPath(), {
-            cluster: clusterName as string,
-          }),
-        });
+        history.replace(from);
       }}
       handleBackButtonPress={() => {
         numClusters > 1 ? history.goBack() : history.push('/');


### PR DESCRIPTION
## Summary

When a user navigates to a deep link (e.g., `/c/main/pods/default/my-pod?view=logs`) while **not authenticated**, the `AuthRoute` component correctly saves the original URL in `location.state.from` before redirecting to the login page.

However, after completing **OIDC authentication** via the popup flow, the `handleOidcAuth` callback in `AuthChooser` always redirects to the **cluster root path** (`/c/<cluster>/`), discarding the saved original URL.

This means users who share or bookmark direct links to specific resources are not returned to those resources after logging in — they always land on the cluster overview page and must navigate manually.

## Root Cause

In `frontend/src/components/authchooser/index.tsx`, the `handleOidcAuth` callback hardcodes a redirect to the cluster root:

```tsx
handleOidcAuth={() => {
  queryClient.invalidateQueries({ queryKey: ['clusterMe', clusterName], exact: true });
  history.replace({
    pathname: generatePath(getClusterPrefixedPath(), {
      cluster: clusterName as string,
    }),
  });
}}
```

The `from` variable (which holds the original URL from `location.state.from`, with a fallback to the cluster root) is already defined in the component but not used in this handler.

Notably, the **non-OIDC auth flow** in the same component already correctly uses `history.replace(from)` (lines 153-154 and 159-160).

## Fix

Replace the hardcoded cluster root redirect with `history.replace(from)`, making the OIDC flow consistent with the non-OIDC flow:

```tsx
handleOidcAuth={() => {
  queryClient.invalidateQueries({ queryKey: ['clusterMe', clusterName], exact: true });
  history.replace(from);
}}
```

The `from` variable defaults to `createRouteURL('cluster')` (the cluster root) when no saved location exists, so existing behavior is preserved for direct logins.

## Steps to Reproduce

1. Configure Headlamp with OIDC authentication
2. In a new browser session (not authenticated), navigate directly to a resource URL, e.g.: `https://headlamp.example.com/c/main/pods/default/my-app-xyz?view=logs`
3. The `AuthRoute` redirects to the login page
4. Click "Sign In" and complete the OIDC authentication popup
5. **Expected**: Redirect back to `/c/main/pods/default/my-app-xyz?view=logs`
6. **Actual**: Redirect to `/c/main/` (cluster root)

## Test Plan

- [ ] Verify unauthenticated access to a deep link redirects to login, and after OIDC auth, returns to the original URL
- [ ] Verify direct navigation to the login page (no saved `from` state) still redirects to the cluster root after OIDC auth
- [ ] Verify non-OIDC (token) auth flow continues to work as expected
- [ ] Verify that query parameters (e.g., `?view=logs`) are preserved through the redirect
