### PR TITLE
frontend: use console.error for caught exceptions

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -328,7 +328,7 @@ export function SearchPopover(props: SearchPopoverProps) {
       });
     } catch (e) {
       // Catch invalid regular expression error
-      console.log('Error searching logs: ', e);
+      console.error('Error searching logs: ', e);
       searchAddonRef.current?.findNext('');
     }
 

--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -347,7 +347,7 @@ export default function PortForwardingList() {
             })
             .catch(error => {
               setPortForwardInAction(null);
-              console.log('Error starting port forward:', error);
+              console.error('Error starting port forward:', error);
             });
         }}
       />

--- a/frontend/src/components/project/ProjectDetails.tsx
+++ b/frontend/src/components/project/ProjectDetails.tsx
@@ -394,7 +394,7 @@ function ProjectDetailsContent({ project }: { project: ProjectDefinition }) {
           }
         })
         .catch(e => {
-          console.log(`Failed to check if custom delete button is ready`, e);
+          console.error(`Failed to check if custom delete button is ready`, e);
         });
     } else {
       setDeleteButton(() => customDeleteButton.component);


### PR DESCRIPTION
## What this PR does / why we need it:
Replaces `console.log()` with `console.error()` inside catch blocks across three frontend components. This ensures caught exceptions are properly flagged in browser DevTools and external log monitoring tools.

## Which issue(s) this PR fixes:
Fixes #5103

## Special notes for your reviewer:
- Only the logging severity level is changed ([log](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/plugins/plugins.go:248:0-267:1) → `error`), no logic changes.
- [runCommand.ts](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/App/runCommand.ts:0:0-0:0) was intentionally excluded as its `console.log` usage is inside JSDoc examples, not runtime code.

## Files changed:
- [frontend/src/components/portforward/index.tsx](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/portforward/index.tsx:0:0-0:0)
- [frontend/src/components/common/LogViewer.tsx](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/common/LogViewer.tsx:0:0-0:0)
- `frontend/src/components/project/ProjectDetails.tsx`
