### PR TITLE
backend: helm repository error handling and regression test coverage

### DIFF
--- a/backend/pkg/helm/charts.go
+++ b/backend/pkg/helm/charts.go
@@ -95,14 +95,15 @@ func (h *Handler) ListCharts(w http.ResponseWriter, r *http.Request) {
 	chartInfos, err := listCharts(filterTerm, h.EnvSettings)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	response := ListAllChartsResponse{
 		Charts: chartInfos,
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {

--- a/backend/pkg/helm/charts_test.go
+++ b/backend/pkg/helm/charts_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
@@ -67,4 +68,25 @@ func TestListChart(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "headlamp_test_repo/headlamp")
 	assert.NotContains(t, rr.Body.String(), "non-existing-chart")
+}
+
+func TestListChartReturnsErrorWithoutSuccessPayload(t *testing.T) {
+	cache := cache.New[interface{}]()
+	require.NotNil(t, cache)
+
+	customSettings := cli.New()
+	customSettings.RepositoryConfig = filepath.Join(t.TempDir(), "missing", "repositories.yaml")
+
+	helmHandler, err := helm.NewHandlerWithSettings(cache, customSettings)
+	require.NoError(t, err)
+
+	listChartsRequest, err := http.NewRequestWithContext(context.Background(),
+		"GET", "/clusters/minikube/helm/repositories/charts", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	helmHandler.ListCharts(rr, listChartsRequest)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "\"charts\"")
 }

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -19,6 +19,7 @@ package helm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -37,6 +38,8 @@ const (
 	defaultNewConfigFileMode   os.FileMode = os.FileMode(0o644)
 	defaultNewConfigFolderMode os.FileMode = os.FileMode(0o770)
 )
+
+var errRepositoryNotFound = errors.New("repository not found")
 
 // add repository.
 type AddUpdateRepoRequest struct {
@@ -235,8 +238,8 @@ func (h *Handler) ListRepo(w http.ResponseWriter, r *http.Request) {
 		Repositories: repositories,
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
@@ -267,6 +270,11 @@ func RemoveRepository(name string, settings *cli.EnvSettings) error {
 		}()
 	}
 
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "locking repository config file")
+		return err
+	}
+
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "reading repo file")
@@ -275,8 +283,8 @@ func RemoveRepository(name string, settings *cli.EnvSettings) error {
 
 	isRemoved := repoFile.Remove(name)
 	if !isRemoved {
-		logger.Log(logger.LevelError, nil, err, "repository not found")
-		return err
+		logger.Log(logger.LevelError, nil, errRepositoryNotFound, "repository not found")
+		return errRepositoryNotFound
 	}
 
 	// write repo file
@@ -292,10 +300,20 @@ func RemoveRepository(name string, settings *cli.EnvSettings) error {
 // Remove repository name.
 func (h *Handler) RemoveRepo(w http.ResponseWriter, r *http.Request) {
 	name := r.URL.Query().Get("name")
+	if name == "" {
+		http.Error(w, "name query parameter is required", http.StatusBadRequest)
+		return
+	}
 
 	err := RemoveRepository(name, h.EnvSettings)
 	if err != nil {
+		if errors.Is(err, errRepositoryNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+
 		return
 	}
 
@@ -320,6 +338,11 @@ func UpdateRepository(name, url string, settings *cli.EnvSettings) error {
 				logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
 			}
 		}()
+	}
+
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "locking repository config file")
+		return err
 	}
 
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+func TestRemoveRepositoryReturnsNotFoundError(t *testing.T) {
+	settings := cli.New()
+	settings.RepositoryConfig = filepath.Join(t.TempDir(), "repositories.yaml")
+
+	repoFile := repo.NewFile()
+	repoFile.Update(&repo.Entry{
+		Name: "existing",
+		URL:  "https://example.test/charts",
+	})
+	require.NoError(t, repoFile.WriteFile(settings.RepositoryConfig, defaultNewConfigFileMode))
+
+	err := RemoveRepository("missing", settings)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errRepositoryNotFound))
+}

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -22,12 +22,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/helm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/repo"
 )
 
 func newHelmHandler(t *testing.T) *helm.Handler {
@@ -137,6 +140,17 @@ func TestRemoveRepository(t *testing.T) {
 
 		assert.False(t, checkRepoExists(t, helmHandler, "headlamp_test_repo"))
 	})
