### PR TITLE
backend/helm: fix Content-Type header silently dropped in release handlers

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -177,6 +177,8 @@ func (h *Handler) ListRelease(clientConfig clientcmd.ClientConfig, w http.Respon
 		Releases: releases,
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+
 	err = json.NewEncoder(w).Encode(res)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"request": "list_releases"},
@@ -185,8 +187,6 @@ func (h *Handler) ListRelease(clientConfig clientcmd.ClientConfig, w http.Respon
 
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 type GetReleaseRequest struct {
@@ -251,6 +251,7 @@ func (h *Handler) GetRelease(clientConfig clientcmd.ClientConfig, w http.Respons
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
 	err = json.NewEncoder(w).Encode(result)
@@ -261,8 +262,6 @@ func (h *Handler) GetRelease(clientConfig clientcmd.ClientConfig, w http.Respons
 
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 type GetReleaseHistoryRequest struct {
@@ -323,6 +322,7 @@ func (h *Handler) GetReleaseHistory(clientConfig clientcmd.ClientConfig, w http.
 		Releases: result,
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
 	err = json.NewEncoder(w).Encode(resp)
@@ -333,8 +333,6 @@ func (h *Handler) GetReleaseHistory(clientConfig clientcmd.ClientConfig, w http.
 
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 type UninstallReleaseRequest struct {
@@ -405,6 +403,7 @@ func (h *Handler) UninstallRelease(clientConfig clientcmd.ClientConfig, w http.R
 		"message": "uninstall request accepted",
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 
 	err = json.NewEncoder(w).Encode(response)
@@ -415,8 +414,6 @@ func (h *Handler) UninstallRelease(clientConfig clientcmd.ClientConfig, w http.R
 
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 func (h *Handler) uninstallRelease(req UninstallReleaseRequest, actionConfig *action.Configuration) {
@@ -502,6 +499,7 @@ func (h *Handler) RollbackRelease(clientConfig clientcmd.ClientConfig, w http.Re
 		"message": "rollback request accepted",
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 
 	err = json.NewEncoder(w).Encode(response)
@@ -511,8 +509,6 @@ func (h *Handler) RollbackRelease(clientConfig clientcmd.ClientConfig, w http.Re
 
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 func (h *Handler) rollbackRelease(req RollbackReleaseRequest, actionConfig *action.Configuration) {
@@ -562,6 +558,7 @@ func (h *Handler) returnResponse(w http.ResponseWriter, reqName string, statusCo
 		"message": message,
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 
 	err := json.NewEncoder(w).Encode(response)
@@ -569,8 +566,6 @@ func (h *Handler) returnResponse(w http.ResponseWriter, reqName string, statusCo
 		handleError(w, reqName, err, "encoding response", http.StatusInternalServerError)
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 func (h *Handler) InstallRelease(clientConfig clientcmd.ClientConfig, w http.ResponseWriter, r *http.Request) {
@@ -927,6 +922,7 @@ func (h *Handler) GetActionStatus(clientConfig clientcmd.ClientConfig, w http.Re
 		response["message"] = "action failed with error: " + *stat.Err
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 
 	err = json.NewEncoder(w).Encode(response)
@@ -936,6 +932,4 @@ func (h *Handler) GetActionStatus(clientConfig clientcmd.ClientConfig, w http.Re
 
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the Helm backend where `Content-Type: application/json` headers were being silently dropped in 7 JSON-returning API handlers. 

In Go's `net/http` package, calling `w.Header().Set()` after `w.WriteHeader()` or after writing to the response body (e.g., via `json.NewEncoder(w).Encode()`) is treated as a no-op. Because the affected handlers were setting the `Content-Type` header *after* the payload was already written, the final HTTP responses lacked the correct JSON content type, potentially causing issues for strict API clients or JSON parsers.

This PR shifts `w.Header().Set("Content-Type", "application/json")` to precede any HTTP status write or explicit body encoding in the following handlers within [backend/pkg/helm/release.go](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:0:0-0:0):
- [ListRelease](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:132:0-189:1)
- [GetRelease](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:212:0-264:1)
- [GetReleaseHistory](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:275:0-335:1)
- [UninstallRelease](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:358:0-416:1)
- [RollbackRelease](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:456:0-511:1)
- [returnResponse](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:555:0-568:1) (helper used by [InstallRelease](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:570:0-610:1) & [UpgradeRelease](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:757:0-800:1))
- [GetActionStatus](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go:885:0-934:1)

**Special notes for reviewer**:
- This strictly structural fix simply reorders the statement execution to conform with Go `net/http` requirements.
- Validated via `go vet` and `go fmt`. 
