### PR TITLE
helm: Improve support for readOnlyRootFilesystem in with emptyDr on /tmp

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -178,6 +178,37 @@ NOTE: for `hostUsers=false` user namespaces must be supported. See: https://kube
 | volumeMounts | list | `[]` | Container volume mounts |
 | volumes | list | `[]` | Pod volumes |
 
+### Read-only root filesystem
+
+When `securityContext.readOnlyRootFilesystem: true` is set, the application needs a writable `/tmp` directory. The chart handles this automatically:
+
+- An `emptyDir` volume named `headlamp-tmp` is created and mounted at `/tmp` in the main container.
+- If `pluginsManager` is enabled and its effective security context (own or inherited) also sets `readOnlyRootFilesystem: true`, a separate `emptyDir` volume named `headlamp-plugins-tmp` is created and mounted at `/tmp` in the plugin manager container.
+
+**Overriding the automatic `/tmp` volume:**
+
+You can customise this behaviour without losing the automatic mount:
+
+```yaml
+# Provide your own headlamp-tmp volume (e.g. to set a size limit).
+# The chart will skip creating the volume but will still add the /tmp mount.
+volumes:
+  - name: headlamp-tmp
+    emptyDir:
+      sizeLimit: 256Mi
+```
+
+To take full control of `/tmp` (and suppress both the automatic mount and volume entirely), add your own `volumeMount` with `mountPath: /tmp`:
+
+```yaml
+volumeMounts:
+  - name: my-tmp
+    mountPath: /tmp
+volumes:
+  - name: my-tmp
+    emptyDir: {}
+```
+
 ### Network Configuration
 
 | Key | Type | Default | Description |
@@ -349,16 +380,17 @@ Ensure your replicaCount and maintenance procedures respect the configured PDB t
 
 ### pluginsManager Configuration
 
-| Key           | Type    | Default           | Description                                                                               |
-| ------------- | ------- | ----------------- | ----------------------------------------------------------------------------------------- |
-| enabled       | boolean | `false`           | Enable plugin manager                                                                     |
-| configFile    | string  | `plugin.yml`      | Plugin configuration file name                                                            |
-| configContent | string  | `""`              | Plugin configuration content in YAML format. This is required if plugins.enabled is true. |
-| baseImage     | string  | `node:lts-alpine` | Base node image to use                                                                    |
-| version       | string  | `latest`          | Headlamp plugin package version to install                                                |
-| env           | list    | `[]`              | Plugin manager env variable configuration                                                 |
-| resources     | object  | `{}`              | Plugin manager resource requests/limits                                                   |
-| volumeMounts  | list    | `[]`              | Plugin manager volume mounts                                                              |
+| Key             | Type    | Default           | Description                                                                               |
+|-----------------|---------|-------------------|-------------------------------------------------------------------------------------------|
+| enabled         | boolean | `false`           | Enable plugin manager                                                                     |
+| configFile      | string  | `plugin.yml`      | Plugin configuration file name                                                            |
+| configContent   | string  | `""`              | Plugin configuration content in YAML format. This is required if plugins.enabled is true. |
+| baseImage       | string  | `node:lts-alpine` | Base node image to use                                                                    |
+| version         | string  | `latest`          | Headlamp plugin package version to install                                                |
+| env             | list    | `[]`              | Plugin manager env variable configuration                                                 |
+| resources       | object  | `{}`              | Plugin manager resource requests/limits                                                   |
+| volumeMounts    | list    | `[]`              | Plugin manager volume mounts                                                              |
+| securityContext | object  | `{}`              | Plugin manager security context. If omitted, inherits the global `securityContext`.       |
 
 Example resource configuration:
 

