### PR TITLE
Frontend: Node: Add pod usage tile for node view

### DIFF
--- a/frontend/src/components/cluster/Charts/ResourceCharts.tsx
+++ b/frontend/src/components/cluster/Charts/ResourceCharts.tsx
@@ -23,6 +23,7 @@ import { parseCpu, parseRam, TO_GB, TO_ONE_CPU } from '../../../lib/units';
 import ResourceCircularChart, {
   CircularChartProps as ResourceCircularChartProps,
 } from '../../common/Resource/CircularChart';
+import TileChart from '../../common/TileChart';
 
 export function MemoryCircularChart(props: ResourceCircularChartProps) {
   const { noMetrics } = props;
@@ -92,6 +93,51 @@ export function CpuCircularChart(props: ResourceCircularChartProps) {
       resourceAvailableGetter={cpuAvailableGetter}
       title={noMetrics ? t('glossary|CPU') : t('translation|CPU Usage')}
       {...props}
+    />
+  );
+}
+
+export function PodCapacityCircularChart(props: { node: Node | null; pods: Pod[] | null }) {
+  const { node, pods } = props;
+  const { t } = useTranslation(['translation', 'glossary']);
+  const used = pods?.length ?? -1;
+  const rawTotal = node?.status?.allocatable?.pods ?? node?.status?.capacity?.pods;
+  const parsedTotal = Number(rawTotal);
+  const total = Number.isFinite(parsedTotal) ? parsedTotal : -1;
+  const isLoading = pods === null || total < 0;
+
+  function getLabel() {
+    if (isLoading || total <= 0) {
+      return '…';
+    }
+
+    return `${((used / total) * 100).toFixed(1)} %`;
+  }
+
+  function getLegend() {
+    if (isLoading || total <= 0) {
+      return '';
+    }
+
+    return t('translation|{{ used }} / {{ total }} Pods', { used, total });
+  }
+
+  return (
+    <TileChart
+      title={t('translation|Pod Usage')}
+      data={
+        isLoading || total <= 0
+          ? []
+          : [
+              {
+                name: 'used',
+                value: used,
+              },
+            ]
+      }
+      label={getLabel()}
+      legend={getLegend()}
+      total={isLoading ? -1 : total}
     />
   );
 }

--- a/frontend/src/components/cluster/Charts/index.ts
+++ b/frontend/src/components/cluster/Charts/index.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { CpuCircularChart, MemoryCircularChart } from './ResourceCharts';
+import { CpuCircularChart, MemoryCircularChart, PodCapacityCircularChart } from './ResourceCharts';
 import { NodesStatusCircleChart, PodsStatusCircleChart } from './StatusCharts';
 
-export { MemoryCircularChart, CpuCircularChart, PodsStatusCircleChart, NodesStatusCircleChart };
+export {
+  MemoryCircularChart,
+  CpuCircularChart,
+  PodCapacityCircularChart,
+  PodsStatusCircleChart,
+  NodesStatusCircleChart,
+};

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -16,7 +16,6 @@
 
 import { InlineIcon } from '@iconify/react';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
 import _ from 'lodash';
 import { useSnackbar } from 'notistack';
@@ -28,11 +27,12 @@ import { apply } from '../../lib/k8s/api/v1/apply';
 import { drainNode, drainNodeStatus } from '../../lib/k8s/api/v1/drainNode';
 import { KubeMetrics } from '../../lib/k8s/cluster';
 import Node from '../../lib/k8s/node';
+import Pod from '../../lib/k8s/pod';
 import { getCluster, timeAgo } from '../../lib/util';
 import { DefaultHeaderAction } from '../../redux/actionButtonsSlice';
 import { clusterAction } from '../../redux/clusterActionSlice';
 import { AppDispatch } from '../../redux/stores/store';
-import { CpuCircularChart, MemoryCircularChart } from '../cluster/Charts';
+import { CpuCircularChart, MemoryCircularChart, PodCapacityCircularChart } from '../cluster/Charts';
 import ActionButton from '../common/ActionButton';
 import ConfirmDialog from '../common/ConfirmDialog';
 import { StatusLabelProps } from '../common/Label';
@@ -66,6 +66,12 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
   const [isupdatingNodeScheduleProperty, setisUpdatingNodeScheduleProperty] = React.useState(false);
   const [isNodeDrainInProgress, setisNodeDrainInProgress] = React.useState(false);
   const [nodeFromAPI, nodeError] = Node.useGet(name);
+  const { items: nodePods } = Pod.useList({
+    fieldSelector: name
+      ? `spec.nodeName=${name},status.phase!=Succeeded,status.phase!=Failed`
+      : undefined,
+    cluster,
+  });
   const [node, setNode] = useState(nodeFromAPI);
   const noMetrics = metricsError?.status === 404;
   const [drainDialogOpen, setDrainDialogOpen] = useState(false);
