### PR TITLE
Fix AppImage crash by disabling setuid sandbox in AppImage environment

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -54,6 +54,10 @@ import {
 import { addRunCmdConsent, removeRunCmdConsent, runScript, setupRunCmdHandlers } from './runCmd';
 import windowSize from './windowSize';
 
+if (process.env.APPIMAGE) {
+  app.commandLine.appendSwitch('disable-setuid-sandbox');
+}
+
 let isRunningScript = false;
 if (process.env.HEADLAMP_RUN_SCRIPT) {
   isRunningScript = true;


### PR DESCRIPTION
Fixes #4993

## Fix AppImage crash due to chrome-sandbox permission issue

### Problem

The AppImage fails to run on Linux systems because Electron attempts to use the `chrome-sandbox`, which requires root ownership (4755). This is not supported in AppImage environments, causing the application to crash.

### Solution

Disable the setuid sandbox when running inside AppImage by checking the `APPIMAGE` environment variable:

```ts
if (process.env.APPIMAGE) {
  app.commandLine.appendSwitch('disable-setuid-sandbox');
}
```

### Result

* AppImage runs successfully on systems like Kubuntu 25.10
* No impact on other platforms

