### PR TITLE
frontend: Fix cross-namespace resource linking in Map view

### DIFF
--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -69,7 +69,16 @@ const makeRelation = <From extends KubeObjectClass, To extends KubeObjectClass>(
     const fromObject = fromNode.kubeObject as InstanceType<From>;
     const toObject = toNode.kubeObject as InstanceType<To>;
 
-    return fromObject.cluster === toObject.cluster && Boolean(selector(fromObject, toObject));
+    const hasSameNamespace =
+      !fromObject.metadata?.namespace || !toObject.metadata?.namespace
+        ? true
+        : fromObject.metadata.namespace === toObject.metadata.namespace;
+
+    return (
+      fromObject.cluster === toObject.cluster &&
+      hasSameNamespace &&
+      Boolean(selector(fromObject, toObject))
+    );
   },
 });
 


### PR DESCRIPTION
**Summary**

This PR solves the bug where resources with the same name in different namespaces were being incorrectly linked in the Map view.

Fixes #5003 

**Changes**

1.Modified makeRelation in relations.tsx to include a namespace check for resource connection.
2.Added a new makeClusterRelation helper for cluster-wide resources (like Webhook and GatewayClass) to still allow cross-namespace communication.
3.Updated vwcToService, mwcToService, and gatewayToGatewayClass to use this new helper.

Before:

<img width="1544" height="908" alt="image" src="https://github.com/user-attachments/assets/ec9dccad-ab6a-4c19-9be9-09f9580c2730" />

After:

<img width="1544" height="908" alt="image" src="https://github.com/user-attachments/assets/c132fafb-fe24-4654-8420-eb5d124ebba1" />


**Steps to Test**

1.Create a ConfigMap named 'config' in Namespace-A and Namespace-B.
2.View them in the Map.
3.Earlier, they would have been connected incorrectly, but now they are isolated in their own namespaces.