### PR TITLE
frontend: NameValueTable: Remove outdated React 18 TODO comment

### DIFF
--- a/frontend/src/components/common/NameValueTable/NameValueTable.tsx
+++ b/frontend/src/components/common/NameValueTable/NameValueTable.tsx
@@ -19,7 +19,6 @@ import Grid from '@mui/material/Grid';
 import React, { ReactNode } from 'react';
 import { ValueLabel } from '../Label';
 
-// TODO: use ReactNode after migration to react 18
 export interface NameValueTableRow {
   /** The name (key) for this row */
   name: ReactNode;


### PR DESCRIPTION
**Summary**
Deleted the dangling `// TODO: use ReactNode after migration to react 18` comment from `NameValueTable.tsx` as the ReactNode typings have already been successfully mapped to the name and value interface properties.
