### PR TITLE
backend/plugins: use structured logging in ListPlugins

### DIFF
--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -267,6 +267,40 @@ func isCatalogInstalledPlugin(pluginDir, pluginName string) bool {
 	return packageData.IsManagedByHeadlampPlugin
 }
 
+// getPluginName reads the plugin's package.json to extract its display name.
+// If the file is missing, unreadable, or lacks a name field, it falls back to the directory basename.
+func getPluginName(pluginDir string) string {
+	packageJSONPath := filepath.Join(pluginDir, "package.json")
+
+	content, err := os.ReadFile(filepath.Clean(packageJSONPath))
+	if err != nil {
+		return filepath.Base(pluginDir)
+	}
+
+	var packageData struct {
+		Name string `json:"name"`
+	}
+
+	if err := json.Unmarshal(content, &packageData); err != nil || packageData.Name == "" {
+		return strings.TrimPrefix(filepath.Base(pluginDir), "plugins/")
+	}
+
+	return packageData.Name
+}
+
+func logPluginGroup(plugins []string, baseDir, pluginType, listingMsg, emptyMsg string) {
+	if len(plugins) > 0 {
+		logger.Log(logger.LevelInfo, map[string]string{"directory": baseDir}, nil, listingMsg)
+
+		for _, plugin := range plugins {
+			name := getPluginName(filepath.Join(baseDir, filepath.Base(plugin)))
+			logger.Log(logger.LevelInfo, map[string]string{"plugin": name, "type": pluginType}, nil, "Found plugin")
+		}
+	} else {
+		logger.Log(logger.LevelInfo, map[string]string{"directory": baseDir, "type": pluginType}, nil, emptyMsg)
+	}
+}
+
 // ListPlugins lists the plugins in the static, user-installed, and development plugin directories.
 func ListPlugins(staticPluginDir, userPluginDir, pluginDir string) error {
 	staticPlugins, userPlugins, devPlugins, err := generateSeparatePluginPaths(staticPluginDir, userPluginDir, pluginDir)
@@ -275,58 +309,12 @@ func ListPlugins(staticPluginDir, userPluginDir, pluginDir string) error {
 		return fmt.Errorf("listing plugins: %w", err)
 	}
 
-	getPluginName := func(pluginDir string) string {
-		packageJSONPath := filepath.Join(pluginDir, "package.json")
-
-		content, err := os.ReadFile(packageJSONPath) //nolint:gosec
-		if err != nil {
-			// If there's an error reading package.json, just return the folder name as fallback.
-			return filepath.Base(pluginDir)
-		}
-
-		var packageData struct {
-			Name string `json:"name"`
-		}
-
-		// Parse the JSON and extract the name. If it fails, return the folder name.
-		if err := json.Unmarshal(content, &packageData); err != nil || packageData.Name == "" {
-			return strings.TrimPrefix(filepath.Base(pluginDir), "plugins/")
-		}
-
-		return packageData.Name
-	}
-
-	if len(staticPlugins) > 0 {
-		fmt.Printf("Shipped Plugins (%s):\n", staticPluginDir)
-
-		for _, plugin := range staticPlugins {
-			fmt.Println(" -", getPluginName(plugin))
-		}
-	} else {
-		fmt.Println("No shipped plugins found.")
-	}
-
-	if len(userPlugins) > 0 {
-		fmt.Printf("\nUser-installed Plugins (%s):\n", userPluginDir)
-
-		for _, plugin := range userPlugins {
-			pluginName := getPluginName(filepath.Join(userPluginDir, plugin))
-			fmt.Println(" -", pluginName)
-		}
-	} else {
-		fmt.Println("No user-installed plugins found.")
-	}
-
-	if len(devPlugins) > 0 {
-		fmt.Printf("\nDevelopment Plugins (%s):\n", pluginDir)
-
-		for _, plugin := range devPlugins {
-			pluginName := getPluginName(filepath.Join(pluginDir, plugin))
-			fmt.Println(" -", pluginName)
-		}
-	} else {
-		fmt.Println("No development plugins found.")
-	}
+	logPluginGroup(staticPlugins, staticPluginDir, PluginTypeShipped,
+		"Listing shipped plugins", "No shipped plugins found")
+	logPluginGroup(userPlugins, userPluginDir, PluginTypeUser,
+		"Listing user-installed plugins", "No user-installed plugins found")
+	logPluginGroup(devPlugins, pluginDir, PluginTypeDevelopment,
+		"Listing development plugins", "No development plugins found")
 
 	return nil
 }

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -18,7 +18,6 @@ package plugins_test
 
 import (
 	"context"
-	"io"
 	"net/http/httptest"
 	"os"
 	"path"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/plugins"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -202,35 +202,10 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 	require.NoError(t, err)
 }
 
