### PR TITLE
frontend: align duration formatting with apimachinery logic

### DIFF
--- a/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
+++ b/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
@@ -548,7 +548,7 @@
                 class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                 data-mui-internal-clone-element="true"
               >
-                3mo
+                90d
               </p>
             </td>
             <td

--- a/frontend/src/components/common/Label.stories/__snapshots__/DateLabel.Default.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/DateLabel.Default.stories.storyshot
@@ -5,7 +5,7 @@
       class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
       data-mui-internal-clone-element="true"
     >
-      3 months
+      90d
     </p>
   </div>
 </body>

--- a/frontend/src/components/common/Label.stories/__snapshots__/DateLabel.MiniLabel.stories.storyshot
+++ b/frontend/src/components/common/Label.stories/__snapshots__/DateLabel.MiniLabel.stories.storyshot
@@ -5,7 +5,7 @@
       class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
       data-mui-internal-clone-element="true"
     >
-      3mo
+      90d
     </p>
   </div>
 </body>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -464,7 +464,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -556,7 +556,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -648,7 +648,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -740,7 +740,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -832,7 +832,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -335,7 +335,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -371,7 +371,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -407,7 +407,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -443,7 +443,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -335,7 +335,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -371,7 +371,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -407,7 +407,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -443,7 +443,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -270,7 +270,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -296,7 +296,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -322,7 +322,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>
@@ -348,7 +348,7 @@
               class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
-              3mo
+              90d
             </p>
           </td>
         </tr>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -124,7 +124,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
               </tr>
@@ -168,7 +168,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
               </tr>

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -625,7 +625,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -722,7 +722,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -1104,7 +1104,7 @@
                         class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                         data-mui-internal-clone-element="true"
                       >
-                        3mo
+                        90d
                       </p>
                     </td>
                     <td
@@ -1201,7 +1201,7 @@
                         class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                         data-mui-internal-clone-element="true"
                       >
-                        3mo
+                        90d
                       </p>
                     </td>
                     <td

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -642,7 +642,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -635,7 +635,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -732,7 +732,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -941,7 +941,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1079,7 +1079,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1217,7 +1217,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1355,7 +1355,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1493,7 +1493,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -1012,7 +1012,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -890,7 +890,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -1029,7 +1029,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -748,7 +748,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -622,7 +622,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -697,7 +697,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -697,7 +697,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -529,7 +529,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -565,7 +565,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -748,7 +748,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -691,7 +691,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -791,7 +791,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -697,7 +697,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -434,7 +434,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3 months
+                          90d
                         </p>
                       </td>
                       <td
@@ -479,7 +479,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3 months
+                          90d
                         </p>
                       </td>
                       <td
@@ -524,7 +524,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3 months
+                          90d
                         </p>
                       </td>
                       <td

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -893,7 +893,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -587,7 +587,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -682,7 +682,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -756,7 +756,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -873,7 +873,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -887,7 +887,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1026,7 +1026,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1165,7 +1165,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1304,7 +1304,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
@@ -214,7 +214,7 @@
                       class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                       data-mui-internal-clone-element="true"
                     >
-                      3 months
+                      90d
                     </p>
                   </dd>
                 </dl>

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -625,7 +625,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -565,7 +565,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -533,7 +533,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -689,7 +689,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -795,7 +795,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -900,7 +900,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -1028,7 +1028,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -945,7 +945,7 @@
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
               >
-                1 (3mo ago)
+                1 (90d ago)
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-4yq1b9-MuiTableCell-root"
@@ -1005,7 +1005,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1170,7 +1170,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1317,7 +1317,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1404,7 +1404,7 @@
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
               >
-                337 (3mo ago)
+                337 (90d ago)
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-4yq1b9-MuiTableCell-root"
@@ -1464,7 +1464,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1611,7 +1611,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1758,7 +1758,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1905,7 +1905,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -2052,7 +2052,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -745,7 +745,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -531,7 +531,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -962,7 +962,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -1113,7 +1113,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -709,7 +709,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -471,7 +471,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -716,7 +716,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -818,7 +818,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -883,7 +883,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -943,7 +943,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -817,7 +817,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -943,7 +943,7 @@ sidecar:2.1"
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -819,7 +819,7 @@ sidecar:2.1"
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -819,7 +819,7 @@ sidecar:2.1"
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -949,7 +949,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1086,7 +1086,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td
@@ -1214,7 +1214,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -709,7 +709,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -703,7 +703,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -497,7 +497,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3 months
+                          90d
                         </p>
                       </td>
                     </tr>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -745,7 +745,7 @@
                   class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
