### PR TITLE
fix: persist rows-per-page selection to localStorage on change in Table.tsx

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -48,7 +48,7 @@ import { MRT_Localization_ZH_HANS } from 'material-react-table/locales/zh-Hans';
 import { MRT_Localization_ZH_HANT } from 'material-react-table/locales/zh-Hant';
 import { memo, ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getTablesRowsPerPage } from '../../../helpers/tablesRowsPerPage';
+import { getTablesRowsPerPage, setTablesRowsPerPage } from '../../../helpers/tablesRowsPerPage';
 import { useShortcut } from '../../../lib/useShortcut';
 import { useURLState } from '../../../lib/util';
 import { useSettings } from '../../App/Settings/hook';
@@ -272,6 +272,9 @@ export default function Table<RowItem extends Record<string, any>>({
       const pagination = updater({ pageIndex: Number(page) - 1, pageSize: Number(pageSize) });
       setPage(pagination.pageIndex + 1);
       setPageSize(pagination.pageSize);
+      if (pagination.pageSize !== Number(pageSize)) {
+        setTablesRowsPerPage(pagination.pageSize);
+      }
     },
     onGlobalFilterChange: setGlobalFilter,
     renderToolbarInternalActions: props => {


### PR DESCRIPTION
## Summary

This PR fixes a bug where the user's rows-per-page selection in table pagination was not persisted to `localStorage`. `getTablesRowsPerPage()` is called on mount to read the saved preference, but `setTablesRowsPerPage()` was never called when the user changed the value — so the selection was lost on navigation or page reload.

## Related Issue

N/A — no existing issue filed.

## Changes

- Updated `onPaginationChange` in `Table.tsx` to call `setTablesRowsPerPage()` when the page size changes
- Added `setTablesRowsPerPage` to the existing import from `../../../helpers/tablesRowsPerPage`

## Steps to Test

1. Open Headlamp and navigate to any resource list (e.g. Pods)
2. Change the rows-per-page selector in the table pagination (e.g. from 10 to 25)
3. Navigate away to another page, then return to the resource list
4. Observe that the rows-per-page selection is remembered (was 10 before this fix, now correctly shows 25)
5. Reload the page and verify the preference is still applied

## Screenshots (if applicable)

N/A — behavior change only, no visual difference beyond the persisted state.

## Notes for the Reviewer

- `SimpleTable.tsx` already called `setTablesRowsPerPage()` correctly on pagination change — this brings `Table.tsx` (used by `ResourceListView`) to parity with that behavior.
- The guard `pagination.pageSize !== Number(pageSize)` ensures we only write to `localStorage` when the page size actually changes, not on every page navigation.
