### PR TITLE
Add ashu8912 to headlamp-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,6 +4,7 @@ aliases:
     - illume
     - sniok
     - yolossn
+    - ashu8912
   headlamp-reviewers:
     - joaquimrocha
     - illume


### PR DESCRIPTION
SUMMARY
I was previously listed as a maintainer and during the kubernetes-sigs org move was listed as reviewer. This PR reverts the ownership back to maintainer.

Refer:
https://raw.githubusercontent.com/cncf/foundation/refs/heads/main/project-maintainers.csv