### PR TITLE
chore(ci): migrate workflow storage to MinIO S3

### DIFF
--- a/.github/workflows/app-artifacts-embedded.yml
+++ b/.github/workflows/app-artifacts-embedded.yml
@@ -29,9 +29,26 @@ jobs:
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 20.x
-        cache: 'npm'
-        cache-dependency-path: |
-          frontend/package-lock.json
+    - name: Restore npm cache from S3
+      continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+        if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          mkdir -p ~/.npm
+          tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+          echo "npm cache restored from S3"
+        else
+          echo "No npm cache found, will create after install"
+        fi
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: '1.24.*'
@@ -50,6 +67,26 @@ jobs:
     - name: Build frontend
       run: |
         make frontend
+    - name: Save npm cache to S3
+      continue-on-error: true
+      if: success()
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+        if ! aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          tar czf /tmp/npm-cache.tar.gz -C ~/.npm . 2>/dev/null
+          aws s3 cp /tmp/npm-cache.tar.gz "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          echo "npm cache saved to S3"
+        else
+          echo "npm cache already exists, skipping upload"
+        fi
     - name: Prepare backend for embedding
       run: |
         make backend-embed-prepare
@@ -57,10 +94,10 @@ jobs:
       run: |
         make backend-embed-all-compressed VERSION=${{ steps.get-version.outputs.version }}
     - name: Upload embedded binaries
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: embedded-binaries
         path: ./backend/dist/*.tar.gz
-        if-no-files-found: error
-        retention-days: 2
-
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}

--- a/.github/workflows/app-artifacts-linux.yml
+++ b/.github/workflows/app-artifacts-linux.yml
@@ -35,23 +35,26 @@ jobs:
       run: |
         FILE_PATH=$(echo app/dist/Headlamp*x86_64*.AppImage); mv ${FILE_PATH} $(echo ${FILE_PATH}|sed s/x86_64/x64/)
     - name: Upload Tarball artifacts
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: Tarballs
         path: ./app/dist/Headlamp*.tar.*
-        if-no-files-found: error
-        retention-days: 1
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}
     - name: Upload AppImage artifacts
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: AppImages
         path: ./app/dist/Headlamp*.AppImage
-        if-no-files-found: error
-        retention-days: 1
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}
     - name: Upload Debian artifacts
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: Debian
         path: ./app/dist/headlamp*.deb
-        if-no-files-found: error
-        retention-days: 1
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}

--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -29,10 +29,26 @@ jobs:
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 20.x
-        cache: 'npm'
-        cache-dependency-path: |
-          app/package-lock.json
-          frontend/package-lock.json
+    - name: Restore npm cache from S3
+      continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=$(sha256sum app/package-lock.json | cut -d' ' -f1)
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+        if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          mkdir -p ~/.npm
+          tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+          echo "npm cache restored from S3"
+        else
+          echo "No npm cache found, will create after install"
+        fi
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: '1.24.*'
@@ -43,6 +59,26 @@ jobs:
     - name: Build Backend and Frontend
       run: |
         make
+    - name: Save npm cache to S3
+      continue-on-error: true
+      if: success()
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=$(sha256sum app/package-lock.json | cut -d' ' -f1)
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+        if ! aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          tar czf /tmp/npm-cache.tar.gz -C ~/.npm . 2>/dev/null
+          aws s3 cp /tmp/npm-cache.tar.gz "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          echo "npm cache saved to S3"
+        else
+          echo "npm cache already exists, skipping upload"
+        fi
     - name: Add MacOS certs
       run: cd ./app/mac/scripts/ && sh ./setup-certificate.sh
       env:
@@ -64,12 +100,13 @@ jobs:
       run: |
         make app-mac
     - name: Upload artifact
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: dmgs
         path: ./app/dist/Headlamp*.dmg
-        if-no-files-found: error
-        retention-days: 1
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}
   notarize:
     permissions:
       id-token: write # For fetching an OpenID Connect (OIDC) token
@@ -85,15 +122,34 @@ jobs:
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 18.x
-        cache: 'npm'
-        cache-dependency-path: |
-          app/package-lock.json
-          frontend/package-lock.json
+    - name: Restore npm cache from S3
+      continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=$(sha256sum app/package-lock.json | cut -d' ' -f1)
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+        if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          mkdir -p ~/.npm
+          tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+          echo "npm cache restored from S3"
+        else
+          echo "No npm cache found, will create after install"
+        fi
+      shell: bash
     - name: Download artifact
-      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      uses: Anomalous-Ventures/devops/.github/actions/download-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: dmgs
         path: ./dmgs
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}
     - name: Azure login
       if: ${{ inputs.signBinaries }}
       uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
@@ -136,13 +192,13 @@ jobs:
         cd ./app/scripts
         node ./esrp.js apple-notarize ../../dmgs/
     - name: Upload Notarized
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: dmgs
         path: ./dmgs/Headlamp*.dmg
-        if-no-files-found: error
-        overwrite: true
-        retention-days: 2
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}
   verify-notarization:
     runs-on: macos-latest
     needs: notarize
@@ -155,10 +211,12 @@ jobs:
         arch: [x86, arm64]
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      uses: Anomalous-Ventures/devops/.github/actions/download-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: dmgs
         path: ./dmgs
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}
     - name: Verify Notarization
       run: |
         cd ./dmgs
@@ -201,18 +259,20 @@ jobs:
     if: ${{ inputs.signBinaries }}
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      uses: Anomalous-Ventures/devops/.github/actions/download-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: dmgs
         path: ./dmgs
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}
     - name: Staple
       run: |
         xcrun stapler staple ./dmgs/Headlamp*.dmg
     - name: Upload Stapled
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: dmgs
         path: ./dmgs/Headlamp*.dmg
-        if-no-files-found: error
-        overwrite: true
-        retention-days: 2
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}

--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -35,10 +35,27 @@ jobs:
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: 20.x
-        cache: 'npm'
-        cache-dependency-path: |
-          headlamp/app/package-lock.json
-          headlamp/frontend/package-lock.json
+    - name: Restore npm cache from S3
+      continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=$(sha256sum headlamp/app/package-lock.json | cut -d' ' -f1)
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+        if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          mkdir -p ~/.npm
+          tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+          echo "npm cache restored from S3"
+        else
+          echo "No npm cache found, will create after install"
+        fi
+      shell: bash
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: '1.24.*'
@@ -88,10 +105,33 @@ jobs:
         }
         make app-win
 
+    - name: Save npm cache to S3
+      continue-on-error: true
+      if: success()
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=$(sha256sum headlamp/app/package-lock.json | cut -d' ' -f1)
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+        if ! aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          tar czf /tmp/npm-cache.tar.gz -C ~/.npm . 2>/dev/null
+          aws s3 cp /tmp/npm-cache.tar.gz "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          echo "npm cache saved to S3"
+        else
+          echo "npm cache already exists, skipping upload"
+        fi
+      shell: bash
+
     - name: Upload artifact
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: Win exes
         path: ./headlamp/app/dist/Headlamp*.*
-        if-no-files-found: error
-        retention-days: 2
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -82,10 +82,13 @@ jobs:
 
       - name: Upload coverage report as artifact
         id: upload-artifact
-        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
+        continue-on-error: true
+        uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
         with:
           name: backend-coverage-report
           path: ./backend/backend_coverage.html
+          access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+          secret-key: ${{ secrets.MINIO_SECRET_KEY }}
 
       - name: Get base branch code coverage
         if: ${{ github.event_name }} == 'pull_request'
@@ -154,7 +157,6 @@ jobs:
           testcoverage_full=$(echo "$testcoverage_full_base64" | base64 --decode)
 
           coverage_diff="${{ env.coverage_diff }}"
-          artifact_url=${{ steps.upload-artifact.outputs.artifact-url }}
 
           if (( $(echo "$coverage_diff < 0" | bc -l) )); then
             emoji="😞" # Decreased coverage
@@ -176,8 +178,6 @@ jobs:
           \`\`\`
 
           </details>
-
-          [Html coverage report download]($artifact_url)
           "
 
           echo "$comment"

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -94,13 +94,29 @@ jobs:
       # now you can run kubectl to see the pods in the cluster
     - name: Try the cluster!
       run: kubectl get pods -A
-    - name: Restore image-cache Folder
+    - name: Restore image cache from S3
       id: cache-image-restore2
-      uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
-      with:
-        path: ~/image-cache
-        # cache the container image. All the paths this PR depends on except the e2e-tests folder for the key.
-        key: ${{ runner.os }}-image-${{ hashFiles('backend/pkg/**', 'backend/cmd/**', 'backend/go.*', 'frontend/src/**', 'frontend/package.json', 'frontend/package-lock.json', 'Makefile', '.github/workflows/build-container.yml', 'Dockerfile', 'Dockerfile.plugins') }}
+      continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=${{ hashFiles('backend/pkg/**', 'backend/cmd/**', 'backend/go.*', 'frontend/src/**', 'frontend/package.json', 'frontend/package-lock.json', 'Makefile', '.github/workflows/build-container.yml', 'Dockerfile', 'Dockerfile.plugins') }}
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/image-cache/${HASH}.tar.gz"
+        if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+          aws s3 cp "$CACHE_KEY" /tmp/image-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+          mkdir -p ~/image-cache
+          tar xzf /tmp/image-cache.tar.gz -C ~/image-cache 2>/dev/null || true
+          echo "cache-hit=true" >> "$GITHUB_OUTPUT"
+          echo "Image cache restored from S3"
+        else
+          echo "cache-hit=false" >> "$GITHUB_OUTPUT"
+          echo "No image cache found"
+        fi
     - name: Restore Cached Docker Images
       if: steps.cache-image-restore2.outputs.cache-hit == 'true'
       run: |
@@ -319,16 +335,28 @@ jobs:
         mkdir -p ~/image-cache
         docker save ghcr.io/headlamp-k8s/headlamp-plugins-test | gzip -9 > ~/image-cache/headlamp-plugins-test.tar.gz
         docker save ghcr.io/headlamp-k8s/headlamp | gzip -9 > ~/image-cache/headlamp.tar.gz
-    - name: Cache image-cache Folder
+    - name: Save image cache to S3
       if: steps.cache-image-restore2.outputs.cache-hit != 'true'
-      id: cache-image-save
-      uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
-      with:
-        path: ~/image-cache
-        key: ${{ steps.cache-image-restore2.outputs.cache-primary-key }}
-    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+      run: |
+        if ! command -v aws &>/dev/null; then
+          pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+        fi
+        HASH=${{ hashFiles('backend/pkg/**', 'backend/cmd/**', 'backend/go.*', 'frontend/src/**', 'frontend/package.json', 'frontend/package-lock.json', 'Makefile', '.github/workflows/build-container.yml', 'Dockerfile', 'Dockerfile.plugins') }}
+        CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/image-cache/${HASH}.tar.gz"
+        tar czf /tmp/image-cache-bundle.tar.gz -C ~/image-cache . 2>/dev/null
+        aws s3 cp /tmp/image-cache-bundle.tar.gz "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+        echo "Image cache saved to S3"
+    - name: Upload e2e test report
+      continue-on-error: true
       if: always()
+      uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
       with:
         name: e2e-tests-report
         path: e2e-tests/playwright-report/
-        retention-days: 30
+        access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+        secret-key: ${{ secrets.MINIO_SECRET_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -40,12 +40,52 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+
+      - name: Restore npm cache from S3
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if ! command -v aws &>/dev/null; then
+            pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+          fi
+          HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+          CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+          if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+            aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+            mkdir -p ~/.npm
+            tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+            echo "npm cache restored from S3"
+          else
+            echo "No npm cache found, will create after install"
+          fi
 
       - name: Install dependencies
         run: |
           make frontend-install
+
+      - name: Save npm cache to S3
+        continue-on-error: true
+        if: success()
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if ! command -v aws &>/dev/null; then
+            pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+          fi
+          HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+          CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+          if ! aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+            tar czf /tmp/npm-cache.tar.gz -C ~/.npm . 2>/dev/null
+            aws s3 cp /tmp/npm-cache.tar.gz "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+            echo "npm cache saved to S3"
+          else
+            echo "npm cache already exists, skipping upload"
+          fi
 
       - name: Run linter
         run: |
@@ -67,8 +107,27 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+
+      - name: Restore npm cache from S3
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if ! command -v aws &>/dev/null; then
+            pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+          fi
+          HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+          CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+          if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+            aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+            mkdir -p ~/.npm
+            tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+            echo "npm cache restored from S3"
+          else
+            echo "No npm cache found, will create after install"
+          fi
 
       - name: Install dependencies
         run: |
@@ -97,8 +156,27 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+
+      - name: Restore npm cache from S3
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if ! command -v aws &>/dev/null; then
+            pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+          fi
+          HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+          CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+          if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+            aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+            mkdir -p ~/.npm
+            tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+            echo "npm cache restored from S3"
+          else
+            echo "No npm cache found, will create after install"
+          fi
 
       - name: Install dependencies
         run: |
@@ -123,8 +201,27 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+
+      - name: Restore npm cache from S3
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if ! command -v aws &>/dev/null; then
+            pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+          fi
+          HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+          CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+          if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+            aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+            mkdir -p ~/.npm
+            tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+            echo "npm cache restored from S3"
+          else
+            echo "No npm cache found, will create after install"
+          fi
 
       - name: Test plugins
         run: |
@@ -145,8 +242,27 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+
+      - name: Restore npm cache from S3
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if ! command -v aws &>/dev/null; then
+            pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+          fi
+          HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+          CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+          if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+            aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+            mkdir -p ~/.npm
+            tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+            echo "npm cache restored from S3"
+          else
+            echo "No npm cache found, will create after install"
+          fi
 
       - name: Build docs
         run: |
@@ -167,8 +283,27 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+
+      - name: Restore npm cache from S3
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          if ! command -v aws &>/dev/null; then
+            pip install --quiet awscli 2>/dev/null || pip3 install --quiet awscli 2>/dev/null
+          fi
+          HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1)
+          CACHE_KEY="s3://ci-artifacts/${{ github.repository }}/npm-cache/${HASH}.tar.gz"
+          if aws s3 ls "$CACHE_KEY" --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null; then
+            aws s3 cp "$CACHE_KEY" /tmp/npm-cache.tar.gz --endpoint-url https://minio.spooty.io --no-verify-ssl 2>/dev/null
+            mkdir -p ~/.npm
+            tar xzf /tmp/npm-cache.tar.gz -C ~/.npm 2>/dev/null || true
+            echo "npm cache restored from S3"
+          else
+            echo "No npm cache found, will create after install"
+          fi
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -40,15 +40,14 @@ jobs:
           # And it's free for you!
           publish_results: true
 
-      # Upload the results as artifacts (optional). Commenting out will disable
-      # uploads of run results in SARIF format to the repository Actions tab.
-      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        continue-on-error: true
+        uses: Anomalous-Ventures/devops/.github/actions/upload-s3@66345e915e2b88f14e9d1426ec37d7247c75921c # main
         with:
           name: SARIF file
           path: results.sarif
-          retention-days: 5
+          access-key: ${{ secrets.MINIO_ACCESS_KEY }}
+          secret-key: ${{ secrets.MINIO_SECRET_KEY }}
 
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard


### PR DESCRIPTION
## Summary

- Replace `actions/upload-artifact` with `upload-s3` action backed by MinIO across 8 workflow files
- Replace `actions/download-artifact` with `download-s3` action backed by MinIO
- Replace `actions/cache` (restore/save) with S3-based cache via awscli
- Replace `setup-node` built-in npm cache with S3-based npm cache restore/save
- Remove `artifact-url` output reference in backend-test PR comment (not supported by S3 action)
- Add `continue-on-error: true` to all upload/cache steps for resilience

## Files changed

| File | Changes |
|------|---------|
| `app-artifacts-linux.yml` | 3 upload-artifact -> upload-s3 |
| `scorecard-analysis.yml` | 1 upload-artifact -> upload-s3 |
| `backend-test.yml` | 1 upload-artifact -> upload-s3, removed artifact-url reference |
| `app-artifacts-embedded.yml` | 1 npm cache -> S3, 1 upload-artifact -> upload-s3 |
| `app-artifacts-win.yml` | 1 npm cache -> S3, 1 upload-artifact -> upload-s3 |
| `app-artifacts-mac.yml` | 2 npm cache -> S3, 4 upload-artifact -> upload-s3, 3 download-artifact -> download-s3 |
| `frontend.yml` | 6 npm cache -> S3 (save in lint job only) |
| `build-container.yml` | cache/restore + cache/save -> S3, 1 upload-artifact -> upload-s3 |

## Test plan

- [ ] Verify `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` secrets are configured in the repo
- [ ] Trigger `app-artifacts-linux.yml` manually and confirm artifacts upload to S3
- [ ] Trigger a frontend PR to validate npm cache restore/save cycle in `frontend.yml`
- [ ] Trigger `build-container.yml` and confirm image cache S3 round-trip works
- [ ] Trigger `app-artifacts-mac.yml` and confirm cross-job download-s3 works for the dmgs artifact