### PR TITLE
frontend: Remove debug console.log from clusterRequests

### DIFF
--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -325,7 +325,6 @@ export function put(
 }
 
 export function remove(url: string, requestOptions: ClusterRequestParams = {}) {
-  console.log(url, requestOptions);
   const { cluster: clusterName, ...restOptions } = requestOptions;
   const cluster = clusterName || getCluster() || '';
   const opts = { method: 'DELETE', headers: JSON_HEADERS, cluster, ...restOptions };


### PR DESCRIPTION
## Description
This PR removes an unnecessary `console.log` statement from the [remove()](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/lib/k8s/api/v1/clusterRequests.ts:326:0-331:1) function within [frontend/src/lib/k8s/api/v1/clusterRequests.ts](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/lib/k8s/api/v1/clusterRequests.ts:0:0-0:0). 

Previously, this debug log was exposing every DELETE request URL and its options to the production browser console. This behavior was inconsistent with other HTTP methods ([post](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/lib/k8s/api/v1/clusterRequests.ts:237:0-254:1), [patch](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/lib/k8s/api/v1/clusterRequests.ts:256:0-274:1), [put](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/lib/k8s/api/v1/clusterRequests.ts:307:0-324:1)), which do not log their request data, and it violated the project's production logging standards. 

This cleanup is similar in nature to previously merged PR #5074.

## Related Issue
N/A

## How has this been tested?
- [x] `npm run frontend:lint` passes with no warnings/errors.
- [x] All automated tests pass (`npx vitest run src/lib/k8s/api/v1`).
- [x] Verified the change locally.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/headlamp-k8s/headlamp/blob/main/CONTRIBUTING.md) guidelines.
- [x] My commit message follows the project's conventions.
- [x] I have signed off my commits.
