### PR TITLE
frontend: Activity: Adjust colors for activity panel text

### DIFF
--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -449,7 +449,10 @@ export function SingleActivityRenderer({
               {cluster && (
                 <Box
                   sx={theme => ({
+                    display: 'flex',
+                    alignItems: 'center',
                     fontSize: '0.875rem',
+                    gap: 0.25,
                     paddingX: 0.5,
                     color: theme.palette.text.secondary,
                   })}
@@ -1152,7 +1155,7 @@ export const ActivityBar = React.memo(function ({
           })}
         >
           <Button
-            sx={{
+            sx={theme => ({
               height: '100%',
               padding: '0px 5px 0 10px',
               lineHeight: 1,
@@ -1160,7 +1163,8 @@ export const ActivityBar = React.memo(function ({
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               justifyContent: 'start',
-            }}
+              color: theme.palette.text.primary,
+            })}
             onClick={() => {
               // Minimize or show Activity, unless it's not active then bring it to front
               Activity.update(it.id, { minimized: it.id !== lastElement ? false : !it.minimized });
@@ -1184,7 +1188,9 @@ export const ActivityBar = React.memo(function ({
                 overflow: 'hidden',
               }}
             >
-              {it.cluster && <Box sx={{ opacity: 0.7 }}>{it.cluster}</Box>}{' '}
+              {it.cluster && (
+                <Box sx={theme => ({ color: theme.palette.text.secondary })}>{it.cluster}</Box>
+              )}
               <Box
                 sx={{
                   whiteSpace: 'nowrap',

--- a/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
+++ b/frontend/src/components/activity/__snapshots__/Activity.Basic.stories.storyshot
@@ -135,7 +135,7 @@
           class="MuiBox-root css-16dgwon"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1jy96qb-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1m1hqao-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -145,7 +145,6 @@
             <div
               class="MuiBox-root css-18bzmof"
             >
-               
               <div
                 class="MuiBox-root css-1h2ruwl"
               >
@@ -171,7 +170,7 @@
           class="MuiBox-root css-15k1pc3"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1jy96qb-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1m1hqao-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -181,7 +180,6 @@
             <div
               class="MuiBox-root css-18bzmof"
             >
-               
               <div
                 class="MuiBox-root css-1h2ruwl"
               >


### PR DESCRIPTION
Fixes text alignment for the cluster indicator in the activity window

<img width="375" height="146" alt="image" src="https://github.com/user-attachments/assets/f92c1f85-b119-463b-bc0f-df315ece7c53" />

Fixes text color for activity bar for themes with custom primary color (like 'lights out')

<img width="379" height="110" alt="image" src="https://github.com/user-attachments/assets/caf59a47-3228-41df-bb97-aee2f08427c4" />

## Steps to Test

1. Open activity
2. Check mentioned elements
