### PR TITLE
frontend: GlobalSearch: Fix visibility on dark navbar

### DIFF
--- a/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
@@ -32,7 +32,7 @@
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                 >
                   <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-1amr0ad-MuiInputBase-root-MuiOutlinedInput-root"
                   >
                     <div
                       class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"

--- a/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
@@ -32,7 +32,7 @@
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                 >
                   <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-1amr0ad-MuiInputBase-root-MuiOutlinedInput-root"
                   >
                     <div
                       class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"

--- a/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
@@ -32,7 +32,7 @@
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                 >
                   <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-1amr0ad-MuiInputBase-root-MuiOutlinedInput-root"
                   >
                     <div
                       class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"

--- a/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
@@ -32,7 +32,7 @@
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
                 >
                   <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-1amr0ad-MuiInputBase-root-MuiOutlinedInput-root"
                   >
                     <div
                       class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"

--- a/frontend/src/components/globalSearch/GlobalSearch.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearch.tsx
@@ -22,7 +22,6 @@ import InputAdornment from '@mui/material/InputAdornment';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { alpha } from '@mui/system/colorManipulator';
 import { lazy, Suspense, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { formatShortcutKey, useShortcut, useShortcutKey } from '../../lib/useShortcut';
@@ -64,19 +63,30 @@ export function GlobalSearch({ isIconButton }: { isIconButton?: boolean }) {
   const textFieldPlaceholder = smallBreakpoint ? (
     <IconButton
       size="medium"
+      color={isIconButton ? 'inherit' : undefined}
       sx={
         isIconButton
           ? undefined
           : {
               borderRadius: '4px',
               fontSize: '1rem',
+              fontFamily: theme.typography.fontFamily,
+              color: theme.palette.text.secondary,
               border: '1px solid',
               borderColor: theme.palette.divider,
+              background: theme.palette.background.default,
+              '&:hover': { background: theme.palette.background.muted },
             }
       }
       onClick={() => setFocused(true)}
+      aria-label={isIconButton ? t('Search') : undefined}
     >
-      <Icon icon="mdi:search" width={iconSize} height={iconSize} />
+      <Icon
+        icon="mdi:search"
+        width={iconSize}
+        height={iconSize}
+        color={isIconButton ? undefined : theme.palette.text.primary}
+      />
       {!isIconButton && <Box mx={1}>{t('Search')}</Box>}
     </IconButton>
   ) : (
@@ -88,11 +98,17 @@ export function GlobalSearch({ isIconButton }: { isIconButton?: boolean }) {
       placeholder={t('Search')}
       InputProps={{
         sx: theme => ({
-          background: alpha(theme.palette.background.default, 0.7),
+          background: theme.palette.background.default,
         }),
         startAdornment: (
           <InputAdornment position="start" sx={{ pointerEvents: 'none' }}>
-            <Icon icon="mdi:search" width={18} height={18} />
+            <Icon
+              icon="mdi:search"
+              width={18}
+              height={18}
+              color={theme.palette.text.primary}
+              aria-hidden
+            />
           </InputAdornment>
         ),
         endAdornment: (
@@ -134,6 +150,7 @@ export function GlobalSearch({ isIconButton }: { isIconButton?: boolean }) {
       variant="outlined"
       placeholder={t('Search resources, pages, clusters by name')}
       InputProps={{
+        sx: theme => ({ background: theme.palette.background.default }),
         autoFocus: true,
         value: placeholderValue,
         onChange: e => {
@@ -185,7 +202,7 @@ export function GlobalSearch({ isIconButton }: { isIconButton?: boolean }) {
               width: '100%',
               left: 0,
               right: 0,
-              background: theme.palette.background.default,
+              background: theme.palette.navbar.background,
               zIndex: 1,
             }
           : {}),

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearch.BasicExample.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearch.BasicExample.stories.storyshot
@@ -10,7 +10,7 @@
           class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-5ntm9s-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-1amr0ad-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
               class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-16yk9m0-MuiInputAdornment-root"


### PR DESCRIPTION
This change ensures the search bar remains visible and consistent across all zoom levels and themes with colored or dark navbars.

Fixes: #4929 

### Summary
- `TextField` and `IconButton` (small/zoomed breakpoint) lacked explicit backgrounds, making them invisible on colored navbars (e.g. Azure blue, dark themes). Both now use `theme.palette.background.default`.
- Small-breakpoint `IconButton` hover now uses `background.muted` instead of inheriting the navbar color.
- Search icons and placeholder text now use `text.primary`/`text.secondary` palette tokens. The standalone icon-only button (`isIconButton`) now sets `color="inherit"` on the `IconButton`, so it inherits the navbar's contrast color instead of MUI's default `action.native` grey.
- `searchFallback` (shown while `GlobalSearchContent` lazy-loads) had no background, causing a flash of navbar color on click. Fixed with `background.default`.
- The full-width overlay shown when the search is focused now correctly uses `navbar.background` instead of `background.default`.
- Added `aria-label` to the icon-only `IconButton` variant; marked the decorative `TextField` search icon `aria-hidden`. Replaced `alpha(text.primary, 0.42)` magic value with semantic `text.secondary` for WCAG-consistent contrast.