### PR TITLE
frontend: avoid invalid field selector for pod metrics

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1659,10 +1659,15 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
     fieldSelector: resource.kind === 'Node' ? `spec.nodeName=${resource.metadata.name}` : undefined,
     cluster: resource.cluster,
   };
+  const podMetricsQueryData = {
+    ...queryData,
+    // The metrics.k8s.io pod metrics list endpoint does not support spec.nodeName field selectors.
+    fieldSelector: undefined,
+  };
 
   const { items: pods, errors } = Pod.useList(queryData);
   const { items: podMetrics } = PodMetrics.useList({
-    ...queryData,
+    ...podMetricsQueryData,
     refetchInterval: METRIC_REFETCH_INTERVAL_MS,
   });
   const onlyOneNamespace = !!resource.metadata.namespace || resource.kind === 'Namespace';


### PR DESCRIPTION
## Summary

  Avoid sending `fieldSelector=spec.nodeName=...` to the pod metrics API when rendering owned pods for a Node.

  ## Problem

  On Node details pages, Headlamp reused the same query parameters for both:

  - the Pod list API
  - the `metrics.k8s.io/v1beta1/pods` metrics API

  This caused requests like:

  `/apis/metrics.k8s.io/v1beta1/pods?fieldSelector=spec.nodeName=...`

  But the pod metrics API does not support `spec.nodeName` as a field selector, so it returned:

  `"spec.nodeName" is not a known field selector`

  ## Fix

  Keep the node field selector for the normal Pod list request, but drop it from the Pod metrics request.

  ## Steps to Test

  1. Open a Node details page.
  2. Go to the owned pods section.
  3. Verify pod metrics load normally.
  4. Confirm no request to `metrics.k8s.io/v1beta1/pods` includes `fieldSelector=spec.nodeName=...`.
  5. Confirm the previous 400 error no longer appears.

  ## Notes for Reviewers

  This is a minimal fix scoped to the Node owned-pods path. It does not change Pod list filtering behavior.