### PR TITLE
frontend: HTTPRouteDetails: Remove debug console.log

### DIFF
--- a/frontend/src/components/gateway/HTTPRouteDetails.tsx
+++ b/frontend/src/components/gateway/HTTPRouteDetails.tsx
@@ -151,7 +151,7 @@ export function RuleBackendRefs(props: RuleBackendRefsProps) {
   if (!backendRefs) {
     return null;
   }
-  console.log(namespace, backendRefs);
+
   return (
     <InnerTable
       columns={[


### PR DESCRIPTION
Fixes #5073 

### What this PR does

Removes a leftover debugging `console.log` statement from the `RuleBackendRefs` component in `HTTPRouteDetails.tsx`.

### Why

Debug logging `console.log(namespace, backendRefs);` was left behind in production code, which creates unnecessary noise in the browser console.

### Testing

- Open a Gateway API HTTPRoute details page.
- Check the browser DevTools Console.
- Verify that `namespace` and `backendRefs` are no longer being logged unnecessarily.
