### PR TITLE
docs: Update Homebrew installation command for Headlamp

### DIFF
--- a/docs/installation/desktop/mac-installation.md
+++ b/docs/installation/desktop/mac-installation.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 Once you have the [Homebrew package manager](https://brew.sh/) itself installed, you can install the latest Headlamp release by running the following command:
 
 ```sh
-brew install --cask --no-quarantine headlamp
+brew install --cask headlamp
 ```
 
 ### Upgrading


### PR DESCRIPTION

## Summary

This PR removes the '--no-quarantine' option from the installation command.

## Related Issue

Fixes https://github.com/kubernetes-sigs/headlamp/issues/4932

## Changes

- Updated [docs/installation/desktop/mac-installation.md]


## Screenshots (if applicable)
<img width="535" height="363" alt="Screenshot 2026-03-23 at 6 47 05 PM" src="https://github.com/user-attachments/assets/db557d02-89a7-4deb-a33d-3e0e222a3681" />



## Notes for the Reviewer

- https://headlamp.dev/docs/latest/installation/desktop/mac-installation/#install-via-homebrew
