### PR TITLE
feat(pod): persist prettify log preference to localStorage

### DIFF
--- a/frontend/src/components/pod/Details.test.tsx
+++ b/frontend/src/components/pod/Details.test.tsx
@@ -311,3 +311,87 @@ describe('PodDetails auto-launch views', () => {
     );
   });
 });
+
+describe('PodLogViewer prettifyLogs persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('passes prettifyLogs: true to getLogs when localStorage has true stored', async () => {
+    localStorage.setItem('headlamp.logs.prettifyLogs', JSON.stringify(true));
+
+    vi.resetModules();
+    vi.doMock('../globalSearch/useLocalStorageState', () => ({
+      useLocalStorageState: (key: string, defaultValue: any) => {
+        const stored = localStorage.getItem(key);
+        const value = stored !== null ? JSON.parse(stored) : defaultValue;
+        return [value, vi.fn()];
+      },
+    }));
+
+    const { PodLogViewer } = await import('./Details');
+
+    const mockItem = {
+      getName: () => 'test-pod',
+      spec: {
+        containers: [{ name: 'nginx' }],
+        initContainers: [],
+        ephemeralContainers: [],
+      },
+      status: { containerStatuses: [] },
+      getLogs: vi.fn(() => () => {}),
+    };
+
+    await act(async () => {
+      render(
+        <TestContext routerMap={{}} urlPrefix="">
+          <PodLogViewer open item={mockItem as any} onClose={() => {}} />
+        </TestContext>
+      );
+    });
+
+    expect(mockItem.getLogs).toHaveBeenCalled();
+    const callWithPrettify = mockItem.getLogs.mock.calls.find(
+      (args: any[]) => args[2]?.prettifyLogs === true
+    );
+    expect(callWithPrettify).toBeDefined();
+  });
+
+  it('passes prettifyLogs: false to getLogs when localStorage has no stored value', async () => {
+    vi.resetModules();
+    vi.doMock('../globalSearch/useLocalStorageState', () => ({
+      useLocalStorageState: (key: string, defaultValue: any) => {
+        const stored = localStorage.getItem(key);
+        const value = stored !== null ? JSON.parse(stored) : defaultValue;
+        return [value, vi.fn()];
+      },
+    }));
+
+    const { PodLogViewer } = await import('./Details');
+
+    const mockItem = {
+      getName: () => 'test-pod',
+      spec: {
+        containers: [{ name: 'nginx' }],
+        initContainers: [],
+        ephemeralContainers: [],
+      },
+      status: { containerStatuses: [] },
+      getLogs: vi.fn(() => () => {}),
+    };
+
+    await act(async () => {
+      render(
+        <TestContext routerMap={{}} urlPrefix="">
+          <PodLogViewer open item={mockItem as any} onClose={() => {}} />
+        </TestContext>
+      );
+    });
+
+    expect(mockItem.getLogs).toHaveBeenCalled();
+    const anyWithPrettify = mockItem.getLogs.mock.calls.some(
+      (args: any[]) => args[2]?.prettifyLogs === true
+    );
+    expect(anyWithPrettify).toBe(false);
+  });
+});

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -71,7 +71,10 @@ export function PodLogViewer(props: PodLogViewerProps) {
     true
   );
   const [follow, setFollow] = React.useState<boolean>(true);
-  const [prettifyLogs, setPrettifyLogs] = React.useState<boolean>(false);
+  const [prettifyLogs, setPrettifyLogs] = useLocalStorageState<boolean>(
+    'headlamp.logs.prettifyLogs',
+    false
+  );
   const [formatJsonValues, setFormatJsonValues] = React.useState<boolean>(false);
   const [hasJsonLogs, setHasJsonLogs] = React.useState<boolean>(false);
   const [lines, setLines] = React.useState<number>(100);


### PR DESCRIPTION
## Summary
This PR fixes the prettify log preference not being persisted by storing it in localStorage using the existing `useLocalStorageState` hook.

## Related Issue
Fixes #5144

## Changes
- Updated `PodLogViewer` in `Details.tsx` to use `useLocalStorageState` for `prettifyLogs` instead of `useState`

## Steps to Test
1. Open any pod's log viewer
2. Enable the Prettify toggle (visible when logs contain JSON)
3. Close the log viewer
4. Reopen the log viewer
5. Observe that the Prettify toggle is still enabled


## Notes for the Reviewer
- `useLocalStorageState` is already imported and used in the same component for `showTimestamps`, so this change follows the existing pattern exactly.
- Storage key used: `headlamp.logs.prettifyLogs`