### PR TITLE
backend: Replace context.TODO() with explicit background context in long-running goroutine

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2553,7 +2553,7 @@ func (c *HeadlampConfig) drainNode(clientset *kubernetes.Clientset, nodeName str
 		cacheKey := uuid.NewSHA1(uuid.Nil, []byte(nodeName+cluster)).String()
 		cacheItemTTL := DrainNodeCacheTTL * time.Minute
 
-		node, err := nodeClient.Get(context.TODO(), nodeName, v1.GetOptions{})
+		node, err := nodeClient.Get(ctx, nodeName, v1.GetOptions{})
 		if err != nil {
 			_ = c.Cache.SetWithTTL(ctx, cacheKey, "error: "+err.Error(), cacheItemTTL)
 			return
@@ -2562,13 +2562,13 @@ func (c *HeadlampConfig) drainNode(clientset *kubernetes.Clientset, nodeName str
 		// cordon the node first
 		node.Spec.Unschedulable = true
 
-		_, err = nodeClient.Update(context.TODO(), node, v1.UpdateOptions{})
+		_, err = nodeClient.Update(ctx, node, v1.UpdateOptions{})
 		if err != nil {
 			_ = c.Cache.SetWithTTL(ctx, cacheKey, "error: "+err.Error(), cacheItemTTL)
 			return
 		}
 
-		pods, err := clientset.CoreV1().Pods("").List(context.TODO(),
+		pods, err := clientset.CoreV1().Pods("").List(ctx,
 			v1.ListOptions{FieldSelector: "spec.nodeName=" + nodeName})
 		if err != nil {
 			_ = c.Cache.SetWithTTL(ctx, cacheKey, "error: "+err.Error(), cacheItemTTL)
@@ -2583,7 +2583,7 @@ func (c *HeadlampConfig) drainNode(clientset *kubernetes.Clientset, nodeName str
 				continue
 			}
 
-			_ = clientset.CoreV1().Pods(pod.Namespace).Delete(context.TODO(),
+			_ = clientset.CoreV1().Pods(pod.Namespace).Delete(ctx,
 				pod.Name, v1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
 		}
 


### PR DESCRIPTION
## Summary
This PR cleans up technical debt in the Golang backend inside the `drainNode` asynchronous API handler. It replaces repeated `context.TODO()` usages with the correctly initialized, explicit `context.Background()` wrapper variable `ctx` that the goroutine actually instantiated but failed to pass downstream. 

## Changes
- `backend/cmd/headlamp.go`: Inside the `drainNode` goroutine, replaced `context.TODO()` in Kubernetes `nodeClient` and `clientset.CoreV1().Pods()` calls with the available `ctx` variable to explicitly signify that this work outlives the HTTP request scope.