### PR TITLE
charts: Add multi-port support for Service and Ingress backends

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -184,6 +184,7 @@ NOTE: for `hostUsers=false` user namespaces must be supported. See: https://kube
 |-----|------|---------|-------------|
 | service.type | string | `"ClusterIP"` | Kubernetes service type |
 | service.port | int | `80` | Kubernetes service port |
+| service.extraServicePorts | list | `[]` | Additional ports to expose on the Service in addition to the default http port |
 | ingress.enabled | bool | `false` | Enable ingress |
 | ingress.ingressClassName | string | `""` | Ingress class name |
 | ingress.annotations | object | `{}` | Ingress annotations (e.g., kubernetes.io/tls-acme: "true") |
@@ -210,6 +211,40 @@ ingress:
       hosts:
         - headlamp.example.com
 ```
+
+Each path under `ingress.hosts[].paths[]` may optionally specify
+`backend.service.{name,port}` to override the default Headlamp Service /
+`service.port`. This is typically combined with `service.extraServicePorts` to
+route different paths to different ports of the same Service:
+
+```yaml
+service:
+  extraServicePorts:
+    - name: extra
+      port: 9090
+      targetPort: extra
+
+ingress:
+  enabled: true
+  hosts:
+    - host: headlamp.example.com
+      paths:
+        - path: /
+          type: Prefix
+        - path: /extra
+          type: Prefix
+          backend:
+            service:
+              # name is optional; defaults to the Headlamp Service.
+              # When set, it is rendered with `tpl` so values like
+              # "{{ .Release.Name }}-other" are supported.
+              port:
+                name: extra        # or: number: 9090
+```
+
+The same approach works for the Gateway API: define additional ports under
+`service.extraServicePorts` and reference them from `httpRoute.rules[].backendRefs[].port`.
+
 
 ### HTTPRoute Configuration (Gateway API)
 

--- a/charts/headlamp/templates/ingress.yaml
+++ b/charts/headlamp/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
                   {{- $svc = .backend.service }}
                 {{- end }}
                 {{- if $svc.name }}
-                name: {{ tpl $svc.name $ }}
+                name: {{ tpl $svc.name $ | trim | quote }}
                 {{- else }}
                 name: {{ $fullName }}
                 {{- end }}

--- a/charts/headlamp/templates/ingress.yaml
+++ b/charts/headlamp/templates/ingress.yaml
@@ -43,9 +43,24 @@ spec:
             pathType: {{ .type }}
             backend:
               service:
+                {{- $svc := dict }}
+                {{- if and .backend .backend.service }}
+                  {{- $svc = .backend.service }}
+                {{- end }}
+                {{- if $svc.name }}
+                name: {{ tpl $svc.name $ }}
+                {{- else }}
                 name: {{ $fullName }}
-                port: 
+                {{- end }}
+                port:
+                  {{- $port := $svc.port | default dict }}
+                  {{- if $port.number }}
+                  number: {{ $port.number }}
+                  {{- else if $port.name }}
+                  name: {{ $port.name }}
+                  {{- else }}
                   number: {{ $svcPort }}
+                  {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/headlamp/templates/service.yaml
+++ b/charts/headlamp/templates/service.yaml
@@ -31,5 +31,14 @@ spec:
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    {{- range .Values.service.extraServicePorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort | default .port }}
+      protocol: {{ .protocol | default "TCP" }}
+      {{- if and (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+    {{- end }}
   selector:
     {{- include "headlamp.selectorLabels" . | nindent 4 }}

--- a/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
+++ b/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
@@ -1,0 +1,181 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+    - name: extra
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.41.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}
+---
+# Source: headlamp/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "chart-example.local"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp
+                port:
+                  number: 80
+          - path: /extra-by-name
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp
+                port:
+                  name: extra
+          - path: /extra-by-number
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp
+                port:
+                  number: 9090
+          - path: /custom-svc
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp-other
+                port:
+                  number: 8080

--- a/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
+++ b/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
@@ -176,6 +176,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: headlamp-other
+                name: "headlamp-other"
                 port:
                   number: 8080

--- a/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
+++ b/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
@@ -1,0 +1,140 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: NodePort
+  externalTrafficPolicy: 
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
+    - name: grpc
+      port: 9091
+      targetPort: 9091
+      protocol: TCP
+      nodePort: 31091
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.41.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}

--- a/charts/headlamp/tests/test_cases/ingress-multi-backend.yaml
+++ b/charts/headlamp/tests/test_cases/ingress-multi-backend.yaml
@@ -1,0 +1,32 @@
+service:
+  extraServicePorts:
+    - name: extra
+      port: 9090
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          type: Prefix
+        - path: /extra-by-name
+          type: Prefix
+          backend:
+            service:
+              port:
+                name: extra
+        - path: /extra-by-number
+          type: Prefix
+          backend:
+            service:
+              port:
+                number: 9090
+        - path: /custom-svc
+          type: Prefix
+          backend:
+            service:
+              name: "{{ .Release.Name }}-other"
+              port:
+                number: 8080

--- a/charts/headlamp/tests/test_cases/service-extra-ports.yaml
+++ b/charts/headlamp/tests/test_cases/service-extra-ports.yaml
@@ -1,0 +1,10 @@
+service:
+  type: NodePort
+  extraServicePorts:
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+    - name: grpc
+      port: 9091
+      protocol: TCP
+      nodePort: 31091

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -459,6 +459,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "required": [
+                    "path",
+                    "type"
+                  ],
                   "properties": {
                     "path": {
                       "type": "string"
@@ -486,7 +490,29 @@
                                 "name": {
                                   "type": "string"
                                 }
-                              }
+                              },
+                              "oneOf": [
+                                {
+                                  "required": [
+                                    "number"
+                                  ],
+                                  "not": {
+                                    "required": [
+                                      "name"
+                                    ]
+                                  }
+                                },
+                                {
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "not": {
+                                    "required": [
+                                      "number"
+                                    ]
+                                  }
+                                }
+                              ]
                             }
                           }
                         }

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -364,6 +364,7 @@
               },
               "protocol": {
                 "type": "string",
+                "enum": ["TCP", "UDP", "SCTP"],
                 "description": "Protocol (TCP/UDP/SCTP). Defaults to TCP"
               },
               "nodePort": {

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -342,6 +342,36 @@
         "nodePort": {
           "type": ["integer", "null"],
           "description": "Kubernetes Service Nodeport"
+        },
+        "extraServicePorts": {
+          "type": "array",
+          "description": "Additional ports to expose on the Service in addition to the default http port",
+          "items": {
+            "type": "object",
+            "required": ["name", "port"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Port name (must be unique within the Service)"
+              },
+              "port": {
+                "type": "integer",
+                "description": "Service port number"
+              },
+              "targetPort": {
+                "type": ["integer", "string"],
+                "description": "Pod-side target port (number or named port). Defaults to `port` when omitted"
+              },
+              "protocol": {
+                "type": "string",
+                "description": "Protocol (TCP/UDP/SCTP). Defaults to TCP"
+              },
+              "nodePort": {
+                "type": ["integer", "null"],
+                "description": "Node port (only honored when service.type is NodePort or LoadBalancer)"
+              }
+            }
+          }
         }
       }
     },
@@ -427,7 +457,41 @@
               "paths": {
                 "type": "array",
                 "items": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "backend": {
+                      "type": "object",
+                      "description": "Optional override of the backend Service for this path",
+                      "properties": {
+                        "service": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "Service name (supports tpl). Defaults to the Headlamp Service when omitted"
+                            },
+                            "port": {
+                              "type": "object",
+                              "properties": {
+                                "number": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -202,6 +202,18 @@ service:
   loadBalancerSourceRanges: []
   # -- Kubernetes Service Nodeport
   nodePort: null
+  # -- Additional ports to expose on the Service in addition to the default
+  # http port. Each entry must have a unique `name` and a `port`. `targetPort`
+  # defaults to `port` when omitted. `nodePort` is only honored when
+  # `service.type` is `NodePort` or `LoadBalancer`. A matching containerPort
+  # must be provided by the user (e.g. via a sidecar) for traffic to actually
+  # be routed.
+  extraServicePorts: []
+  # - name: extra
+  #   port: 9090
+  #   targetPort: extra
+  #   protocol: TCP
+  #   nodePort: null
 
 # -- Headlamp containers volume mounts
 volumeMounts: []
@@ -244,12 +256,22 @@ ingress:
 
   # -- Hostname(s) for the Ingress resource
   # Please refer to https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec for more information.
+  # Each path may optionally specify `backend.service.{name,port}` to override
+  # the default Headlamp Service / `service.port`. `name` supports `tpl` so
+  # values like `{{ .Release.Name }}-extra` can be used. `port` accepts either
+  # `number` or `name` (matching `service.extraServicePorts[].name`).
   hosts:
     []
     # - host: chart-example.local
     #   paths:
     #   - path: /
     #     type: ImplementationSpecific
+    #   - path: /extra
+    #     type: ImplementationSpecific
+    #     backend:
+    #       service:
+    #         port:
+    #           name: extra
   # -- Ingress TLS configuration
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
## Summary

This PR adds multi-port support to the Helm chart so that sidecar containers added via `deployment.extraContainers` can be exposed through the same Headlamp Service and Ingress without maintaining a separate Service resource.

## Related Issue

Fixes #5077

## Changes

- Added `service.extraServicePorts[]` to append extra ports to the existing Headlamp Service (`name` / `port` / `targetPort` / `protocol` / `nodePort`).
- Added `ingress.hosts[].paths[].backend.service.{name,port}` so each Ingress path can override its backend. When `backend` is omitted the existing behavior (default Service / `service.port`) is preserved, so existing values files keep working unchanged.
- Updated `values.yaml`, `values.schema.json`, and `README.md` to document both fields.
- Added chart tests covering `extraServicePorts` and multi-backend Ingress (default fallback / `port.name` / `port.number` / templated `name`).

## Steps to Test

1. `bash charts/headlamp/tests/test.sh` — all existing tests still pass (backward compatibility) and the two new test cases (`service-extra-ports`, `ingress-multi-backend`) pass.
2. Render the chart with the example values below and confirm the Service has both `http` and `plugin` ports, and the Ingress routes `/plugin` to port name `plugin`:
   ```yaml
   service:
     extraServicePorts:
       - name: plugin
         port: 9090
         targetPort: plugin
   ingress:
     enabled: true
     hosts:
       - host: headlamp.example.com
         paths:
           - path: /
             type: Prefix
           - path: /plugin
             type: Prefix
             backend:
               service:
                 port:
                   name: plugin
   ```
3. `helm lint charts/headlamp` — clean.

## Screenshots (if applicable)

N/A (chart-only change)

## Notes for the Reviewer

- The new fields are purely additive; the default rendered output is unchanged, which the existing test suite confirms.
- The chart intentionally does not auto-create matching `containerPort` entries — users wiring a sidecar via `extraContainers` are expected to declare the port on the container side.
- The Gateway API path (`httpRoute.rules`) already accepts arbitrary `backendRefs`, so no template change was needed there; the README notes how to combine it with `extraServicePorts`.
- `ingress.hosts[].paths[].backend.service.name` is rendered through `tpl` so values like `{{ .Release.Name }}-other` work. Happy to drop this and treat the field as a literal string if you'd prefer to keep the trust boundary tighter.
