### PR TITLE
frontend: Resource: Fix condition table column width

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -603,10 +603,12 @@ export function ConditionsTable(props: ConditionsTableProps) {
       label: string;
       getter: (arg: KubeCondition) => void;
       hide?: boolean;
+      gridTemplate?: number | string;
     }[] = [
       {
         label: t('Condition'),
         getter: makeStatusLabel,
+        gridTemplate: 'min-content',
       },
       {
         label: t('translation|Status'),

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -366,7 +366,7 @@
                 tabindex="0"
               >
                 <table
-                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                  class="MuiTable-root css-qm21mn-MuiTable-root"
                 >
                   <thead
                     class="MuiTableHead-root css-15wwp11-MuiTableHead-root"


### PR DESCRIPTION
## Summary

This PR fixes a UI bug where long Kubernetes condition names (like PodReadyToStartContainers) were truncated in the Conditions table of resource details views. The fix ensures that the Condition column expands to accommodate the full name of the condition by using a min-content grid template.

## Related Issue

Fixes #4966

## Changes

`frontend/src/components/common/Resource/Resource.tsx:`
 1.Updated the ConditionsTable definition to support a gridTemplate property in its column configuration.
2.Set the gridTemplate to 'min-content' for the Condition column to prevent text truncation.

## Steps to Test

1.Navigate to the Workloads -> Pods section and select a Pod.
2.Scroll down to the Conditions section at the bottom of the details page.
3.Observe the first column (Condition).
4.Verification: Confirm that long condition names (e.g., PodReadyToStartContainers) are fully visible and no longer cut off with ellipses.

## Screenshots (if applicable)

Before:
<img width="750" height="144" alt="image" src="https://github.com/user-attachments/assets/6dc60418-d582-4efe-acd8-efc15be7e406" />


After:
<img width="750" height="144" alt="image" src="https://github.com/user-attachments/assets/987f7c7e-c826-45d8-9334-99a5401132eb" />

