### PR TITLE
SECURITY.md: Update to use kubernetes-sigs SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,22 @@
 # Security Policy
 
+## Security Announcements
+
+Join the [kubernetes-security-announce] group for security and vulnerability announcements.
+
+You can also subscribe to an RSS feed of the above using [this link][kubernetes-security-announce-rss].
+
 ## Reporting a Vulnerability
 
-Please read our documentation on how to [report security issues](https://headlamp.dev/docs/latest/contributing/#security-issues).
+Instructions for reporting a vulnerability can be found on the
+[Kubernetes Security and Disclosure Information] page.
 
-We kindly ask that you responsibly disclose any vulnerabilities and give us appropriate time to develop a fix.
+## Supported Versions
+
+Information about supported Kubernetes versions can be found on the
+[Kubernetes version and version skew support policy] page on the Kubernetes website.
+
+[kubernetes-security-announce]: https://groups.google.com/forum/#!forum/kubernetes-security-announce
+[kubernetes-security-announce-rss]: https://groups.google.com/forum/feed/kubernetes-security-announce/msgs/rss_v2_0.xml?num=50
+[Kubernetes version and version skew support policy]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
+[Kubernetes Security and Disclosure Information]: https://kubernetes.io/docs/reference/issues-security/security/#report-a-vulnerability


### PR DESCRIPTION
Note, keeping the file in the repo like minikube does so it
is easier to find for people browsing via github files or via
a checked out copy of the repo.

https://github.com/kubernetes-sigs/.github/blob/master/SECURITY.md
