### PR TITLE
frontend: redux: Surface original error messages in cluster actions

### DIFF
--- a/frontend/src/redux/clusterActionSlice.test.ts
+++ b/frontend/src/redux/clusterActionSlice.test.ts
@@ -167,7 +167,7 @@ describe('clusterActionSlice', () => {
         expect.objectContaining({
           type: updateClusterAction.type,
           payload: expect.objectContaining({
-            message: 'Error',
+            message: 'Error. Something went wrong',
           }),
         })
       );

--- a/frontend/src/redux/clusterActionSlice.ts
+++ b/frontend/src/redux/clusterActionSlice.ts
@@ -236,13 +236,22 @@ export const executeClusterAction = createAsyncThunk(
         })
       );
     }
-    function dispatchError() {
+    function dispatchError(err?: Error | string | null) {
+      let message = errorMessage || '';
+      if (err) {
+        const originalMessage = typeof err === 'string' ? err : err.message;
+        if (originalMessage) {
+          const separator = message ? (message.endsWith('.') ? ' ' : '. ') : '';
+          message = `${message}${separator}${originalMessage}`;
+        }
+      }
+
       dispatch(
         updateClusterAction({
           buttons: undefined,
           dismissSnackbar: actionKey,
           id: actionKey,
-          message: errorMessage,
+          message,
           state: 'error',
           snackbarProps: errorOptions,
           url: errorUrl,
@@ -278,7 +287,8 @@ export const executeClusterAction = createAsyncThunk(
         }
         dispatchSuccess();
       } catch (err) {
-        if ((err as Error).message === 'Action cancelled' || controller.signal.aborted) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        if (error.message === 'Action cancelled' || controller.signal.aborted) {
           dispatchCancelled();
 
           if (cancelCallback) {
@@ -289,7 +299,7 @@ export const executeClusterAction = createAsyncThunk(
             }
           }
         } else {
-          dispatchError();
+          dispatchError(error);
         }
       } finally {
         controllers.delete(actionKey);


### PR DESCRIPTION
## Summary
Refactor `dispatchError` in `clusterActionSlice` to surface detailed API error messages in notifications. 

Currently, many cluster actions (like creating or editing a Namespace) show a generic error message (e.g., "Failed to apply changes to XXX.") even when the Kubernetes API provides a specific reason for rejection (e.g., a `ValidatingAdmissionPolicy` failure). While some resources like Pods may show more detail, others only show the generic fallback.

This change ensures that if an error object is caught, its original message is appended to the generic error string, providing users with the necessary context (like admission policy details) to understand why an action failed.

## Changes
- Modified `dispatchError` in `frontend/src/redux/clusterActionSlice.ts` to accept an optional `err` parameter and append its message to the generic notification text.
- Added punctuation handling to ensure messages are concatenated cleanly.
- Updated `executeClusterAction` to pass caught errors to `dispatchError`.
- Updated `clusterActionSlice.test.ts` to verify the new concatenated error message format.

## Steps to Test
1. Set up a `ValidatingAdmissionPolicy` that blocks Namespace creation or updates (as described in the reported issue).
2. Attempt to perform an action in Headlamp that violates this policy.
3. **Before**: Observe a generic "Failed to apply changes to..." message.
4. **After**: Observe the generic message followed by the specific detail from the admission controller.

## Related Issue
Fixes #5013 
