### PR TITLE
Helm Chart: Adding support for secrets enabled multi-cluster

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -202,49 +202,41 @@ config:
       name: your-oidc-secret
 ```
 
-### Cluster Inventory Configuration
-
-> **Warning**
-> Cluster Inventory support in Headlamp is alpha/experimental and disabled by
-> default. The upstream Cluster Inventory API is currently `v1alpha1` and this
-> integration uses the `v0.1.x` API, so fields and behavior may change.
-
-When `config.clusterInventory.enabled` is true, the chart creates a provider
-ConfigMap, makes it available read-only at `/etc/cluster-inventory/config.json`,
-and adds the Headlamp Cluster Inventory flags automatically.
-
-```yaml
-config:
-  clusterInventory:
-    enabled: true
-    accessProvidersConfig:
-      providers:
-        - name: secretreader
-          execConfig:
-            apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/bin/secretreader-plugin
-            interactiveMode: Never
-            provideClusterInfo: true
-        - name: kubeconfig-secretreader
-          execConfig:
-            apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/kubeconfig-secretreader/bin/kubeconfig-secretreader-plugin
-            interactiveMode: Never
-            provideClusterInfo: true
-    plugins:
-      - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
-        mountPath: /access-plugins/secretreader
-      - name: kubeconfig-secretreader
-        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3@sha256:b92966cc6e4ac78002a63862921022a71d54956826f6e4febcb7247495eb98c0
-        mountPath: /access-plugins/kubeconfig-secretreader
-```
-
-`plugins[]` is for Cluster Inventory access provider binaries, not Headlamp UI
+### Cluster Inventory Plugins
+`config.clusterInventory.plugins[]` is for Cluster Inventory access provider binaries, not Headlamp UI
 plugins. Each entry renders as a Kubernetes `image` volume and is mounted
 read-only into the Headlamp container. If an access provider `execConfig.command`
 is configured, the command must be under one of the absolute
-`plugins[].mountPath` values.
+`config.clusterInventory.plugins[].mountPath` values.
+
+### Multi-Cluster Configuration
+
+Headlamp supports managing multiple Kubernetes clusters by mounting kubeconfig files from secrets. This is ideal for fleet management scenarios where you want to access multiple clusters from a single Headlamp installation.
+
+#### Using Kubeconfig Secrets
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| config.kubeconfigSecrets | list | `[]` | List of secrets containing kubeconfig files |
+| config.kubeconfigSecrets[].secretName | string | required | Name of the secret containing kubeconfig |
+| config.kubeconfigSecrets[].key | string | `"config"` | Key within the secret data (optional, defaults to "config") |
+
+**Example: Multiple Clusters with Custom Keys**
+```yaml
+config:
+  kubeconfigSecrets:
+    - secretName: prod-cluster-kubeconfig
+      key: config
+    - secretName: dev-cluster-kubeconfig
+      key: kubeconfig
+    - secretName: staging-cluster-kubeconfig
+```
+
+When `config.kubeconfigSecrets` is set, the chart mounts each secret and passes
+the joined kubeconfig paths to Headlamp via the `-kubeconfig` argument. This
+works alongside `config.inCluster` (the default), so the in-cluster context and
+the clusters from the mounted kubeconfig secrets are all loaded together into the
+same store.
 
 ### Deployment Configuration
 

--- a/charts/headlamp/templates/_helpers.tpl
+++ b/charts/headlamp/templates/_helpers.tpl
@@ -75,7 +75,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-
 {{/*
 Check if readOnlyRootFilesystem is enabled, returns string "true" if enabled, otherwise returns "false".
 */}}
@@ -116,4 +115,27 @@ Output (YAML dict, intended for use with fromYaml):
 {{- end -}}
 addMount: {{ and .readOnly (not $hasTmpMount) }}
 addVolume: {{ and .readOnly (not $hasTmpMount) (not $hasTmpVolume) }}
+{{- end }}
+
+{{/*
+Build the -kubeconfig argument value from the kubeconfigSecrets list
+Returns a colon-separated list of kubeconfig file paths
+*/}}
+{{- define "headlamp.kubeconfigPath" -}}
+{{- $paths := list }}
+{{- range $index, $secret := .Values.config.kubeconfigSecrets }}
+{{- $paths = append $paths (printf "/kubeconfigs/%d/%s" $index (default "config" $secret.key)) }}
+{{- end }}
+{{- join ":" $paths }}
+{{- end }}
+
+{{/*
+Check if kubeconfig secrets are configured
+*/}}
+{{- define "headlamp.hasKubeconfigSecrets" -}}
+{{- if .Values.config.kubeconfigSecrets }}
+{{- if gt (len .Values.config.kubeconfigSecrets) 0 }}
+true
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -267,14 +267,17 @@ spec:
             - "-in-cluster-context-name={{ .Values.config.inClusterContextName }}"
             {{- end }}
             {{- end }}
+            {{- if include "headlamp.hasKubeconfigSecrets" . }}
+            - "-kubeconfig={{ include "headlamp.kubeconfigPath" . }}"
+            {{- end }}
             {{- with .Values.config.enableHelm }}
             - "-enable-helm"
             {{- end }}
             {{- if .Values.config.watchPlugins }}
             - "-watch-plugins-changes"
             {{- end }}
-            {{- if .Values.config.oidc.useCookie }}  
-            - "-oidc-use-cookie"                     
+            {{- if .Values.config.oidc.useCookie }}
+            - "-oidc-use-cookie"
             {{- end }}
             {{- with .Values.config.pluginsDir}}
             - "-plugins-dir={{ . }}"
@@ -418,7 +421,7 @@ spec:
             failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled .Values.volumeMounts $tmpCtx.addMount }}
+          {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled .Values.volumeMounts $tmpCtx.addMount (include "headlamp.hasKubeconfigSecrets" .) }}
           volumeMounts:
             {{- if .Values.pluginsManager.enabled }}
             - name: plugins-dir
@@ -435,6 +438,13 @@ spec:
             {{- end }}
             - name: {{ $plugin.name }}
               mountPath: {{ $mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if include "headlamp.hasKubeconfigSecrets" . }}
+            {{- range $index, $secret := .Values.config.kubeconfigSecrets }}
+            - name: kubeconfig-{{ $index }}
+              mountPath: /kubeconfigs/{{ $index }}
               readOnly: true
             {{- end }}
             {{- end }}
@@ -523,7 +533,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled .Values.volumes $tmpCtx.addVolume $pluginsTmpCtx.addVolume }}
+      {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled .Values.volumes $tmpCtx.addVolume $pluginsTmpCtx.addVolume (include "headlamp.hasKubeconfigSecrets" .) }}
       volumes:
         {{- if .Values.pluginsManager.enabled }}
         - name: plugins-dir
@@ -552,6 +562,16 @@ spec:
         {{- if $tmpCtx.addVolume }}
         - name: headlamp-tmp
           emptyDir: {}
+        {{- end }}
+        {{- if include "headlamp.hasKubeconfigSecrets" . }}
+        {{- range $index, $secret := .Values.config.kubeconfigSecrets }}
+        - name: kubeconfig-{{ $index }}
+          secret:
+            secretName: {{ required (printf "config.kubeconfigSecrets[%d].secretName is required" $index) $secret.secretName }}
+            items:
+              - key: {{ default "config" $secret.key }}
+                path: {{ default "config" $secret.key }}
+        {{- end }}
         {{- end }}
         {{- with .Values.volumes}}
         {{- toYaml . | nindent 8 }}

--- a/charts/headlamp/tests/expected_templates/multi-cluster.yaml
+++ b/charts/headlamp/tests/expected_templates/multi-cluster.yaml
@@ -1,0 +1,172 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.44.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.44.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.44.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-kubeconfig=/kubeconfigs/0/kubeconfig:/kubeconfigs/1/kubeconfig:/kubeconfigs/2/config"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}
+          volumeMounts:
+            - name: kubeconfig-0
+              mountPath: /kubeconfigs/0
+              readOnly: true
+            - name: kubeconfig-1
+              mountPath: /kubeconfigs/1
+              readOnly: true
+            - name: kubeconfig-2
+              mountPath: /kubeconfigs/2
+              readOnly: true
+      volumes:
+        - name: kubeconfig-0
+          secret:
+            secretName: prod-cluster-kubeconfig
+            items:
+              - key: kubeconfig
+                path: kubeconfig
+        - name: kubeconfig-1
+          secret:
+            secretName: dev-cluster-kubeconfig
+            items:
+              - key: kubeconfig
+                path: kubeconfig
+        - name: kubeconfig-2
+          secret:
+            secretName: staging-cluster-kubeconfig
+            items:
+              - key: config
+                path: config

--- a/charts/headlamp/tests/test_cases/multi-cluster.yaml
+++ b/charts/headlamp/tests/test_cases/multi-cluster.yaml
@@ -1,0 +1,11 @@
+config:
+  # kubeconfigSecrets works alongside in-cluster mode; both the in-cluster
+  # context and the mounted kubeconfig clusters are loaded together.
+  inCluster: true
+
+  kubeconfigSecrets:
+    - secretName: prod-cluster-kubeconfig
+      key: kubeconfig
+    - secretName: dev-cluster-kubeconfig
+      key: kubeconfig
+    - secretName: staging-cluster-kubeconfig

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -177,6 +177,20 @@ config:
   # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.
   extraArgs: []
 
+  # -- Kubeconfig secrets configuration for multi-cluster access
+  # Allows mounting multiple Kubernetes secrets containing kubeconfig files.
+  # The joined kubeconfig paths are passed to Headlamp via the -kubeconfig argument,
+  # so this works alongside config.inCluster (the in-cluster context and the mounted
+  # kubeconfig clusters are all loaded together).
+  # Example:
+  # kubeconfigSecrets:
+  #   - secretName: prod-cluster-kubeconfig
+  #     key: config  # optional, defaults to "config"
+  #   - secretName: dev-cluster-kubeconfig
+  #     key: kubeconfig
+  #   - secretName: staging-cluster-kubeconfig
+  kubeconfigSecrets: []
+
 # -- An optional list of environment variables
 # env:
 #   - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
## Summary
This simplifies the process of configuring kubeconfigs in secrets for Headlamp. This functionality already exists; the Helm chart just doesn't make it easy to configure.

## Changes

- Updated Deployment YAML to add a volume/volumeMount for each kubeconfig secret
- Updated Deployment YAML to pass the joined kubeconfig paths to Headlamp via the `-kubeconfig` argument
- Updated values file to allow for a list of secrets containing kubeconfigs
- Updated helm documentation

## Steps to Test

1. Create 1+ secret containing a kubeconfig

2. Configure the `kubeconfigSecrets`
``` YAML
config:
  kubeconfigSecrets:
    - secretName: prod-cluster-kubeconfig
      key: config  # optional, defaults to "config"
```
3.  `helm install headlamp`
4.  Navigate to clusters and validate that you can see multiple clusters configured with the secrets you provided.

> Note: There is no need to disable `config.inCluster`. Because the chart now passes the kubeconfig paths via the `-kubeconfig` argument (instead of the `KUBECONFIG` env var, which is ignored in in-cluster mode), the in-cluster context and the clusters from the mounted kubeconfig secrets all load together into the same store.

## Screenshots (if applicable)
<img width="2932" height="802" alt="image" src="https://github.com/user-attachments/assets/4f62c2da-5727-4aaf-9764-d59ac3b84d1a" />

## Notes for the Reviewer

Reworked per review feedback to pass the kubeconfig paths via the `-kubeconfig` argument rather than the `KUBECONFIG` env var, so in-cluster and kubeconfig-secret contexts are no longer mutually exclusive.