### PR TITLE
frontend: ResourceTable: Add new 'labels' column to all list views to allow searching by label

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -112,7 +112,7 @@ export type ResourceTableColumn<RowItem> = {
     }
 );
 
-export type ColumnType = 'age' | 'name' | 'namespace' | 'type' | 'kind' | 'cluster';
+export type ColumnType = 'age' | 'name' | 'namespace' | 'type' | 'kind' | 'cluster' | 'labels';
 
 /**
  * Default column ID to use for sorting when no explicit default is provided.
@@ -220,6 +220,10 @@ function initColumnVisibilityState(columns: ResourceTableProps<any>['columns'], 
 
   // Apply default visibility we got from the props
   columns.forEach((col, index) => {
+    // Labels column is hidden by default
+    if (col === 'labels') {
+      visibility[col] = false;
+    }
     if (typeof col === 'string') return;
 
     if ('show' in col) {
@@ -427,6 +431,19 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
                     iconProps={{ color: theme.palette.text.primary }}
                   />
                 ),
+            };
+
+          case 'labels':
+            return {
+              id: 'labels',
+              header: t('translation|Labels'),
+              gridTemplate: 'min-content',
+              accessorFn: (item: RowItem) =>
+                item.metadata.labels
+                  ? Object.entries(item.metadata.labels)
+                      .map(([key, value]) => key + '=' + value)
+                      .join(', ')
+                  : '',
             };
           case 'namespace':
             return {

--- a/frontend/src/components/configmap/List.tsx
+++ b/frontend/src/components/configmap/List.tsx
@@ -35,6 +35,7 @@ export default function ConfigMapList() {
           getValue: (configmap: ConfigMap) => Object.keys(configmap.data || {}).length || 0,
           gridTemplate: 'min-content',
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -144,6 +144,7 @@ function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
             },
           },
           'namespace',
+          'labels',
           'age',
         ]}
       />

--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -158,6 +158,7 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
       },
       ...(isMultiCluster ? (['cluster'] as ColumnType[]) : ([] as ColumnType[])),
       ...additionalPrinterCols,
+      'labels',
       'age',
     ];
 

--- a/frontend/src/components/crd/List.tsx
+++ b/frontend/src/components/crd/List.tsx
@@ -95,6 +95,7 @@ export default function CustomResourceDefinitionList() {
           filterSelectOptions: categories,
         },
         'cluster',
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/cronjob/List.tsx
+++ b/frontend/src/components/cronjob/List.tsx
@@ -119,6 +119,7 @@ export default function CronJobList() {
             );
           },
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/daemonset/List.tsx
+++ b/frontend/src/components/daemonset/List.tsx
@@ -103,6 +103,7 @@ export default function DaemonSetList() {
             );
           },
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/deployments/List.tsx
+++ b/frontend/src/components/deployments/List.tsx
@@ -176,6 +176,7 @@ export default function DeploymentsList() {
           },
           show: false,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/endpointSlices/List.tsx
+++ b/frontend/src/components/endpointSlices/List.tsx
@@ -77,6 +77,7 @@ export default function EndpointSliceList() {
           filterVariant: 'multi-select',
           getValue: endpoint => endpoint?.spec?.addressType ?? '',
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/endpoints/List.tsx
+++ b/frontend/src/components/endpoints/List.tsx
@@ -44,6 +44,7 @@ export default function EndpointList() {
           render: endpoint => <LabelListItem labels={endpoint.getAddresses()} />,
           gridTemplate: 1.5,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/gateway/BackendTLSPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.tsx
@@ -47,6 +47,7 @@ export default function BackendTLSPolicyList() {
             <LabelListItem labels={[policy.validation.hostname]} />
           ),
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
@@ -52,6 +52,7 @@ export default function BackendTrafficPolicyList() {
             return <LabelListItem labels={[label]} />;
           },
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/gateway/ClassList.tsx
+++ b/frontend/src/components/gateway/ClassList.tsx
@@ -87,6 +87,7 @@ export default function GatewayClassList() {
           render: (gatewayClass: GatewayClass) =>
             makeGatewayStatusLabel(gatewayClass.status?.conditions || null),
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/gateway/GatewayList.tsx
+++ b/frontend/src/components/gateway/GatewayList.tsx
@@ -60,6 +60,7 @@ export default function GatewayList() {
           label: t('translation|Listeners'),
           getValue: (gateway: Gateway) => gateway.spec.listeners.length,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/gateway/HTTPRouteList.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.tsx
@@ -43,6 +43,7 @@ export default function HTTPRouteList() {
           label: t('translation|rules'),
           getValue: (httpRoute: HTTPRoute) => httpRoute.spec.rules?.length,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/gateway/ReferenceGrantList.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantList.tsx
@@ -50,6 +50,7 @@ export default function ReferenceGrantList() {
             />
           ),
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/horizontalPodAutoscaler/List.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/List.tsx
@@ -104,6 +104,7 @@ export default function HpaList() {
           gridTemplate: 'min-content',
           getValue: item => item.status.currentReplicas,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/ingress/ClassList.tsx
+++ b/frontend/src/components/ingress/ClassList.tsx
@@ -55,6 +55,7 @@ export default function IngressClassList() {
             return apiGroup ? `${kind}.${apiGroup}/${name}` : name;
           },
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/ingress/List.tsx
+++ b/frontend/src/components/ingress/List.tsx
@@ -95,6 +95,7 @@ export default function IngressList() {
           getValue: () => '',
           render: (ingress: Ingress) => <RulesDisplay ingress={ingress} />,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/job/List.tsx
+++ b/frontend/src/components/job/List.tsx
@@ -202,6 +202,7 @@ export function JobsListRenderer(props: JobsListRendererProps) {
             );
           },
         },
+        'labels',
         'age',
       ]}
       data={jobs}

--- a/frontend/src/components/lease/List.tsx
+++ b/frontend/src/components/lease/List.tsx
@@ -33,6 +33,7 @@ export function LeaseList() {
           label: t('translation|Holder'),
           getValue: item => item?.spec.holderIdentity,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/networkpolicy/List.tsx
+++ b/frontend/src/components/networkpolicy/List.tsx
@@ -75,6 +75,7 @@ export function NetworkPolicyList() {
             );
           },
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -166,6 +166,7 @@ export default function NodeList() {
           },
           show: false,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -474,6 +474,7 @@ export function PodListRenderer(props: PodListProps) {
           },
           show: false,
         },
+        'labels',
         'age',
       ]}
       data={pods}

--- a/frontend/src/components/podDisruptionBudget/List.tsx
+++ b/frontend/src/components/podDisruptionBudget/List.tsx
@@ -47,6 +47,7 @@ export default function PDBList() {
           gridTemplate: 'min-content',
           getValue: (item: PDB) => item.status.disruptionsAllowed || t('translation|N/A'),
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/priorityClass/List.tsx
+++ b/frontend/src/components/priorityClass/List.tsx
@@ -40,6 +40,7 @@ export default function PriorityClassList() {
           gridTemplate: 'min-content',
           getValue: item => String(item.globalDefault || 'False'),
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/replicaset/List.tsx
+++ b/frontend/src/components/replicaset/List.tsx
@@ -105,6 +105,7 @@ export default function ReplicaSetList() {
             return matchLabels && <MetadataDictGrid dict={matchLabels} />;
           },
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/resourceQuota/List.tsx
+++ b/frontend/src/components/resourceQuota/List.tsx
@@ -90,6 +90,7 @@ export function ResourceQuotaRenderer(props: ResourceQuotaProps) {
             return <WrappingBox>{limits}</WrappingBox>;
           },
         },
+        'labels',
         'age',
       ]}
       headerProps={{

--- a/frontend/src/components/role/BindingList.tsx
+++ b/frontend/src/components/role/BindingList.tsx
@@ -178,6 +178,7 @@ export default function RoleBindingList() {
           ),
           sort: sortBindings('Service Accounts'),
         },
+        'labels',
         'age',
       ]}
       data={allRoles}

--- a/frontend/src/components/role/List.tsx
+++ b/frontend/src/components/role/List.tsx
@@ -76,6 +76,7 @@ export default function RoleList({ namespaces }: { namespaces?: string[] }) {
         },
         'namespace',
         ...(isMultiCluster ? (['cluster'] as ColumnType[]) : ([] as ColumnType[])),
+        'labels',
         'age',
       ]}
       data={allRoles}

--- a/frontend/src/components/runtimeClass/List.tsx
+++ b/frontend/src/components/runtimeClass/List.tsx
@@ -33,6 +33,7 @@ export function RuntimeClassList() {
           label: t('translation|Handler'),
           getValue: item => item?.jsonData?.handler,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/secret/List.tsx
+++ b/frontend/src/components/secret/List.tsx
@@ -88,6 +88,7 @@ export default function SecretList() {
           gridTemplate: 'min-content',
           getValue: (secret: Secret) => Object.keys(secret.data || {}).length || 0,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/service/List.tsx
+++ b/frontend/src/components/service/List.tsx
@@ -86,6 +86,7 @@ export default function ServiceList() {
           render: service =>
             service.spec.selector ? <MetadataDictGrid dict={service.spec.selector} /> : null,
         },
+        'labels',
         'age',
       ]}
       actions={[

--- a/frontend/src/components/serviceaccount/List.tsx
+++ b/frontend/src/components/serviceaccount/List.tsx
@@ -35,6 +35,7 @@ export default function ServiceAccountList() {
           getValue: (serviceaccount: ServiceAccount) => serviceaccount?.secrets?.length || 0,
           gridTemplate: 'min-content',
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/statefulset/List.tsx
+++ b/frontend/src/components/statefulset/List.tsx
@@ -91,6 +91,7 @@ export default function StatefulSetList() {
             );
           },
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/storage/ClaimList.tsx
+++ b/frontend/src/components/storage/ClaimList.tsx
@@ -101,6 +101,7 @@ export default function VolumeClaimList() {
           render: volume => makePVCStatusLabel(volume),
           gridTemplate: 0.3,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/storage/ClassList.tsx
+++ b/frontend/src/components/storage/ClassList.tsx
@@ -62,6 +62,7 @@ export default function ClassList() {
           filterVariant: 'checkbox',
           getValue: storageClass => String(storageClass.allowVolumeExpansion),
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/storage/VolumeList.tsx
+++ b/frontend/src/components/storage/VolumeList.tsx
@@ -116,6 +116,7 @@ export default function VolumeList() {
           render: volume => makePVStatusLabel(volume),
           gridTemplate: 0.3,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/verticalPodAutoscaler/List.tsx
+++ b/frontend/src/components/verticalPodAutoscaler/List.tsx
@@ -71,6 +71,7 @@ export default function VpaList() {
               label: t('translation|Provided'),
               getValue: item => item?.status?.conditions?.[0]?.status ?? null,
             },
+            'labels',
             'age',
           ]}
         />

--- a/frontend/src/components/webhookconfiguration/MutatingWebhookConfigList.tsx
+++ b/frontend/src/components/webhookconfiguration/MutatingWebhookConfigList.tsx
@@ -33,6 +33,7 @@ export default function MutatingWebhookConfigurationList() {
           gridTemplate: 'min-content',
           getValue: mutatingWebhookConfig => mutatingWebhookConfig.webhooks?.length || 0,
         },
+        'labels',
         'age',
       ]}
     />

--- a/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.tsx
+++ b/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.tsx
@@ -34,6 +34,7 @@ export default function ValidatingWebhookConfigurationList() {
           gridTemplate: 'min-content',
           getValue: mutatingWebhookConfig => mutatingWebhookConfig.webhooks?.length || 0,
         },
+        'labels',
         'age',
       ]}
     />


### PR DESCRIPTION
fixes #2547

This PR adds a new 'labels' column (hidden by default) to all list views
This allows users to search items by label (like `app=test`) using the existing search bar in the table
Search works even if column is hidden, which it is by default

I've chosen the `label=value` format instead of `label:value` to keep it in line with kubectl (for example `kubectl get pods -l app=agent-sandbox-controller -A`)

<img width="1361" height="471" alt="image" src="https://github.com/user-attachments/assets/81e57f3f-5124-41e2-9e81-b68b31bc6bc8" />

How to test

1. Go to any table
2. type in label selector in the search bar