### PR TITLE
test: add backend helm auth token and frontend RouteSwitcher key uniqueness tests

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1378,10 +1378,8 @@ func (c *HeadlampConfig) helmRouteReleaseHandler(
 	// Create a copy of the context to avoid modifying the cached context
 	context = context.Copy()
 
-	// If running in cluster or explicitly enabled via flag, use the token from the cookie for oidc auth
-	if (c.UseInCluster || c.OidcUseCookie) && context.OidcConf != nil {
-		setTokenFromCookie(r, clusterName)
-	}
+	// Always attempt to set the token from the cookie as the function is a no operation when no cookie is present
+	setTokenFromCookie(r, clusterName)
 
 	bearerToken := r.Header.Get("Authorization")
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -2162,4 +2163,80 @@ func TestOidcUseCookieLogic(t *testing.T) {
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
+}
+
+// TestHelmRouteReleaseHandlerTokenExtraction verifies that helmRouteReleaseHandler
+// sets the Authorization header and propagates the bearer token into the clientConfig
+// in a non-OIDC in-cluster deployment where OidcConf is nil. This is a regression
+// test for the bug where the OIDC guard prevented token extraction for non-OIDC setups.
+//
+//nolint:funlen
+func TestHelmRouteReleaseHandlerTokenExtraction(t *testing.T) {
+	clusterName := "test-cluster-nooidc"
+	cookieName := "headlamp-auth-" + clusterName + ".0"
+
+	// #nosec G101 -- test credential, not a real secret
+	testToken := "non-oidc-test-token"
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	err := kubeConfigStore.AddContext(&kubeconfig.Context{
+		Name: clusterName,
+		Cluster: &api.Cluster{
+			Server: "https://test-cluster.example.com",
+		},
+		AuthInfo: &api.AuthInfo{},
+	})
+	require.NoError(t, err)
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    true,
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	var capturedAuthHeader string
+
+	var capturedBearerToken string
+
+	handler := func(clientConfig clientcmd.ClientConfig, w http.ResponseWriter, r *http.Request) {
+		capturedAuthHeader = r.Header.Get("Authorization")
+
+		restConfig, restErr := clientConfig.ClientConfig()
+		if restErr == nil && restConfig != nil {
+			capturedBearerToken = restConfig.BearerToken
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/helm/release/test", nil)
+	require.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{
+		Name:  cookieName,
+		Value: testToken,
+	})
+
+	w := httptest.NewRecorder()
+
+	tracer := otel.GetTracerProvider().Tracer("test-tracer")
+
+	ctx, span := tracer.Start(context.Background(), "test-span")
+
+	defer span.End()
+
+	c.helmRouteReleaseHandler(ctx, span, req, w, clusterName, "/helm/release/test", "test", handler)
+
+	assert.Equal(t, "Bearer "+testToken, capturedAuthHeader,
+		"Authorization header should be set from cookie in non-OIDC in-cluster deployment")
+
+	assert.Equal(t, testToken, capturedBearerToken,
+		"clientConfig bearer token should be set from cookie in non-OIDC in-cluster deployment")
 }

--- a/frontend/src/components/App/RouteSwitcher.test.tsx
+++ b/frontend/src/components/App/RouteSwitcher.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+
+vi.mock('../../lib/k8s', () => ({
+  useCluster: vi.fn(() => null),
+  useClustersConf: vi.fn(() => ({})),
+  useClustersVersion: vi.fn(() => ({})),
+  useConnectApi: vi.fn(),
+  useSelectedClusters: vi.fn(() => []),
+}));
+
+vi.mock('../../lib/k8s/event', () => ({ default: class Event {} }));
+vi.mock('../common/ObjectEventList', () => ({ default: () => null }));
+
+import RouteSwitcher from './RouteSwitcher';
+
+// Verify RouteSwitcher renders stable route keys and handles an unset cluster.
+
+describe('RouteSwitcher', () => {
+  it('assigns unique keys to all rendered AuthRoute components', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <TestContext>
+            <RouteSwitcher requiresToken={() => false} />
+          </TestContext>
+        </QueryClientProvider>
+      );
+
+      const duplicateKeyWarnings = consoleError.mock.calls.filter(args => {
+        if (typeof args[0] !== 'string') {
+          return false;
+        }
+
+        return (
+          args[0].includes('Each child in a list should have a unique "key" prop') ||
+          args[0].includes('Encountered two children with the same key')
+        );
+      });
+
+      expect(duplicateKeyWarnings).toHaveLength(0);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('does not throw when rendering with no cluster set', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    expect(() =>
+      render(
+        <QueryClientProvider client={queryClient}>
+          <TestContext>
+            <RouteSwitcher requiresToken={() => false} />
+          </TestContext>
+        </QueryClientProvider>
+      )
+    ).not.toThrow();
+  });
+});

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -69,8 +69,8 @@ export default function RouteSwitcher(props: { requiresToken: () => boolean }) {
               exact={!!route.exact}
               clusters={clusters}
               requiresToken={props.requiresToken}
-              children={<RouteComponent route={route} key={getCluster()} />}
-              key={`${getCluster()}`}
+              children={<RouteComponent route={route} key={`${route.path}-${getCluster()}`} />}
+              key={`${route.path}-${getCluster()}`}
             />
           )
         )}


### PR DESCRIPTION
## Summary
This PR includes the fixes from #5066 and regression tests for them. The fixes were previously submitted in #5096 this branch is based on that work and adds the tests requested in the review by @v0lkan.

## Related Issue
Fixes #5066
Follow-up to #5096

## Changes
- Fixed `helmRouteReleaseHandler` to always call `setTokenFromCookie` unconditionally, removing the OIDC-only guard that prevented token extraction in non-OIDC in-cluster deployments
- Fixed `RouteSwitcher.tsx` route key generation to prevent key collisions between routes
- Added `TestHelmRouteReleaseHandlerTokenExtraction` in `backend/cmd/headlamp_test.go` covering the non-OIDC path where `OidcConf` is nil and the auth token must be read from the cookie, also asserting bearer token propagation into `clientConfig`
- Added `RouteSwitcher.test.tsx` with a duplicate key warning assertion to prevent regression of the route key collision fix

## Steps to Test

**Backend:**
1. Navigate to `backend/`
2. Run `go test ./cmd/... -run TestHelmRouteReleaseHandlerTokenExtraction -v`
3. Observe the test passes; temporarily revert the cookie token fix in `helmRouteReleaseHandler` and confirm it fails

**Frontend:**
1. Navigate to `frontend/`
2. Run `npx vitest run src/components/App/RouteSwitcher.test.tsx --reporter=verbose`
3. Observe both tests pass

## Screenshots
Test Result →
<img width="1506" height="129" alt="Screenshot from 2026-04-10 09-31-39" src="https://github.com/user-attachments/assets/399f7338-1fb9-424d-bad9-bfb9f0ff8dc4" />

Test Coverage →
<img width="1510" height="110" alt="Screenshot from 2026-04-10 09-31-57" src="https://github.com/user-attachments/assets/6f9b807e-4030-43ff-9ebb-f44fdb4b95f3" />

## Notes for the Reviewer
- The backend test guards against regression: if someone re-adds the OIDC guard around cookie token extraction, the test breaks
- The backend test also asserts that the bearer token is correctly propagated into `clientConfig`, not just the request header
- The frontend test uses `console.error` interception to catch React's duplicate key warnings, which is the correct approach since the project uses the automatic JSX runtime