### PR TITLE
feat: add deep-link support for pod exec/terminal via ?view=exec

### DIFF
--- a/frontend/src/components/pod/Details.test.tsx
+++ b/frontend/src/components/pod/Details.test.tsx
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { TestContext } from '../../test';
+
+const { mockActivityLaunch, mockDispatchHeadlampEvent } = vi.hoisted(() => ({
+  mockActivityLaunch: vi.fn(),
+  mockDispatchHeadlampEvent: vi.fn(),
+}));
+
+vi.mock('../activity/Activity', () => ({
+  Activity: {
+    launch: (...args: any[]) => mockActivityLaunch(...args),
+    close: vi.fn(),
+  },
+}));
+
+vi.mock('../../redux/headlampEventSlice', async () => {
+  const actual = await vi.importActual<typeof import('../../redux/headlampEventSlice')>(
+    '../../redux/headlampEventSlice'
+  );
+
+  return {
+    ...actual,
+    useEventCallback: () => mockDispatchHeadlampEvent,
+  };
+});
+let capturedOnResourceUpdate: ((item: any, error?: any) => void) | undefined;
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    capturedOnResourceUpdate = props.onResourceUpdate;
+    return <div data-testid="details-grid" />;
+  },
+  ConditionsSection: () => null,
+  ContainersSection: () => null,
+  VolumeSection: () => null,
+}));
+
+vi.mock('../common/Terminal', () => ({
+  default: () => <div data-testid="mock-terminal" />,
+}));
+
+vi.mock('../common/LogViewer', () => ({
+  LogViewer: () => <div data-testid="mock-log-viewer" />,
+}));
+
+vi.mock('../common/ActionButton', () => ({
+  default: () => null,
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('../common/SectionBox', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('../common/SimpleTable', () => ({
+  default: () => null,
+}));
+
+vi.mock('../common/Tooltip/TooltipLight', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('../common/Resource/AuthVisible', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('../../lib/k8s', () => ({}));
+
+vi.mock('../../lib/k8s/pod', () => {
+  const Pod = vi.fn();
+  return { default: Pod, __esModule: true };
+});
+
+vi.mock('../../lib/k8s/cluster', () => ({}));
+
+vi.mock('./List', () => ({
+  makePodStatusLabel: () => 'Running',
+}));
+
+vi.mock('./PodDebugAction', () => ({
+  PodDebugAction: () => null,
+}));
+
+vi.mock('../globalSearch/useLocalStorageState', () => ({
+  useLocalStorageState: () => [false, vi.fn()],
+}));
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(),
+}));
+
+// Must import after mocks are set up
+const { default: PodDetails } = await import('./Details');
+
+const mockPod = {
+  metadata: {
+    name: 'test-pod',
+    namespace: 'default',
+    uid: 'pod-uid-123',
+    creationTimestamp: '2024-01-01T00:00:00Z',
+    resourceVersion: '1',
+  },
+  spec: {
+    containers: [{ name: 'nginx', image: 'nginx:latest' }],
+    nodeName: 'test-node',
+  },
+  status: {
+    phase: 'Running',
+    conditions: [],
+    containerStatuses: [
+      {
+        name: 'nginx',
+        state: { running: { startedAt: '2024-01-01T00:00:00Z' } },
+        ready: true,
+        restartCount: 0,
+        image: 'nginx:latest',
+        imageID: 'nginx@sha256:abc',
+        containerID: 'containerd://abc',
+      },
+    ],
+    hostIP: '10.0.0.1',
+    podIP: '10.0.0.2',
+  },
+  cluster: 'main',
+};
+
+function simulatePodLoad() {
+  if (capturedOnResourceUpdate) {
+    capturedOnResourceUpdate(mockPod);
+  }
+}
+
+describe('PodDetails auto-launch views', () => {
+  beforeEach(() => {
+    mockActivityLaunch.mockReset();
+    mockDispatchHeadlampEvent.mockReset();
+    capturedOnResourceUpdate = undefined;
+  });
+
+  it('auto-launches terminal when ?view=exec is present', () => {
+    render(
+      <TestContext
+        routerMap={{ namespace: 'default', name: 'test-pod' }}
+        urlPrefix="/c/main/pods"
+        urlSearchParams={{ view: 'exec' }}
+      >
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      simulatePodLoad();
+    });
+
+    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+    expect(mockActivityLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'terminal-pod-uid-123',
+        title: 'test-pod',
+      })
+    );
+  });
+
+  it('auto-launches logs when ?view=logs is present', () => {
+    render(
+      <TestContext
+        routerMap={{ namespace: 'default', name: 'test-pod' }}
+        urlPrefix="/c/main/pods"
+        urlSearchParams={{ view: 'logs' }}
+      >
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      simulatePodLoad();
+    });
+
+    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+    expect(mockActivityLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'logs-pod-uid-123',
+      })
+    );
+  });
+
+  it('does not re-launch logs on subsequent renders for the same pod', () => {
+    const { rerender } = render(
+      <TestContext
+        routerMap={{ namespace: 'default', name: 'test-pod' }}
+        urlPrefix="/c/main/pods"
+        urlSearchParams={{ view: 'logs' }}
+      >
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      simulatePodLoad();
+    });
+    act(() => {
+      rerender(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'logs' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+      simulatePodLoad();
+    });
+
+    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+  });
+  it('does not auto-launch anything when no view param is present', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }} urlPrefix="/c/main/pods">
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      simulatePodLoad();
+    });
+
+    expect(mockActivityLaunch).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-launch terminal when view param is something else', () => {
+    render(
+      <TestContext
+        routerMap={{ namespace: 'default', name: 'test-pod' }}
+        urlPrefix="/c/main/pods"
+        urlSearchParams={{ view: 'other' }}
+      >
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      simulatePodLoad();
+    });
+
+    expect(mockActivityLaunch).not.toHaveBeenCalled();
+  });
+
+  it('does not re-launch terminal on subsequent renders for the same pod', () => {
+    render(
+      <TestContext
+        routerMap={{ namespace: 'default', name: 'test-pod' }}
+        urlPrefix="/c/main/pods"
+        urlSearchParams={{ view: 'exec' }}
+      >
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      simulatePodLoad();
+    });
+    act(() => {
+      simulatePodLoad();
+    });
+
+    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches TERMINAL event with OPENED status for exec deep-link', () => {
+    render(
+      <TestContext
+        routerMap={{ namespace: 'default', name: 'test-pod' }}
+        urlPrefix="/c/main/pods"
+        urlSearchParams={{ view: 'exec' }}
+      >
+        <PodDetails name="test-pod" namespace="default" />
+      </TestContext>
+    );
+
+    act(() => {
+      simulatePodLoad();
+    });
+
+    expect(mockDispatchHeadlampEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'headlamp.terminal',
+        data: expect.objectContaining({
+          status: 'open',
+        }),
+      })
+    );
+  });
+});

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -496,7 +496,8 @@ export default function PodDetails(props: PodDetailsProps) {
   const { t } = useTranslation('glossary');
   const dispatchHeadlampEvent = useEventCallback();
 
-  const lastAutoLaunchedPod = React.useRef<string | null>(null);
+  const lastAutoLaunchedPodLogs = React.useRef<string | null>(null);
+  const lastAutoLaunchedPodExec = React.useRef<string | null>(null);
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const autoLaunchView = queryParams.get('view');
@@ -522,21 +523,67 @@ export default function PodDetails(props: PodDetailsProps) {
     [t, dispatchHeadlampEvent]
   );
 
+  const launchTerminal = React.useCallback(
+    (item: Pod) => {
+      const activityId = 'terminal-' + item.metadata.uid;
+      Activity.launch({
+        id: activityId,
+        title: item.metadata.name,
+        cluster: item.cluster,
+        icon: <Icon icon="mdi:console" width="100%" height="100%" />,
+        location: 'full',
+        content: (
+          <Terminal
+            noDialog
+            open
+            item={item}
+            onClose={() => Activity.close(activityId)}
+            isAttach={false}
+          />
+        ),
+      });
+      dispatchHeadlampEvent({
+        type: HeadlampEventType.TERMINAL,
+        data: {
+          resource: item,
+          status: EventStatus.OPENED,
+        },
+      });
+    },
+    [dispatchHeadlampEvent]
+  );
+
   React.useEffect(() => {
     if (autoLaunchView !== 'logs') {
-      lastAutoLaunchedPod.current = null;
+      lastAutoLaunchedPodLogs.current = null;
       return;
     }
 
     if (
       podItem &&
       autoLaunchView === 'logs' &&
-      lastAutoLaunchedPod.current !== podItem.metadata.uid
+      lastAutoLaunchedPodLogs.current !== podItem.metadata.uid
     ) {
-      lastAutoLaunchedPod.current = podItem.metadata.uid;
+      lastAutoLaunchedPodLogs.current = podItem.metadata.uid;
       launchLogs(podItem);
     }
   }, [podItem, launchLogs, autoLaunchView]);
+
+  React.useEffect(() => {
+    if (autoLaunchView !== 'exec') {
+      lastAutoLaunchedPodExec.current = null;
+      return;
+    }
+
+    if (
+      podItem &&
+      autoLaunchView === 'exec' &&
+      lastAutoLaunchedPodExec.current !== podItem.metadata.uid
+    ) {
+      lastAutoLaunchedPodExec.current = podItem.metadata.uid;
+      launchTerminal(podItem);
+    }
+  }, [podItem, launchTerminal, autoLaunchView]);
 
   function prepareExtraInfo(item: Pod | null) {
     let extraInfo: {
@@ -660,25 +707,7 @@ export default function PodDetails(props: PodDetailsProps) {
                 <ActionButton
                   description={t('Terminal / Exec')}
                   icon="mdi:console"
-                  onClick={() => {
-                    Activity.launch({
-                      id: 'terminal-' + item.metadata.uid,
-                      title: item.metadata.name,
-                      cluster: item.cluster,
-                      icon: <Icon icon="mdi:console" width="100%" height="100%" />,
-                      location: 'full',
-                      content: (
-                        <Terminal noDialog open item={item} onClose={() => {}} isAttach={false} />
-                      ),
-                    });
-                    dispatchHeadlampEvent({
-                      type: HeadlampEventType.TERMINAL,
-                      data: {
-                        resource: item,
-                        status: EventStatus.CLOSED,
-                      },
-                    });
-                  }}
+                  onClick={() => launchTerminal(item)}
                 />
               </AuthVisible>
             ),


### PR DESCRIPTION
## Summary

Add support for the `?view=exec` query parameter on pod detail pages to auto-launch the terminal/exec Activity panel, mirroring the existing `?view=logs` deep-link support.

This enables users to share and bookmark direct links to exec into a specific pod:

```
/c/<cluster>/pods/<namespace>/<pod-name>?view=exec
```

### Motivation

Headlamp already supports `?view=logs` for deep-linking to pod logs. This is useful for sharing links from alerting systems, CI/CD pipelines, runbooks, and incident management tools. The same capability for exec/terminal is a natural complement — teams often need to quickly exec into a pod to debug an issue flagged by monitoring.

### Changes

**`frontend/src/components/pod/Details.tsx`:**

- Added a `launchTerminal` callback (via `useCallback`), mirroring the existing `launchLogs` pattern. It calls `Activity.launch()` with the `Terminal` component and dispatches the `TERMINAL` event with `OPENED` status.
- Added a `useEffect` that watches for `?view=exec` in the URL query parameters and auto-launches the terminal once the pod data is loaded, using a ref (`lastAutoLaunchedPodExec`) to prevent duplicate launches — the same pattern used for `?view=logs`.
- Refactored the existing inline terminal launch in the `POD_TERMINAL` header action button to reuse the new `launchTerminal` callback instead of inlining the `Activity.launch()` call, keeping the code DRY and consistent with how `launchLogs` is already used for the logs button.

**`frontend/src/components/pod/Details.test.tsx`** (new):

- Added unit tests for both `?view=exec` (new) and `?view=logs` (existing) auto-launch behavior
- Tests verify Activity.launch is called correctly, not called when param is absent, and not re-triggered on re-renders

### Usage

| Deep link | Behavior |
|-----------|----------|
| `/c/main/pods/default/my-app?view=logs` | Opens log viewer (existing) |
| `/c/main/pods/default/my-app?view=exec` | Opens terminal/exec (new) |

## Test Plan

- [ ] Navigate to `/c/<cluster>/pods/<namespace>/<pod>?view=exec` — terminal Activity panel should auto-open
- [ ] Navigate to `/c/<cluster>/pods/<namespace>/<pod>?view=logs` — log viewer should still auto-open (no regression)
- [ ] Navigate to `/c/<cluster>/pods/<namespace>/<pod>` (no query param) — neither should auto-open
- [ ] Click the "Terminal / Exec" header action button on a pod detail page — terminal should open as before
- [ ] Verify the terminal connects and allows command execution
- [ ] Unit tests pass (`npx vitest run src/components/pod/Details.test.tsx`)