-// Helper function for capturing output.
-func captureOutput(f func()) (string, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return "", err
-	}
-
-	originalStdout := os.Stdout
-	os.Stdout = w
-
-	f()
-
-	err = w.Close()
-	if err != nil {
-		return "", err
-	}
-
-	os.Stdout = originalStdout
-
-	outputBytes, err := io.ReadAll(r)
-	if err != nil {
-		return "", err
-	}
-
-	return string(outputBytes), nil
-}
-
-// Helper function for creating a plugin.
+// createPlugin creates a plugin directory with main.js and package.json.
 func createPlugin(t *testing.T, baseDir string, pluginName string) string {
+	t.Helper()
+
 	pluginDir := path.Join(baseDir, pluginName)
 	err := os.Mkdir(pluginDir, 0o750)
 	require.NoError(t, err)
@@ -248,59 +223,104 @@ func createPlugin(t *testing.T, baseDir string, pluginName string) string {
 	return pluginDir
 }
 
-func TestListPlugins(t *testing.T) {
-	// Create a temporary directory if it doesn't exist
-	_, err := os.Stat("/tmp/")
-	if os.IsNotExist(err) {
-		err = os.Mkdir("/tmp/", 0o750)
-		require.NoError(t, err)
-	}
+// logEntry captures a structured log event for test assertions.
+type logEntry struct {
+	msg    string
+	fields map[string]string
+}
 
-	// create a static plugin directory in /tmp
-	staticPluginDir := path.Join("/tmp", uuid.NewString())
-	err = os.Mkdir(staticPluginDir, 0o750)
-	require.NoError(t, err)
+const (
+	msgFoundPlugin    = "Found plugin"
+	testDevPluginName = "dev-plugin-1"
+)
+
+func TestListPlugins(t *testing.T) { //nolint:funlen
+	// Capture log output via logger.SetLogFunc.
+	var logEntries []logEntry
+
+	originalLogFunc := logger.SetLogFunc(
+		func(_ uint, fields map[string]string, _ interface{}, msg string) {
+			logEntries = append(logEntries, logEntry{msg: msg, fields: fields})
+		},
+	)
+	defer logger.SetLogFunc(originalLogFunc)
+
+	// Use t.TempDir() for automatic cleanup.
+	staticPluginDir := t.TempDir()
+	pluginDir := t.TempDir()
+	userPluginDir := t.TempDir()
 
 	createPlugin(t, staticPluginDir, "static-plugin-1")
+	createPlugin(t, userPluginDir, "user-plugin-1")
+	plugin1Dir := createPlugin(t, pluginDir, testDevPluginName)
 
-	// create a user plugin directory in /tmp
-	pluginDir := path.Join("/tmp", uuid.NewString())
-	err = os.Mkdir(pluginDir, 0o750)
+	// ListPlugins should succeed and emit log messages.
+	err := plugins.ListPlugins(staticPluginDir, userPluginDir, pluginDir)
 	require.NoError(t, err)
 
-	plugin1Dir := createPlugin(t, pluginDir, "user-plugin-1")
+	// Collect all messages for Contains checks.
+	messages := make([]string, 0, len(logEntries))
+	for _, e := range logEntries {
+		messages = append(messages, e.msg)
+	}
 
-	// capture the output of the ListPlugins function
-	output, err := captureOutput(func() {
-		err := plugins.ListPlugins(staticPluginDir, "", pluginDir)
-		require.NoError(t, err)
-	})
-	require.NoError(t, err)
+	assert.Contains(t, messages, "Listing shipped plugins")
+	assert.Contains(t, messages, "Listing user-installed plugins")
+	assert.Contains(t, messages, "Listing development plugins")
+	assert.Contains(t, messages, msgFoundPlugin)
 
-	require.Contains(t, output, "Shipped Plugins")
-	require.Contains(t, output, "static-plugin-1")
-	require.Contains(t, output, "Development Plugins")
-	require.Contains(t, output, "user-plugin-1")
+	// Verify structured fields on "Found plugin" entries.
+	for _, e := range logEntries {
+		if e.msg == msgFoundPlugin {
+			assert.NotEmpty(t, e.fields["plugin"], "plugin field should be set")
+			assert.NotEmpty(t, e.fields["type"], "type field should be set")
+		}
+	}
 
-	// test missing package.json
+	// Reset captured logs.
+	logEntries = nil
+
+	// test missing package.json — should still succeed (falls back to folder name).
 	_ = os.Remove(path.Join(plugin1Dir, "package.json"))
 
-	output, err = captureOutput(func() {
-		err := plugins.ListPlugins(staticPluginDir, "", pluginDir)
-		require.NoError(t, err)
-	})
+	err = plugins.ListPlugins(staticPluginDir, userPluginDir, pluginDir)
 	require.NoError(t, err)
-	require.Contains(t, output, "user-plugin-1") // should use folder name
 
-	// test invalid package.json
+	// Verify fallback: plugin name should be the folder name when package.json is missing.
+	foundFallback := false
+
+	for _, e := range logEntries {
+		if e.msg == msgFoundPlugin && e.fields["plugin"] == testDevPluginName {
+			foundFallback = true
+
+			break
+		}
+	}
+
+	assert.True(t, foundFallback, "should fall back to folder name when package.json is missing")
+
+	// Reset captured logs.
+	logEntries = nil
+
+	// test invalid package.json — should still succeed (falls back to folder name).
 	err = os.WriteFile(path.Join(plugin1Dir, "package.json"), []byte("invalid json"), 0o600)
 	require.NoError(t, err)
-	output, err = captureOutput(func() {
-		err := plugins.ListPlugins(staticPluginDir, "", pluginDir)
-		require.NoError(t, err)
-	})
+
+	err = plugins.ListPlugins(staticPluginDir, userPluginDir, pluginDir)
 	require.NoError(t, err)
-	require.Contains(t, output, "user-plugin-1") // should use folder name
+
+	// Verify fallback: plugin name should be the folder name when package.json is invalid.
+	foundFallback = false
+
+	for _, e := range logEntries {
+		if e.msg == msgFoundPlugin && e.fields["plugin"] == testDevPluginName {
+			foundFallback = true
+
+			break
+		}
+	}
+
+	assert.True(t, foundFallback, "should fall back to folder name when package.json is invalid")
 }
 
 func TestHandlePluginEvents(t *testing.T) { //nolint:funlen


### PR DESCRIPTION
Fixes #5069

### What this PR does

Refactors [ListPlugins](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins.go:269:0-337:1) to replace raw `fmt.Printf` / `fmt.Println` calls with Headlamp's structured `logger.Log`, and removes the brittle `os.Pipe` stdout-capture technique from the test.

### Changes

| File | Change |
|---|---|
| [backend/pkg/plugins/plugins.go](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins.go:0:0-0:0) | Replace 9 `fmt.Printf`/`fmt.Println` calls with `logger.Log(logger.LevelInfo, ...)` using structured key-value maps ([plugin](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins.go:339:0-390:1), `type`, [directory](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins.go:582:0-589:1)) |
| [backend/pkg/plugins/plugins_test.go](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins_test.go:0:0-0:0) | Delete `captureOutput` (os.Pipe hack), add `t.Helper()` to [createPlugin](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins_test.go:203:0-222:1), rewrite [TestListPlugins](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins_test.go:224:0-262:1) to assert no-error directly |

### Why

- [plugins.go](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins.go:0:0-0:0) was the **only file** in the entire backend still using `fmt.Println` for output - every other package uses the structured logger.
- The `captureOutput` test helper hijacked `os.Stdout` via `os.Pipe`, which is fragile and not goroutine-safe.
- Structured logs enable proper filtering and ingestion in Kubernetes pod log pipelines.

### Testing

- `go vet ./pkg/plugins/...` - Clean
- `go fmt ./pkg/plugins/...` - No changes
- `go test ./pkg/plugins/... -v` - All tests pass
