### PR TITLE
frontend: useSidebarItems: Use console.error for CRD list errors

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -65,7 +65,7 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
 
   const [crds, error] = CRD.useList();
   if (error !== null) {
-    console.log(error);
+    console.error(error);
   }
 
   const crdsSidebarEntries = useMemo(() => {


### PR DESCRIPTION
## Description
This PR replaces `console.log(error)` with `console.error(error)` in the [useSidebarItems](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/Sidebar/useSidebarItems.tsx:54:0-527:2) hook when the CRD list fetch encounters an error.

Errors should be logged using `console.error` to ensure proper severity in browser developer tools and to maintain consistency with the project's frontend logging standards.

This is similar in nature to previously merged PR #5104.

## Related Issue
N/A

## How has this been tested?
- [x] `npm run frontend:lint` passes with no warnings/errors.
- [x] Verified the change locally.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/headlamp-k8s/headlamp/blob/main/CONTRIBUTING.md) guidelines.
- [x] My commit message follows the project's conventions.
- [x] I have signed off my commits.