--- a/charts/headlamp/templates/_helpers.tpl
+++ b/charts/headlamp/templates/_helpers.tpl
@@ -86,8 +86,14 @@ Check if readOnlyRootFilesystem is enabled, returns string "true" if enabled, ot
 
 {{/*
 Compute whether to auto-add a writable /tmp emptyDir for a container with
-readOnlyRootFilesystem: true, skipping if the user already supplies a
-conflicting volumeMount (mountPath: /tmp) or a volume with the same name.
+readOnlyRootFilesystem: true.
+
+- addMount is false when the user already has a volumeMount at /tmp
+  (avoids duplicate mountPath).
+- addVolume is false when the user already has a /tmp mount (avoids an
+  orphaned volume) OR when a volume with mountName already exists (allows
+  users to supply their own headlamp-tmp with custom emptyDir settings
+  such as sizeLimit, while the chart still wires up the /tmp mount).
 
 Input (dict):
   volumeMounts - list of existing volumeMounts for this container
@@ -108,7 +114,6 @@ Output (YAML dict, intended for use with fromYaml):
 {{- range .volumes -}}
   {{- if eq .name $.mountName -}}{{- $hasTmpVolume = true -}}{{- end -}}
 {{- end -}}
-{{- $add := and .readOnly (not $hasTmpMount) (not $hasTmpVolume) -}}
-addMount: {{ $add }}
-addVolume: {{ $add }}
+addMount: {{ and .readOnly (not $hasTmpMount) }}
+addVolume: {{ and .readOnly (not $hasTmpMount) (not $hasTmpVolume) }}
 {{- end }}

--- a/charts/headlamp/templates/_helpers.tpl
+++ b/charts/headlamp/templates/_helpers.tpl
@@ -74,3 +74,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Check if readOnlyRootFilesystem is enabled, returns string "true" if enabled, otherwise returns "false".
+*/}}
+{{- define "headlamp.readOnlyRootFilesystem" -}}
+{{- $securityContextReadOnly := and .securityContext (hasKey .securityContext "readOnlyRootFilesystem") .securityContext.readOnlyRootFilesystem -}}
+{{- if $securityContextReadOnly -}}true{{- else -}}false{{- end -}}
+{{- end }}

--- a/charts/headlamp/templates/_helpers.tpl
+++ b/charts/headlamp/templates/_helpers.tpl
@@ -83,3 +83,32 @@ Check if readOnlyRootFilesystem is enabled, returns string "true" if enabled, ot
 {{- $securityContextReadOnly := and .securityContext (hasKey .securityContext "readOnlyRootFilesystem") .securityContext.readOnlyRootFilesystem -}}
 {{- if $securityContextReadOnly -}}true{{- else -}}false{{- end -}}
 {{- end }}
+
+{{/*
+Compute whether to auto-add a writable /tmp emptyDir for a container with
+readOnlyRootFilesystem: true, skipping if the user already supplies a
+conflicting volumeMount (mountPath: /tmp) or a volume with the same name.
+
+Input (dict):
+  volumeMounts - list of existing volumeMounts for this container
+  volumes      - list of existing pod-level volumes
+  readOnly     - bool: is readOnlyRootFilesystem active for this container
+  mountName    - string: name for the auto-created volume (e.g. "headlamp-tmp")
+
+Output (YAML dict, intended for use with fromYaml):
+  addMount: bool
+  addVolume: bool
+*/}}
+{{- define "headlamp.tmpVolumeContext" -}}
+{{- $hasTmpMount := false -}}
+{{- range .volumeMounts -}}
+  {{- if eq .mountPath "/tmp" -}}{{- $hasTmpMount = true -}}{{- end -}}
+{{- end -}}
+{{- $hasTmpVolume := false -}}
+{{- range .volumes -}}
+  {{- if eq .name $.mountName -}}{{- $hasTmpVolume = true -}}{{- end -}}
+{{- end -}}
+{{- $add := and .readOnly (not $hasTmpMount) (not $hasTmpVolume) -}}
+addMount: {{ $add }}
+addVolume: {{ $add }}
+{{- end }}

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -19,6 +19,8 @@
 {{- $pluginManagerSecurityContext = .Values.securityContext }}
 {{- end }}
 {{- $readOnlyRootFsPlugins := and .Values.pluginsManager.enabled (eq (include "headlamp.readOnlyRootFilesystem" (dict "securityContext" $pluginManagerSecurityContext)) "true") }}
