### PR TITLE
fix(ci): use stax-builder ARC runner and fix buildx DNS

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   push_to_registry:
     name: Test building container image
-    runs-on: ubuntu-latest
+    runs-on: stax-builder
     permissions:
       packages: write # needed for publishing the container image
     steps:
@@ -32,6 +32,8 @@ jobs:
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+      with:
+        driver-opts: network=host
     - name: Figure out the tag based on event trigger
       env:
         TRIGGER: ${{ github.event_name }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,7 +16,7 @@ jobs:
   push_to_registry:
     if: ${{ github.repository == 'kubernetes-sigs/headlamp' }}
     name: Build and push nightly container image
-    runs-on: ubuntu-latest
+    runs-on: stax-builder
     permissions:
       packages: write
     steps:
@@ -28,6 +28,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+        with:
+          driver-opts: network=host
 
       - name: Log in to the Container registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0


### PR DESCRIPTION
## Summary

- Replaces `ubuntu-latest` with `stax-builder` ARC runner in container-publish.yml and nightly-build.yml
- Adds `driver-opts: network=host` to buildx setup for DinD DNS fix

## Test plan

- [ ] Trigger nightly-build workflow and verify it runs on ARC runner
- [ ] Push a version tag and verify container-publish runs on ARC runner