### PR TITLE
frontend: SectionFilterHeader: reset global namespace filter for no-namespace view

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1729,6 +1729,7 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   });
   const onlyOneNamespace = !!resource.metadata.namespace || resource.kind === 'Namespace';
   const hideNamespaceFilter = onlyOneNamespace || noSearch;
+  const clearGlobalNamespaceFilterOnMount = onlyOneNamespace;
 
   return (
     <PodListRenderer
@@ -1737,6 +1738,7 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
       errors={errors}
       metrics={podMetrics}
       noNamespaceFilter={hideNamespaceFilter}
+      clearGlobalNamespaceFilterOnMount={clearGlobalNamespaceFilterOnMount}
       hideCreateButton
     />
   );

--- a/frontend/src/components/common/SectionFilterHeader.test.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import reducers from '../../redux/reducers/reducers';
+import { TestContext } from '../../test';
+import SectionFilterHeader from './SectionFilterHeader';
+
+vi.mock('../../lib/cluster', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../lib/cluster')>();
+  return {
+    ...actual,
+    getCluster: () => 'test-cluster',
+  };
+});
+
+vi.mock('./NamespacesAutocomplete', () => ({
+  NamespacesAutocomplete: () => null,
+}));
+
+vi.mock('./SectionHeader', () => ({
+  default: () => null,
+}));
+
+function createStore(namespaces: string[]) {
+  return configureStore({
+    reducer: reducers,
+    preloadedState: {
+      filter: {
+        namespaces: new Set(namespaces),
+      },
+    },
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        thunk: true,
+      }),
+  });
+}
+
+describe('SectionFilterHeader', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('syncs store namespaces from URL when selections differ in one position', async () => {
+    const store = createStore(['a', 'c']);
+
+    render(
+      <TestContext store={store} urlSearchParams={{ namespace: 'a b' }}>
+        <SectionFilterHeader title="Pods" />
+      </TestContext>
+    );
+
+    await waitFor(() => {
+      expect([...store.getState().filter.namespaces].sort()).toEqual(['a', 'b']);
+    });
+  });
+
+  it('clears global namespace filter state when namespace filtering is disabled on mount', async () => {
+    const store = createStore(['a', 'b']);
+    localStorage.setItem('headlamp-selected-namespace_test-cluster', JSON.stringify(['a', 'b']));
+
+    render(
+      <TestContext store={store} urlPrefix="/c/test-cluster">
+        <SectionFilterHeader title="Pods" noNamespaceFilter clearGlobalNamespaceFilterOnMount />
+      </TestContext>
+    );
+
+    await waitFor(() => {
+      expect([...store.getState().filter.namespaces]).toEqual([]);
+      expect(localStorage.getItem('headlamp-selected-namespace_test-cluster')).toBe('[]');
+    });
+  });
+});