+{{- $tmpCtx := include "headlamp.tmpVolumeContext" (dict "volumeMounts" .Values.volumeMounts "volumes" .Values.volumes "readOnly" $readOnlyRootFs "mountName" "headlamp-tmp") | fromYaml }}
+{{- $pluginsTmpCtx := include "headlamp.tmpVolumeContext" (dict "volumeMounts" .Values.pluginsManager.volumeMounts "volumes" .Values.volumes "readOnly" $readOnlyRootFsPlugins "mountName" "headlamp-plugins-tmp") | fromYaml }}
 
 # This block of code is used to extract the values from the env.
 # This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
@@ -353,7 +355,7 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.pluginsManager.enabled .Values.volumeMounts $readOnlyRootFs }}
+          {{- if or .Values.pluginsManager.enabled .Values.volumeMounts $tmpCtx.addMount }}
           volumeMounts:
             {{- if .Values.pluginsManager.enabled }}
             - name: plugins-dir
@@ -362,7 +364,7 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if $readOnlyRootFs }}
+            {{- if $tmpCtx.addMount }}
             - name: headlamp-tmp
               mountPath: /tmp
             {{- end }}
@@ -392,7 +394,7 @@ spec:
               mountPath: {{ .Values.config.pluginsDir }}
             - name: plugin-config
               mountPath: /config
-            {{- if $readOnlyRootFsPlugins }}
+            {{- if $pluginsTmpCtx.addMount }}
             - name: headlamp-plugins-tmp
               mountPath: /tmp
             {{- end }}
@@ -440,7 +442,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- if or .Values.pluginsManager.enabled .Values.volumes $readOnlyRootFs $readOnlyRootFsPlugins }}
+      {{- if or .Values.pluginsManager.enabled .Values.volumes $tmpCtx.addVolume $pluginsTmpCtx.addVolume }}
       volumes:
         {{- if .Values.pluginsManager.enabled }}
         - name: plugins-dir
@@ -448,12 +450,12 @@ spec:
         - name: plugin-config
           configMap:
             name: {{ include "headlamp.fullname" . }}-plugin-config
-        {{- if $readOnlyRootFsPlugins }}
+        {{- if $pluginsTmpCtx.addVolume }}
         - name: headlamp-plugins-tmp
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- if $readOnlyRootFs }}
+        {{- if $tmpCtx.addVolume }}
         - name: headlamp-tmp
           emptyDir: {}
         {{- end }}

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -11,6 +11,14 @@
 {{- $usePKCE := "" }}
 {{- $useAccessToken := "" }}
 {{- $meUserInfoURL := "" }}
+{{- $readOnlyRootFs := eq (include "headlamp.readOnlyRootFilesystem" .Values) "true" }}
+{{- $pluginManagerSecurityContext := dict }}
+{{- if .Values.pluginsManager.securityContext }}
+{{- $pluginManagerSecurityContext = .Values.pluginsManager.securityContext }}
+{{- else if .Values.securityContext }}
+{{- $pluginManagerSecurityContext = .Values.securityContext }}
+{{- end }}
+{{- $readOnlyRootFsPlugins := and .Values.pluginsManager.enabled (eq (include "headlamp.readOnlyRootFilesystem" (dict "securityContext" $pluginManagerSecurityContext)) "true") }}
 
 # This block of code is used to extract the values from the env.
 # This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
@@ -345,7 +353,7 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.pluginsManager.enabled .Values.volumeMounts }}
+          {{- if or .Values.pluginsManager.enabled .Values.volumeMounts $readOnlyRootFs }}
           volumeMounts:
             {{- if .Values.pluginsManager.enabled }}
             - name: plugins-dir
@@ -353,6 +361,10 @@ spec:
             {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if $readOnlyRootFs }}
+            - name: headlamp-tmp
+              mountPath: /tmp
             {{- end }}
           {{- end }}
         {{- if .Values.pluginsManager.enabled }}
@@ -380,6 +392,10 @@ spec:
               mountPath: {{ .Values.config.pluginsDir }}
             - name: plugin-config
               mountPath: /config