@@ -209,7 +215,7 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
         cluster={cluster}
         error={nodeError}
         headerSection={item => (
-          <ChartsSection node={item} metrics={nodeMetrics} noMetrics={noMetrics} />
+          <ChartsSection node={item} pods={nodePods} metrics={nodeMetrics} noMetrics={noMetrics} />
         )}
         withEvents
         actions={item => {
@@ -297,12 +303,13 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
 
 interface ChartsSectionProps {
   node: Node | null;
+  pods: Pod[] | null;
   metrics: KubeMetrics[] | null;
   noMetrics?: boolean;
 }
 
 function ChartsSection(props: ChartsSectionProps) {
-  const { node, metrics, noMetrics } = props;
+  const { node, pods, metrics, noMetrics } = props;
   const { t } = useTranslation('glossary');
 
   function getUptime() {
@@ -320,15 +327,15 @@ function ChartsSection(props: ChartsSectionProps) {
 
   return (
     <Box py={2}>
-      <Grid
-        container
-        style={{
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))',
           marginBottom: '2rem',
         }}
-        alignItems="stretch"
-        spacing={2}
       >
-        <Grid item xs={4}>
+        <Box>
           <Paper
             variant="outlined"
             sx={theme => ({
@@ -341,18 +348,21 @@ function ChartsSection(props: ChartsSectionProps) {
           >
             <HeaderLabel value={getUptime()} label={t('Uptime')} />
           </Paper>
-        </Grid>
-        <Grid item xs={4}>
+        </Box>
+        <Box>
           <CpuCircularChart items={node && [node]} itemsMetrics={metrics} noMetrics={noMetrics} />
-        </Grid>
-        <Grid item xs={4}>
+        </Box>
+        <Box>
           <MemoryCircularChart
             items={node && [node]}
             itemsMetrics={metrics}
             noMetrics={noMetrics}
           />
-        </Grid>
-      </Grid>
+        </Box>
+        <Box>
+          <PodCapacityCircularChart node={node} pods={pods} />
+        </Box>
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "Speicherverbrauch",
   "{{ available }} units": "{{ available }} CPU-Anteile",
   "CPU Usage": "CPU-Nutzung",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Angefordert",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Bereit",
   "Recent clusters": "Aktuelle Cluster",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "Memory Usage",
   "{{ available }} units": "{{ available }} units",
   "CPU Usage": "CPU Usage",
+  "{{ used }} / {{ total }} Pods": "{{ used }} / {{ total }} Pods",
+  "Pod Usage": "Pod Usage",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Requested",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Recent clusters",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "Uso de la memoria",
   "{{ available }} units": "{{ available }} unidades",
   "CPU Usage": "Uso de la CPU",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} requeridos",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Clusters recientes",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "Utilisation de la mémoire",
   "{{ available }} units": "{{ available }} unités",
   "CPU Usage": "Utilisation du CPU",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Demandé(s)",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Groupes récents",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "मेमोरी उपयोग",
   "{{ available }} units": "{{ available }} इकाइयाँ",
   "CPU Usage": "CPU उपयोग",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} अनुरोधित",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} तैयार",
   "Recent clusters": "हाल के क्लस्टर",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "Utilizzo Memoria",
   "{{ available }} units": "{{ available }} unità",
   "CPU Usage": "Utilizzo CPU",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Richiesti",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Pronti",
   "Recent clusters": "Cluster recenti",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "メモリ使用量",
   "{{ available }} units": "{{ available }} ユニット",
   "CPU Usage": "CPU 使用量",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} リクエスト済み",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} 準備完了",
   "Recent clusters": "最近のクラスター",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "메모리 사용량",
   "{{ available }} units": "{{ available }} 단위",
   "CPU Usage": "CPU 사용량",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "요청됨: {{ numReady }} / {{ numItems }}",
   "{{ numReady }} / {{ numItems }} Ready": "준비됨: {{ numReady }} / {{ numItems }}",
   "Recent clusters": "최근 클러스터",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "Uso da memória",
   "{{ available }} units": "{{ available }} unidades",
   "CPU Usage": "Uso do CPU",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} requeridos",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Clusters recentes",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "நினைவக பயன்பாடு",
   "{{ available }} units": "{{ available }} அலகுகள்",
   "CPU Usage": "CPU பயன்பாடு",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} கோரப்பட்டது",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} தயார்",
   "Recent clusters": "சமீபத்திய க்ளஸ்டர்கள்",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "記憶體使用",
   "{{ available }} units": "{{ available }} 單位",
   "CPU Usage": "CPU 使用",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} 已請求",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} 已準備好",
   "Recent clusters": "最近的叢集",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -210,6 +210,8 @@
   "Memory Usage": "内存使用",
   "{{ available }} units": "{{ available }} 单位",
   "CPU Usage": "CPU 使用",
+  "{{ used }} / {{ total }} Pods": "",
+  "Pod Usage": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} 已请求",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} 已准备好",
   "Recent clusters": "最近的集群",


### PR DESCRIPTION
## Summary

This PR adds pod capacity usage to the node details view so users can see how many pods are scheduled on a node compared with that node's allocatable pod limit.

## Related Issue

Fixes #5034 


## Changes

- Added a pod usage circular tile for the node details header
- Fetched node-scoped pods using a `spec.nodeName=<node>` field selector in the node details view

## Steps to Test

1. Navigate to the Nodes page and open any single node details view
2. Confirm a Pod Usage tile appears 
3. Verify the Pod Usage tile shows the number of pods on that node out of the node pod limit


## Screenshots (if applicable)
<img width="3066" height="1535" alt="Screenshot from 2026-04-02 23-21-10" src="https://github.com/user-attachments/assets/5ab9d7cc-4621-4b4b-bbc7-c1868bd4b9c2" />


## Notes for the Reviewer

- Pod usage is calculated from pods fetched with `fieldSelector=spec.nodeName=<node-name>`
- The total uses `status.allocatable.pods` and falls back to `status.capacity.pods`
