### PR TITLE
frontend: portforward: Add user notification toast on failure

### DIFF
--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -347,6 +347,17 @@ export default function PortForwardingList() {
             })
             .catch(error => {
               setPortForwardInAction(null);
+              const errorMessage =
+                error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+              const displayMessage = errorMessage
+                ? `${t('translation|Error starting port forward')}: ${errorMessage}`
+                : t('translation|Error starting port forward');
+
+              enqueueSnackbar(displayMessage, {
+                key: 'portforward-error',
+                preventDuplicate: true,
+                variant: 'error',
+              });
               console.error('Error starting port forward:', error);
             });
         }}

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -603,6 +603,7 @@
   "Loading port forwarding": "Laden der Portweiterleitung",
   "Pod Port": "Pod-Port",
   "Local Port": "Lokaler Port",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -603,6 +603,7 @@
   "Loading port forwarding": "Loading port forwarding",
   "Pod Port": "Pod Port",
   "Local Port": "Local Port",
+  "Error starting port forward": "Error starting port forward",
   "Please enter a valid port number (1-65535).": "Please enter a valid port number (1-65535).",
   "Docker Desktop requires ports in range 30000-32000.": "Docker Desktop requires ports in range 30000-32000.",
   "Leave empty to auto-assign from range 30000-32000.": "Leave empty to auto-assign from range 30000-32000.",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -607,6 +607,7 @@
   "Loading port forwarding": "Cargango redireccionamientos de puerto",
   "Pod Port": "Puerto del Pod",
   "Local Port": "Perto Local",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -607,6 +607,7 @@
   "Loading port forwarding": "Chargement du transfert de port",
   "Pod Port": "Port du pod",
   "Local Port": "Port local",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "Veuillez entrer un numéro de port valide (1-65535).",
   "Docker Desktop requires ports in range 30000-32000.": "Docker Desktop nécessite des ports dans la plage 30000-32000.",
   "Leave empty to auto-assign from range 30000-32000.": "Laisser vide pour assigner automatiquement depuis la plage 30000-32000.",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -603,6 +603,7 @@
   "Loading port forwarding": "",
   "Pod Port": "",
   "Local Port": "",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -607,6 +607,7 @@
   "Loading port forwarding": "Caricamento del port forwarding",
   "Pod Port": "Porta del Pod",
   "Local Port": "Porta Locale",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -599,6 +599,7 @@
   "Loading port forwarding": "ポートフォワーディングを読み込み中",
   "Pod Port": "ポッドポート",
   "Local Port": "ローカルポート",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -599,6 +599,7 @@
   "Loading port forwarding": "포트 포워딩 로딩 중",
   "Pod Port": "파드 포트",
   "Local Port": "로컬 포트",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -607,6 +607,7 @@
   "Loading port forwarding": "A carregar redir. de portas",
   "Pod Port": "Porta do \"Pod\"",
   "Local Port": "Porta Local",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -603,6 +603,7 @@
   "Loading port forwarding": "போர்ட் ஃபார்வர்டிங் ஏற்றுகிறது",
   "Pod Port": "பாட் போர்ட்",
   "Local Port": "லோக்கல் போர்ட்",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "",
   "Docker Desktop requires ports in range 30000-32000.": "",
   "Leave empty to auto-assign from range 30000-32000.": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -599,6 +599,7 @@
   "Loading port forwarding": "讀取連接埠轉發",
   "Pod Port": "Pod 連接埠",
   "Local Port": "本地連接埠",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "請輸入有效的連接埠號碼（1-65535）。",
   "Docker Desktop requires ports in range 30000-32000.": "Docker Desktop 需要 30000-32000 範圍內的連接埠。",
   "Leave empty to auto-assign from range 30000-32000.": "留空以從 30000-32000 範圍內自動分配。",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -599,6 +599,7 @@
   "Loading port forwarding": "读取端口转发",
   "Pod Port": "Pod 端口",
   "Local Port": "本地端口",
+  "Error starting port forward": "",
   "Please enter a valid port number (1-65535).": "请输入有效的端口号（1-65535）。",
   "Docker Desktop requires ports in range 30000-32000.": "Docker Desktop 要求端口范围在 30000-32000 之间。",
   "Leave empty to auto-assign from range 30000-32000.": "留空以从 30000-32000 范围内自动分配。",


### PR DESCRIPTION
### Summary

This PR improves user feedback for the Port-Forwarding feature. Previously, if `startPortForward` failed (e.g., due to the port already being in use or connection issues), the failure was only logged silently to the console (`console.error`). This change adds an explicit snackbar toast notification so the user is properly informed when their port-forward action fails.

### Changes
- Updated the `.catch` block in `frontend/src/components/portforward/index.tsx`.
- Dispatched `enqueueSnackbar` to immediately render the error message string directly to the UI, falling back to a sanitized translation string if the error object varies.

### Steps to Test
1. Navigate to Headlamp -> Port Forwarding.
2. Attempt to Start a Port Forward on a port that is explicitly unavailable (already in use on your host machine) or forcefully break the connection.
3. Observe that instead of a silent error, a red error toast notification now appears at the bottom of the screen with a readable error message.