+            {{- if $readOnlyRootFsPlugins }}
+            - name: headlamp-plugins-tmp
+              mountPath: /tmp
+            {{- end }}
             {{- with .Values.pluginsManager.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -424,7 +440,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- if or .Values.pluginsManager.enabled .Values.volumes }}
+      {{- if or .Values.pluginsManager.enabled .Values.volumes $readOnlyRootFs $readOnlyRootFsPlugins }}
       volumes:
         {{- if .Values.pluginsManager.enabled }}
         - name: plugins-dir
@@ -432,6 +448,14 @@ spec:
         - name: plugin-config
           configMap:
             name: {{ include "headlamp.fullname" . }}-plugin-config
+        {{- if $readOnlyRootFsPlugins }}
+        - name: headlamp-plugins-tmp
+          emptyDir: {}
+        {{- end }}
+        {{- end }}
+        {{- if $readOnlyRootFs }}
+        - name: headlamp-tmp
+          emptyDir: {}
         {{- end }}
         {{- with .Values.volumes}}
         {{- toYaml . | nindent 8 }}

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
@@ -1,0 +1,138 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.41.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}
+          volumeMounts:
+            - name: headlamp-tmp
+              mountPath: /tmp
+      volumes:
+        - emptyDir:
+            sizeLimit: 100Mi
+          name: headlamp-tmp

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
@@ -1,0 +1,137 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.41.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.41.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+          resources:
+            {}
+          volumeMounts:
+            - mountPath: /tmp
+              name: my-tmp
+      volumes:
+        - emptyDir: {}
+          name: my-tmp

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
@@ -111,25 +111,15 @@ spec:
       automountServiceAccountToken: true
       hostUsers: true
       securityContext:
-        fsGroup: 2000
-        runAsGroup: 3000
-        runAsUser: 1000
-        seccompProfile:
-          type: RuntimeDefault
+        {}
       containers:
         - name: headlamp
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
             privileged: false
             readOnlyRootFilesystem: true
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-            seccompProfile:
-              type: RuntimeDefault
           image: "ghcr.io/headlamp-k8s/headlamp:v0.41.0"
           imagePullPolicy: IfNotPresent
           
@@ -160,7 +150,7 @@ spec:
             - name: headlamp-tmp
               mountPath: /tmp
         - name: headlamp-plugin
-          image: node:18-alpine
+          image: node:lts-alpine
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -172,7 +162,7 @@ spec:
                 # Use a writable config directory
                 export NPM_CONFIG_USERCONFIG=/tmp/npm-userconfig
                 mkdir -p /tmp/npm-cache /tmp/npm-userconfig
-                npx --yes @headlamp-k8s/pluginctl@1.0.0 install --config /config/plugin.yml --folderName /headlamp/plugins --watch
+                npx --yes @headlamp-k8s/pluginctl@latest install --config /config/plugin.yml --folderName /headlamp/plugins --watch
               fi
           volumeMounts:
             - name: plugins-dir
@@ -184,13 +174,11 @@ spec:
           resources:
             null
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
+            privileged: false
             readOnlyRootFilesystem: true
+            runAsGroup: 101
             runAsNonRoot: true
-            runAsUser: 1001
+            runAsUser: 100
       volumes:
         - name: plugins-dir
           emptyDir: {}

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
@@ -111,25 +111,15 @@ spec:
       automountServiceAccountToken: true
       hostUsers: true
       securityContext:
-        fsGroup: 2000
-        runAsGroup: 3000
-        runAsUser: 1000
-        seccompProfile:
-          type: RuntimeDefault
+        {}
       containers:
         - name: headlamp
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
             privileged: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-            seccompProfile:
-              type: RuntimeDefault
           image: "ghcr.io/headlamp-k8s/headlamp:v0.41.0"
           imagePullPolicy: IfNotPresent
           
@@ -157,10 +147,8 @@ spec:
           volumeMounts:
             - name: plugins-dir
               mountPath: /headlamp/plugins
-            - name: headlamp-tmp
-              mountPath: /tmp
         - name: headlamp-plugin
