### PR TITLE
frontend: Cleanup debug logs and typo

### DIFF
--- a/frontend/src/components/project/NewProjectPopup.tsx
+++ b/frontend/src/components/project/NewProjectPopup.tsx
@@ -302,7 +302,6 @@ function ProjectFromExistingNamespace({ onBack }: { onBack: () => void }) {
           options={uniq(namespaces?.map(it => it.metadata.name)) ?? []}
           value={selectedNamespace}
           onChange={(event, newValue) => {
-            console.log({ newValue });
             setSelectedNamespace(newValue ?? undefined);
           }}
           onInputChange={(e, v) => {

--- a/frontend/src/plugin/pluginI18n.ts
+++ b/frontend/src/plugin/pluginI18n.ts
@@ -355,7 +355,7 @@ export async function initializePluginI18n(
   if (i18nEnabled) {
     // Store supported locales for later use
     pluginSupportedLocales[pluginName] = supportedLocales;
-    console.log(
+    console.debug(
       `Initializing i18n for plugin ${pluginName} (supported locales: ${supportedLocales.join(
         ', '
       )})`
@@ -366,6 +366,6 @@ export async function initializePluginI18n(
       console.error(`Failed to initialize i18n for plugin ${pluginName}:`, error);
     }
   } else {
-    console.log(`Plugin ${pluginName} does not have i18n enabled in package.json`);
+    console.debug(`Plugin ${pluginName} does not have i18n enabled in package.json`);
   }
 }


### PR DESCRIPTION
## Description
This PR cleans up several minor frontend issues discovered during code review. It combines related non-functional quality-of-life improvements to maintain a clean production console:

- **project:** Removed debug `console.log({ newValue })` in the namespace selector ([NewProjectPopup.tsx](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/project/NewProjectPopup.tsx:0:0-0:0)).
- **plugin:** Converted informational plugin initialization logs ([pluginI18n.ts](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/plugin/pluginI18n.ts:0:0-0:0)) from `console.log` to `console.debug`.
- **sidebar:** Fixed a minor source-code typo (`accidentaly` -> `accidentally`) in [useSidebarItems.tsx](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/Sidebar/useSidebarItems.tsx:0:0-0:0).

These changes align with the project's frontend guidelines of ensuring `console.log` is avoided for errors, and unnecessary debug logs are stripped from production.

*(Note: The backstageMessageReceiver debug log initially spotted was found to be already resolved in upstream).*

## Related Issue
N/A

## How has this been tested?
- [x] Ran `npm run frontend:lint` successfully (no warnings or errors).
- [x] Tested the app locally and confirmed cleaner browser console output.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/headlamp-k8s/headlamp/blob/main/CONTRIBUTING.md) guidelines.
- [x] My commit message follows the project's conventions.
- [x] I have signed off my commits.
