### PR TITLE
frontend: pods: Fix status icon stuck on warning after pod becomes ready

### DIFF
--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartNoMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartNoMetrics.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartPod.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartPod.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartWithMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.CpuChartWithMetrics.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartNoMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartNoMetrics.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartPod.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartPod.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartWithMetrics.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/ResourceCharts.MemoryChartWithMetrics.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusEmpty.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusEmpty.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusLoading.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusLoading.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusWithMixedStates.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.NodesStatusWithMixedStates.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusEmpty.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusEmpty.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusLoading.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusLoading.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusWithMixedStates.stories.storyshot
+++ b/frontend/src/components/cluster/Charts/__snapshots__/StatusCharts.PodsStatusWithMixedStates.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/__snapshots__/Overview.EmptyState.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.EmptyState.stories.storyshot
@@ -45,7 +45,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -161,7 +161,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -277,7 +277,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -399,7 +399,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
@@ -45,7 +45,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -161,7 +161,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -277,7 +277,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -399,7 +399,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
@@ -45,7 +45,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -161,7 +161,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -277,7 +277,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -399,7 +399,7 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-18ph6tx-MuiGrid-root"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithProgress.stories.storyshot
+++ b/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithProgress.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithoutProgress.stories.storyshot
+++ b/frontend/src/components/common/TileChart/__snapshots__/TileChart.WithoutProgress.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -260,7 +260,12 @@ export function PodListRenderer(props: PodListProps) {
           gridTemplate: 'min-content',
           filterVariant: 'multi-select',
           label: t('translation|Status'),
-          getValue: pod => pod.getDetailedStatus().reason,
+          // include ready condition status so the cell re-renders when icon state changes
+          getValue: pod => {
+            const status = pod.getDetailedStatus();
+            const readyCondition = pod.status?.conditions?.find(c => c.type === 'Ready');
+            return `${status.reason}:${readyCondition?.status ?? ''}`;
+          },
           render: makePodStatusLabel,
         },
         ...(metrics?.length

--- a/frontend/src/components/workload/__snapshots__/Charts.AllFailedDeployment.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.AllFailedDeployment.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.AllFailedStatefulSet.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.AllFailedStatefulSet.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.AllRunningDeployment.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.AllRunningDeployment.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.AllRunningStatefulSet.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.AllRunningStatefulSet.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.DefaultDeployment.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.DefaultDeployment.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.DefaultStatefulSet.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.DefaultStatefulSet.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.Empty.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.Empty.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.LoadingWorkload.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.LoadingWorkload.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Charts.MixedWorkloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.MixedWorkloads.stories.storyshot
@@ -1,7 +1,7 @@
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
     >
       <div
         class="MuiBox-root css-qrw4x1"

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -23,9 +23,10 @@
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -146,9 +147,10 @@
                   </div>
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -269,9 +271,10 @@
                   </div>
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -392,9 +395,10 @@
                   </div>
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -515,9 +519,10 @@
                   </div>
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -638,9 +643,10 @@
                   </div>
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"
@@ -761,9 +767,10 @@
                   </div>
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4 MuiGrid-grid-lg-3 css-10tsekr-MuiGrid-root"
+                    style="min-width: 0;"
                   >
                     <div
-                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
                     >
                       <div
                         class="MuiBox-root css-qrw4x1"


### PR DESCRIPTION
## Summary

The pod status icon in the list view was getting stuck on warning even after the pod was Running and healthy. It only fixed itself after a page refresh. The issue was that getValue was only returning the reason string ("Running"), which stayed the same even when the Ready condition changed : so the table never re-rendered. Added the Ready condition status to the return value so it picks up the change.

## Related Issue

Fixes #4905

## Changes

- Updated `getValue` in the status column in `frontend/src/components/pod/List.tsx` to return both the reason and the Ready condition status
- Earlier it only returned the reason string which was "Running" in both warning and success states, so nothing triggered a re-render

## Steps to Test

1. Start Headlamp locally
2. Go to Workloads → Pods
3. Run `kubectl create deployment nginx-test --image=nginx`
4. Watch the pod without refreshing the page
5. Icon should turn green when pod becomes ready

## Notes for the Reviewer

- Only `List.tsx` is changed
- Snapshot files changed too but that's just MUI CSS class names, nothing to do with this fix