### PR TITLE
backend/helm: fix double-write HTTP response and missing headers

### DIFF
--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -17,10 +17,13 @@ limitations under the License.
 package helm
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"path/filepath"
 	"strings"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 
 	"helm.sh/helm/v3/cmd/helm/search"
 	"helm.sh/helm/v3/pkg/cli"
@@ -88,13 +91,15 @@ func listCharts(filter string, settings *cli.EnvSettings) ([]chartInfo, error) {
 	return chartInfos, nil
 }
 
-// list charts.
+// ListCharts lists all charts from configured repositories.
 func (h *Handler) ListCharts(w http.ResponseWriter, r *http.Request) {
 	filterTerm := r.URL.Query().Get("filter")
 
 	chartInfos, err := listCharts(filterTerm, h.EnvSettings)
 	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "listing charts")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+
 		return
 	}
 
@@ -102,13 +107,20 @@ func (h *Handler) ListCharts(w http.ResponseWriter, r *http.Request) {
 		Charts: chartInfos,
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	var buf bytes.Buffer
 
-	err = json.NewEncoder(w).Encode(response)
+	err = json.NewEncoder(&buf).Encode(response)
 	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "encoding charts response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		logger.Log(logger.LevelError, nil, err, "writing charts response")
 	}
 }

--- a/backend/pkg/helm/charts_test.go
+++ b/backend/pkg/helm/charts_test.go
@@ -90,3 +90,26 @@ func TestListChartReturnsErrorWithoutSuccessPayload(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.NotContains(t, rr.Body.String(), "\"charts\"")
 }
+
+func TestListChartContentType(t *testing.T) {
+	ch := cache.New[interface{}]()
+	require.NotNil(t, ch)
+
+	helmHandler, err := helm.NewHandlerWithSettings(ch, settings)
+	require.NoError(t, err)
+
+	testAddRepo(t, helmHandler, "headlamp_test_repo", "https://kubernetes-sigs.github.io/headlamp/")
+
+	listChartsRequest, err := http.NewRequestWithContext(context.Background(),
+		"GET", "/clusters/minikube/helm/repositories/charts", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	helmHandler.ListCharts(rr, listChartsRequest)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify Content-Type header is correctly set.
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+}

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -238,15 +239,21 @@ func (h *Handler) ListRepo(w http.ResponseWriter, r *http.Request) {
 		Repositories: repositories,
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	var buf bytes.Buffer
 
-	err = json.NewEncoder(w).Encode(response)
+	err = json.NewEncoder(&buf).Encode(response)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "encoding response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		logger.Log(logger.LevelError, nil, err, "writing repo list response")
 	}
 }
 


### PR DESCRIPTION
Fixes #5055

## What this PR does

Following #5170 which fixed the missing `return` after `http.Error`, this PR addresses the remaining HTTP response correctness issues in the Helm backend handlers.

### 1. Buffer JSON encoding in [ListCharts](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go#94-124) and [ListRepo](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/repository.go#231-256)

**Files:** [backend/pkg/helm/charts.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go), [backend/pkg/helm/repository.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/repository.go)

Both handlers previously wrote JSON directly to `http.ResponseWriter` via `json.NewEncoder(w).Encode()`. If encoding failed mid-stream - for example due to a client disconnect -the response was already partially sent with a `200 OK` status, making it impossible to communicate the failure cleanly to the client.

**Fix:** Encode into an intermediate `bytes.Buffer` first. If encoding succeeds, set headers and write the buffer. If it fails, return a proper `500` before any bytes are sent.

### 2. Add structured logging to [charts.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go)

Unlike [repository.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/repository.go) and `release.go`, [charts.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go) had no `logger.Log` calls on its error paths. Added structured logging for both the [listCharts](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go#46-93) failure and the encoding failure paths in [ListCharts](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go#94-124) for consistent observability across all Helm handlers.

### 3. Add [TestListChartContentType](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts_test.go#94-116)

Adds a regression test verifying that [ListCharts](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go#94-124) correctly sets the `Content-Type: application/json` header on success responses.

## Testing

- `go vet ./pkg/helm/` -Clean
- `go test ./pkg/helm/ -v` -All 32 tests pass (1.124s)

| Test | Result |
|------|--------|
| TestListChart | PASS |
| TestListChartReturnsErrorWithoutSuccessPayload | PASS |
| **TestListChartContentType** | **PASS (new)** |
| TestAddRepository | PASS |
| TestRemoveRepository | PASS |
| TestUpdateRepo | PASS |
| TestListRepositories | PASS |
| TestListRepoSetsJSONContentType | PASS |

## Changes

| File | Changes |
|------|---------|
| [backend/pkg/helm/charts.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts.go) | Buffer encoding, add `logger.Log`, improve doc comment |
| [backend/pkg/helm/repository.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/repository.go) | Buffer encoding in [ListRepo](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/repository.go#231-256) |
| [backend/pkg/helm/charts_test.go](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts_test.go) | Add [TestListChartContentType](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/charts_test.go#94-116) |
