### PR TITLE
frontend: fix editor showing old yaml after save

### DIFF
--- a/frontend/src/components/activity/Activity.test.tsx
+++ b/frontend/src/components/activity/Activity.test.tsx
@@ -64,7 +64,7 @@ describe('activitySlice', () => {
             ...newActivity,
             title: 'Old Title',
             content: 'Old Content',
-            icon: 'mdi:old-icon',
+            icon: 'mdi:home',
             hideTitleInHeader: true,
             minimized: true,
           },
@@ -79,7 +79,7 @@ describe('activitySlice', () => {
       expect(nextState.activities['1'].title).toEqual('New Title');
       expect(nextState.activities['1'].content).toEqual('New Content');
       expect(nextState.activities['1'].minimized).toBe(false);
-      expect(nextState.activities['1'].icon).toEqual('mdi:old-icon');
+      expect(nextState.activities['1'].icon).toEqual('mdi:home');
       expect(nextState.activities['1'].hideTitleInHeader).toBe(true);
       expect(nextState.history).toEqual(['1']);
     });

--- a/frontend/src/components/activity/Activity.test.tsx
+++ b/frontend/src/components/activity/Activity.test.tsx
@@ -60,20 +60,27 @@ describe('activitySlice', () => {
       const stateWithExistingActivity: ActivityState = {
         history: [],
         activities: {
-          '1': { ...newActivity, title: 'Old Title', minimized: true },
+          '1': {
+            ...newActivity,
+            title: 'Old Title',
+            content: 'Old Content',
+            icon: 'mdi:old-icon',
+            hideTitleInHeader: true,
+            minimized: true,
+          },
         },
       };
-
       const updatedActivity: Activity = {
         ...newActivity,
         title: 'New Title',
+        content: 'New Content',
       };
-
       const nextState = reducer(stateWithExistingActivity, launchActivity(updatedActivity));
-
       expect(nextState.activities['1'].title).toEqual('New Title');
-      expect(nextState.activities['1'].content).toEqual('Test Content');
+      expect(nextState.activities['1'].content).toEqual('New Content');
       expect(nextState.activities['1'].minimized).toBe(false);
+      expect(nextState.activities['1'].icon).toEqual('mdi:old-icon');
+      expect(nextState.activities['1'].hideTitleInHeader).toBe(true);
       expect(nextState.history).toEqual(['1']);
     });
 

--- a/frontend/src/components/activity/Activity.test.tsx
+++ b/frontend/src/components/activity/Activity.test.tsx
@@ -56,6 +56,27 @@ describe('activitySlice', () => {
       expect(nextState.history).toEqual(['1']);
     });
 
+    it('should merge new payload into existing activity', () => {
+      const stateWithExistingActivity: ActivityState = {
+        history: [],
+        activities: {
+          '1': { ...newActivity, title: 'Old Title', minimized: true },
+        },
+      };
+
+      const updatedActivity: Activity = {
+        ...newActivity,
+        title: 'New Title',
+      };
+
+      const nextState = reducer(stateWithExistingActivity, launchActivity(updatedActivity));
+
+      expect(nextState.activities['1'].title).toEqual('New Title');
+      expect(nextState.activities['1'].content).toEqual('Test Content');
+      expect(nextState.activities['1'].minimized).toBe(false);
+      expect(nextState.history).toEqual(['1']);
+    });
+
     it('should close temporary activities', () => {
       const temporaryActivity: Activity = {
         id: '2',

--- a/frontend/src/components/activity/activitySlice.tsx
+++ b/frontend/src/components/activity/activitySlice.tsx
@@ -52,8 +52,12 @@ export const activitySlice = createSlice({
         // New activity, add it to the state
         state.activities[action.payload.id] = action.payload;
       } else {
-        // Existing activity, un-minimize it
-        state.activities[action.payload.id].minimized = false;
+        // Existing activity, replace content and un-minimize
+        state.activities[action.payload.id] = {
+          ...state.activities[action.payload.id],
+          ...action.payload,
+          minimized: false,
+        };
       }
 
       // Make it fullscreen on small windows

--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -63,7 +63,10 @@ export default function EditButton(props: EditButtonProps) {
 
   async function updateFunc(newItem: KubeObjectInterface) {
     try {
-      await item.update(newItem);
+      const updatedItem = await item.update(newItem);
+      if (updatedItem) {
+        item.jsonData = updatedItem as KubeObjectInterface;
+      }
       Activity.close(activityId);
     } catch (err) {
       Activity.update(activityId, { minimized: false });

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -329,6 +329,8 @@ export default function EditorDialog(props: EditorDialogProps) {
         });
       }
     );
+    // reset the ref so next time editor opens it loads fresh data from kubernetes
+    originalCodeRef.current = { code: '', format: '' };
     onClose();
   };
 

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -329,8 +329,6 @@ export default function EditorDialog(props: EditorDialogProps) {
         });
       }
     );
-    // reset the ref so next time editor opens it loads fresh data from kubernetes
-    originalCodeRef.current = { code: '', format: '' };
     onClose();
   };
 


### PR DESCRIPTION
### Summary

Fixes #4906.

The editor was showing old YAML after clicking Save & Apply. Even after 
the save worked fine, reopening the editor still showed the previous 
version. Had to refresh the page to see the updated manifest.

Took a while to track down but there were two things causing this:

1. In `activitySlice.tsx`, when the editor was re-opened for the same 
resource, the reducer was only un-minimizing the existing activity and 
ignoring the new payload. So the fresh `<EditorDialog>` that EditButton 
created just got thrown away by Redux.

2. In `EditButton.tsx`, the response from `item.update()` was never 
stored anywhere. So `item.jsonData` stayed stale after save and 
`getEditableObject()` kept returning the old data.

Both needed to be fixed together.

### Related Issue

Fixes #4906

### Changes

- `activitySlice.tsx`: `launchActivity` now merges the new payload into 
the existing activity instead of just un-minimizing it
- `EditButton.tsx`: storing the response from `item.update()` back into 
`item.jsonData` after a successful save
- `EditorDialog.tsx`: removed the `originalCodeRef` reset, it wasn't 
actually fixing anything
- `Activity.test.tsx`: added a test for the merge behavior in 
`launchActivity`

### Steps to Test

1. Open any resource in the YAML editor
2. Make a change (e.g. add a label)
3. Click **Save & Apply**
4. Open the editor again on the same resource
5. Should show the updated YAML without needing a page refresh