### PR TITLE
frontend: ResourceMap: Fix some performance regressions

### DIFF
--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -314,7 +314,7 @@ export function GraphSourceManager({ sources, children, relations }: GraphSource
       };
     },
     [sources, selectedSources, sourceData, setSelectedSources, relations],
-    500
+    1000
   );
 
   return (

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -147,7 +147,7 @@ const SourceLoader = memo(
 );
 
 export default function useThrottledMemo<T>(factory: () => T, deps: any[], throttleMs: number): T {
-  const [state, setState] = useState(factory());
+  const [state, setState] = useState(factory);
 
   const debouncedSetState = useCallback(throttle(setState, throttleMs), []);
 

--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -266,38 +266,37 @@ const backendTrafficPolicyToService = makeRelation(
     trafficPolicy.spec.targetRef?.kind === 'Service'
 );
 
+const staticRelations = [
+  configMapUsedInPods,
+  configMapUsedInJobs,
+  secretsUsedInPods,
+  secretsUsedInJobs,
+  hpaToDeployment,
+  hpaToStatefulSet,
+  vwcToService,
+  mwcToService,
+  serviceToPods,
+  endpointsToServices,
+  endpointSlicesToServices,
+  ingressToService,
+  ingressToSecret,
+  networkPolicyToPod,
+  roleBindingsToRole,
+  roleBindingToServiceAccount,
+  serviceAccountToDeployments,
+  serviceAccountToDaemonSets,
+  pvcToPods,
+  podToOwner,
+  repliaceSetToOwner,
+  jobToCronJob,
+  gatewayToGatewayClass,
+  httpRouteToGateway,
+  httpRouteToService,
+  backendTLSPolicyToService,
+  backendTrafficPolicyToService,
+];
 export function useGetAllRelations(): Relation[] {
-  const staticRelations = [
-    configMapUsedInPods,
-    configMapUsedInJobs,
-    secretsUsedInPods,
-    secretsUsedInJobs,
-    hpaToDeployment,
-    hpaToStatefulSet,
-    vwcToService,
-    mwcToService,
-    serviceToPods,
-    endpointsToServices,
-    endpointSlicesToServices,
-    ingressToService,
-    ingressToSecret,
-    networkPolicyToPod,
-    roleBindingsToRole,
-    roleBindingToServiceAccount,
-    serviceAccountToDeployments,
-    serviceAccountToDaemonSets,
-    pvcToPods,
-    podToOwner,
-    repliaceSetToOwner,
-    jobToCronJob,
-    gatewayToGatewayClass,
-    httpRouteToGateway,
-    httpRouteToService,
-    backendTLSPolicyToService,
-    backendTrafficPolicyToService,
-  ];
-
   const crdRelations = useGetCRToOwnerRelations();
 
-  return [...staticRelations, ...crdRelations];
+  return useMemo(() => [...staticRelations, ...crdRelations], [crdRelations, staticRelations]);
 }

--- a/frontend/src/components/resourceMap/sources/definitions/sources.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/sources.tsx
@@ -99,133 +99,144 @@ const generateCRSources = (crds: CRD[]): GraphSource[] => {
 export function useGetAllSources(): GraphSource[] {
   const { items: CustomResourceDefinition } = CRD.useList({ namespace: useNamespaces() });
 
-  const sources = [
-    {
-      id: 'workloads',
-      label: 'Workloads',
-      icon: (
-        <Icon
-          icon="mdi:circle-slice-2"
-          width="100%"
-          height="100%"
-          color={getKindGroupColor('workloads')}
-        />
-      ),
-      sources: [
-        makeKubeSource(Pod),
-        makeKubeSource(Deployment),
-        makeKubeSource(StatefulSet),
-        makeKubeSource(DaemonSet),
-        makeKubeSource(ReplicaSet),
-        makeKubeSource(Job),
-        makeKubeSource(CronJob),
-      ],
-    },
-    {
-      id: 'storage',
-      label: 'Storage',
-      icon: (
-        <Icon icon="mdi:database" width="100%" height="100%" color={getKindGroupColor('storage')} />
-      ),
-      sources: [makeKubeSource(PersistentVolumeClaim)],
-    },
-    {
-      id: 'network',
-      label: 'Network',
-      icon: (
-        <Icon
-          icon="mdi:folder-network-outline"
-          width="100%"
-          height="100%"
-          color={getKindGroupColor('network')}
-        />
-      ),
-      sources: [
-        makeKubeSource(Service),
-        makeKubeSource(Endpoints),
-        makeKubeSource(EndpointSlice),
-        makeKubeSource(Ingress),
-        makeKubeSource(IngressClass),
-        makeKubeSource(NetworkPolicy),
-      ],
-    },
-    {
-      id: 'security',
-      label: 'Security',
-      isEnabledByDefault: false,
-      icon: (
-        <Icon icon="mdi:lock" width="100%" height="100%" color={getKindGroupColor('security')} />
-      ),
-      sources: [makeKubeSource(ServiceAccount), makeKubeSource(Role), makeKubeSource(RoleBinding)],
-    },
-    {
-      id: 'configuration',
-      label: 'Configuration',
-      icon: (
-        <Icon
-          icon="mdi:format-list-checks"
-          width="100%"
-          height="100%"
-          color={getKindGroupColor('configuration')}
-        />
-      ),
-      isEnabledByDefault: false,
-      sources: [
-        makeKubeSource(ConfigMap),
-        makeKubeSource(Secret),
-        makeKubeSource(MutatingWebhookConfiguration),
-        makeKubeSource(ValidatingWebhookConfiguration),
-        makeKubeSource(HPA),
-        // TODO: Implement the rest of resources
-        // vpa
-        // pdb
-        // rq
-        // lr
-        // priorityClass
-        // runtimeClass
-        // leases
-      ],
-    },
-    {
-      id: 'gateway-beta',
-      label: 'Gateway (beta)',
-      icon: (
-        <Icon
-          icon="mdi:lan-connect"
-          width="100%"
-          height="100%"
-          color={getKindGroupColor('network')}
-        />
-      ),
-      isEnabledByDefault: false,
-      sources: [
-        makeKubeSource(GatewayClass),
-        makeKubeSource(Gateway),
-        makeKubeSource(HTTPRoute),
-        makeKubeSource(GRPCRoute),
-        makeKubeSource(ReferenceGrant),
-        makeKubeSource(BackendTLSPolicy),
-        makeKubeSource(BackendTrafficPolicy),
-      ],
-    },
-  ];
+  return useMemo(() => {
+    const sources = [
+      {
+        id: 'workloads',
+        label: 'Workloads',
+        icon: (
+          <Icon
+            icon="mdi:circle-slice-2"
+            width="100%"
+            height="100%"
+            color={getKindGroupColor('workloads')}
+          />
+        ),
+        sources: [
+          makeKubeSource(Pod),
+          makeKubeSource(Deployment),
+          makeKubeSource(StatefulSet),
+          makeKubeSource(DaemonSet),
+          makeKubeSource(ReplicaSet),
+          makeKubeSource(Job),
+          makeKubeSource(CronJob),
+        ],
+      },
+      {
+        id: 'storage',
+        label: 'Storage',
+        icon: (
+          <Icon
+            icon="mdi:database"
+            width="100%"
+            height="100%"
+            color={getKindGroupColor('storage')}
+          />
+        ),
+        sources: [makeKubeSource(PersistentVolumeClaim)],
+      },
+      {
+        id: 'network',
+        label: 'Network',
+        icon: (
+          <Icon
+            icon="mdi:folder-network-outline"
+            width="100%"
+            height="100%"
+            color={getKindGroupColor('network')}
+          />
+        ),
+        sources: [
+          makeKubeSource(Service),
+          makeKubeSource(Endpoints),
+          makeKubeSource(EndpointSlice),
+          makeKubeSource(Ingress),
+          makeKubeSource(IngressClass),
+          makeKubeSource(NetworkPolicy),
+        ],
+      },
+      {
+        id: 'security',
+        label: 'Security',
+        isEnabledByDefault: false,
+        icon: (
+          <Icon icon="mdi:lock" width="100%" height="100%" color={getKindGroupColor('security')} />
+        ),
+        sources: [
+          makeKubeSource(ServiceAccount),
+          makeKubeSource(Role),
+          makeKubeSource(RoleBinding),
+        ],
+      },
+      {
+        id: 'configuration',
+        label: 'Configuration',
+        icon: (
+          <Icon
+            icon="mdi:format-list-checks"
+            width="100%"
+            height="100%"
+            color={getKindGroupColor('configuration')}
+          />
+        ),
+        isEnabledByDefault: false,
+        sources: [
+          makeKubeSource(ConfigMap),
+          makeKubeSource(Secret),
+          makeKubeSource(MutatingWebhookConfiguration),
+          makeKubeSource(ValidatingWebhookConfiguration),
+          makeKubeSource(HPA),
+          // TODO: Implement the rest of resources
+          // vpa
+          // pdb
+          // rq
+          // lr
+          // priorityClass
+          // runtimeClass
+          // leases
+        ],
+      },
+      {
+        id: 'gateway-beta',
+        label: 'Gateway (beta)',
+        icon: (
+          <Icon
+            icon="mdi:lan-connect"
+            width="100%"
+            height="100%"
+            color={getKindGroupColor('network')}
+          />
+        ),
+        isEnabledByDefault: false,
+        sources: [
+          makeKubeSource(GatewayClass),
+          makeKubeSource(Gateway),
+          makeKubeSource(HTTPRoute),
+          makeKubeSource(GRPCRoute),
+          makeKubeSource(ReferenceGrant),
+          makeKubeSource(BackendTLSPolicy),
+          makeKubeSource(BackendTrafficPolicy),
+        ],
+      },
+    ];
 
-  if (CustomResourceDefinition !== null) {
-    sources.push({
-      id: 'customresource',
-      label: 'Custom Resources',
-      icon: (
-        <Icon
-          icon="mdi:select-group"
-          width="100%"
-          height="100%"
-          color={getKindGroupColor('configuration')}
-        />
-      ),
-      isEnabledByDefault: false,
-      sources: generateCRSources(CustomResourceDefinition),
-    });
-  }
+    if (CustomResourceDefinition !== null) {
+      sources.push({
+        id: 'customresource',
+        label: 'Custom Resources',
+        icon: (
+          <Icon
+            icon="mdi:select-group"
+            width="100%"
+            height="100%"
+            color={getKindGroupColor('configuration')}
+          />
+        ),
+        isEnabledByDefault: false,
+        sources: generateCRSources(CustomResourceDefinition),
+      });
+    }
 
-  return sources;
+    return sources;
+  }, [CustomResourceDefinition]);
 }


### PR DESCRIPTION
## Summary

With some recent changes to the map a lot of values were recreated too often which caused certain expensive operations like building a graph to be execute way too often. This PR makes sure that those values are properly memoized. 
Along that this PR adjusts useThrottledMemo interval to somwhat improve performance for larger clusters

## Related Issue

Somewhat fixes #3813  

## Changes

frontend: ResourceMap: Properly memoize sources and relations

frontend: ResourceMap: Increase throttle interval for graph generation

## Steps to Test

1. Go to map
2. Hit record in performance profiler
3. Click on any group and make sure the cpu usage isn't high
