### PR TITLE
frontend: Improve Overview Events Node column behavior

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -210,7 +210,13 @@ function EventsSection() {
           label: t('glossary|Node'),
           gridTemplate: 'min-content',
           filterVariant: 'multi-select',
-          getValue: event => event.source?.host ?? '',
+          getValue: event =>
+            (event.involvedObject.kind === 'Node' && event.involvedObject.name) ||
+            event.source?.host ||
+            ((event.reportingComponent === 'kubelet' || event.source?.component === 'kubelet') &&
+              event.reportingInstance) ||
+            '',
+          show: false,
         },
         {
           id: 'reason',

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -37,6 +37,15 @@ export interface KubeEvent {
     resourceVersion: string;
     fieldPath: string;
   };
+  /** Instance name of the component reporting this event (e.g. "kubelet-node1"). */
+  reportingInstance?: string;
+  /** Name of the controller that emitted this event (e.g. "kubelet"). */
+  reportingComponent?: string;
+  /** Legacy source information for the event. */
+  source?: {
+    component?: string;
+    host?: string;
+  };
   [otherProps: string]: any;
 }
 
@@ -89,6 +98,14 @@ class Event extends KubeObject<KubeEvent> {
 
   get source() {
     return this.getValue('source');
+  }
+
+  get reportingInstance() {
+    return this.getValue('reportingInstance');
+  }
+
+  get reportingComponent() {
+    return this.getValue('reportingComponent');
   }
 
   get count() {


### PR DESCRIPTION
This PR updates the Cluster Overview Events table's existing Node column behavior.

The column remains optional and hidden by default (`show: false`) so the default table layout stays unchanged. When users enable it from the Show/Hide Columns picker, it now derives the node name more reliably:

- Uses `involvedObject.name` for events where the involved object is a Node.
- Falls back to `source.host` for legacy event payloads.
- Falls back to kubelet `reportingInstance` when applicable.

This also adds typed Event model fields for the reporting/source values used by the fallback logic.

<img width="1440" height="802" alt="Screenshot 2026-03-21 at 6 29 17 PM" src="https://github.com/user-attachments/assets/404d9cae-98ef-447b-9fd0-99a0448daa99" />