### PR TITLE
frontend: ErrorPage: Remove legacy Webpack fallback

### DIFF
--- a/frontend/src/components/common/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/components/common/ErrorPage/ErrorPage.tsx
@@ -106,9 +106,7 @@ export default function ErrorComponent(props: ErrorComponentProps) {
     title = t('Uh-oh! Something went wrong.'),
     message = '',
     withTypography = true,
-    // In vite headlampBrokenImage is a string, but in webpack it is an object
-    // TODO: Remove this once we migrate plugins to vite
-    graphic = headlampBrokenImage as any as string,
+    graphic = headlampBrokenImage,
     error,
   } = props;
   return (


### PR DESCRIPTION
### Summary

This PR cleans up the `ErrorPage` component by removing a deprecated Webpack-specific comment and type casting behavior. Since Headlamp has aggressively moved towards Vite (where imported SVGs are natively resolved as string URLs), the `as any as string` workaround for the `graphic` prop is no longer necessary.