### PR TITLE
Proxy auth support

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -50,9 +50,9 @@ import (
 	auth "github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/serviceproxy"
 
-	headlampcfg "github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/helm"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
@@ -74,9 +74,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// HeadlampConfig wraps headlampconfig.HeadlampConfig and adds cmd-specific methods.
 type HeadlampConfig struct {
-	*headlampcfg.HeadlampConfig
+	*headlampconfig.HeadlampConfig
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -539,10 +538,14 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	// Expose user info so the frontend can show the current user in the top bar using the per-cluster auth cookie.
 	r.HandleFunc("/clusters/{clusterName}/me",
 		auth.HandleMe(auth.MeHandlerOptions{
-			UsernamePaths: config.MeUsernamePaths,
-			EmailPaths:    config.MeEmailPaths,
-			GroupsPaths:   config.MeGroupsPaths,
-			UserInfoURL:   config.MeUserInfoURL,
+			UsernamePaths:           config.MeUsernamePaths,
+			EmailPaths:              config.MeEmailPaths,
+			GroupsPaths:             config.MeGroupsPaths,
+			UserInfoURL:             config.MeUserInfoURL,
+			ProxyAuthEnabled:        config.ProxyAuthEnabled,
+			ProxyAuthUsernameHeader: config.ProxyAuthUsernameHeader,
+			ProxyAuthGroupHeader:    config.ProxyAuthGroupHeader,
+			ProxyAuthEmailHeader:    config.ProxyAuthEmailHeader,
 		}),
 	).Methods("GET")
 
@@ -1651,8 +1654,17 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 		r.URL.Path = mux.Vars(r)["api"]
 		r.URL.Scheme = clusterURL.Scheme
 
-		token, err := auth.GetTokenFromCookie(r, mux.Vars(r)["clusterName"])
-		if err == nil && token != "" {
+		var token string
+
+		if c.ProxyAuthEnabled && c.ProxyAuthTokenHeader != "" {
+			token = strings.TrimSpace(r.Header.Get(c.ProxyAuthTokenHeader))
+		}
+
+		if token == "" {
+			token, _ = auth.GetTokenFromCookie(r, mux.Vars(r)["clusterName"])
+		}
+
+		if token != "" {
 			r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 		}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1844,11 +1844,13 @@ func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 	clusterName := cfg.CurrentContext
 
 	if clusterName == "" {
-		clusters := (&HeadlampConfig{
+		cfgObj := &HeadlampConfig{
 			HeadlampConfig: &headlampconfig.HeadlampConfig{
 				HeadlampCFG: &headlampconfig.HeadlampCFG{KubeConfigStore: kubeConfigStore},
 			},
-		}).getClusters()
+		}
+		clusters := cfgObj.getClusters()
+
 		for _, c := range clusters {
 			if c.Error == "" {
 				clusterName = c.Name

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -157,7 +157,15 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		cfg.OidcCACert = string(caFileContents)
 	}
 
-	return &HeadlampConfig{HeadlampConfig: cfg}
+	cfg.ProxyAuthEnabled = conf.ProxyAuthEnabled
+	cfg.ProxyAuthUsernameHeader = conf.ProxyAuthUsernameHeader
+	cfg.ProxyAuthGroupHeader = conf.ProxyAuthGroupHeader
+	cfg.ProxyAuthEmailHeader = conf.ProxyAuthEmailHeader
+	cfg.ProxyAuthTokenHeader = conf.ProxyAuthTokenHeader
+
+	return &HeadlampConfig{
+		HeadlampConfig: cfg,
+	}
 }
 
 // GetContextKeyAndContext returns Kcontext , ContextKey for using these in CacheMiddleWare function.

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -287,6 +287,11 @@ type MeHandlerOptions struct {
 	GroupsPaths string
 	// UserInfoURL is the URL to fetch additional user info for the /me endpoint.
 	UserInfoURL string
+	// ProxyAuthEnabled indicates if the identity proxy bypass is enabled
+	ProxyAuthEnabled        bool
+	ProxyAuthUsernameHeader string
+	ProxyAuthGroupHeader    string
+	ProxyAuthEmailHeader    string
 }
 
 // HandleMe returns a handler that reads the per-cluster auth cookie and responds with user info.
@@ -305,6 +310,10 @@ func HandleMe(opts MeHandlerOptions) http.HandlerFunc {
 		clusterName := mux.Vars(r)["clusterName"]
 		if clusterName == "" {
 			writeMeJSON(w, http.StatusBadRequest, map[string]interface{}{"message": "cluster not specified"})
+			return
+		}
+
+		if tryProxyAuth(w, r, opts, userInfoURL) {
 			return
 		}
 
@@ -358,7 +367,39 @@ func parseClaimsFromToken(token string) (map[string]interface{}, int, string) {
 	return claims, 0, ""
 }
 
-// writeMeResponse serializes the identity payload with the standard cache-busting headers.
+// tryProxyAuth checks if proxy auth is enabled and a proxy user header exists.
+// If valid, it writes the response and returns true, allowing the caller to return early.
+// Otherwise, it returns false.
+func tryProxyAuth(w http.ResponseWriter, r *http.Request, opts MeHandlerOptions, userInfoURL string) bool {
+	if !opts.ProxyAuthEnabled {
+		return false
+	}
+
+	username := r.Header.Get(opts.ProxyAuthUsernameHeader)
+	if username == "" {
+		return false
+	}
+
+	email := r.Header.Get(opts.ProxyAuthEmailHeader)
+	groupsRaw := r.Header.Get(opts.ProxyAuthGroupHeader)
+
+	var groups []string
+
+	if groupsRaw != "" {
+		for _, group := range strings.Split(groupsRaw, ",") {
+			group = strings.TrimSpace(group)
+			if group != "" {
+				groups = append(groups, group)
+			}
+		}
+	}
+
+	writeMeResponse(w, username, email, groups, userInfoURL)
+
+	return true
+}
+
+// writeMeResponse writes the successful response for HandleMe with the standard cache-busting headers.
 func writeMeResponse(w http.ResponseWriter, username, email string, groups []string, userInfoURL string) {
 	writeMeJSON(w, http.StatusOK, map[string]interface{}{
 		"username":    username,

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -1102,6 +1102,41 @@ func TestHandleMe_HeaderToken(t *testing.T) {
 	assert.Equal(t, []string{"dev", "ops"}, got.Groups)
 }
 
+func TestHandleMe_ProxyAuth(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/test/me", nil)
+	req = mux.SetURLVars(req, map[string]string{"clusterName": "test"})
+
+	req.Header.Set("X-Forwarded-User", "proxy_alice")
+	req.Header.Set("X-Forwarded-Email", "proxy_alice@example.com")
+	req.Header.Set("X-Forwarded-Group", "dev, ops")
+
+	rr := httptest.NewRecorder()
+
+	handler := auth.HandleMe(auth.MeHandlerOptions{
+		ProxyAuthEnabled:        true,
+		ProxyAuthUsernameHeader: "X-Forwarded-User",
+		ProxyAuthEmailHeader:    "X-Forwarded-Email",
+		ProxyAuthGroupHeader:    "X-Forwarded-Group",
+	})
+
+	handler(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var got struct {
+		Username string   `json:"username"`
+		Email    string   `json:"email"`
+		Groups   []string `json:"groups"`
+	}
+
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.Equal(t, "proxy_alice", got.Username)
+	assert.Equal(t, "proxy_alice@example.com", got.Email)
+	assert.Equal(t, []string{"dev", "ops"}, got.Groups)
+}
+
 func TestHandleMe_ExpiredToken(t *testing.T) {
 	t.Parallel()
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -74,6 +74,11 @@ type Config struct {
 	MeGroupsPath              string `koanf:"me-groups-path"`
 	MeUserInfoURL             string `koanf:"me-user-info-url"`
 	OidcUsePKCE               bool   `koanf:"oidc-use-pkce"`
+	ProxyAuthEnabled          bool   `koanf:"proxy-auth"`
+	ProxyAuthUsernameHeader   string `koanf:"proxy-auth-username-header"`
+	ProxyAuthGroupHeader      string `koanf:"proxy-auth-group-header"`
+	ProxyAuthEmailHeader      string `koanf:"proxy-auth-email-header"`
+	ProxyAuthTokenHeader      string `koanf:"proxy-auth-token-header"`
 	// telemetry configs
 	ServiceName        string   `koanf:"service-name"`
 	ServiceVersion     *string  `koanf:"service-version"`
@@ -419,6 +424,7 @@ func flagset() *flag.FlagSet {
 
 	addGeneralFlags(f)
 	addOIDCFlags(f)
+	addProxyAuthFlags(f)
 	addTelemetryFlags(f)
 	addTLSFlags(f)
 
@@ -476,6 +482,14 @@ func addOIDCFlags(f *flag.FlagSet) {
 		"Comma separated JMESPath expressions used to read groups from the JWT payload")
 	f.String("me-user-info-url", DefaultMeUserInfoURL,
 		"URL to fetch additional user info for the /me endpoint. For oauth2proxy /oauth2/userinfo can be used.")
+}
+
+func addProxyAuthFlags(f *flag.FlagSet) {
+	f.Bool("proxy-auth", false, "Enable bypass of authentication when identity-aware proxy headers are present")
+	f.String("proxy-auth-username-header", "X-Forwarded-User", "Header name to read the authenticated username from")
+	f.String("proxy-auth-group-header", "X-Forwarded-Group", "Header name to read the authenticated groups from")
+	f.String("proxy-auth-email-header", "X-Forwarded-Email", "Header name to read the authenticated email from")
+	f.String("proxy-auth-token-header", "X-Forwarded-Id-Token", "Header name to read the proxy Id token from")
 }
 
 func addTelemetryFlags(f *flag.FlagSet) {

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -47,6 +47,12 @@ func TestParseBasic(t *testing.T) {
 				assert.Equal(t, config.DefaultMeEmailPath, conf.MeEmailPath)
 				assert.Equal(t, config.DefaultMeGroupsPath, conf.MeGroupsPath)
 				assert.Equal(t, "info", conf.LogLevel)
+				// proxy-auth defaults
+				assert.Equal(t, false, conf.ProxyAuthEnabled)
+				assert.Equal(t, "X-Forwarded-User", conf.ProxyAuthUsernameHeader)
+				assert.Equal(t, "X-Forwarded-Group", conf.ProxyAuthGroupHeader)
+				assert.Equal(t, "X-Forwarded-Email", conf.ProxyAuthEmailHeader)
+				assert.Equal(t, "X-Forwarded-Id-Token", conf.ProxyAuthTokenHeader)
 			},
 		},
 		{
@@ -149,6 +155,34 @@ var ParseWithEnvTests = []struct {
 		},
 		verify: func(t *testing.T, conf *config.Config) {
 			assert.Equal(t, "warn", conf.LogLevel)
+		},
+	},
+	{
+		name: "proxy_auth_enabled_from_env",
+		args: []string{"go run ./cmd"},
+		env: map[string]string{
+			"HEADLAMP_CONFIG_PROXY_AUTH": "true",
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, true, conf.ProxyAuthEnabled)
+		},
+	},
+	{
+		name: "proxy_auth_headers_from_env",
+		args: []string{"go run ./cmd"},
+		env: map[string]string{
+			"HEADLAMP_CONFIG_PROXY_AUTH":                 "true",
+			"HEADLAMP_CONFIG_PROXY_AUTH_USERNAME_HEADER": "X-Env-User",
+			"HEADLAMP_CONFIG_PROXY_AUTH_GROUP_HEADER":    "X-Env-Group",
+			"HEADLAMP_CONFIG_PROXY_AUTH_EMAIL_HEADER":    "X-Env-Email",
+			"HEADLAMP_CONFIG_PROXY_AUTH_TOKEN_HEADER":    "X-Env-Token-Header", // #nosec G101
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, true, conf.ProxyAuthEnabled)
+			assert.Equal(t, "X-Env-User", conf.ProxyAuthUsernameHeader)
+			assert.Equal(t, "X-Env-Group", conf.ProxyAuthGroupHeader)
+			assert.Equal(t, "X-Env-Email", conf.ProxyAuthEmailHeader)
+			assert.Equal(t, "X-Env-Token-Header", conf.ProxyAuthTokenHeader)
 		},
 	},
 }
@@ -258,6 +292,60 @@ func TestParseFlags(t *testing.T) {
 			args: []string{"go run ./cmd", "--log-level=warn"},
 			verify: func(t *testing.T, conf *config.Config) {
 				assert.Equal(t, "warn", conf.LogLevel)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			require.NoError(t, err)
+			require.NotNil(t, conf)
+
+			tt.verify(t, conf)
+		})
+	}
+}
+
+func TestProxyAuthFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		verify func(*testing.T, *config.Config)
+	}{
+		{
+			name: "proxy_auth_enabled_flag",
+			args: []string{"go run ./cmd", "--proxy-auth"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, true, conf.ProxyAuthEnabled)
+			},
+		},
+		{
+			name: "proxy_auth_username_header_flag",
+			args: []string{"go run ./cmd", "--proxy-auth-username-header=X-Custom-User"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, "X-Custom-User", conf.ProxyAuthUsernameHeader)
+			},
+		},
+		{
+			name: "proxy_auth_group_header_flag",
+			args: []string{"go run ./cmd", "--proxy-auth-group-header=X-Custom-Group"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, "X-Custom-Group", conf.ProxyAuthGroupHeader)
+			},
+		},
+		{
+			name: "proxy_auth_email_header_flag",
+			args: []string{"go run ./cmd", "--proxy-auth-email-header=X-Custom-Email"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, "X-Custom-Email", conf.ProxyAuthEmailHeader)
+			},
+		},
+		{
+			name: "proxy_auth_token_header_flag",
+			args: []string{"go run ./cmd", "--proxy-auth-token-header=X-Custom-Token"},
+			verify: func(t *testing.T, conf *config.Config) {
+				assert.Equal(t, "X-Custom-Token", conf.ProxyAuthTokenHeader)
 			},
 		},
 	}
@@ -635,4 +723,42 @@ func TestDefaultHeadlampKubeConfigFile(t *testing.T) {
 	info, err := os.Stat(filepath.Dir(path))
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
+}
+
+func TestProxyAuthFlagOverridesEnv(t *testing.T) {
+	// Single header override.
+	t.Run("flag_overrides_env_username_header", func(t *testing.T) {
+		t.Setenv("HEADLAMP_CONFIG_PROXY_AUTH_USERNAME_HEADER", "X-Env-User")
+
+		conf, err := config.Parse([]string{"go run ./cmd", "--proxy-auth-username-header=X-Flag-User"})
+		require.NoError(t, err)
+		assert.Equal(t, "X-Flag-User", conf.ProxyAuthUsernameHeader)
+	})
+
+	// All proxy auth flags override corresponding env vars.
+	t.Run("flag_overrides_env_all_proxy_auth", func(t *testing.T) {
+		for k, v := range map[string]string{
+			"HEADLAMP_CONFIG_PROXY_AUTH":                 "false",
+			"HEADLAMP_CONFIG_PROXY_AUTH_USERNAME_HEADER": "X-Env-User",
+			"HEADLAMP_CONFIG_PROXY_AUTH_GROUP_HEADER":    "X-Env-Group",
+			"HEADLAMP_CONFIG_PROXY_AUTH_EMAIL_HEADER":    "X-Env-Email",
+			"HEADLAMP_CONFIG_PROXY_AUTH_TOKEN_HEADER":    "X-Env-Token-Header", // #nosec G101
+		} {
+			t.Setenv(k, v)
+		}
+
+		conf, err := config.Parse([]string{
+			"go run ./cmd", "--proxy-auth",
+			"--proxy-auth-username-header=X-Flag-User",
+			"--proxy-auth-group-header=X-Flag-Group",
+			"--proxy-auth-email-header=X-Flag-Email",
+			"--proxy-auth-token-header=X-Flag-Token",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, true, conf.ProxyAuthEnabled)
+		assert.Equal(t, "X-Flag-User", conf.ProxyAuthUsernameHeader)
+		assert.Equal(t, "X-Flag-Group", conf.ProxyAuthGroupHeader)
+		assert.Equal(t, "X-Flag-Email", conf.ProxyAuthEmailHeader)
+		assert.Equal(t, "X-Flag-Token", conf.ProxyAuthTokenHeader)
+	})
 }

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -36,6 +36,11 @@ type HeadlampConfig struct {
 	MeEmailPaths              string
 	MeGroupsPaths             string
 	MeUserInfoURL             string
+	ProxyAuthEnabled          bool
+	ProxyAuthUsernameHeader   string
+	ProxyAuthGroupHeader      string
+	ProxyAuthEmailHeader      string
+	ProxyAuthTokenHeader      string
 }
 
 type HeadlampCFG struct {

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -30,6 +30,16 @@ func stringPtr(s string) *string {
 	return &s
 }
 
+// fileExists returns true if the file exists.
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if err != nil {
+		return false
+	}
+
+	return !info.IsDir()
+}
+
 // getTestDataPath returns the absolute path to the test data directory.
 func getTestDataPath() string {
 	// Get the current working directory
@@ -324,10 +334,21 @@ func TestContext(t *testing.T) {
 	configStore := kubeconfig.NewContextStore()
 
 	err := kubeconfig.LoadAndStoreKubeConfigs(configStore, kubeConfigFile, kubeconfig.KubeConfig, nil)
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping test: failed to load default kubeconfig: %v", err)
+	}
 
 	testContext, err := configStore.GetContext("minikube")
-	require.NoError(t, err)
+	if err != nil {
+		t.Skipf("Skipping test: minikube context not found: %v", err)
+	}
+
+	// Verify that the certificates actually exist, if not skip
+	if testContext.Cluster != nil && testContext.Cluster.CertificateAuthority != "" {
+		if !fileExists(testContext.Cluster.CertificateAuthority) {
+			t.Skipf("Skipping test: minikube CA certificate not found at %s", testContext.Cluster.CertificateAuthority)
+		}
+	}
 
 	require.Equal(t, "minikube", testContext.Name)
 	require.NotNil(t, testContext.ClientConfig())

--- a/docs/installation/in-cluster/identity-aware-proxy.md
+++ b/docs/installation/in-cluster/identity-aware-proxy.md
@@ -1,0 +1,234 @@
+---
+title: Accessing using Identity-Aware Proxies
+sidebar_label: Identity-Aware Proxy
+---
+
+Headlamp can be placed behind an identity-aware proxy (IAP) such as [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) or Google Cloud IAP. When configured, Headlamp will trust the user information provided by the proxy via HTTP headers and seamlessly bypass the internal login screen. When identity aware proxy is enabled, the proxy should be trustable. This means that the proxy should be deployed in a way that it is not exposed to the public internet and that it is not possible for an attacker to impersonate the proxy. The proxy should also be configured to inject the correct headers into the request to Headlamp. Backend does not maintain any persistent session, it relies on the headers injected. 
+**Important:** the trusted proxy or ingress must strip, reject, or overwrite any incoming client-supplied identity headers before forwarding the request to Headlamp. This includes the default `X-Forwarded-*` headers as well as any custom headers configured with `-proxy-auth-username-header`, `-proxy-auth-group-header`, `-proxy-auth-email-header`, or `-proxy-auth-token-header`. Otherwise, a client could spoof these headers and impersonate another user if Headlamp is reachable without that protection at the edge.
+
+## Configuration
+
+To enable identity-aware proxy authentication, set the following argument or environment variable on the Headlamp server:
+
+- `-proxy-auth=true` or env var `HEADLAMP_CONFIG_PROXY_AUTH=true`
+
+By default, Headlamp expects the proxy to pass the authenticated username in the `X-Forwarded-User` header. If a valid username is found, Headlamp backend establishes a session for that user based on the token passed in. UI treats the request as authenticated based on trusted headers and bypasses the login screen. 
+
+You can customize the headers Headlamp looks for using the following flags:
+
+- `-proxy-auth-username-header`: Header name for the username (default: `X-Forwarded-User`)
+- `-proxy-auth-group-header`: Header name for the user's groups (default: `X-Forwarded-Group`)
+- `-proxy-auth-email-header`: Header name for the user's email (default: `X-Forwarded-Email`)
+- `-proxy-auth-token-header`: Header name for the user's token (default: `X-Forwarded-Id-Token`)
+
+### Kubernetes API Server Authentication
+
+When using an identity-aware proxy for the Headlamp UI, Headlamp still needs a way to authenticate with the Kubernetes API Server on behalf of the user. 
+
+By default, Headlamp will use its own in-cluster Service Account (or provided kubeconfig) to talk to the API Server. The proxy handles user identification for the UI, but Headlamp handles Kubernetes authorization.
+
+If you instead want Headlamp to forward the proxy's authentication token directly to the Kubernetes API Server (for example, if your proxy issues valid Kubernetes OIDC `id_token`s), you can specify the header containing the raw token value:
+
+ - `-proxy-auth-token-header`: Header name containing the raw token only (default: `X-Forwarded-Id-Token`). Do not include the `Bearer ` prefix in the header value. If set, Headlamp will extract the token and send it as `Authorization: Bearer <token>` for requests to the Kubernetes API Server.
+
+## Example: Traefik and oauth2-proxy Middleware
+
+A common pattern in Kubernetes is to use an Ingress Controller like Traefik alongside `oauth2-proxy` as an authentication middleware (ForwardAuth).
+
+In this setup:
+1. A user attempts to access Headlamp via Traefik.
+2. Traefik sends the request to `oauth2-proxy` for authentication.
+3. `oauth2-proxy` authenticates the user with your designated Identity Provider (OIDC, GitHub, Google, etc.).
+4. `oauth2-proxy` returns a successful response to Traefik, injecting headers like `X-Forwarded-User` and `X-Forwarded-Email`.
+5. Traefik forwards the original request, along with the injected user headers, to Headlamp.
+6. Headlamp reads `X-Forwarded-User`, logs the user in, and serves the UI.
+
+### 1. Deploy OAuth2Proxy via Helm
+
+#### Add the Helm repo:
+```bash
+helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests
+helm repo update
+```
+
+#### Prepare your `values.yaml`
+
+Below is an example configuration you can start with. Be sure to replace placeholders like `<Client-ID>`, `<Client-Secret>`, `<Tenant-ID>`, etc.
+
+```yaml
+config:
+  configFile: |-
+    email_domains = ["*"]
+    cookie_secret = <Cookie-Secret>
+
+alphaConfig:
+  enabled: true
+  configData:
+    injectResponseHeaders:
+      - name: Authorization
+        values:
+          - claim: access_token
+            prefix: 'Bearer '
+      - name: X-Forwarded-Id-Token
+        values:
+          - claimSource:
+              claim: id_token
+      - name: X-Forwarded-Email
+        values:
+          - claimSource:
+              claim: email
+      - name: X-Forwarded-Group
+        values:
+          - claimSource:
+              claim: groups
+    providers:
+    - id: entra
+      provider: oidc
+      clientID: "<clientid>"
+      clientSecret: "<clientsecret>"
+      loginURL: "https://login.microsoftonline.com/<tenantid>/oauth2/authorize"
+      redeemURL: "https://login.microsoftonline.com/<tenantid>/oauth2/token"
+      scope: "openid email profile"
+      oidcConfig:
+        issuerURL: "https://sts.windows.net/<tenantid>/"
+        jwksURL: "https://login.microsoftonline.com/<tenantid>/discovery/keys?appid=<clientid>"
+        insecureAllowUnverifiedEmail: true
+        skipDiscovery: true
+        emailClaim: upn
+        audienceClaims:
+        - aud
+extraArgs:
+  redirect-url: "https://oauth.example.com/oauth2/callback" 
+  reverse-proxy: "true" 
+  cookie-secure: "true"
+  cookie-samesite: "lax"
+  cookie-domain: ".example.com"
+  whitelist-domain: ".example.com"
+```
+
+#### Deploy OAuth2Proxy:
+```bash
+helm install my-release oauth2-proxy/oauth2-proxy -f values.yaml
+```
+
+Verify it's up:
+```bash
+kubectl get pods
+```
+
+---
+### 2. Configure Traefik ForwardAuth
+
+Create a Traefik `Middleware` and `Ingress` that points to your `oauth2-proxy` service, ensuring it forwards the authentication headers:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: headlamp-proxy-auth
+  namespace: oauth2-proxy
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.auth-namespace.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Forwarded-User
+      - X-Forwarded-Email
+      - X-Forwarded-Group
+      - X-Forwarded-Id-Token
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: headlamp-error-redir
+  namespace: oauth2-proxy
+spec:
+  errors:
+    # 401 is what the ForwardAuth middleware returns when not logged in
+    status:
+      - "401-403"
+    # This sends the user to the login start page and preserves their original URL
+    query: "/oauth2/sign_in?rd=https://headlamp.example.com{url}"
+    service:
+      name: oauth2-proxy 
+      port: 80
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: auth-headers
+  namespace: oauth2-proxy
+spec:
+  headers:
+    sslRedirect: true
+    stsSeconds: 315360000
+    browserXssFilter: true
+    contentTypeNosniff: true
+    forceSTSHeader: true
+    sslHost: example.com
+    stsIncludeSubdomains: true
+    stsPreload: true
+    frameDeny: true
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-auth-headers@kubernetescrd
+  name: headlamp-oauth2
+  namespace: oauth2-proxy
+spec:
+  ingressClassName: traefik-mgmt-blue
+  rules:
+  - host: headlamp.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: oauth2-proxy
+            port:
+              number: 80
+        path: /oauth2/
+        pathType: Prefix
+```
+
+### 3. Configure Headlamp Ingress and Deployment
+
+Attach the middleware to your Headlamp `IngressRoute` and ensure the Headlamp deployment has `-proxy-auth=true` enabled:
+
+```yaml
+# Headlamp IngressRoute
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.middlewares: oauth2-proxy-headlamp-error-redir@kubernetescrd,oauth2-proxy-headlamp-proxy-auth@kubernetescrd
+  name: headlamp
+  namespace: kube-system
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: headlamp.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: headlamp
+            port:
+              number: 80
+```
+
+### 4. Deploy Headlamp with the `proxy-auth` flag enabled:
+
+```yaml
+# Headlamp Helm Values (values.yaml)
+config:
+  extraArgs:
+    - "-proxy-auth=true"
+```

--- a/frontend/src/components/App/TopBar.stories.tsx
+++ b/frontend/src/components/App/TopBar.stories.tsx
@@ -128,6 +128,10 @@ OneCluster.args = {
 OneCluster.parameters = {
   msw: {
     handlers: [
+      http.get(
+        'http://localhost:4466/clusters/ak8s-desktop/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
       http.post(
         'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
         () => HttpResponse.json({ status: { userInfo: { username: 'one-cluster-user' } } })
@@ -146,6 +150,10 @@ TwoCluster.args = {
 TwoCluster.parameters = {
   msw: {
     handlers: [
+      http.get(
+        'http://localhost:4466/clusters/ak8s-desktop/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
       http.post(
         'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
         () => HttpResponse.json({ status: { userInfo: { username: 'two-cluster-user' } } })
@@ -164,6 +172,10 @@ WithUserInfo.args = {
 WithUserInfo.parameters = {
   msw: {
     handlers: [
+      http.get(
+        'http://localhost:4466/clusters/ak8s-desktop/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
       http.post(
         'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
         () =>
@@ -189,6 +201,10 @@ WithEmailOnly.args = {
 WithEmailOnly.parameters = {
   msw: {
     handlers: [
+      http.get(
+        'http://localhost:4466/clusters/ak8s-desktop/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
       http.post(
         'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
         () =>
@@ -214,6 +230,10 @@ UndefinedData.args = {
 UndefinedData.parameters = {
   msw: {
     handlers: [
+      http.get(
+        'http://localhost:4466/clusters/ak8s-desktop/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
       // Return 404 to simulate missing API or data
       http.post(
         'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
@@ -233,6 +253,10 @@ EmptyUserInfo.args = {
 EmptyUserInfo.parameters = {
   msw: {
     handlers: [
+      http.get(
+        'http://localhost:4466/clusters/ak8s-desktop/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
       http.post(
         'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
         () => HttpResponse.json({})
@@ -256,6 +280,14 @@ MultiCluster.args = {
 MultiCluster.parameters = {
   msw: {
     handlers: [
+      http.get(
+        'http://localhost:4466/clusters/admin-cluster/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
+      http.get(
+        'http://localhost:4466/clusters/view-cluster/me',
+        () => new HttpResponse(null, { status: 404 })
+      ),
       http.post(
         'http://localhost:4466/clusters/admin-cluster/apis/authentication.k8s.io/v1/selfsubjectreviews',
         () =>

--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -849,6 +849,7 @@ describe('apiProxy', () => {
 
   describe('getClusterUserInfo', () => {
     const apiPath = '/apis/authentication.k8s.io/v1/selfsubjectreviews';
+    const mePath = '/me';
     const mockUserInfo = {
       username: 'test-user',
       uid: 'test-uid',
@@ -864,14 +865,26 @@ describe('apiProxy', () => {
       nock.cleanAll();
     });
 
-    it('Successfully returns user info when API is available', async () => {
+    it('Successfully returns user info from /me API', async () => {
+      nock(baseApiUrl).get(`/clusters/${clusterName}${mePath}`).reply(200, {
+        username: 'me-user',
+        groups: ['me-group'],
+      });
+
+      const userInfo = await apiProxy.getClusterUserInfo(clusterName);
+      expect(userInfo).toEqual({ username: 'me-user', groups: ['me-group'] });
+    });
+
+    it('Falls back to SelfSubjectReview when /me API is unavailable', async () => {
+      nock(baseApiUrl).get(`/clusters/${clusterName}${mePath}`).reply(404);
       nock(baseApiUrl).post(`/clusters/${clusterName}${apiPath}`).reply(200, mockSuccessResponse);
 
       const userInfo = await apiProxy.getClusterUserInfo(clusterName);
       expect(userInfo).toEqual(mockUserInfo);
     });
 
-    it('Falls back to cluster name when API returns error', async () => {
+    it('Falls back to cluster name when both APIs return error', async () => {
+      nock(baseApiUrl).get(`/clusters/${clusterName}${mePath}`).reply(404);
       nock(baseApiUrl)
         .post(`/clusters/${clusterName}${apiPath}`)
         .reply(404, { message: 'Not Found' });
@@ -880,7 +893,8 @@ describe('apiProxy', () => {
       expect(userInfo).toEqual({ username: clusterName });
     });
 
-    it('Falls back to cluster name when API returns no user info', async () => {
+    it('Falls back to cluster name when both APIs return no user info', async () => {
+      nock(baseApiUrl).get(`/clusters/${clusterName}${mePath}`).reply(200, {});
       nock(baseApiUrl).post(`/clusters/${clusterName}${apiPath}`).reply(200, {});
 
       const userInfo = await apiProxy.getClusterUserInfo(clusterName);

--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -866,10 +866,12 @@ describe('apiProxy', () => {
     });
 
     it('Successfully returns user info from /me API', async () => {
-      nock(baseApiUrl).get(`/clusters/${clusterName}${mePath}`).reply(200, {
-        username: 'me-user',
-        groups: ['me-group'],
-      });
+      nock(baseApiUrl)
+        .get(`/clusters/${clusterName}${mePath}`)
+        .reply(200, {
+          username: 'me-user',
+          groups: ['me-group'],
+        });
 
       const userInfo = await apiProxy.getClusterUserInfo(clusterName);
       expect(userInfo).toEqual({ username: 'me-user', groups: ['me-group'] });

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -72,6 +72,23 @@ export async function getClusterUserInfo(cluster = ''): Promise<ClusterUserInfo>
   }
 
   try {
+    const res = await clusterRequest('/me', {
+      timeout: 5 * 1000,
+      cluster: clusterName,
+    });
+    if (res && res.username) {
+      return {
+        username: res.username,
+        groups: res.groups,
+      };
+    }
+  } catch (error) {
+    if (isDebugVerbose('k8s/api/v1/clusterApi@getClusterUserInfo')) {
+      console.debug('Failed to get user info from /me for cluster', clusterName, error);
+    }
+  }
+
+  try {
     // Try SelfSubjectReview API (available in K8s 1.28+)
     const response = await post(
       '/apis/authentication.k8s.io/v1/selfsubjectreviews',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -145,6 +152,39 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -209,12 +249,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -234,6 +291,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shell-quote": {
@@ -315,6 +395,22 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",


### PR DESCRIPTION
## Summary

This PR adds feature by supporting auth handled by middlewares and injecting auth headers for headlamp to use for access. 

Key Changes

## Changes

Header Proxy Support: Added configuration options to define specific proxy headers for injection.
Identity Extraction: Implemented logic for Headlamp to retrieve the id_token from headers.
K8s Access Integration: Enabled the use of these extracted tokens for seamless Kubernetes API authentication.

## Steps to Test
1. Setup headlamp using oauth2 proxy as an authentication middleware

<img width="1037" height="433" alt="image" src="https://github.com/user-attachments/assets/0eab409e-622c-425e-87da-2e7203f319dd" />

2. Setup Ingress to inject id_token, email and groups via headers. 
3. Headlamp should be able to use id_token to access kubernetes cluster api. 