### PR TITLE
frontend: Replace ts-ignore with proper type fixes

### DIFF
--- a/frontend/src/components/resourceMap/graph/graphLayout.tsx
+++ b/frontend/src/components/resourceMap/graph/graphLayout.tsx
@@ -29,6 +29,7 @@ type ElkNodeWithData = Omit<ElkNode, 'edges'> & {
 type ElkEdgeWithData = ElkExtendedEdge & {
   type: string;
   data: any;
+  label?: string;
 };
 
 let elk: ELKInterface | undefined;
@@ -175,7 +176,6 @@ function convertToReactFlowGraph(elkGraph: ElkNodeWithData) {
         data: {
           data: edge.data,
           sections: edge.sections,
-          // @ts-ignore
           label: edge?.label,
           labels: edge.labels,
           parentOffset: {

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -497,8 +497,11 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
       params.gracePeriodSeconds = 0;
     }
 
-    // @ts-ignore
-    return this._class().apiEndpoint.delete(...args, params, this._clusterName);
+    return (this._class().apiEndpoint.delete as (...args: any[]) => Promise<any>)(
+      ...args,
+      params,
+      this._clusterName
+    );
   }
 
   update(data: KubeObjectInterface) {
@@ -547,8 +550,11 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
 
     args.push(this.getName());
 
-    // @ts-ignore
-    return this._class().apiEndpoint.patch(...args, {}, this._clusterName);
+    return (this._class().apiEndpoint.patch as (...args: any[]) => Promise<any>)(
+      ...args,
+      {},
+      this._clusterName
+    );
   }
 
   /** Performs a request to check if the user has the given permission.

--- a/frontend/src/lib/k8s/api/v2/hooks.ts
+++ b/frontend/src/lib/k8s/api/v2/hooks.ts
@@ -197,20 +197,16 @@ export function useKubeObject<K extends KubeObject>({
     });
   }
 
-  // @ts-ignore
-  return {
+  const error = endpointError ?? query.error;
+  return Object.assign([data, error] as [K | null, ApiError | null], {
     data,
-    error: endpointError ?? query.error,
+    error,
     isError: query.isError,
     isLoading: query.isLoading,
     isFetching: query.isFetching,
     isSuccess: query.isSuccess,
     status: query.status,
-    *[Symbol.iterator](): ArrayIterator<ApiError | K | null> {
-      yield data;
-      yield endpointError ?? query.error;
-    },
-  };
+  });
 }
 
 /**


### PR DESCRIPTION
These changes replace `@ts-ignore` suppressions with proper fixes across three files:
- `KubeObject.ts` - targeted function casts on `delete` and `patch` spread calls
- `hooks.ts` - `Object.assign` tuple pattern to satisfy the intersection return type
- `graphLayout.tsx` - added missing `label?` field to `ElkEdgeWithoutData`