-          image: node:18-alpine
+          image: node:lts-alpine
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -172,7 +160,7 @@ spec:
                 # Use a writable config directory
                 export NPM_CONFIG_USERCONFIG=/tmp/npm-userconfig
                 mkdir -p /tmp/npm-cache /tmp/npm-userconfig
-                npx --yes @headlamp-k8s/pluginctl@1.0.0 install --config /config/plugin.yml --folderName /headlamp/plugins --watch
+                npx --yes @headlamp-k8s/pluginctl@latest install --config /config/plugin.yml --folderName /headlamp/plugins --watch
               fi
           volumeMounts:
             - name: plugins-dir
@@ -184,13 +172,7 @@ spec:
           resources:
             null
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 1001
       volumes:
         - name: plugins-dir
           emptyDir: {}
@@ -198,6 +180,4 @@ spec:
           configMap:
             name: headlamp-plugin-config
         - name: headlamp-plugins-tmp
-          emptyDir: {}
-        - name: headlamp-tmp
           emptyDir: {}

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
@@ -21,21 +21,6 @@ metadata:
 type: Opaque
 data:
 ---
-# Source: headlamp/templates/plugin-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: headlamp-plugin-config
-  namespace: default
-  labels:
-    helm.sh/chart: headlamp-0.41.0
-    app.kubernetes.io/name: headlamp
-    app.kubernetes.io/instance: headlamp
-    app.kubernetes.io/version: "0.41.0"
-    app.kubernetes.io/managed-by: Helm
-data:
-  plugin.yml: |
----
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -111,25 +96,15 @@ spec:
       automountServiceAccountToken: true
       hostUsers: true
       securityContext:
-        fsGroup: 2000
-        runAsGroup: 3000
-        runAsUser: 1000
-        seccompProfile:
-          type: RuntimeDefault
+        {}
       containers:
         - name: headlamp
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
             privileged: false
             readOnlyRootFilesystem: true
             runAsGroup: 101
             runAsNonRoot: true
             runAsUser: 100
-            seccompProfile:
-              type: RuntimeDefault
           image: "ghcr.io/headlamp-k8s/headlamp:v0.41.0"
           imagePullPolicy: IfNotPresent
           
@@ -155,49 +130,8 @@ spec:
           resources:
             {}
           volumeMounts:
-            - name: plugins-dir
-              mountPath: /headlamp/plugins
             - name: headlamp-tmp
               mountPath: /tmp
-        - name: headlamp-plugin
-          image: node:18-alpine
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              if [ -f "/config/plugin.yml" ]; then
-                echo "Installing plugins from config..."
-                cat /config/plugin.yml
-                # Use a writable cache directory
-                export NPM_CONFIG_CACHE=/tmp/npm-cache
-                # Use a writable config directory
-                export NPM_CONFIG_USERCONFIG=/tmp/npm-userconfig
-                mkdir -p /tmp/npm-cache /tmp/npm-userconfig
-                npx --yes @headlamp-k8s/pluginctl@1.0.0 install --config /config/plugin.yml --folderName /headlamp/plugins --watch
-              fi
-          volumeMounts:
-            - name: plugins-dir
-              mountPath: /headlamp/plugins
-            - name: plugin-config
-              mountPath: /config
-            - name: headlamp-plugins-tmp
-              mountPath: /tmp
-          resources:
-            null
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 1001
       volumes:
-        - name: plugins-dir
-          emptyDir: {}
-        - name: plugin-config
-          configMap:
-            name: headlamp-plugin-config
-        - name: headlamp-plugins-tmp
-          emptyDir: {}
         - name: headlamp-tmp
           emptyDir: {}

--- a/charts/headlamp/tests/test_cases/readonly-root-filesystem-custom-tmp-volume.yaml
+++ b/charts/headlamp/tests/test_cases/readonly-root-filesystem-custom-tmp-volume.yaml
@@ -1,0 +1,7 @@
+securityContext:
+  readOnlyRootFilesystem: true
+
+volumes:
+  - name: headlamp-tmp
+    emptyDir:
+      sizeLimit: 100Mi

