### PR TITLE
frontend: Storybook: fix ResourceTable Name Search filter

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.stories.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.stories.tsx
@@ -47,14 +47,13 @@ export default {
 const TemplateWithFilter: StoryFn<{
   resourceTableArgs: ResourceTableFromResourceClassProps<typeof MyPod>;
   namespaces: string[];
-  search: string;
 }> = args => {
-  const { resourceTableArgs, search, namespaces = [] } = args;
+  const { resourceTableArgs, namespaces = [] } = args;
 
   const storeWithFilterAndSettings = configureStore({
     reducer: (
       state = {
-        filter: { namespaces: new Set<string>(), search: '' },
+        filter: { namespaces: new Set<string>() },
         config: { settings: { tableRowsPerPageOptions: [10, 20, 50, 100] } },
         ui: { ...uiSlice.getInitialState() },
         drawerMode: { isDetailDrawerEnabled: false },
@@ -65,7 +64,6 @@ const TemplateWithFilter: StoryFn<{
       ui: { ...uiSlice.getInitialState() },
       filter: {
         namespaces: new Set(namespaces),
-        search,
       },
       config: {
         settings: {
@@ -174,17 +172,17 @@ const withHiddenCols: ResourceTableFromResourceClassProps<typeof MyPod> = {
 export const NoFilter = TemplateWithFilter.bind({});
 NoFilter.args = {
   resourceTableArgs: podData,
-  search: '',
 };
 
 export const NameSearch = TemplateWithFilter.bind({});
 NameSearch.args = {
-  resourceTableArgs: podData,
-  search: 'mypod3',
+  resourceTableArgs: {
+    ...podData,
+    defaultGlobalFilter: 'mypod3',
+  },
 };
 
 export const WithHiddenCols = TemplateWithFilter.bind({});
 WithHiddenCols.args = {
   resourceTableArgs: withHiddenCols,
-  search: '',
 };

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -52,30 +52,95 @@
           class="MuiBox-root css-1p0wbhh"
         >
           <div
+            class="MuiCollapse-root MuiCollapse-horizontal MuiCollapse-entered css-1d98dbz-MuiCollapse-root"
+            style="min-width: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper MuiCollapse-horizontal css-18w3a48-MuiCollapse-wrapper"
+            >
+              <div
+                class="MuiCollapse-wrapperInner MuiCollapse-horizontal css-14vyde3-MuiCollapse-wrapperInner"
+              >
+                <div
+                  class="MuiFormControl-root MuiTextField-root css-11sh9fj-MuiFormControl-root-MuiTextField-root"
+                >
+                  <div
+                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-19jxtzy-MuiInputBase-root-MuiOutlinedInput-root"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      data-testid="SearchIcon"
+                      focusable="false"
+                      style="margin-right: 4px;"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                      />
+                    </svg>
+                    <input
+                      aria-invalid="false"
+                      autocomplete="new-password"
+                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-12yjm75-MuiInputBase-input-MuiOutlinedInput-input"
+                      id="table-search-field"
+                      placeholder="Search"
+                      type="text"
+                      value="mypod3"
+                    />
+                    <div
+                      class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                    >
+                      <span
+                        aria-label="Clear search"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          aria-label="Clear search"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </span>
+                    </div>
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    >
+                      <legend
+                        class="css-1whs34k-MuiNotchedOutlined-root"
+                      >
+                        <span
+                          class="notranslate"
+                        >
+                          ​
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
             class="MuiBox-root css-di3982"
           >
-            <button
-              aria-label="Show/Hide search"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-              data-mui-internal-clone-element="true"
-              tabindex="0"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                data-testid="SearchIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-                />
-              </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </button>
             <button
               aria-label="Show/Hide filters"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
@@ -303,114 +368,6 @@
       <tbody
         class="css-1obf64m"
       >
-        <tr
-          class="css-1ospngb"
-          data-selected="false"
-        >
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
-          >
-            <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-              href="/"
-            >
-              mypod0
-            </a>
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
-          >
-            <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-              href="/"
-            >
-              MyNamespace0
-            </a>
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
-          >
-            <p
-              aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
-              data-mui-internal-clone-element="true"
-            >
-              90d
-            </p>
-          </td>
-        </tr>
-        <tr
-          class="css-1ospngb"
-          data-selected="false"
-        >
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
-          >
-            <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-              href="/"
-            >
-              mypod1
-            </a>
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
-          >
-            <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-              href="/"
-            >
-              MyNamespace1
-            </a>
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
-          >
-            <p
-              aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
-              data-mui-internal-clone-element="true"
-            >
-              90d
-            </p>
-          </td>
-        </tr>
-        <tr
-          class="css-1ospngb"
-          data-selected="false"
-        >
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
-          >
-            <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-              href="/"
-            >
-              mypod2
-            </a>
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
-          >
-            <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-              href="/"
-            >
-              MyNamespace2
-            </a>
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
-          >
-            <p
-              aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
-              data-mui-internal-clone-element="true"
-            >
-              90d
-            </p>
-          </td>
-        </tr>
         <tr
           class="css-1ospngb"
           data-selected="false"

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -196,10 +196,21 @@ export default function Table<RowItem extends Record<string, any>>({
   const prefix = reflectInURL === true ? '' : reflectInURL || '';
   const [page, setPage] = usePageURLState(shouldReflectInURL ? 'p' : '', prefix, initialPage);
   const filterKey = prefix ? `${prefix}filter` : 'filter';
-  const [globalFilter, setGlobalFilter] = useQueryParamsState<string | undefined>(
-    shouldReflectInURL ? filterKey : '',
-    shouldReflectInURL ? '' : undefined
+  const [globalFilterState, setGlobalFilterState] = useState<string | undefined>(
+    tableProps.initialState?.globalFilter
   );
+  const [globalFilterQueryParam, setGlobalFilterQueryParam] = useQueryParamsState<
+    string | undefined
+  >(
+    shouldReflectInURL ? filterKey : '',
+    shouldReflectInURL ? tableProps.initialState?.globalFilter : undefined
+  );
+
+  // When `reflectInURL` is enabled, the filter needs to stay in sync with the URL
+  // query parameter. Otherwise we keep the filter in plain React state only.
+  const [globalFilter, setGlobalFilter] = shouldReflectInURL
+    ? [globalFilterQueryParam, setGlobalFilterQueryParam]
+    : [globalFilterState, setGlobalFilterState];
 
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
   const rowsPerPageOptions = rowsPerPage || storeRowsPerPageOptions;

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -86,7 +86,7 @@
                       id="table-search-field"
                       placeholder="Search"
                       type="text"
-                      value=""
+                      value="value1"
                     />
                     <div
                       class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
@@ -98,9 +98,8 @@
                       >
                         <button
                           aria-label="Clear search"
-                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
-                          disabled=""
-                          tabindex="-1"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
                           type="button"
                         >
                           <svg
@@ -114,6 +113,9 @@
                               d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
                             />
                           </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
                         </button>
                       </span>
                     </div>
@@ -216,12 +218,12 @@
                   Name
                 </div>
                 <span
-                  aria-label="Sort by Name ascending"
+                  aria-label="Sort by Name descending"
                   class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                   data-mui-internal-clone-element="true"
                 >
                   <span
-                    aria-label="Sort by Name ascending"
+                    aria-label="Sort by Name descending"
                     class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                     role="button"
                     tabindex="0"
@@ -271,12 +273,12 @@
                   Namespace
                 </div>
                 <span
-                  aria-label="Sort by Namespace ascending"
+                  aria-label="Sort by Namespace descending"
                   class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                   data-mui-internal-clone-element="true"
                 >
                   <span
-                    aria-label="Sort by Namespace ascending"
+                    aria-label="Sort by Namespace descending"
                     class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                     role="button"
                     tabindex="0"
@@ -326,12 +328,12 @@
                   UID
                 </div>
                 <span
-                  aria-label="Sort by UID ascending"
+                  aria-label="Sort by UID descending"
                   class="MuiBadge-root css-1c32n2y-MuiBadge-root"
                   data-mui-internal-clone-element="true"
                 >
                   <span
-                    aria-label="Sort by UID ascending"
+                    aria-label="Sort by UID descending"
                     class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
                     role="button"
                     tabindex="0"
@@ -420,106 +422,7 @@
       </thead>
       <tbody
         class="css-1obf64m"
-      >
-        <tr
-          class="css-1ospngb"
-          data-selected="false"
-        >
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
-          >
-            mydefinition.phonyresources0.io
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
-          >
-            MyNamespace0
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
-          >
-            phony0
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
-          />
-        </tr>
-        <tr
-          class="css-1ospngb"
-          data-selected="false"
-        >
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
-          >
-            mydefinition.phonyresources1.io
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
-          >
-            MyNamespace1
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
-          >
-            phony1
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
-          >
-            {"mylabel1":"myvalue1"}
-          </td>
-        </tr>
-        <tr
-          class="css-1ospngb"
-          data-selected="false"
-        >
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
-          >
-            mydefinition.phonyresources2.io
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
-          >
-            MyNamespace2
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
-          >
-            phony2
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
-          >
-            {"mykey2":"mylabel"}
-          </td>
-        </tr>
-        <tr
-          class="css-1ospngb"
-          data-selected="false"
-        >
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
-          >
-            mydefinition.phonyresources3.io
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2wxm0s-MuiTableCell-root"
-          >
-            MyNamespace3
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
-          >
-            phony3
-          </td>
-          <td
-            class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1yl63d8-MuiTableCell-root"
-          >
-            {"mykey3":"myvalue3"}
-          </td>
-        </tr>
-      </tbody>
+      />
     </table>
     <div
       class="MuiBox-root css-1bxknjp"


### PR DESCRIPTION
## Summary

This PR fixes the `ResourceTable` **Name Search** Storybook example so the search input is actually prefilled and the table filters as intended.

## Related Issue

Fixes #5082

## Changes

- Updated `frontend/src/components/common/Resource/ResourceTable.stories.tsx`
- Switched the story from Redux-only search state to the URL query param that `ResourceTable` actually reads
- Enabled `reflectInURL` on the `ResourceTable` story so the global filter is applied correctly
- Kept the existing example data and story structure intact

## Steps to Test

1. Run `npm run frontend:storybook`
2. Open `ResourceTable` in Storybook
3. Select the `Name Search` story
4. Confirm the search box is prefilled with `mypod3`
5. Confirm the table is filtered to the matching row only

## Screenshots (if applicable)
<img width="3072" height="1728" alt="Screenshot from 2026-04-09 15-57-09" src="https://github.com/user-attachments/assets/faa68d0f-354a-4d37-8708-304138a1c535" />

- Storybook screenshot showing the `Name Search` story with the search field populated and filtered results

## Notes for the Reviewer

