### PR TITLE
frontend:Show container port name if available

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1591,11 +1591,12 @@ export function ContainerInfo(props: ContainerInfoProps) {
         name: t('Ports'),
         value: (
           <Grid container>
-            {container.ports?.map(({ containerPort, protocol }, index) => (
+            {container.ports?.map(({ containerPort, protocol, name }, index) => (
               <>
                 <Grid item xs={12} key={`port_line_${index}`}>
                   <Box display="flex" alignItems={'center'}>
                     <Box px={0.5} minWidth={120}>
+                      {name && <ValueLabel>{`${name} `}</ValueLabel>}
                       <ValueLabel>{`${protocol}:`}</ValueLabel>
                       <ValueLabel>{containerPort}</ValueLabel>
                     </Box>


### PR DESCRIPTION
## Summary

This PR addresses the issue of missing container port names in the UI. It modifies the containers list component so that the name attribute of a container port is displayed alongside its protocol and port number, as requested in issue #4955.

## Related Issue

Fixes #4955

## Changes

Updated: 

`frontend/src/components/common/Resource/Resource.tsx`

Modified the rendering logic inside `ContainerInfo` , `containerRows` where the "Ports" array is mapped. It now conditionally renders the name property if it exists in the port object.

Before (No name)
<img width="761" height="740" alt="image" src="https://github.com/user-attachments/assets/a352f8ab-a631-48e4-9cfe-b0fc97e0d02a" />

After (You can see the name attached prior to TCP:80)
<img width="761" height="740" alt="image" src="https://github.com/user-attachments/assets/8c804f01-40b8-49e3-85c3-47e6dc7b77c0" />


## Steps to Test

1.Ensure your local cluster (minikube/kind) has a Pod running that defines a name in its containerPort configuration. (e.g., 2.name: web-api, containerPort: 80).
3.Run the application locally using npm start.
4.Navigate to Workloads > Pods in the Headlamp UI.
5.Click on the Pod with the named configuration to open its details page.
6.Scroll down to the Containers table.
7.Verify that the Ports row now displays the name correctly alongside the protocol and port (e.g., web-api TCP:80).

