### PR TITLE
fix: upgrade zlib to 1.3.2-r0 to address CVE-2026-22184 and CVE-2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 # Final container image
-ARG IMAGE_BASE=alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+ARG IMAGE_BASE=alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 FROM ${IMAGE_BASE} AS image-base
 
-FROM --platform=${BUILDPLATFORM} golang:1.25.8@sha256:f55a6ec7f24aedc1ed66e2641fdc52de01f2d24d6e49d1fa38582c07dd5f601d AS backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.25.8@sha256:3ac2864710f25e84381bf5d4272261c7ba73ada0339d62034df4de20dabb33ca AS backend-build
 
 WORKDIR /headlamp
 
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go build -o ./headlamp-server ./cmd/
 
-FROM --platform=${BUILDPLATFORM} node:22@sha256:f90672bf4c76dfc077d17be4c115b1ae7731d2e8558b457d86bca42aeb193866 AS frontend-build
+FROM --platform=${BUILDPLATFORM} node:22@sha256:9059d9d7db987b86299e052ff6630cd95e5a770336967c21110e53289a877433 AS frontend-build
 
 # We need .git and app/ in order to get the version and git version for the frontend/.env file
 # that's generated when building the frontend.

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,5 +1,5 @@
 # Build the plugin
-FROM node:22@sha256:f90672bf4c76dfc077d17be4c115b1ae7731d2e8558b457d86bca42aeb193866 as builder
+FROM node:22@sha256:9059d9d7db987b86299e052ff6630cd95e5a770336967c21110e53289a877433 as builder
 
 # Set the working directory
 WORKDIR /headlamp-plugins
@@ -25,7 +25,7 @@ RUN find /headlamp-plugins -mindepth 1 -maxdepth 1 -type d ! -name "headlamp-plu
 RUN find /headlamp-plugins -mindepth 1 -maxdepth 1 -type d ! -name "headlamp-plugin" -exec ./headlamp-plugin/bin/headlamp-plugin.js extract {} /headlamp-plugins/build \;
 
 # Create the final image
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 # Copy the built plugin files from the first stage to /plugins directory
 COPY --from=builder /headlamp-plugins/build/ /plugins/


### PR DESCRIPTION
Fixes #5028

## Summary

This PR fixes a security vulnerability by upgrading zlib from 1.3.1-r2 to 1.3.2-r0 in the final Alpine-based stages of Dockerfile and Dockerfile.plugins. This addresses two CVEs flagged by Trivy in the container image ghcr.io/headlamp- k8s/headlamp:v0.41.0 (alpine 3.23.3):

## Related Issue

Fixes #5028

## Changes

1.Added RUN apk upgrade --no-cache zlib to the final stage in Dockerfile
2.Added RUN apk upgrade --no-cache zlib after the FROM alpine:3.23.3 line in Dockerfile.plugins

## Steps to Test

1.Build the main image: docker build --target final -t headlamp-test .
2.Verify zlib version: docker run --rm headlamp-test apk info zlib → should show zlib-1.3.2-r0
3.Build the plugins image: docker build -f Dockerfile.plugins -t headlamp-plugins-test .
4.Verify zlib version: docker run --rm headlamp-plugins-test apk info zlib → should show zlib-1.3.2-r0