### PR TITLE
frontend: resourceQuota: make ResourceQuota getters handle missing status

### DIFF
--- a/frontend/src/lib/k8s/resourceQuota.ts
+++ b/frontend/src/lib/k8s/resourceQuota.ts
@@ -43,7 +43,7 @@ interface status {
 
 export interface KubeResourceQuota extends KubeObjectInterface {
   spec: spec;
-  status: status;
+  status?: status;
 }
 
 class ResourceQuota extends KubeObject<KubeResourceQuota> {
@@ -62,17 +62,18 @@ class ResourceQuota extends KubeObject<KubeResourceQuota> {
     return this.jsonData.spec;
   }
 
-  get status(): status {
+  get status(): status | undefined {
     return this.jsonData.status;
   }
 
   get requests(): string[] {
     const req: string[] = [];
+    const used = this.jsonData.status?.used ?? {};
     this.spec.hard &&
       Object.keys(this.spec.hard).forEach(key => {
         if (key === 'cpu' || key === 'memory' || key.startsWith('requests.')) {
           req.push(
-            `${key}: ${normalizeUnit(key, this.status.used[key])}/${normalizeUnit(
+            `${key}: ${normalizeUnit(key, used[key] ?? '0')}/${normalizeUnit(
               key,
               this.spec.hard[key]
             )}`
@@ -84,11 +85,12 @@ class ResourceQuota extends KubeObject<KubeResourceQuota> {
 
   get limits(): string[] {
     const limits: string[] = [];
+    const used = this.jsonData.status?.used ?? {};
     this.spec.hard &&
       Object.keys(this.spec.hard).forEach(key => {
         if (key.startsWith('limits.')) {
           limits.push(
-            `${key}: ${normalizeUnit(key, this.status.used[key])}/${normalizeUnit(
+            `${key}: ${normalizeUnit(key, used[key] ?? '0')}/${normalizeUnit(
               key,
               this.spec.hard[key]
             )}`
@@ -100,12 +102,14 @@ class ResourceQuota extends KubeObject<KubeResourceQuota> {
 
   get resourceStats() {
     const stats: { name: string; hard: string; used: string }[] = [];
-    this.status.hard &&
-      Object.keys(this.status.hard).forEach(key => {
+    const status = this.jsonData.status;
+    const used = status?.used ?? {};
+    status?.hard &&
+      Object.keys(status.hard).forEach(key => {
         stats.push({
           name: key,
-          hard: `${this.status.hard[key]}`,
-          used: `${this.status.used[key]}`,
+          hard: `${status.hard[key]}`,
+          used: `${used[key] ?? '0'}`,
         });
       });
     return stats;


### PR DESCRIPTION

## Summary
This PR fixes a ResourceQuota rendering issue on the Namespace details page by making ResourceQuota getters handle cases where status is not yet present immediately after creation.

## Related Issue

Fixes #4989 

## Changes

- Updated `frontend/src/lib/k8s/resourceQuota.ts` to guard requests, limits, and resourceStats against missing runtime  status
- Fixed the case where creating a new ResourceQuota could cause the Resource Quotas section to disappear

## Steps to Test

- Navigate to a Namespace details page that has a Resource Quotas section.
- Create a new `ResourceQuota` from that page and click Apply.
- Confirm the Resource Quotas section remains visible immediately after apply.
- Confirm the newly created `ResourceQuota `appears without requiring a full page refresh.
- Confirm quota usage/details populate normally once Kubernetes returns status.

## Screenshots (if applicable)
[Screencast from 2026-03-26 16-22-14.webm](https://github.com/user-attachments/assets/f814cad8-3bda-4927-849d-66a8322f8eff)


## Notes for the Reviewer

- This is a minimal fix scoped only to `ResourceQuota` getter behavior.
- The main issue was unsafe access to status.used and status.hard during the brief window after creation when Kubernetes had not populated status yet.