+
+	t.Run("remove_repo_not_found", func(t *testing.T) {
+		removeRepoRequest, err := http.NewRequestWithContext(context.Background(), "DELETE",
+			"/clusters/minikube/helm/repositories/?name=repo-that-does-not-exist", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		helmHandler.RemoveRepo(rr, removeRepoRequest)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
 }
 
 // TestUpdateRepo.
@@ -217,9 +231,53 @@ func TestListRepositories(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	helmHandler.ListRepo(rr, listRepoReq)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
 
 	var listRepoResponse helm.ListRepoResponse
 
 	err = json.Unmarshal(rr.Body.Bytes(), &listRepoResponse)
 	assert.NoError(t, err)
+}
+
+func TestRemoveRepositoryMissingNameReturnsBadRequest(t *testing.T) {
+	helmHandler := newHelmHandler(t)
+
+	removeRepoRequest, err := http.NewRequestWithContext(context.Background(), "DELETE",
+		"/clusters/minikube/helm/repositories/", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	helmHandler.RemoveRepo(rr, removeRepoRequest)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "name query parameter is required")
+}
+
+func TestListRepoSetsJSONContentType(t *testing.T) {
+	customSettings := cli.New()
+	customSettings.RepositoryConfig = filepath.Join(t.TempDir(), "repositories.yaml")
+
+	repoFile := repo.NewFile()
+	repoFile.Update(&repo.Entry{
+		Name: "sample",
+		URL:  "https://example.test/charts",
+	})
+	require.NoError(t, repoFile.WriteFile(customSettings.RepositoryConfig, 0o644))
+
+	cache := cache.New[interface{}]()
+	require.NotNil(t, cache)
+
+	helmHandler, err := helm.NewHandlerWithSettings(cache, customSettings)
+	require.NoError(t, err)
+
+	listRepoReq, err := http.NewRequestWithContext(context.Background(),
+		"GET", "/clusters/minikube/helm/repositories", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	helmHandler.ListRepo(rr, listRepoReq)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
 }


### PR DESCRIPTION
## Summary

This PR fixes Helm repository/chart handler error behavior by returning early on chart-list failures, mapping repository-not-found deletes to 404, improving repository lock error handling, and adding regression tests for these paths.

## Related Issue

Fixes #ISSUE_NUMBER

## Changes

- Added/Updated backend Helm handler logic for safer error handling and HTTP status mapping
- Fixed a flow issue where success payload logic could continue after an error
- Added regression tests for:
  - chart list error path (no success payload on failure)
  - repository delete not-found behavior (expects 404)
  - JSON content-type behavior for list endpoints
  - repository internal behaviors via internal test coverage
- Refactored response handling to set JSON Content-Type before writing status for JSON responses
- Increased backend Helm package test coverage from 21.4% to 22.6% (+1.2 percentage points)

## Steps to Test

1. From repository root, run:
   - cd backend
   - golangci-lint run ./pkg/helm/...
   - go build ./pkg/helm/...
   - go test ./pkg/helm/... -count=1
2. Verify coverage on feature branch:
   - go test ./pkg/helm -coverprofile=/tmp/helm-after.out -count=1
   - go tool cover -func=/tmp/helm-after.out | tail -n 1
3. (Optional baseline) Compare with main:
   - git checkout main
   - go test ./pkg/helm -coverprofile=/tmp/helm-before.out -count=1
   - go tool cover -func=/tmp/helm-before.out | tail -n 1
   - git checkout backend/helm-repo-error-handling-tests

## Notes for the Reviewer

- Scope is intentionally limited to backend Helm package.
- No frontend tests/builds were run.
- Coverage delta is +1.2 percentage points for backend/pkg/helm.