### PR TITLE
frontend: ResourseTable: add button to download yml

### DIFF
--- a/frontend/src/components/common/Resource/DownloadButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DownloadButton.stories.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../../../i18n/config';
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { KubeObject } from '../../../lib/k8s/cluster';
+import store from '../../../redux/stores/store';
+import DownloadButton from './DownloadButton';
+import { DownloadButtonProps } from './DownloadButton';
+
+export default {
+  title: 'Resource/DownloadButton',
+  component: DownloadButton,
+  argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <Provider store={store}>
+          <Story />
+        </Provider>
+      );
+    },
+  ],
+} as Meta;
+
+const Template: StoryFn<DownloadButtonProps> = args => <DownloadButton {...args} />;
+
+const defaultItem = {
+  metadata: {
+    uid: '123',
+    name: 'example-resource',
+  },
+  jsonData: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'example-resource',
+      namespace: 'default',
+    },
+    data: {
+      key: 'value',
+    },
+  },
+  getName: function () {
+    return this.metadata?.name ?? '';
+  },
+} as KubeObject;
+
+export const Default = Template.bind({});
+Default.args = {
+  item: defaultItem,
+};
+
+export const MenuStyle = Template.bind({});
+MenuStyle.args = {
+  item: defaultItem,
+  buttonStyle: 'menu',
+};

