### PR TITLE
frontend: clusterAction: Show specific PodDisruptionBudget error 

### DIFF
--- a/frontend/src/redux/clusterActionSlice.test.ts
+++ b/frontend/src/redux/clusterActionSlice.test.ts
@@ -167,12 +167,43 @@ describe('clusterActionSlice', () => {
         expect.objectContaining({
           type: updateClusterAction.type,
           payload: expect.objectContaining({
-            message: 'Error',
+            message: 'Error. Something went wrong',
           }),
         })
       );
 
       expect(callback).toHaveBeenCalled();
+    });
+
+    it('should show the full error message and avoid double punctuation', async () => {
+      const callback = vi.fn(() => {
+        throw new Error(
+          "error context - Cannot evict pod as it would violate the pod's disruption budget."
+        );
+      });
+
+      const action: CallbackAction = {
+        callback,
+        startMessage: 'Starting',
+        successMessage: 'Success',
+        errorMessage: 'Error deleting item.',
+      };
+
+      vi.useFakeTimers();
+      const dispatchedAction = store.dispatch(executeClusterAction(action));
+      vi.advanceTimersByTime(CLUSTER_ACTION_GRACE_PERIOD);
+      await dispatchedAction;
+
+      const actions = store.getActions();
+      expect(actions).toContainEqual(
+        expect.objectContaining({
+          type: updateClusterAction.type,
+          payload: expect.objectContaining({
+            message:
+              "Error deleting item. error context - Cannot evict pod as it would violate the pod's disruption budget.",
+          }),
+        })
+      );
     });
   });
 

--- a/frontend/src/redux/clusterActionSlice.ts
+++ b/frontend/src/redux/clusterActionSlice.ts
@@ -236,13 +236,29 @@ export const executeClusterAction = createAsyncThunk(
         })
       );
     }
-    function dispatchError() {
+    function dispatchError(err?: unknown) {
+      const originalMessage =
+        err instanceof Error
+          ? err.message
+          : err &&
+            typeof err === 'object' &&
+            'message' in err &&
+            typeof (err as any).message === 'string'
+          ? (err as any).message
+          : '';
+
+      let message = errorMessage;
+      if (originalMessage) {
+        const separator = errorMessage && !errorMessage.trim().endsWith('.') ? '. ' : ' ';
+        message = errorMessage ? `${errorMessage}${separator}${originalMessage}` : originalMessage;
+      }
+
       dispatch(
         updateClusterAction({
           buttons: undefined,
           dismissSnackbar: actionKey,
           id: actionKey,
-          message: errorMessage,
+          message,
           state: 'error',
           snackbarProps: errorOptions,
           url: errorUrl,
@@ -289,7 +305,7 @@ export const executeClusterAction = createAsyncThunk(
             }
           }
         } else {
-          dispatchError();
+          dispatchError(err);
         }
       } finally {
         controllers.delete(actionKey);


### PR DESCRIPTION
**Summary:**
Improved error feedback in Headlamp by surfacing the original backend error message in cluster action notifications (e.g., pod deletion, eviction).

Previously, users only saw a generic error message (e.g., "Error deleting item.").Now, the specific error returned by the Kubernetes API is appended to that message,giving users actionable context — for example, when a PodDisruptionBudget blocks an eviction.

Fixes #5014

**Changes:**
- Updated `executeClusterAction` Redux thunk in `clusterActionSlice.ts` to pass the original error object to `dispatchError`.
- Updated `dispatchError` to extract and append the backend error message to the user-facing snackbar notification for any cluster action failure.
- Added tests verifying the full error message is shown and double-punctuation is handled cleanly.

**Steps to Test:**
1. Go to Settings and enable "Use Eviction instead of Deletion".
2. Create a Pod and a corresponding PDB with `maxUnavailable: 0`.
3. Try deleting the pod from the Pods list.
4. **Expected:** A red notification appears showing both the generic message and the specific Kubernetes API error  (e.g., _"Error deleting item. Cannot evict pod as it would violate the pod's disruption budget."_)
