### PR TITLE
frontend: ClusterTable: Add cluster name toolip and expand name col

### DIFF
--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -18,6 +18,7 @@ import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import { useTheme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import {
   MRT_ColumnFiltersState,
@@ -249,16 +250,21 @@ export default function ClusterTable({
           id: 'name',
           header: t('Name'),
           accessorKey: 'name',
+          gridTemplate: 2,
           Cell: ({ row: { original } }) => {
             const appearance = getClusterAppearanceFromMeta(original.name);
             return (
-              <Link routeName="cluster" params={{ cluster: original.name }}>
-                <ClusterBadge
-                  name={original.name}
-                  icon={appearance.icon}
-                  accentColor={appearance.accentColor}
-                />
-              </Link>
+              <Tooltip title={original.name} arrow>
+                <span>
+                  <Link routeName="cluster" params={{ cluster: original.name }}>
+                    <ClusterBadge
+                      name={original.name}
+                      icon={appearance.icon}
+                      accentColor={appearance.accentColor}
+                    />
+                  </Link>
+                </span>
+              </Tooltip>
             );
           },
         },

--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -215,7 +215,7 @@
                 </div>
               </div>
               <table
-                class="MuiTable-root css-tvuahe-MuiTable-root"
+                class="MuiTable-root css-g0cegk-MuiTable-root"
               >
                 <thead
                   class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
@@ -613,20 +613,26 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                        href="/c/cluster0/"
+                      <span
+                        aria-label="cluster0"
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="MuiBox-root css-172hjuw"
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster0/"
                         >
-                          <span
-                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                          <div
+                            class="MuiBox-root css-172hjuw"
                           >
-                            cluster0
-                          </span>
-                        </div>
-                      </a>
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster0
+                            </span>
+                          </div>
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
@@ -721,20 +727,26 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                        href="/c/cluster1/"
+                      <span
+                        aria-label="cluster1"
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="MuiBox-root css-172hjuw"
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster1/"
                         >
-                          <span
-                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                          <div
+                            class="MuiBox-root css-172hjuw"
                           >
-                            cluster1
-                          </span>
-                        </div>
-                      </a>
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster1
+                            </span>
+                          </div>
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
@@ -829,20 +841,26 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                        href="/c/cluster2/"
+                      <span
+                        aria-label="cluster2"
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="MuiBox-root css-172hjuw"
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster2/"
                         >
-                          <span
-                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                          <div
+                            class="MuiBox-root css-172hjuw"
                           >
-                            cluster2
-                          </span>
-                        </div>
-                      </a>
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster2
+                            </span>
+                          </div>
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"


### PR DESCRIPTION
## Summary

This PR improves the readability of long cluster names on the Home page cluster table by dynamically expanding the name column and adding a tooltip on hover to display the full cluster name.

## Related Issue

Fixes https://github.com/kubernetes-sigs/headlamp/issues/4731
Fixes https://github.com/kubernetes-sigs/headlamp/issues/4756

## Changes

- Updated `frontend/src/components/App/Home/ClusterTable.tsx`:
  - Added dynamic `gridTemplate` sizing for the name column, expands when any cluster name exceeds 40 characters
  - Added a `Tooltip` on cluster name cells that displays the full cluster name on hover

## Steps to Test

1. Navigate to the Home page
2. Observe the cluster table with short cluster names (the name column should have normal width)
3. Add or configure a cluster with a name longer than 40 characters
4. Observe that the name column expands to take more space
5. Hover over any cluster name and the tooltip should appear showing the full cluster name

## Images

<img width="1838" height="882" alt="image" src="https://github.com/user-attachments/assets/e38dd73b-77c5-455e-a7a1-78e6b0a8fd13" />
