### PR TITLE
Add sig/ui label to auto-apply on PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,5 @@ approvers:
 reviewers:
 - headlamp-maintainers
 - headlamp-reviewers
+labels:
+- sig/ui


### PR DESCRIPTION
This PR adds the `sig/ui` label to automatically apply to PRs in this repository, which is needed to properly track PR workload for DevStats.

cc: @joaquimrocha @illume @sniok @yolossn @ashu8912