-                  3mo
+                  90d
                 </p>
               </td>
               <td

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -474,7 +474,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -561,7 +561,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -648,7 +648,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -735,7 +735,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -822,7 +822,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -909,7 +909,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -474,7 +474,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -561,7 +561,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -648,7 +648,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -735,7 +735,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -822,7 +822,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td
@@ -909,7 +909,7 @@
                     class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
-                    3mo
+                    90d
                   </p>
                 </td>
                 <td

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1573,7 +1573,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3mo
+                          90d
                         </p>
                       </td>
                       <td
@@ -1675,7 +1675,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3mo
+                          90d
                         </p>
                       </td>
                       <td
@@ -1777,7 +1777,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3mo
+                          90d
                         </p>
                       </td>
                       <td
@@ -1879,7 +1879,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3mo
+                          90d
                         </p>
                       </td>
                       <td
@@ -1981,7 +1981,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3mo
+                          90d
                         </p>
                       </td>
                       <td
@@ -2083,7 +2083,7 @@
                           class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
-                          3mo
+                          90d
                         </p>
                       </td>
                       <td

--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { combineClusterListErrors, flattenClusterListItems } from './util';
+import { combineClusterListErrors, flattenClusterListItems, formatDuration, timeAgo } from './util';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const YEAR = 365 * DAY;
+const NEG_TWO_SECONDS_PLUS_ONE_NS = -1999999999 / 1e6;
 
 describe('flattenClusterListItems', () => {
   it('should return a flattened list of items', () => {
@@ -82,5 +89,118 @@ describe('combineClusterListErrors', () => {
 
     const result = combineClusterListErrors(clusterErrors1, clusterErrors2);
     expect(result).toBeNull();
+  });
+});
+
+const HUMAN_DURATION_CASES: { ms: number; want: string }[] = [
+  { ms: 1 * SECOND, want: '1s' },
+  { ms: 70 * SECOND, want: '70s' },
+  { ms: 190 * SECOND, want: '3m10s' },
+  { ms: 70 * MINUTE, want: '70m' },
+  { ms: 47 * HOUR, want: '47h' },
+  { ms: 49 * HOUR, want: '2d1h' },
+  { ms: (8 * 24 + 2) * HOUR, want: '8d' },
+  { ms: 367 * 24 * HOUR, want: '367d' },
+  { ms: (365 * 2 * 24 + 25) * HOUR, want: '2y1d' },
+  { ms: (365 * 8 * 24 + 2) * HOUR, want: '8y' },
+];
+
+const HUMAN_DURATION_BOUNDARY_CASES: { ms: number; want: string }[] = [
+  { ms: -2 * SECOND, want: '<invalid>' },
+  { ms: NEG_TWO_SECONDS_PLUS_ONE_NS, want: '0s' },
+  { ms: 0, want: '0s' },
+  { ms: SECOND - 1, want: '0s' },
+  { ms: 2 * MINUTE - 1, want: '119s' },
+  { ms: 2 * MINUTE, want: '2m' },
+  { ms: 2 * MINUTE + SECOND, want: '2m1s' },
+  { ms: 10 * MINUTE - 1, want: '9m59s' },
+  { ms: 10 * MINUTE, want: '10m' },
+  { ms: 10 * MINUTE + SECOND, want: '10m' },
+  { ms: 3 * HOUR - 1, want: '179m' },
+  { ms: 3 * HOUR, want: '3h' },
+  { ms: 3 * HOUR + MINUTE, want: '3h1m' },
+  { ms: 8 * HOUR - 1, want: '7h59m' },
+  { ms: 8 * HOUR, want: '8h' },
+  { ms: 8 * HOUR + 59 * MINUTE, want: '8h' },
+  { ms: 2 * DAY - 1, want: '47h' },
+  { ms: 2 * DAY, want: '2d' },
+  { ms: 2 * DAY + HOUR, want: '2d1h' },
+  { ms: 8 * DAY - 1, want: '7d23h' },
+  { ms: 8 * DAY, want: '8d' },
+  { ms: 8 * DAY + 23 * HOUR, want: '8d' },
+  { ms: 2 * YEAR - 1, want: '729d' },
+  { ms: 2 * YEAR, want: '2y' },
+  { ms: 2 * YEAR + 23 * HOUR, want: '2y' },
+  { ms: 2 * YEAR + 23 * HOUR + 59 * MINUTE, want: '2y' },
+  { ms: 2 * YEAR + 24 * HOUR - 1, want: '2y' },
+  { ms: 2 * YEAR + 24 * HOUR, want: '2y1d' },
+  { ms: 3 * YEAR, want: '3y' },
+  { ms: 4 * YEAR, want: '4y' },
+  { ms: 5 * YEAR, want: '5y' },
+  { ms: 6 * YEAR, want: '6y' },
+  { ms: 7 * YEAR, want: '7y' },
+  { ms: 8 * YEAR - 1, want: '7y364d' },
+  { ms: 8 * YEAR, want: '8y' },
+  { ms: 8 * YEAR + 364 * DAY, want: '8y' },
+  { ms: 9 * YEAR, want: '9y' },
+];
+
+const SHORT_HUMAN_DURATION_BOUNDARY_CASES: { ms: number; want: string }[] = [
+  { ms: -2 * SECOND, want: '<invalid>' },
+  { ms: NEG_TWO_SECONDS_PLUS_ONE_NS, want: '0s' },
+  { ms: 0, want: '0s' },
+  { ms: SECOND - 1, want: '0s' },
+  { ms: SECOND, want: '1s' },
+  { ms: 2 * SECOND - 1, want: '1s' },
+  { ms: MINUTE - 1, want: '59s' },
+  { ms: MINUTE, want: '1m' },
+  { ms: 2 * MINUTE - 1, want: '1m' },
+  { ms: HOUR - 1, want: '59m' },
+  { ms: HOUR, want: '1h' },
+  { ms: 2 * HOUR - 1, want: '1h' },
+  { ms: DAY - 1, want: '23h' },
+  { ms: DAY, want: '1d' },
+  { ms: 2 * DAY - 1, want: '1d' },
+  { ms: YEAR - 1, want: '364d' },
+  { ms: YEAR, want: '1y' },
+  { ms: 2 * YEAR - 1, want: '1y' },
+  { ms: 2 * YEAR, want: '2y' },
+];
+
+describe('formatDuration (Kubernetes apimachinery parity)', () => {
+  describe('HumanDuration — TestHumanDuration', () => {
+    it.each(HUMAN_DURATION_CASES)('HumanDuration %#: $want', ({ ms, want }) => {
+      expect(formatDuration(ms, { format: 'mini' })).toBe(want);
+    });
+  });
+
+  describe('HumanDuration — TestHumanDurationBoundaries', () => {
+    it.each(HUMAN_DURATION_BOUNDARY_CASES)('HumanDuration boundary %#: $want', ({ ms, want }) => {
+      expect(formatDuration(ms, { format: 'mini' })).toBe(want);
+    });
+  });
+
+  describe('ShortHumanDuration — TestShortHumanDurationBoundaries', () => {
+    it.each(SHORT_HUMAN_DURATION_BOUNDARY_CASES)(
+      'ShortHumanDuration boundary %#: $want',
+      ({ ms, want }) => {
+        expect(formatDuration(ms)).toBe(want);
+        expect(formatDuration(ms, { format: 'brief' })).toBe(want);
+      }
+    );
+  });
+});
+
+describe('timeAgo', () => {
+  it('matches formatDuration for the fixed test clock offset (UNDER_TEST)', () => {
+    const start = new Date('2020-06-15T12:00:00.000Z');
+    const ninetyDaysMs = 90 * DAY;
+
+    expect(timeAgo(start)).toBe(formatDuration(ninetyDaysMs, {}));
+    expect(timeAgo(start, { format: 'mini' })).toBe(
+      formatDuration(ninetyDaysMs, { format: 'mini' })
+    );
+    expect(timeAgo(start)).toBe('90d');
+    expect(timeAgo(start, { format: 'mini' })).toBe('90d');
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import humanizeDuration from 'humanize-duration';
 import merge from 'lodash/merge';
 import React from 'react';
 import { useHistory } from 'react-router';
@@ -33,18 +32,6 @@ import { parseCpu, parseRam, unparseCpu, unparseRam } from './units';
 // Exported to keep compatibility for plugins that may have used them.
 export { filterGeneric, filterResource, getClusterPrefixedPath, getCluster, getClusterGroup };
 
-const humanize = humanizeDuration.humanizer();
-humanize.languages['en-mini'] = {
-  y: () => 'y',
-  mo: () => 'mo',
-  w: () => 'w',
-  d: () => 'd',
-  h: () => 'h',
-  m: () => 'm',
-  s: () => 's',
-  ms: () => 'ms',
-};
-
 export const CLUSTER_ACTION_GRACE_PERIOD = 5000; // ms
 
 export type DateParam = string | number | Date;
@@ -56,11 +43,131 @@ export interface TimeAgoOptions {
 }
 
 /**
- * Show the time passed since the given date, in the desired format.
+ * Format a duration in milliseconds into a compact, single-unit string.
  *
- * @param date - The date since which to calculate the duration.
- * @param options - `format` takes "brief" or "mini". "brief" rounds the date and uses the largest suitable unit (e.g. "4 weeks"). "mini" uses something like "4w" (for 4 weeks).
- * @returns The formatted date.
+ * Uses the largest applicable unit:
+ * - seconds (< 60s)
+ * - minutes (< 60m)
+ * - hours (< 24h)
+ * - days (< 1y)
+ * - years (>= 1y)
+ *
+ * Examples: "45s", "10m", "3h", "12d", "2y"
+ *
+ * @param durationMs - The duration in milliseconds.
+ * @returns A short, human-readable duration string.
+ */
+function shortHumanDuration(durationMs: number): string {
+  const seconds = Math.trunc(durationMs / 1000);
+  if (seconds < -1) {
+    return '<invalid>';
+  }
+  if (seconds < 0) {
+    return '0s';
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.trunc(durationMs / (60 * 1000));
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.trunc(durationMs / (60 * 60 * 1000));
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+
+  if (hours < 24 * 365) {
+    return `${Math.trunc(hours / 24)}d`;
+  }
+
+  return `${Math.trunc(hours / 24 / 365)}y`;
+}
+
+/**
+ * Format a duration in milliseconds into a more detailed human-readable string.
+ *
+ * Uses mixed units depending on range:
+ * - seconds (< 2m)
+ * - minutes + seconds (< 10m)
+ * - minutes (< 3h)
+ * - hours + minutes (< 8h)
+ * - hours (< 48h)
+ * - days + hours (< 8d)
+ * - days (< ~2y)
+ * - years + days (< ~8y)
+ * - years (>= ~8y)
+ *
+ * Examples: "2m30s", "1h15m", "3d4h", "2y2d"
+ *
+ * @param durationMs - The duration in milliseconds.
+ * @returns The formatted duration.
+ */
+function humanDuration(durationMs: number): string {
+  const seconds = Math.trunc(durationMs / 1000);
+  if (seconds < -1) {
+    return '<invalid>';
+  }
+  if (seconds < 0) {
+    return '0s';
+  }
+  if (seconds < 60 * 2) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.trunc(durationMs / (60 * 1000));
+  if (minutes < 10) {
+    const totalSeconds = Math.trunc(durationMs / 1000);
+    const s = totalSeconds % 60;
+    if (s === 0) {
+      return `${minutes}m`;
+    }
+    return `${minutes}m${s}s`;
+  } else if (minutes < 60 * 3) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.trunc(durationMs / (60 * 60 * 1000));
+  if (hours < 8) {
+    const totalMinutes = Math.trunc(durationMs / (60 * 1000));
+    const m = totalMinutes % 60;
+    if (m === 0) {
+      return `${hours}h`;
+    }
+    return `${hours}h${m}m`;
+  } else if (hours < 48) {
+    return `${hours}h`;
+  } else if (hours < 24 * 8) {
+    const h = hours % 24;
+    if (h === 0) {
+      return `${Math.trunc(hours / 24)}d`;
+    }
+    return `${Math.trunc(hours / 24)}d${h}h`;
+  } else if (hours < 24 * 365 * 2) {
+    return `${Math.trunc(hours / 24)}d`;
+  } else if (hours < 24 * 365 * 8) {
+    const dy = Math.trunc(hours / 24) % 365;
+    const years = Math.trunc(hours / 24 / 365);
+    if (dy === 0) {
+      return `${years}y`;
+    }
+    return `${years}y${dy}d`;
+  }
+
+  return `${Math.trunc(hours / 24 / 365)}y`;
+}
+
+/**
+ * Returns the time elapsed since the given date.
+ *
+ * @param date - The date from which to calculate elapsed time.
+ * @param options - Formatting options:
+ *   - 'brief': single-unit format (e.g. "5m", "2h")
+ *   - 'mini': multi-unit format (e.g. "2m30s", "1h15m")
+ *
+ * @returns The formatted elapsed duration.
  */
 export function timeAgo(date: DateParam, options: TimeAgoOptions = {}) {
   const fromDate = new Date(date);
@@ -75,30 +182,25 @@ export function timeAgo(date: DateParam, options: TimeAgoOptions = {}) {
   return formatDuration(now.getTime() - fromDate.getTime(), options);
 }
 
-/** Format a duration in milliseconds to a human-readable string.
+/**
+ * Format a duration in milliseconds using either compact or detailed style.
  *
- * @param duration - The duration in milliseconds.
- * @param options - `format` takes "brief" or "mini". "brief" rounds the date and uses the largest suitable unit (e.g. "4 weeks"). "mini" uses something like "4w" (for 4 weeks).
- * @returns The formatted duration.
- * */
+ * @param duration - Duration in milliseconds.
+ * @param options - Options object:
+ *   - format: 'brief' | 'mini' (default: 'brief')
+ *     - 'brief': single-unit output (e.g. "5s", "12m", "3h", "2d", "2y")
+ *     - 'mini': multi-unit output (e.g. "2m30s", "1h15m", "2y2d")
+ *
+ * @returns Formatted duration string.
+ */
 export function formatDuration(duration: number, options: TimeAgoOptions = {}) {
   const { format = 'brief' } = options;
 
   if (format === 'brief') {
-    return humanize(duration, {
-      fallbacks: ['en'],
-      round: true,
-      largest: 1,
-    });
+    return shortHumanDuration(duration);
   }
 
-  return humanize(duration, {
-    language: 'en-mini',
-    spacer: '',
-    fallbacks: ['en'],
-    round: true,
-    largest: 1,
-  });
+  return humanDuration(duration);
 }
 
 export function localeDate(date: DateParam) {


### PR DESCRIPTION
## Summary

Align frontend duration/age formatting with Kubernetes apimachinery behavior.

## Related Issue

Fixes https://github.com/headlamp-k8s/plugins/issues/485 -> duration issue 

## Changes

- Replaced `humanize-duration` based age formatting in `frontend/src/lib/util.ts`.
- Implemented Kubernetes-style logic equivalent to:
  - `ShortHumanDuration` for compact age values.
  - `HumanDuration` for slightly more detailed duration values.
- Updated `formatDuration()` to use the new internal formatter functions.

## Why

This makes Age/Duration output consistent with Kubernetes conventions and avoids mismatches in relative time rendering.

## Steps to Test

1. Open resource list views that show `Age` (for example Pods, Deployments, Jobs).
2. Verify compact age values render in Kubernetes-like format (`s`, `m`, `h`, `d`, `y`).
3. Check places using mini/expanded duration formatting still display correctly.

## Screenshots

<img width="1695" height="847" alt="image" src="https://github.com/user-attachments/assets/fec83d4b-b923-47d6-a19c-e10b1cf7ce7a" />

