### PR TITLE
frontend: Hide create button for pods in owned resource sections

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1698,6 +1698,7 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
       errors={errors}
       metrics={podMetrics}
       noNamespaceFilter={hideNamespaceFilter}
+      hideCreateButton
     />
   );
 }

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
@@ -329,19 +329,7 @@
                   </h1>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  >
-                    <button
-                      aria-label="Create Pod"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-                      data-mui-internal-clone-element="true"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
-                  </div>
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -186,6 +186,7 @@ export interface PodListProps {
   reflectTableInURL?: SimpleTableProps['reflectInURL'];
   noNamespaceFilter?: boolean;
   errors?: ApiError[] | null;
+  hideCreateButton?: boolean;
 }
 
 export function PodListRenderer(props: PodListProps) {
@@ -196,6 +197,7 @@ export function PodListRenderer(props: PodListProps) {
     reflectTableInURL = 'pods',
     noNamespaceFilter,
     errors,
+    hideCreateButton,
   } = props;
   const { t } = useTranslation(['glossary', 'translation']);
 
@@ -227,7 +229,9 @@ export function PodListRenderer(props: PodListProps) {
       title={t('Pods')}
       headerProps={{
         noNamespaceFilter,
-        titleSideActions: [<CreateResourceButton resourceClass={Pod} key="create-pod-button" />],
+        titleSideActions: hideCreateButton
+          ? []
+          : [<CreateResourceButton resourceClass={Pod} key="create-pod-button" />],
       }}
       hideColumns={hideColumns}
       errors={errors}


### PR DESCRIPTION

## Summary

Pods listed within a parent resource's detail view (e.g. Job, Deployment) should not show a "Create" button since pods cannot be added to existing workloads. Add hideCreateButton prop to PodListRenderer and set it in OwnedPodsSection.

## Related Issue

Fixes #5133 

## Changes

- Fixed #5133


## Steps to Test

1. Create a Job
2. See that pods no longer have the Create action.


## Screenshots (if applicable)

old:

<img width="1175" height="761" alt="image" src="https://github.com/user-attachments/assets/ca63e14a-b5c5-460f-ba3e-7c8a57d7ff70" />

new:
<img width="1095" height="619" alt="image" src="https://github.com/user-attachments/assets/ec7b44eb-c802-4e02-978d-8a5f7b377802" />


## Notes for the Reviewer

None.
