### PR TITLE
fix: show error notification when cluster deletion fails

### DIFF
--- a/frontend/src/components/App/Home/ClusterContextMenu.tsx
+++ b/frontend/src/components/App/Home/ClusterContextMenu.tsx
@@ -34,6 +34,7 @@ import { setConfig } from '../../../redux/configSlice';
 import { useTypedSelector } from '../../../redux/hooks';
 import { ConfirmDialog } from '../../common/ConfirmDialog';
 import ErrorBoundary from '../../common/ErrorBoundary/ErrorBoundary';
+import { Notification, setNotifications } from '../Notifications/notificationsSlice';
 
 interface ClusterContextMenuProps {
   /** The cluster for the context menu to act on. */
@@ -68,9 +69,14 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
         dispatch(setConfig(config));
       })
       .catch((err: Error) => {
-        if (err.message === 'Not Found') {
-          // TODO: create notification with error message
-        }
+        const notification = new Notification({
+          message: t('translation|Failed to delete cluster "{{ clusterName }}": {{ error }}', {
+            clusterName,
+            error: err.message,
+          }),
+          cluster: clusterName,
+        });
+        dispatch(setNotifications(notification.toJSON()));
       })
       .finally(() => {
         history.push('/');

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -42,6 +42,7 @@ import Link from '../../common/Link';
 import Loader from '../../common/Loader';
 import NameValueTable from '../../common/NameValueTable';
 import SectionBox from '../../common/SectionBox';
+import { Notification, setNotifications } from '../Notifications/notificationsSlice';
 import { ClusterNameEditor } from './ClusterNameEditor';
 import ClusterSelector from './ClusterSelector';
 import ColorPicker from './ColorPicker';
@@ -83,9 +84,14 @@ export default function SettingsCluster() {
         history.push('/');
       })
       .catch((err: Error) => {
-        if (err.message === 'Not Found') {
-          // TODO: create notification with error message
-        }
+        const notification = new Notification({
+          message: t('translation|Failed to delete cluster "{{ clusterName }}": {{ error }}', {
+            clusterName: cluster,
+            error: err.message,
+          }),
+          cluster: cluster || '',
+        });
+        dispatch(setNotifications(notification.toJSON()));
       });
   };
 

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Laden aus KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Load from KubeConfig",
   "Providers": "Providers",
   "Add Local Cluster Provider": "Add Local Cluster Provider",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "Failed to delete cluster \"{{ clusterName }}\": {{ error }}",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "This action will remove cluster \"{{ clusterName }}\".",
   "This action cannot be undone! Do you want to proceed?": "This action cannot be undone! Do you want to proceed?",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Cargar desde KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Charger à partir d'un KubeConfig",
   "Providers": "Fournisseurs",
   "Add Local Cluster Provider": "Ajouter un fournisseur de cluster local",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "Cette action supprimera le cluster \"{{ clusterName }}\" de \"{{ source }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "Cette action supprimera le cluster \"{{ clusterName }}\".",
   "This action cannot be undone! Do you want to proceed?": "Cette action ne peut pas être annulée ! Voulez-vous continuer ?",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "KubeConfig से लोड करें",
   "Providers": "प्रदाता",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Carica da KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "KubeConfig から読み込む",
   "Providers": "プロバイダー",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "KubeConfig에서 불러오기",
   "Providers": "제공자",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Carregar a partir de um KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "கியூப்கான்ஃபிக்கிலிருந்து ஏற்றுக",
   "Providers": "வழங்குநர்கள்",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "இந்த செயல் \"{{ source }}\" இலிருந்து \"{{ clusterName }}\" க்ளஸ்டரை நீக்கும்.",
   "This action will remove cluster \"{{ clusterName }}\".": "இந்த செயல் \"{{ clusterName }}\" க்ளஸ்டரை நீக்கும்.",
   "This action cannot be undone! Do you want to proceed?": "இந்த செயலை மீட்டெடுக்க முடியாது! நீங்கள் தொடர விரும்புகிறீர்களா?",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "從 KubeConfig 讀取",
   "Providers": "提供者",
   "Add Local Cluster Provider": "新增本地叢集提供者",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "此操作將從 \"{{ source }}\" 刪除叢集 \"{{ clusterName }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "此操作將移除叢集 \"{{ clusterName }}\"。",
   "This action cannot be undone! Do you want to proceed?": "此操作無法復原！您要繼續嗎？",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "从 kubeconfig 加载",
   "Providers": "提供者",
   "Add Local Cluster Provider": "添加本地集群提供者",
+  "Failed to delete cluster \"{{ clusterName }}\": {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "此操作将从 \"{{ source }}\" 中删除集群 \"{{ clusterName }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "此操作将移除集群 \"{{ clusterName }}\"。",
   "This action cannot be undone! Do you want to proceed?": "此操作无法撤销！是否继续？",


### PR DESCRIPTION
## Summary

@illume @joaquimrocha  This PR fixes a bug where errors from `deleteCluster()` were silently swallowed and the user was redirected to home with no feedback. This resolves the TODO comments in `ClusterContextMenu` and `SettingsCluster` by dispatching an error notification via the existing Redux notification system.

## Related Issue

Fixes #4928 

## Changes

- Updated `frontend/src/components/App/Home/ClusterContextMenu.tsx` to dispatch an error notification when cluster deletion fails
- Updated `frontend/src/components/App/Settings/SettingsCluster.tsx` with the same error notification fix
- Removed the `// TODO: create notification with error message` comments in both files

## Steps to Test

1. Add a dynamic cluster or kubeconfig-based cluster in Headlamp
2. Attempt to delete the cluster via the ⋮ context menu on the Home page while the cluster is already unavailable on the backend (or simulate a failure)
3. Observe that an error notification now appears in the notification bell instead of a silent redirect to `/`
4. Repeat steps 1–3 from the cluster Settings page (Settings > Cluster > Remove Cluster button)

## Screenshots (if applicable)

_Before: user is silently redirected to home with no feedback._
_After: an error notification appears in the notification bell with the cluster name and error message._

## Notes for the Reviewer

- This fix handles **all** errors from `deleteCluster()`, not just `Not Found`, which is a superset of what the original TODO described as this is intentional since any failure should be surfaced to the user.
- The notification message uses the existing i18n `t()` function, so please check translation key consistency if needed.
- No new dependencies or infrastructure were added; this uses the existing `Notification` class and `setNotifications` Redux action already in the codebase.
