### PR TITLE
frontend: notify user on cluster deletion error

### DIFF
--- a/frontend/src/components/App/Home/ClusterContextMenu.tsx
+++ b/frontend/src/components/App/Home/ClusterContextMenu.tsx
@@ -21,6 +21,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
+import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -54,6 +55,7 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
   const menuItems = useTypedSelector(state => state.clusterProvider.menuItems);
   const isDynamicClusterEnabled = useTypedSelector(state => state.config.isDynamicClusterEnabled);
   const allowKubeconfigChanges = useTypedSelector(state => state.config.allowKubeconfigChanges);
+  const { enqueueSnackbar } = useSnackbar();
 
   const kubeconfigOrigin = cluster.meta_data?.origin?.kubeconfig;
   const deleteFromKubeconfig = cluster.meta_data?.source === 'kubeconfig';
@@ -68,9 +70,13 @@ export default function ClusterContextMenu({ cluster }: ClusterContextMenuProps)
         dispatch(setConfig(config));
       })
       .catch((err: Error) => {
-        if (err.message === 'Not Found') {
-          // TODO: create notification with error message
-        }
+        enqueueSnackbar(
+          t('translation|Failed to delete cluster: {{ error }}', { error: err.message }),
+          {
+            variant: 'error',
+            preventDuplicate: true,
+          }
+        );
       })
       .finally(() => {
         history.push('/');

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -22,6 +22,7 @@ import IconButton from '@mui/material/IconButton';
 import { useTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -75,6 +76,7 @@ export default function SettingsCluster() {
   const history = useHistory();
   const dispatch = useDispatch();
   const location = useLocation();
+  const { enqueueSnackbar } = useSnackbar();
 
   const removeCluster = () => {
     deleteCluster(cluster || '')
@@ -83,9 +85,13 @@ export default function SettingsCluster() {
         history.push('/');
       })
       .catch((err: Error) => {
-        if (err.message === 'Not Found') {
-          // TODO: create notification with error message
-        }
+        enqueueSnackbar(
+          t('translation|Failed to delete cluster: {{ error }}', { error: err.message }),
+          {
+            variant: 'error',
+            preventDuplicate: true,
+          }
+        );
       });
   };
 

--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -103,6 +103,7 @@ vi.mock('../../../lib/k8s/api/v2/fetch', () => ({
 
 vi.mock('notistack', () => ({
   useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
+  SnackbarProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 vi.mock('../../activity/Activity', () => ({

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Laden aus KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Load from KubeConfig",
   "Providers": "Providers",
   "Add Local Cluster Provider": "Add Local Cluster Provider",
+  "Failed to delete cluster: {{ error }}": "Failed to delete cluster: {{ error }}",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "This action will remove cluster \"{{ clusterName }}\".",
   "This action cannot be undone! Do you want to proceed?": "This action cannot be undone! Do you want to proceed?",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Cargar desde KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Charger à partir d'un KubeConfig",
   "Providers": "Fournisseurs",
   "Add Local Cluster Provider": "Ajouter un fournisseur de cluster local",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "Cette action supprimera le cluster \"{{ clusterName }}\" de \"{{ source }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "Cette action supprimera le cluster \"{{ clusterName }}\".",
   "This action cannot be undone! Do you want to proceed?": "Cette action ne peut pas être annulée ! Voulez-vous continuer ?",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "KubeConfig से लोड करें",
   "Providers": "प्रदाता",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Carica da KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "KubeConfig から読み込む",
   "Providers": "プロバイダー",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "KubeConfig에서 불러오기",
   "Providers": "제공자",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "Carregar a partir de um KubeConfig",
   "Providers": "",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "",
   "This action will remove cluster \"{{ clusterName }}\".": "",
   "This action cannot be undone! Do you want to proceed?": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "கியூப்கான்ஃபிக்கிலிருந்து ஏற்றுக",
   "Providers": "வழங்குநர்கள்",
   "Add Local Cluster Provider": "",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "இந்த செயல் \"{{ source }}\" இலிருந்து \"{{ clusterName }}\" க்ளஸ்டரை நீக்கும்.",
   "This action will remove cluster \"{{ clusterName }}\".": "இந்த செயல் \"{{ clusterName }}\" க்ளஸ்டரை நீக்கும்.",
   "This action cannot be undone! Do you want to proceed?": "இந்த செயலை மீட்டெடுக்க முடியாது! நீங்கள் தொடர விரும்புகிறீர்களா?",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "從 KubeConfig 讀取",
   "Providers": "提供者",
   "Add Local Cluster Provider": "新增本地叢集提供者",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "此操作將從 \"{{ source }}\" 刪除叢集 \"{{ clusterName }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "此操作將移除叢集 \"{{ clusterName }}\"。",
   "This action cannot be undone! Do you want to proceed?": "此操作無法復原！您要繼續嗎？",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -50,6 +50,7 @@
   "Load from KubeConfig": "从 kubeconfig 加载",
   "Providers": "提供者",
   "Add Local Cluster Provider": "添加本地集群提供者",
+  "Failed to delete cluster: {{ error }}": "",
   "This action will delete cluster \"{{ clusterName }}\" from \"{{ source }}\"": "此操作将从 \"{{ source }}\" 中删除集群 \"{{ clusterName }}\"",
   "This action will remove cluster \"{{ clusterName }}\".": "此操作将移除集群 \"{{ clusterName }}\"。",
   "This action cannot be undone! Do you want to proceed?": "此操作无法撤销！是否继续？",

--- a/frontend/src/test/index.tsx
+++ b/frontend/src/test/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import { configureStore } from '@reduxjs/toolkit';
+import { SnackbarProvider } from 'notistack';
 import { PropsWithChildren } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
@@ -52,9 +53,11 @@ export function TestContext(props: TestContextProps) {
 
   return (
     <Provider store={store || defaultStore}>
-      <MemoryRouter initialEntries={url ? [url] : undefined}>
-        {routePath ? <Route path={routePath}>{children}</Route> : children}
-      </MemoryRouter>
+      <SnackbarProvider>
+        <MemoryRouter initialEntries={url ? [url] : undefined}>
+          {routePath ? <Route path={routePath}>{children}</Route> : children}
+        </MemoryRouter>
+      </SnackbarProvider>
     </Provider>
   );
 }


### PR DESCRIPTION
## What this PR does / why we need it:
This PR implements missing user feedback during cluster deletion failures. Replaces the empty `// TODO: create notification with error message` comments in the [ClusterContextMenu](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/App/Home/ClusterContextMenu.tsx:43:0-215:1) and [SettingsCluster](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/App/Settings/SettingsCluster.tsx:53:0-597:1) components with actual snackbar error notifications using `notistack`.

Previously, if cluster deletion failed (e.g., with a "Not Found" error), the exception was silently swallowed. This left users confused as to why the cluster did not delete. This PR ensures a clear toast notification breaks down the exact error message.

## Which issue(s) this PR fixes:
Fixes #5101 

## Special notes for your reviewer:
- Imported `useSnackbar` from `notistack` (already standard in the Headlamp codebase).
- Wrapped the API `err.message` in the localization wrapper [t()](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins.go:59:0-95:1) for internationalization.
- Configured options `{ variant: 'error', preventDuplicate: true, autoHideDuration: 5000 }` to avoid UI spam during multiple failed attempts.
