### PR TITLE
storybook: Use 404 for unsupported v1beta1 CRD API endpoints

### DIFF
--- a/frontend/src/components/crd/CustomResourceDefinition.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceDefinition.stories.tsx
@@ -37,7 +37,7 @@ export default {
         storyBase: [
           http.get(
             'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () => HttpResponse.error()
+            () => new HttpResponse(null, { status: 404 })
           ),
           http.get(
             'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',

--- a/frontend/src/components/crd/CustomResourceDetails.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.stories.tsx
@@ -30,7 +30,19 @@ export default {
         storyBase: [
           http.get(
             'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () => HttpResponse.error()
+            () =>
+              HttpResponse.json(
+                {
+                  kind: 'Status',
+                  apiVersion: 'v1',
+                  status: 'Failure',
+                  message:
+                    'the server could not find the requested resource for /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+                  reason: 'NotFound',
+                  code: 404,
+                },
+                { status: 404 }
+              )
           ),
           http.get(
             'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',

--- a/frontend/src/components/crd/CustomResourceList.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceList.stories.tsx
@@ -44,7 +44,7 @@ export default {
           ),
           http.get(
             'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () => HttpResponse.error()
+            () => new HttpResponse(null, { status: 404 })
           ),
           http.get(
             'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',

--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -41,7 +41,18 @@ export default {
           ),
           http.get(
             'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () => HttpResponse.error()
+            () =>
+              HttpResponse.json(
+                {
+                  kind: 'Status',
+                  apiVersion: 'v1',
+                  status: 'Failure',
+                  reason: 'NotFound',
+                  message: 'the server could not find the requested resource',
+                  code: 404,
+                },
+                { status: 404 }
+              )
           ),
         ],
       },


### PR DESCRIPTION
## Summary

This PR replaces the previous logic in Storybook mocks for the deprecated v1beta1 CRD endpoint with a proper HTTP 404 response.

## Related Issue

Fixes #4735 

## Changes

- Updated `frontend/src/components/crd/CustomResourceDefinition.stories.tsx` to return a 404 status for the v1beta1 CRD endpoint.
- Updated `frontend/src/components/crd/CustomResourceList.stories.tsx` to return a 404 status for the v1beta1 CRD endpoint.

## Steps to Test

1. Run Storybook: `npm run frontend:storybook`
2. Navigate to the `crd/CustomResourceDefinition` or `crd/CustomResourceList` stories.
3. Open the browser DevTools Network tab.
4. Observe that the request to `.../apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions` now returns a 404 instead of a network error.

## Notes for the Reviewer

- I noticed `NS_ERROR_CONNECTION_REFUSED` errors in the network tab for `ws://` URLs. Are they in the scope of this PR ?