--- a/frontend/src/components/common/SectionFilterHeader.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.tsx
@@ -19,7 +19,7 @@ import Grid from '@mui/material/Grid';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { setNamespaceFilter } from '../../redux/filterSlice';
+import { resetFilter, setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { NamespacesAutocomplete } from './NamespacesAutocomplete';
 import SectionHeader, { SectionHeaderProps } from './SectionHeader';
@@ -43,6 +43,7 @@ function getFilterValueByNameFromURL(key: string, location: any): string[] {
 
 export interface SectionFilterHeaderProps extends SectionHeaderProps {
   noNamespaceFilter?: boolean;
+  clearGlobalNamespaceFilterOnMount?: boolean;
   /**
    * @deprecated
    * This prop has no effect, search has moved inside the Table component.
@@ -55,6 +56,7 @@ export interface SectionFilterHeaderProps extends SectionHeaderProps {
 export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
   const {
     noNamespaceFilter = false,
+    clearGlobalNamespaceFilterOnMount = false,
     actions: propsActions = [],
     preRenderFromFilterActions,
     ...headerProps
@@ -63,24 +65,30 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
   const dispatch = useDispatch();
   const location = useLocation();
 
-  React.useEffect(
-    () => {
-      const namespace = getFilterValueByNameFromURL('namespace', location);
-      if (namespace.length > 0) {
-        const namespaceFromStore = [...filter.namespaces].sort();
-        if (
-          namespace
-            .slice()
-            .sort()
-            .every((value: string, index: number) => value !== namespaceFromStore[index])
-        ) {
-          dispatch(setNamespaceFilter(namespace));
-        }
+  React.useEffect(() => {
+    if (noNamespaceFilter) {
+      if (clearGlobalNamespaceFilterOnMount && filter.namespaces.size > 0) {
+        dispatch(resetFilter());
       }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+      return;
+    }
+
+    const namespace = getFilterValueByNameFromURL('namespace', location);
+    if (namespace.length > 0) {
+      const sortedNamespace = namespace.slice().sort();
+      const namespaceFromStore = [...filter.namespaces].sort();
+
+      const namespacesAreEqual =
+        sortedNamespace.length === namespaceFromStore.length &&
+        sortedNamespace.every(
+          (value: string, index: number) => value === namespaceFromStore[index]
+        );
+
+      if (!namespacesAreEqual) {
+        dispatch(setNamespaceFilter(namespace));
+      }
+    }
+  }, [clearGlobalNamespaceFilterOnMount, dispatch, filter.namespaces, location, noNamespaceFilter]);
 
   let actions: React.ReactNode[] = [];
   if (preRenderFromFilterActions) {

--- a/frontend/src/components/common/SectionFilterHeader.tsx
+++ b/frontend/src/components/common/SectionFilterHeader.tsx
@@ -19,7 +19,7 @@ import Grid from '@mui/material/Grid';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { setNamespaceFilter } from '../../redux/filterSlice';
+import { resetFilter, setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { NamespacesAutocomplete } from './NamespacesAutocomplete';
 import SectionHeader, { SectionHeaderProps } from './SectionHeader';
@@ -63,24 +63,27 @@ export default function SectionFilterHeader(props: SectionFilterHeaderProps) {
   const dispatch = useDispatch();
   const location = useLocation();
 
-  React.useEffect(
-    () => {
-      const namespace = getFilterValueByNameFromURL('namespace', location);
-      if (namespace.length > 0) {
-        const namespaceFromStore = [...filter.namespaces].sort();
-        if (
-          namespace
-            .slice()
-            .sort()
-            .every((value: string, index: number) => value !== namespaceFromStore[index])
-        ) {
-          dispatch(setNamespaceFilter(namespace));
-        }
+  React.useEffect(() => {
+    if (noNamespaceFilter) {
+      if (filter.namespaces.size > 0) {
+        dispatch(resetFilter());
       }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+      return;
+    }
+
+    const namespace = getFilterValueByNameFromURL('namespace', location);
+    if (namespace.length > 0) {
+      const namespaceFromStore = [...filter.namespaces].sort();
+      if (
+        namespace
+          .slice()
+          .sort()
+          .every((value: string, index: number) => value !== namespaceFromStore[index])
+      ) {
+        dispatch(setNamespaceFilter(namespace));
+      }
+    }
+  }, [dispatch, filter.namespaces, location, noNamespaceFilter]);
 
   let actions: React.ReactNode[] = [];
   if (preRenderFromFilterActions) {

--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -185,6 +185,7 @@ export interface PodListProps {
   hideColumns?: ('namespace' | 'restarts')[];
   reflectTableInURL?: SimpleTableProps['reflectInURL'];
   noNamespaceFilter?: boolean;
+  clearGlobalNamespaceFilterOnMount?: boolean;
   errors?: ApiError[] | null;
   hideCreateButton?: boolean;
 }
@@ -196,6 +197,7 @@ export function PodListRenderer(props: PodListProps) {
     hideColumns = [],
     reflectTableInURL = 'pods',
     noNamespaceFilter,
+    clearGlobalNamespaceFilterOnMount,
     errors,
     hideCreateButton,
   } = props;
@@ -229,6 +231,7 @@ export function PodListRenderer(props: PodListProps) {
       title={t('Pods')}
       headerProps={{
         noNamespaceFilter,
+        clearGlobalNamespaceFilterOnMount,
         titleSideActions: hideCreateButton
           ? []
           : [<CreateResourceButton resourceClass={Pod} key="create-pod-button" />],


### PR DESCRIPTION
## Summary

This PR fixes a bug where a stale global namespace filter could remain active and hide pod results in namespace-scoped views.

## Related Issue

Fixes #4502

## Changes

- Updated `frontend/src/components/common/SectionFilterHeader.tsx`
- Cleared the global namespace filter when `noNamespaceFilter=true`
- Prevented hidden Workloads namespace filter state from affecting namespace-scoped pod views

## Steps to Test

1. Navigate to the Workloads page and apply a namespace filter.
2. Navigate to a namespace-scoped page that shows pods (for example, the Namespace details page).
3. Confirm that pods for the currently scoped namespace are displayed and the hidden old namespace filter does not cause an empty list.

## Screenshots (if applicable)
[Screencast from 2026-04-17 19-14-20.webm](https://github.com/user-attachments/assets/32503a21-7172-4ebc-8dd2-d15e42e74a2f)


## Notes for the Reviewer

- This only changes namespace filter reset behavior in `SectionFilterHeader`.