--- a/charts/headlamp/tests/test_cases/readonly-root-filesystem-custom-tmp.yaml
+++ b/charts/headlamp/tests/test_cases/readonly-root-filesystem-custom-tmp.yaml
@@ -1,0 +1,10 @@
+securityContext:
+  readOnlyRootFilesystem: true
+
+volumeMounts:
+  - name: my-tmp
+    mountPath: /tmp
+
+volumes:
+  - name: my-tmp
+    emptyDir: {}

--- a/charts/headlamp/tests/test_cases/readonly-root-filesystem-plugins-inherit.yaml
+++ b/charts/headlamp/tests/test_cases/readonly-root-filesystem-plugins-inherit.yaml
@@ -1,0 +1,5 @@
+securityContext:
+  readOnlyRootFilesystem: true
+
+pluginsManager:
+  enabled: true

--- a/charts/headlamp/tests/test_cases/readonly-root-filesystem-plugins-only.yaml
+++ b/charts/headlamp/tests/test_cases/readonly-root-filesystem-plugins-only.yaml
@@ -1,0 +1,7 @@
+securityContext:
+  readOnlyRootFilesystem: false
+
+pluginsManager:
+  enabled: true
+  securityContext:
+    readOnlyRootFilesystem: true

--- a/charts/headlamp/tests/test_cases/readonly-root-filesystem.yaml
+++ b/charts/headlamp/tests/test_cases/readonly-root-filesystem.yaml
@@ -1,0 +1,2 @@
+securityContext:
+  readOnlyRootFilesystem: true

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -168,6 +168,15 @@ podSecurityContext:
   # fsGroup: 2000
 
 # -- Headlamp containers Security Context
+# When readOnlyRootFilesystem: true is set, the chart automatically adds a
+# writable emptyDir volume named "headlamp-tmp" mounted at /tmp so the
+# application can write temporary files.
+# You can override this behavior in two ways:
+#   1. Supply your own volumeMount with mountPath: /tmp — the chart will skip
+#      adding both the automatic mount and the automatic volume.
+#   2. Supply your own volume named "headlamp-tmp" (e.g. to set sizeLimit) —
+#      the chart will skip creating the volume but will still add the /tmp mount
+#      pointing to your volume.
 securityContext:
   # capabilities:
   #   drop:
@@ -354,7 +363,13 @@ pluginsManager:
   #   limits:
   #     cpu: "1000m"
   #     memory: "4096Mi"
-  # If omitted, the plugin manager will inherit the global securityContext
+  # If omitted, the plugin manager will inherit the global securityContext.
+  # When readOnlyRootFilesystem: true is active (set here or inherited), the
+  # chart automatically adds a writable emptyDir volume named
+  # "headlamp-plugins-tmp" mounted at /tmp in the plugin manager container.
+  # Override behavior mirrors the main container: supply your own /tmp
+  # volumeMount to skip both, or supply your own "headlamp-plugins-tmp" volume
+  # (e.g. to set sizeLimit) to have the chart only add the mount.
   securityContext:
     {}
     # runAsUser: 1001


### PR DESCRIPTION
## Summary

This PR fixes #4830 by dynamically mounting an `emptyDir` volume under /tmp if either `securityContext.readOnlyRootFilesystem` or `podSecurityContext.readOnlyRootFilesystem` are `true`

## Related Issue

Fixes #4830   

## Changes

- Added a new Helm template helper, `headlamp.readOnlyRootFilesystem`, to check if `readOnlyRootFilesystem` is enabled in either `securityContext` or `podSecurityContext` values.
- Updated the deployment template to conditionally add a `tmp` volume and mount at `/tmp` when a read-only root filesystem is enabled, ensuring the application has a writable temporary directory. 

## Steps to Test

1. Deploy the chart with either `securityContext.readOnlyRootFilesystem` or `podSecurityContext.readOnlyRootFilesystem` set to `true`
2. verify headlamp start properly.

## Notes

I opened this PR because this is the solution I think is the best however I did ask for comments in [this slack message](https://kubernetes.slack.com/archives/C01FXB5E8ER/p1775565157280729) so I am waiting to hear opinions before marking this PR for review.
