### PR TITLE
frontend: Fix resourceFieldRef not resolving sidecar or injection-templated containers

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -995,7 +995,31 @@ function buildEnvironmentVariables(
         }
 
         try {
-          const targetContainer = pod.spec?.containers?.find(c => c.name === containerName);
+          const allContainers: any[] = [
+            ...(pod.spec?.containers || []),
+            ...(pod.spec?.initContainers || []),
+            ...(pod.spec?.ephemeralContainers || []),
+          ];
+
+          const templateSpec = (pod.spec as any)?.template?.spec;
+          if (templateSpec) {
+            allContainers.push(
+              ...(templateSpec.containers || []),
+              ...(templateSpec.initContainers || []),
+              ...(templateSpec.ephemeralContainers || [])
+            );
+          }
+
+          const jobTemplateSpec = (pod.spec as any)?.jobTemplate?.spec?.template?.spec;
+          if (jobTemplateSpec) {
+            allContainers.push(
+              ...(jobTemplateSpec.containers || []),
+              ...(jobTemplateSpec.initContainers || []),
+              ...(jobTemplateSpec.ephemeralContainers || [])
+            );
+          }
+
+          const targetContainer = allContainers.find(c => c.name === containerName);
           if (!targetContainer) {
             throw new Error(`Container ${containerName} not found`);
           }


### PR DESCRIPTION
## Summary
Resolves an issue where `resourceFieldRef` environment variables (e.g. `limits.cpu`) failed to correctly map to containers injected at admission time by mutating webhooks (like `istio-proxy` or `istio-init`). 

When viewing Pods or Workloads with external sidecars, users would see the error `Container [name] not found` for any mapped resources. This happened because the internal frontend logic was only searching strictly inside `pod.spec?.containers`, completely omitting `initContainers`, `ephemeralContainers`, and template-based structures like Deployments/Jobs.

Fixes #5106 

## Changes
- Updated `Resource.tsx` (`buildEnvironmentVariables`) to utilize a robust "Gather All Containers" check.
- The `targetContainer` lookup now properly aggregates across `containers`, `initContainers`, `ephemeralContainers`, `template.spec`, and `jobTemplate.spec` before failing.
- Handled TypeScript typing compatibility by casting the generic API wrapper `KubePod` safely.

## How to Test
1. Deploy a workload to an Istio-enabled namespace (or Linkerd/Dapr) ensuring a sidecar like `istio-proxy` is injected.
2. The proxy must use a `valueFrom: resourceFieldRef` environment variable (Istio natively injects `GOMAXPROCS`, `GOMEMLIMIT`, etc.)
3. View the Pod details in Headlamp and expand the environment variables mapping for the proxy container. 
4. Headlamp should cleanly render the CPU / Memory limits without any "Container not found" errors.
