### PR TITLE
fix(frontend): handle cluster-scoped CRD links without failing on empty namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG IMAGE_BASE=alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 FROM ${IMAGE_BASE} AS image-base
 
-FROM --platform=${BUILDPLATFORM} golang:1.25.8@sha256:dfae680962532eeea67ab297f1166c2c4e686edb9a8f05f9d02d96fc9191833e AS backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.25.8@sha256:3ac2864710f25e84381bf5d4272261c7ba73ada0339d62034df4de20dabb33ca AS backend-build
 
 WORKDIR /headlamp
 
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go build -o ./headlamp-server ./cmd/
 
-FROM --platform=${BUILDPLATFORM} node:22@sha256:7e791fc54bd02fc89fd4fb39eb37e5bea753c75679c8022478d81679367d995a AS frontend-build
+FROM --platform=${BUILDPLATFORM} node:22@sha256:ecabd1cb6956d7acfffe8af6bbfbe2df42362269fd28c227f36367213d0bb777 AS frontend-build
 
 # We need .git and app/ in order to get the version and git version for the frontend/.env file
 # that's generated when building the frontend.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG IMAGE_BASE=alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 FROM ${IMAGE_BASE} AS image-base
 
-FROM --platform=${BUILDPLATFORM} golang:1.25.8@sha256:f55a6ec7f24aedc1ed66e2641fdc52de01f2d24d6e49d1fa38582c07dd5f601d AS backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.25.8@sha256:dfae680962532eeea67ab297f1166c2c4e686edb9a8f05f9d02d96fc9191833e AS backend-build
 
 WORKDIR /headlamp
 
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go build -o ./headlamp-server ./cmd/
 
-FROM --platform=${BUILDPLATFORM} node:22@sha256:f90672bf4c76dfc077d17be4c115b1ae7731d2e8558b457d86bca42aeb193866 AS frontend-build
+FROM --platform=${BUILDPLATFORM} node:22@sha256:7e791fc54bd02fc89fd4fb39eb37e5bea753c75679c8022478d81679367d995a AS frontend-build
 
 # We need .git and app/ in order to get the version and git version for the frontend/.env file
 # that's generated when building the frontend.

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,5 +1,5 @@
 # Build the plugin
-FROM node:22@sha256:f90672bf4c76dfc077d17be4c115b1ae7731d2e8558b457d86bca42aeb193866 as builder
+FROM node:22@sha256:7e791fc54bd02fc89fd4fb39eb37e5bea753c75679c8022478d81679367d995a as builder
 
 # Set the working directory
 WORKDIR /headlamp-plugins

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,5 +1,5 @@
 # Build the plugin
-FROM node:22@sha256:7e791fc54bd02fc89fd4fb39eb37e5bea753c75679c8022478d81679367d995a as builder
+FROM node:22@sha256:ecabd1cb6956d7acfffe8af6bbfbe2df42362269fd28c227f36367213d0bb777 as builder
 
 # Set the working directory
 WORKDIR /headlamp-plugins

--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -104,11 +104,11 @@ function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
             render: cr => {
               return (
                 <Link
-                  routeName="customresource"
+                  routeName={cr.metadata.namespace ? 'customresource' : 'clusterCustomResource'}
                   params={{
                     crName: cr.metadata.name,
                     crd: getCRDForCR(cr).metadata.name,
-                    namespace: cr.metadata.namespace ?? '-',
+                    ...(cr.metadata.namespace && { namespace: cr.metadata.namespace }),
                   }}
                   activeCluster={cr.cluster}
                 >

--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -104,11 +104,11 @@ function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
             render: cr => {
               return (
                 <Link
-                  routeName={cr.metadata.namespace ? 'customresource' : 'clusterCustomResource'}
+                  routeName="customresource"
                   params={{
                     crName: cr.metadata.name,
                     crd: getCRDForCR(cr).metadata.name,
-                    ...(cr.metadata.namespace && { namespace: cr.metadata.namespace }),
+                    namespace: cr.metadata.namespace || '-',
                   }}
                   activeCluster={cr.cluster}
                 >

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -65,11 +65,11 @@ function CustomResourceLink(props: {
   return (
     <Link
       sx={{ cursor: 'pointer' }}
-      routeName="customresource"
+      routeName={resource.metadata.namespace ? 'customresource' : 'clusterCustomResource'}
       params={{
         crName: resource.metadata.name,
         crd: crd.metadata.name,
-        namespace: resource.metadata.namespace || '-',
+        ...(resource.metadata.namespace && { namespace: resource.metadata.namespace }),
       }}
       activeCluster={resource.cluster}
       {...otherProps}

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -65,11 +65,11 @@ function CustomResourceLink(props: {
   return (
     <Link
       sx={{ cursor: 'pointer' }}
-      routeName={resource.metadata.namespace ? 'customresource' : 'clusterCustomResource'}
+      routeName="customresource"
       params={{
         crName: resource.metadata.name,
         crd: crd.metadata.name,
-        ...(resource.metadata.namespace && { namespace: resource.metadata.namespace }),
+        namespace: resource.metadata.namespace || '-',
       }}
       activeCluster={resource.cluster}
       {...otherProps}

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -806,6 +806,13 @@ const defaultRoutes: { [routeName: string]: Route } = {
     sidebar: 'crds',
     component: () => <CustomResourceDefinitionDetails />,
   },
+  clusterCustomResource: {
+    path: '/customresources/:crd/:crName',
+    exact: true,
+    name: 'Cluster Custom Resource',
+    sidebar: 'customresources',
+    component: () => <CustomResourceDetails />,
+  },
   customresource: {
     path: '/customresources/:crd/:namespace/:crName',
     exact: true,

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -806,13 +806,7 @@ const defaultRoutes: { [routeName: string]: Route } = {
     sidebar: 'crds',
     component: () => <CustomResourceDefinitionDetails />,
   },
-  clusterCustomResource: {
-    path: '/customresources/:crd/:crName',
-    exact: true,
-    name: 'Cluster Custom Resource',
-    sidebar: 'customresources',
-    component: () => <CustomResourceDetails />,
-  },
+
   customresource: {
     path: '/customresources/:crd/:namespace/:crName',
     exact: true,


### PR DESCRIPTION
Fixes #4921
This PR address issue #4921 where clicking the details link of a cluster-scoped custom resource (such as a ClusterVulnerabilityReport or other CVE-related plugins) crashed the UI with TypeError: Expected "namespace" to match "[^\/]+?", but received "".

The crashing behavior occurred because react-router requires all path parameters (like :namespace) to be non-empty, but cluster-scoped CRs naturally do not have a namespace. Attempting to use the customresource route fallback resulted in an empty parameter validation crash.

Changes made:

Added clusterCustomResource route in frontend/src/lib/router/index.tsx that explicitly omits the :namespace parameter (/customresources/:crd/:crName).
Updated Link Generation in CustomResourceList.tsx and CustomResourceInstancesList.tsx. It now dynamically checks if a namespace is present (cr.metadata.namespace). If it is, it uses the standard customresource route. If not, it uses the new clusterCustomResource route and omits the namespace param entirely.