### PR TITLE
frontend: EditorDialog :add yaml diff view in editor to compare original manifest against edited

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import '../../../i18n/config';
-import Editor from '@monaco-editor/react';
+import { DiffEditor, Editor } from '@monaco-editor/react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import DialogActions from '@mui/material/DialogActions';
@@ -121,6 +121,7 @@ export default function EditorDialog(props: EditorDialogProps) {
     false
   );
   const [uploadFiles, setUploadFiles] = React.useState(false);
+  const [hasOpenedDiffEditor, setHasOpenedDiffEditor] = React.useState(false);
 
   const dispatchCreateEvent = useEventCallback(HeadlampEventType.CREATE_RESOURCE);
   const dispatch: AppDispatch = useDispatch();
@@ -266,6 +267,10 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   function handleTabChange(tabIndex: number) {
+    if (tabIndex === 2) {
+      setHasOpenedDiffEditor(true);
+    }
+
     // Check if the docs tab has been selected.
     if (tabIndex !== 1) {
       return;
@@ -377,6 +382,27 @@ export default function EditorDialog(props: EditorDialogProps) {
     );
   }
 
+  function makeDiffEditor() {
+    const language = code.format || originalCodeRef.current.format || 'yaml';
+
+    return (
+      <Box height="100%">
+        <DiffEditor
+          original={originalCodeRef.current.code}
+          modified={code.code}
+          language={language}
+          theme={theme.base === 'dark' ? 'vs-dark' : 'light'}
+          height="100%"
+          options={{
+            automaticLayout: true,
+            readOnly: true,
+            renderSideBySide: true,
+          }}
+        />
+      </Box>
+    );
+  }
+
   const errorLabel = error || errorMessage;
   let dialogTitle = title;
   if (!dialogTitle && item) {
@@ -468,6 +494,10 @@ export default function EditorDialog(props: EditorDialogProps) {
                     <DocsViewer docSpecs={docSpecs} />
                   </Box>
                 ),
+              },
+              {
+                label: t('translation|Review Changes'),
+                component: hasOpenedDiffEditor ? makeDiffEditor() : null,
               },
             ]}
           />

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -185,6 +185,20 @@
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </button>
+                <button
+                  aria-controls="full-width-tabpanel-2-Editor-tabs-id"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                  id="full-width-tab-2-Editor-tabs-id"
+                  role="tab"
+                  tabindex="-1"
+                  type="button"
+                >
+                  Review Changes
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
               </div>
               <span
                 class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
@@ -227,6 +241,13 @@
               </div>
             </div>
           </div>
+          <div
+            aria-labelledby="full-width-tab-2-Editor-tabs-id"
+            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            hidden=""
+            id="full-width-tabpanel-2-Editor-tabs-id"
+            role="tabpanel"
+          />
         </div>
         <div
           class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -221,6 +221,20 @@
                     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   />
                 </button>
+                <button
+                  aria-controls="full-width-tabpanel-2-Editor-tabs-id"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                  id="full-width-tab-2-Editor-tabs-id"
+                  role="tab"
+                  tabindex="-1"
+                  type="button"
+                >
+                  Review Changes
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
               </div>
               <span
                 class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
@@ -263,6 +277,13 @@
               </div>
             </div>
           </div>
+          <div
+            aria-labelledby="full-width-tab-2-Editor-tabs-id"
+            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            hidden=""
+            id="full-width-tabpanel-2-Editor-tabs-id"
+            role="tabpanel"
+          />
         </div>
         <div
           class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -331,6 +331,7 @@
   "Upload File/URL": "",
   "Editor": "Editor",
   "Documentation": "Dokumentation",
+  "Review Changes": "",
   "Undo": "Rückgängig machen",
   "Are you sure?": "Sind Sie sicher?",
   "This will discard your changes in the editor. Do you want to proceed?": "Dadurch werden Ihre Änderungen im Editor verworfen. Möchten Sie fortfahren?",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -331,6 +331,7 @@
   "Upload File/URL": "Upload File/URL",
   "Editor": "Editor",
   "Documentation": "Documentation",
+  "Review Changes": "Review Changes",
   "Undo": "Undo",
   "Are you sure?": "Are you sure?",
   "This will discard your changes in the editor. Do you want to proceed?": "This will discard your changes in the editor. Do you want to proceed?",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -332,6 +332,7 @@
   "Upload File/URL": "",
   "Editor": "Editor",
   "Documentation": "Documentación",
+  "Review Changes": "",
   "Undo": "Deshacer",
   "Are you sure?": "¿Está seguro?",
   "This will discard your changes in the editor. Do you want to proceed?": "Esto descartará sus cambios en el editor. ¿Desea avanzar?",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -332,6 +332,7 @@
   "Upload File/URL": "Télécharger un fichier/URL",
   "Editor": "Éditeur",
   "Documentation": "Documentation",
+  "Review Changes": "",
   "Undo": "Annuler",
   "Are you sure?": "Êtes-vous sûr ?",
   "This will discard your changes in the editor. Do you want to proceed?": "Vos modifications seront perdues. Voulez-vous continuer ?",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -331,6 +331,7 @@
   "Upload File/URL": "",
   "Editor": "संपादक",
   "Documentation": "दस्तावेज़ीकरण",
