### PR TITLE
frontend: ResourceMap: Introduce node limit per source

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -169,7 +169,8 @@ function GraphViewContent({
   const [expandAll, setExpandAll] = useState(false);
 
   // Load source data
-  const { nodes, edges, selectedSources, sourceData, isLoading, toggleSelection } = useSources();
+  const { nodes, edges, selectedSources, hiddenSources, sourceData, isLoading, toggleSelection } =
+    useSources();
 
   // Graph with applied layout, has sizes and positions for all elements
   const [layoutedGraph, setLayoutedGraph] = useState<{ nodes: Node[]; edges: Edge[] }>({
@@ -304,6 +305,7 @@ function GraphViewContent({
                   sources={defaultSources}
                   selectedSources={selectedSources}
                   toggleSource={toggleSelection}
+                  hiddenSources={hiddenSources}
                   sourceData={sourceData ?? new Map()}
                 />
                 <Box sx={{ fontSize: '14px', marginLeft: 1 }}>{t('Group By')}</Box>

--- a/frontend/src/components/resourceMap/__snapshots__/GraphView.BasicExample.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/GraphView.BasicExample.stories.storyshot
@@ -86,26 +86,33 @@
               </div>
             </div>
           </div>
-          <div
-            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-qsy4j-MuiButtonBase-root-MuiChip-root"
-            role="button"
-            tabindex="0"
+          <span
+            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
           >
-            <span
-              class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorPrimary MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-filledPrimary css-qsy4j-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
             >
-              <div
-                class="MuiStack-root css-1qxw92a-MuiStack-root"
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
               >
-                 
-                Pods
-                 
-              </div>
-            </span>
+                <div
+                  class="MuiStack-root css-1qxw92a-MuiStack-root"
+                >
+                   
+                  Pods
+                   
+                </div>
+              </span>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
             <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              class="MuiBadge-badge MuiBadge-standard MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightRectangular MuiBadge-overlapRectangular css-1wenaic-MuiBadge-badge"
             />
-          </div>
+          </span>
           <div
             class="MuiBox-root css-19ideir"
           >

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -27,6 +27,7 @@ import {
 } from 'react';
 import { KubeObject } from '../../../lib/k8s/cluster';
 import { GraphEdge, GraphNode, GraphSource, Relation } from '../graph/graphModel';
+import { GraphSourcesConfig } from './GraphSourcesConfig';
 
 /**
  * Map of nodes and edges where the key is source id
@@ -44,6 +45,8 @@ interface GraphSourcesContext {
   toggleSelection: (source: GraphSource) => void;
   setSelectedSources: (sources: Set<string>) => void;
   selectedSources: Set<string>;
+  /** Sources that exceed limits */
+  hiddenSources: Set<string>;
   sourceData?: SourceData;
   isLoading?: boolean;
 }
@@ -270,8 +273,15 @@ export function GraphSourceManager({ sources, children, relations }: GraphSource
 
       const nodesPerSource = new Map<string, GraphNode[]>();
 
+      const hiddenSources = new Set<string>();
+
       selectedSources.forEach(id => {
         const data = sourceData.get(id);
+        if ((data?.nodes?.length ?? 0) > GraphSourcesConfig.nodeLimitPerSource) {
+          console.log('exclude', id);
+          hiddenSources.add(id);
+          return;
+        }
         if (data?.nodes) {
           nodes = nodes.concat(data.nodes);
           nodesPerSource.set(id, data.nodes);
@@ -303,12 +313,15 @@ export function GraphSourceManager({ sources, children, relations }: GraphSource
         sourceData.size === 0 ||
         selectedSources?.values()?.some?.(source => sourceData.get(source) === null);
 
+      console.log(hiddenSources);
+
       return {
         nodes,
         edges,
         toggleSelection,
         setSelectedSources,
         selectedSources,
+        hiddenSources,
         sourceData,
         isLoading,
       };

--- a/frontend/src/components/resourceMap/sources/GraphSourcesConfig.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSourcesConfig.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const GraphSourcesConfig = {
+  /** Maximum number of items per source we can display, otherwise hide them */
+  nodeLimitPerSource: 500,
+};

--- a/frontend/src/components/resourceMap/sources/GraphSourcesView.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSourcesView.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Icon } from '@iconify/react';
+import { Tooltip } from '@mui/material';
 import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
@@ -26,8 +27,10 @@ import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/system/colorManipulator';
 import { memo, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { GraphSource } from '../graph/graphModel';
 import { getFlatSources, SourceData } from './GraphSources';
+import { GraphSourcesConfig } from './GraphSourcesConfig';
 
 const Node = styled('div')(() => ({
   display: 'flex',
@@ -62,6 +65,7 @@ function GraphSourceView({
   source,
   sourceData,
   selection,
+  hiddenSources,
   toggleSelection,
 }: {
   /** Source definition */
@@ -71,7 +75,9 @@ function GraphSourceView({
   /** Set of selected source ids */
   selection: Set<string>;
   toggleSelection: (source: GraphSource) => void;
+  hiddenSources: Set<string>;
 }) {
+  const { t } = useTranslation();
   const [isActive, setIsActive] = useState(false);
   const hasChildren = 'sources' in source;
   const isSelected = (source: GraphSource): boolean =>
@@ -81,20 +87,54 @@ function GraphSourceView({
     'sources' in source && getFlatSources(source.sources).some(s => isSelected(s)) && !isChecked;
 
   const data = sourceData.get(source.id);
+  const isDisabled = hiddenSources.has(source.id);
+  const hasDisabled =
+    'sources' in source ? source.sources.some(s => hiddenSources.has(s.id)) : false;
 
   const check = (
     <>
       <Box mr={1} display="flex">
-        <Badge badgeContent={isChecked ? data?.nodes?.length : undefined} overlap="circular">
+        <Badge
+          badgeContent={
+            hasDisabled || isDisabled ? (
+              <Box sx={{ color: 'warning.main' }}>
+                <Icon icon="mdi:warning" />
+              </Box>
+            ) : isChecked ? (
+              data?.nodes?.length
+            ) : undefined
+          }
+          overlap="circular"
+        >
           <Box width={hasChildren ? '24px' : '24px'} height={hasChildren ? '24px' : '24px'}>
             {source.icon}
           </Box>
         </Badge>
       </Box>
-      <Typography variant="subtitle2">{source.label}</Typography>
+      <Typography variant="subtitle2" sx={{ marginRight: 'auto' }}>
+        {source.label}
+      </Typography>
       {!('sources' in source) && isChecked && !data && <CircularProgress />}
+      {isDisabled && (
+        <Tooltip
+          title={t(
+            'These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.',
+            { limit: GraphSourcesConfig.nodeLimitPerSource }
+          )}
+        >
+          <Chip
+            color="warning"
+            size="small"
+            label={
+              <Box sx={{ display: 'flex', gap: 0.5, lineHeight: 1 }}>
+                <Icon icon="mdi:warning" />
+                <Trans>Hidden</Trans>
+              </Box>
+            }
+          />
+        </Tooltip>
+      )}
       <Checkbox
-        sx={() => ({ marginLeft: 'auto' })}
         checked={isChecked}
         indeterminate={intermediate}
         onClick={e => {
@@ -115,6 +155,9 @@ function GraphSourceView({
   if (!('sources' in source)) {
     return (
       <Node
+        tabIndex={0}
+        role="button"
+        aria-disabled={isDisabled}
         onClick={() => {
           toggleSelection(source);
         }}
@@ -153,6 +196,7 @@ function GraphSourceView({
             <GraphSourceView
               source={source}
               selection={selection}
+              hiddenSources={hiddenSources}
               toggleSelection={toggleSelection}
               key={source.id}
               sourceData={sourceData}
@@ -172,10 +216,18 @@ export interface GraphSourcesViewProps {
   selectedSources: Set<string>;
   /** Callback when a source is toggled */
   toggleSource: (source: GraphSource) => void;
+  /** Disabled sources due to exceeding the limit */
+  hiddenSources: Set<string>;
 }
 
 export const GraphSourcesView = memo(
-  ({ sources, sourceData, selectedSources, toggleSource }: GraphSourcesViewProps) => {
+  ({
+    sources,
+    sourceData,
+    selectedSources,
+    hiddenSources,
+    toggleSource,
+  }: GraphSourcesViewProps) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
     const selected = sources.filter(source => {
@@ -191,19 +243,28 @@ export const GraphSourcesView = memo(
 
     return (
       <>
-        <Chip
-          label={
-            <Stack direction="row" gap={1} alignItems="center">
-              <Icon icon="mdi:filter" /> {selectedText}{' '}
-            </Stack>
+        <Badge
+          badgeContent={
+            hiddenSources.size > 0 && (
+              <Chip color="warning" size="small" label={<Icon icon="mdi:warning" />}></Chip>
+            )
           }
-          color="primary"
-          variant={'filled'}
-          onClick={e => setAnchorEl(e.currentTarget)}
-          sx={{
-            lineHeight: '1',
-          }}
-        />
+        >
+          <Chip
+            label={
+              <Stack direction="row" gap={1} alignItems="center">
+                <Icon icon="mdi:filter" /> {selectedText}{' '}
+              </Stack>
+            }
+            color="primary"
+            variant={'filled'}
+            onClick={e => setAnchorEl(e.currentTarget)}
+            sx={{
+              lineHeight: '1',
+            }}
+          />
+        </Badge>
+
         <Popover
           elevation={4}
           anchorOrigin={{
@@ -230,6 +291,7 @@ export const GraphSourcesView = memo(
                 toggleSelection={toggleSource}
                 key={index}
                 sourceData={sourceData}
+                hiddenSources={hiddenSources}
               />
             ))}
           </Box>

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -704,6 +704,8 @@
   "Fit to screen": "",
   "Zoom to 100%": "",
   "Home": "Startseite",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "Genutzt",
   "Hard": "Hart",
   "Request": "Anfrage",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -704,6 +704,8 @@
   "Fit to screen": "Fit to screen",
   "Zoom to 100%": "Zoom to 100%",
   "Home": "Home",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.",
+  "Hidden": "Hidden",
   "Used": "Used",
   "Hard": "Hard",
   "Request": "Request",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -709,6 +709,8 @@
   "Fit to screen": "Ajustar a pantalla",
   "Zoom to 100%": "Ajustar a 100%",
   "Home": "Inicio",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "Usado",
   "Hard": "Duro",
   "Request": "Solicitud",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -709,6 +709,8 @@
   "Fit to screen": "Ajuster à l'écran",
   "Zoom to 100%": "Zoom à 100%",
   "Home": "Accueil",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "Utilisé",
   "Hard": "Dur",
   "Request": "Demande",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -704,6 +704,8 @@
   "Fit to screen": "",
   "Zoom to 100%": "",
   "Home": "होम",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "",
   "Hard": "",
   "Request": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -709,6 +709,8 @@
   "Fit to screen": "Adatta allo schermo",
   "Zoom to 100%": "Zoom al 100%",
   "Home": "Home",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "Usato",
   "Hard": "Duro",
   "Request": "Richiesta",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -699,6 +699,8 @@
   "Fit to screen": "画面に合わせる",
   "Zoom to 100%": "100% にズーム",
   "Home": "ホーム",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "使用中",
   "Hard": "ハード",
   "Request": "リクエスト",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -699,6 +699,8 @@
   "Fit to screen": "화면에 맞추기",
   "Zoom to 100%": "100%로 확대",
   "Home": "홈",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "Used",
   "Hard": "Hard",
   "Request": "Request",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -709,6 +709,8 @@
   "Fit to screen": "Ajustar ao ecrã",
   "Zoom to 100%": "Ajustar a 100%",
   "Home": "Início",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "Usado",
   "Hard": "Rígido",
   "Request": "Pedido",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -704,6 +704,8 @@
   "Fit to screen": "ஸ்க்ரீனுக்குப் பொருத்து",
   "Zoom to 100%": "100% க்கு பெரிதாக்கு",
   "Home": "முகப்பு",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "பயன்படுத்தப்பட்டது",
   "Hard": "ஹார்ட்",
   "Request": "ரிக்வெஸ்ட்",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -699,6 +699,8 @@
   "Fit to screen": "適合螢幕",
   "Zoom to 100%": "縮放到 100%",
   "Home": "首頁",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "已用",
   "Hard": "硬性",
   "Request": "請求",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -699,6 +699,8 @@
   "Fit to screen": "适合屏幕",
   "Zoom to 100%": "缩放到 100%",
   "Home": "首页",
+  "These items are hidden for performance reasons. The amount exceeded the limit of {{limit}}.": "",
+  "Hidden": "",
   "Used": "已用",
   "Hard": "硬性",
   "Request": "请求",


### PR DESCRIPTION
Fixes #3813 

Adds new limit that hides sources that have too many items.
Hardcoded to 500 for now.

<img width="512" height="337" alt="image" src="https://github.com/user-attachments/assets/fa03d765-c4d8-4d68-9c26-b04b37df2447" />
