### PR TITLE
fix: Pod metrics matching missing namespace (#4927)

### DIFF
--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -200,7 +200,9 @@ export function PodListRenderer(props: PodListProps) {
   const { t } = useTranslation(['glossary', 'translation']);
 
   const getCpuUsage = (pod: Pod) => {
-    const metric = metrics?.find(it => it.getName() === pod.getName());
+    const metric = metrics?.find(
+      it => it.getName() === pod.getName() && it.getNamespace() === pod.getNamespace()
+    );
     if (!metric) return;
 
     return (
@@ -209,7 +211,9 @@ export function PodListRenderer(props: PodListProps) {
   };
 
   const getMemoryUsage = (pod: Pod) => {
-    const metric = metrics?.find(it => it.getName() === pod.getName());
+    const metric = metrics?.find(
+      it => it.getName() === pod.getName() && it.getNamespace() === pod.getNamespace()
+    );
     if (!metric) return;
 
     return (

--- a/frontend/src/components/pod/PodList.stories.tsx
+++ b/frontend/src/components/pod/PodList.stories.tsx
@@ -54,6 +54,7 @@ export default {
                 {
                   metadata: {
                     name: 'successful',
+                    namespace: 'default',
                   },
                   containers: [
                     {


### PR DESCRIPTION
Fixes issue #4927 

This PR fixes a bug where Headlamp displays incorrect CPU and memory metrics for pods that share the same name across different namespaces (e.g., in the Workloads > Pods view).

Previously, the 
getCpuUsage and getMemoryUsage functions in List.tsx matched metrics to pods using only the pod name (it.getName() === pod.getName()). This caused all pods with the same name to display the metrics of the first matched pod.

This fix updates the lookup logic to also compare the namespace (it.getNamespace() === pod.getNamespace()), ensuring each pod correctly displays its own individual metrics.