### PR TITLE
frontend: OauthPopup: Fix typos and use console.error

### DIFF
--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -72,7 +72,7 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
           window.removeEventListener('storage', storageListener);
         }
       } catch (e) {
-        console.log('error occured while closing auth window', e);
+        console.error('Error occurred while closing auth window', e);
         window.removeEventListener('storage', storageListener);
       }
     };
@@ -91,7 +91,7 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
           false
         );
       } catch (e) {
-        console.log('error occured while adding beforeunload event listener');
+        console.error('Error occurred while adding beforeunload event listener');
       }
     }
   };


### PR DESCRIPTION
Fixes #5053

## Summary
Fix two error catch blocks in `OauthPopup` that had the typo "occured" (should be "occurred") and were using `console.log` instead of `console.error` for error conditions.

## Changes
- Fix typo: "occured" → "occurred" in both error messages  
- Change `console.log` to `console.error` for proper error severity  
- Capitalize error messages consistently  

## Steps to Test
1. Trigger OIDC auth flow that opens the OAuth popup  
2. Open browser DevTools → Console → filter by "Errors"  
3. Verify error messages appear correctly if the popup fails  