### PR TITLE
frontend: Add react-hooks lint rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ run-only-app:
 	cd app && npm install && node ./scripts/setup-plugins.js && npm run dev-only-app
 
 frontend-lint:
-	cd frontend && npm run lint -- --max-warnings 0 && npm run format-check
+	cd frontend && npm run lint && npm run format-check
 
 frontend-lint-fix:
 	cd frontend && npm run lint -- --fix && npm run format

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,7 @@
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-jsx-a11y": "^6.9.0",
         "eslint-plugin-react": "7.35.0",
-        "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.3",
         "fake-indexeddb": "^6.0.0",
@@ -7864,15 +7864,22 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/balanced-match": {
@@ -9242,6 +9249,21 @@
       "integrity": "sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
     },
     "node_modules/highlight-words": {
       "version": "1.2.2",
@@ -17165,6 +17187,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jsx-a11y": "^6.9.0",
     "eslint-plugin-react": "7.35.0",
-    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.3",
     "fake-indexeddb": "^6.0.0",
@@ -96,7 +96,8 @@
     "domain-browser": "npm:dry-uninstall",
     "typescript": "5.6.2",
     "cheerio": "1.0.0-rc.12",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "eslint-plugin-react-hooks": "^7.0.1"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "*",
@@ -174,7 +175,8 @@
   },
   "eslintConfig": {
     "plugins": [
-      "license-header"
+      "license-header",
+      "react-hooks"
     ],
     "extends": [
       "@headlamp-k8s",
@@ -182,6 +184,18 @@
       "plugin:jsx-a11y/recommended"
     ],
     "rules": {
+      "react-hooks/rules-of-hooks": "warn",
+      "react-hooks/exhaustive-deps": "warn",
+      "react-hooks/component-hook-factories": "warn",
+      "react-hooks/globals": "warn",
+      "react-hooks/immutability": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/refs": "warn",
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/set-state-in-render": "warn",
+      "react-hooks/static-components": "warn",
+      "react-hooks/unsupported-syntax": "warn",
+      "react-hooks/use-memo": "warn",
       "license-header/header": [
         "error",
         [

--- a/plugins/headlamp-plugin/dependencies-sync.js
+++ b/plugins/headlamp-plugin/dependencies-sync.js
@@ -74,6 +74,9 @@ const dependenciesToNotCopy = [
   '@tanstack/react-query-devtools',
 ];
 
+// Dependencies that can have different versions
+const differentlyVersionedDependencies = ['eslint-plugin-react-hooks'];
+
 const yargs = require('yargs/yargs');
 const fs = require('fs-extra');
 const headlampPluginPkg = require('./package.json');
@@ -197,6 +200,8 @@ function updateDependencies(packageJsonPath, checkOnly) {
     const changed = [];
 
     for (const [key, value] of Object.entries(dependencies)) {
+      if (differentlyVersionedDependencies.includes(key)) continue;
+
       if (dependenciesFront[key] !== undefined && dependenciesFront[key] !== value) {
         changed.push({ name: key, frontend: dependenciesFront[key], headlampPlugin: value });
         dependencies[key] = dependenciesFront[key];


### PR DESCRIPTION
eslint-plugin-react-hooks is very useful for catching react bugs that are hard to debug
this PR enables react-hooks rules,

### why not update `eslint-config/` module that we have?
that config is used in many places (especially plugins) and we don't want to suddenly introduce a bunch of warnings for people, so the change is limited to the `frontend/`

### why are the rules set to "warn" and not "error"?
after enabling these rules there are a lot of issues right now and it's not feasible to fix all of them at once. I'm hoping that we can gradually fix those issues and then turn that to "error". Alternately maybe we can somehow have a stricter lint config for new code so we can catch it during PR CI checks.

### why aren't all the rules from 'eslint-plugin-react-hooks' enabled?
that plugins provides two "core" rules: rules-of-hooks and exhaustive-deps, both of those were added. And there are also some "React Compiler" rules. Since we're not using the compiler I've only added some of them that make sense.

## Related Issue

Fixes #2238

