### PR TITLE
frontend: globalsearh: Add Clear button in the search field and showing  a pointer cursor for search results

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -17,16 +17,18 @@
 import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Popper from '@mui/material/Popper';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import useAutocomplete from '@mui/material/useAutocomplete';
 import { UseAutocompleteReturnValue } from '@mui/material/useAutocomplete';
 import Fuse, { Expression, FuseResultMatch } from 'fuse.js';
 import { capitalize } from 'lodash';
 import { lazy, Suspense, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { generatePath, useHistory, useLocation, useRouteMatch } from 'react-router';
 import { FixedSizeList } from 'react-window';
@@ -486,6 +488,11 @@ export function GlobalSearchContent({
             autoFocus: true,
             endAdornment: (
               <>
+                <Tooltip title={<Trans>Clear</Trans>} sx={{ opacity: query.length ? 1 : 0 }}>
+                  <IconButton onClick={() => setQuery('')} aria-label={t('Clear')} size="small">
+                    <Icon icon="mdi:close" />
+                  </IconButton>
+                </Tooltip>
                 {loading.length > 0 && (
                   <Delayed display="flex" mr={1}>
                     <CircularProgress size="16px" />
@@ -571,6 +578,7 @@ function SearchRow({
         padding: '8px !important',
         alignItems: 'center',
         lineHeight: 1,
+        cursor: 'pointer',
         overflow: 'hidden',
         '&.Mui-focused': {
           backgroundColor:


### PR DESCRIPTION
## Summary

This PR improves the global search UX by adding a clear button to the search input and showing a pointer cursor for search result rows.

## Related Issue

Fixes #4958 

## Changes

- Updated global search input to include a clear button when a query is present
- Updated global search result rows to show a pointer cursor on hover
- Kept the change minimal and scoped to the global search UI

## Steps to Test

1. Open Headlamp and click the global search bar.
2. Type a query into the search input.
3. Confirm a clear `x` button appears on the right side of the input.
4. Click the clear button and verify the query is cleared.
5. Type a query again so search results appear.
6. Hover over a search result and verify the cursor changes to a pointer.

## Screenshots (if applicable)
<img width="2495" height="1390" alt="Screenshot from 2026-03-25 13-18-28" src="https://github.com/user-attachments/assets/bcac7e08-b364-4f2c-bbb0-ff4092fcbe03" />


## Notes for the Reviewer
- This is a small UI-only change in the global search flow.