+  "Review Changes": "",
   "Undo": "पूर्ववत करें",
   "Are you sure?": "क्या आप निश्चित हैं?",
   "This will discard your changes in the editor. Do you want to proceed?": "इससे संपादक में आपके परिवर्तन त्याग दिए जाएंगे। क्या आप आगे बढ़ना चाहते हैं?",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -332,6 +332,7 @@
   "Upload File/URL": "",
   "Editor": "Editor",
   "Documentation": "Documentazione",
+  "Review Changes": "",
   "Undo": "Annulla",
   "Are you sure?": "Sei sicuro?",
   "This will discard your changes in the editor. Do you want to proceed?": "Questo annullerà le modifiche apportate nell'editor. Vuoi procedere?",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -330,6 +330,7 @@
   "Upload File/URL": "",
   "Editor": "エディター",
   "Documentation": "ドキュメント",
+  "Review Changes": "",
   "Undo": "元に戻す",
   "Are you sure?": "よろしいですか？",
   "This will discard your changes in the editor. Do you want to proceed?": "エディターでの変更が破棄されます。続行しますか？",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -330,6 +330,7 @@
   "Upload File/URL": "",
   "Editor": "에디터",
   "Documentation": "문서",
+  "Review Changes": "",
   "Undo": "실행 취소",
   "Are you sure?": "확실합니까?",
   "This will discard your changes in the editor. Do you want to proceed?": "편집기의 변경 사항이 삭제됩니다. 계속하시겠습니까?",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -332,6 +332,7 @@
   "Upload File/URL": "",
   "Editor": "Editor",
   "Documentation": "Documentação",
+  "Review Changes": "",
   "Undo": "Desfazer",
   "Are you sure?": "Tem a certeza?",
   "This will discard your changes in the editor. Do you want to proceed?": "Irá descartar as suas modificações no editor. Deseja prosseguir?",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -331,6 +331,7 @@
   "Upload File/URL": "",
   "Editor": "எடிட்டர்",
   "Documentation": "ஆவணப்படுத்தல்",
+  "Review Changes": "",
   "Undo": "செயல்தவிர்",
   "Are you sure?": "உறுதியாகவா?",
   "This will discard your changes in the editor. Do you want to proceed?": "இது எடிட்டரில் உங்கள் மாற்றங்களை நிராகரிக்கும். தொடர விரும்புகிறீர்களா?",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -330,6 +330,7 @@
   "Upload File/URL": "",
   "Editor": "編輯器",
   "Documentation": "檔案",
+  "Review Changes": "",
   "Undo": "撤銷",
   "Are you sure?": "您確定嗎？",
   "This will discard your changes in the editor. Do you want to proceed?": "這將放棄您在編輯器中的更改。您要繼續嗎？",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -330,6 +330,7 @@
   "Upload File/URL": "上传文件/URL",
   "Editor": "编辑器",
   "Documentation": "文件",
+  "Review Changes": "",
   "Undo": "撤销",
   "Are you sure?": "您确定吗？",
   "This will discard your changes in the editor. Do you want to proceed?": "这将放弃您在编辑器中的更改。您要继续吗？",

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@iconify/react', () => ({
 
 vi.mock('@monaco-editor/react', () => ({
   Editor: () => <div className="mock-monaco-editor" />,
+  DiffEditor: () => <div className="mock-monaco-diff-editor" />,
   useMonaco: () => null,
   loader: { config: () => null },
   default: () => <div className="mock-monaco-editor" />,


### PR DESCRIPTION
## Summary

This PR adds a YAML diff view to the resource editor by introducing a read-only `Review changes` tab in the existing editor dialog, allowing users to compare the original manifest with their edited version before applying changes.

## Related Issue

Fixes #5012 

## Changes

- Added a new `Review changes` tab in the resource editor dialog
- Updated `EditorDialog` to render Monaco's read-only `DiffEditor` with original vs edited manifest content
- Updated the Storybook Monaco mock to include `DiffEditor` so editor stories continue to render in tests

## Steps to Test

1. Start Headlamp locally and open any editable Kubernetes resource in the YAML editor.
2. Make a change to the manifest in the `Editor` tab.
3. Switch to the `Review changes` tab and confirm the original manifest is shown on one side and the edited manifest on the other.
4. Verify that added, removed, and modified lines are highlighted and that the diff view is read-only.
5. Switch between `Editor`, `Documentation`, and `Review changes` to confirm the existing editing flow still works.
6. Apply the manifest and confirm the save/apply behavior is unchanged.

## Screenshots (if applicable)
<img width="3071" height="1555" alt="image" src="https://github.com/user-attachments/assets/0b197298-e8f5-4045-85e4-92113d6397dc" />



## Notes for the Reviewer

- This is a minimal UI change localized to the resource editor dialog.
- No new dependency was added; it reuses Monaco's built-in `DiffEditor`.
- Storybook test mocks needed a small update because `@monaco-editor/react` was previously only mocking `Editor`.
