### PR TITLE
build: include static plugin locales

### DIFF
--- a/container/fetch-plugins.sh
+++ b/container/fetch-plugins.sh
@@ -23,7 +23,7 @@ for plugin in $plugins; do
 
   archivedir=$TMPDIR/$plugin
   mkdir -p $archivedir
-  tar -xzf $TMPDIR/$plugin.tgz -C $archivedir --wildcards '*/main.js' '*/package.json'
+  tar -xzf $TMPDIR/$plugin.tgz -C $archivedir --wildcards '*/main.js' '*/package.json' '*/locales/*/translation.json'
 
   ls -lr $archivedir
 
@@ -32,6 +32,9 @@ for plugin in $plugins; do
   dir=$DESTDIR/$plugin
   mkdir -p $dir
   cp $extracted_dir/main.js $extracted_dir/package.json $dir
+  if [ -d "$extracted_dir/locales" ]; then
+    cp -r $extracted_dir/locales $dir
+  fi
 
   echo " done"
 done


### PR DESCRIPTION
## Summary

  Include plugin locale files when fetching static plugins for bundled/container builds.

  ## Problem

  Static plugin fetching only extracted and copied:

  - `main.js`
  - `package.json`

  This meant plugin translation files under:

  - `locales/<locale>/translation.json`

  were missing from the final `static-plugins/<plugin>/` output.

  As a result, requests such as:

  `/static-plugins/prometheus/locales/it/translation.json`

  returned `404 Not Found`, and plugin i18n fell back incorrectly.

  ## Fix

  Update `container/fetch-plugins.sh` to:

  1. extract `locales/*/translation.json` from plugin archives
  2. copy the extracted `locales/` directory into the final static plugin output when present

  ## Impact

  This allows bundled static plugins such as `prometheus` to serve their translation files correctly in production/container environments.

  ## Steps to Test

  1. Build or fetch static plugins using `container/fetch-plugins.sh`.
  2. Verify the output plugin directory contains:
     - `main.js`
     - `package.json`
     - `locales/<locale>/translation.json`
  3. Start Headlamp with the static plugin bundle.
  4. Request a plugin locale file, for example:
     - `/static-plugins/prometheus/locales/it/translation.json`
  5. Confirm the file is returned successfully instead of `404`.

  ## Notes for Reviewers

  This is a minimal packaging fix only. It does not change plugin runtime behavior beyond making already-shipped translation assets available.