### PR TITLE
frontend: cronjob: Handle undefined spec.suspend in List and Details

### DIFF
--- a/frontend/src/components/cronjob/Details.tsx
+++ b/frontend/src/components/cronjob/Details.tsx
@@ -149,7 +149,7 @@ export default function CronJobDetails(props: {
   const { items: jobs, errors } = Job.useList({ namespace, cluster: cronJob?.cluster });
   const [isSpawnDialogOpen, setIsSpawnDialogOpen] = useState(false);
   const [isPendingSuspend, setIsPendingSuspend] = useState(false);
-  const isCronSuspended = cronJob?.spec.suspend;
+  const isCronSuspended = cronJob?.spec?.suspend ?? false;
 
   const ownedJobs = useMemo(
     () =>
@@ -238,7 +238,7 @@ export default function CronJobDetails(props: {
           },
           {
             name: t('translation|Suspend'),
-            value: item.spec.suspend.toString(),
+            value: (item.spec?.suspend ?? false).toString(),
           },
           {
             name: t('Starting deadline'),

--- a/frontend/src/components/cronjob/List.tsx
+++ b/frontend/src/components/cronjob/List.tsx
@@ -66,7 +66,7 @@ export default function CronJobList() {
         {
           id: 'suspend',
           label: t('translation|Suspend'),
-          getValue: cronJob => cronJob.spec.suspend.toString(),
+          getValue: cronJob => (cronJob.spec?.suspend ?? false).toString(),
           gridTemplate: 0.6,
         },
         {


### PR DESCRIPTION
## Summary
This PR fixes a crash in the CronJob list and details pages when `spec.suspend` is not explicitly set in the CronJob manifest. Kubernetes defaults `spec.suspend` to `false` but does not always include it in the API response, causing `.toString()` to be called on `undefined` and throwing a `TypeError`

## Related Issue

Fixes #5083

## Changes
- Fixed `frontend/src/components/cronjob/List.tsx` added `?? false` fallback before `.toString()` on `spec.suspend `in the Suspend column `getValue`
- Fixed `frontend/src/components/cronjob/Details.tsx` added `?. `optional chaining on `spec` and `?? false` fallback for `isCronSuspended` derivation
- Fixed `frontend/src/components/cronjob/Details.tsx` added `?? false` fallback before `.toString()` on `spec.suspend` in the `extraInfo` Suspend field

## Steps to Test

1. Apply a CronJob manifest that omits `spec.suspend` e.g. a Helm generated CronJob
2. Navigate to Workloads -> CronJobs
3. Verify the list renders correctly and shows `false` in the Suspend column without crashing
4. Click on the CronJob to open its details page
5. Verify the details page renders correctly and shows `false` for the Suspend field
6. Repeat with a CronJob that has `spec.suspend:true` explicitly set and verify it still shows `true` correctly

## Notes for the Reviewer
`spec.suspend` is defined as optional in the Kubernetes `batch/v1 CronJobSpec` its absence from the API response is valid behaviour, not a bug in the cluster
The `?? false` fallback exactly matches the Kubernetes-defined default for this field, so there is no behaviour change for CronJobs that have the field explicitly set
The additional `?.` on `spec` in `isCronSuspended` guards against the loading phase before the API response arrives, which the original `cronJob?.spec.suspend` did not cover