--- a/frontend/src/components/common/Resource/DownloadButton.tsx
+++ b/frontend/src/components/common/Resource/DownloadButton.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as jsyaml from 'js-yaml';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { KubeObject } from '../../../lib/k8s/cluster';
+import ActionButton, { ButtonStyle } from '../ActionButton';
+
+export interface DownloadButtonProps {
+  /** The Kubernetes resource object to download as YAML. */
+  item: KubeObject;
+  /** Optional button rendering style. */
+  buttonStyle?: ButtonStyle;
+}
+
+/**
+ * Renders a download action button for a Kubernetes resource.
+ * When clicked, it serializes the item to YAML and downloads it.
+ */
+function DownloadButton({ item, buttonStyle }: DownloadButtonProps) {
+  const { t } = useTranslation();
+
+  const downloadYaml = () => {
+    if (!item?.jsonData) {
+      return;
+    }
+
+    const yaml = jsyaml.dump(item.jsonData, { lineWidth: -1 });
+    const blob = new Blob([yaml], { type: 'application/x-yaml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const element = document.createElement('a');
+
+    element.href = url;
+    element.download = `${item.getName()}.yaml`;
+    element.style.display = 'none';
+
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <ActionButton
+      description={t('translation|Download')}
+      longDescription={t('translation|Download')}
+      buttonStyle={buttonStyle}
+      onClick={downloadYaml}
+      icon="mdi:file-download-outline"
+      edge="end"
+    />
+  );
+}
+
+export default DownloadButton;

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -57,6 +57,7 @@ import Link from '../Link';
 import Table, { TableColumn } from '../Table';
 import { getA8RMetadata } from './A8RInfo';
 import DeleteButton from './DeleteButton';
+import DownloadButton from './DownloadButton';
 import EditButton from './EditButton';
 import ResourceTableMultiActions from './ResourceTableMultiActions';
 import { RestartButton } from './RestartButton';
@@ -556,6 +557,10 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
       action: ({ item, closeMenu }) => (
         <EditButton item={item} buttonStyle="menu" afterConfirm={closeMenu} key="edit" />
       ),
+    },
+    {
+      id: DefaultHeaderAction.DOWNLOAD,
+      action: ({ item }) => <DownloadButton item={item} buttonStyle="menu" key="download" />,
     },
     {
       id: DefaultHeaderAction.VIEW,

--- a/frontend/src/components/common/Resource/__snapshots__/DownloadButton.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DownloadButton.Default.stories.storyshot
@@ -1,0 +1,15 @@
+<body>
+  <div>
+    <button
+      aria-label="Download"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1d2b2o6-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DownloadButton.MenuStyle.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DownloadButton.MenuStyle.stories.storyshot
@@ -1,0 +1,25 @@
+<body>
+  <div>
+    <li
+      class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-1sgjfx9-MuiButtonBase-root-MuiMenuItem-root"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+      />
+      <div
+        class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+        >
+          Download
+        </span>
+      </div>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </li>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/index.test.ts
+++ b/frontend/src/components/common/Resource/index.test.ts
@@ -53,6 +53,7 @@ const checkExports = [
   'RestartButton',
   'RestartMultipleButton',
   'RevisionHistorySection',
+  'DownloadButton',
   'RollbackButton',
   'RollbackDialog',
   'ScaleButton',

--- a/frontend/src/components/common/Resource/index.tsx
+++ b/frontend/src/components/common/Resource/index.tsx
@@ -35,6 +35,8 @@ export * from './DocsViewer';
 export { default as DocsViewer } from './DocsViewer';
 export * from './EditButton';
 export { default as EditButton } from './EditButton';
+export * from './DownloadButton';
+export { default as DownloadButton } from './DownloadButton';
 export * from './EditorDialog';
 export { default as EditorDialog } from './EditorDialog';
 export * from './MatchExpressions';

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -60,6 +60,7 @@
     "Dialog": [Function],
     "DialogTitle": [Function],
     "DocsViewer": [Function],
+    "DownloadButton": [Function],
     "EditButton": [Function],
     "EditorDialog": [Function],
     "EmptyContent": [Function],
@@ -110,6 +111,7 @@
       "DeleteButton": [Function],
       "DetailsGrid": [Function],
       "DocsViewer": [Function],
+      "DownloadButton": [Function],
       "EditButton": [Function],
       "EditorDialog": [Function],
       "EnvVarGrid": [Function],
@@ -271,6 +273,7 @@
   },
   "DetailsViewDefaultHeaderActions": {
     "DELETE": "DELETE",
+    "DOWNLOAD": "DOWNLOAD",
     "EDIT": "EDIT",
     "NODE_DRAIN": "NODE_DRAIN",
     "NODE_SHELL": "NODE_SHELL",

--- a/frontend/src/redux/actionButtonsSlice.ts
+++ b/frontend/src/redux/actionButtonsSlice.ts
@@ -47,6 +47,7 @@ export enum DefaultHeaderAction {
   EDIT = 'EDIT',
   VIEW = 'VIEW',
   SCALE = 'SCALE',
+  DOWNLOAD = 'DOWNLOAD',
   POD_LOGS = 'POD_LOGS',
   POD_TERMINAL = 'POD_TERMINAL',
   POD_DEBUG = 'POD_DEBUG',


### PR DESCRIPTION
## Summary

This PR adds a download YAML button to the resource table action column so users can export a selected resource manifest directly from the table.

## Related Issue

Fixes #5125 

## Changes

- Added `frontend/src/components/common/Resource/DownloadButton.tsx` to implement the YAML export button.
- Updated `frontend/src/components/common/Resource/ResourceTable.tsx` to surface the download action in the resource table row actions.
- Added/updated unit tests in `frontend/src/components/common/Resource/index.test.ts`.
- Updated action state handling in `frontend/src/redux/actionButtonsSlice.ts` to support the new download workflow.
- Updated plugin snapshot in `frontend/src/plugin/__snapshots__/pluginLib.snapshot` to reflect the new resource action button.

## Steps to Test

1. Open Headlamp and navigate to a resource list.
2. Confirm each row has a download YAML button in the action column.
3. Click the button and verify that the resource YAML is downloaded as a `.yaml` file.
4. Open the downloaded file and verify it contains the correct resource manifest data.

screenshot
<img width="3072" height="1728" alt="Screenshot from 2026-04-12 19-27-27" src="https://github.com/user-attachments/assets/c339986b-cb9d-4c91-a2ad-e90add022e97" />
 : 

## Notes for the Reviewer

