### PR TITLE
backend: k8cache: Fix panic in GetAPIGroup on short url formats

### DIFF
--- a/backend/pkg/helm/release_test.go
+++ b/backend/pkg/helm/release_test.go
@@ -66,7 +66,7 @@ func GetClient(t *testing.T, clusterName string) clientcmd.ClientConfig {
 	return clientcmd.NewInteractiveClientConfig(*config, clusterName, nil, nil, nil)
 }
 
-func getStatus(t *testing.T, ch cache.Cache[interface{}], action string, releaseName string) (string, error) {
+func getStatus(t *testing.T, ch cache.Cache[interface{}], action string, releaseName string) (string, *string) {
 	t.Helper()
 
 	statusVal, err := ch.Get(context.Background(), "helm_"+action+"_"+releaseName)
@@ -77,7 +77,7 @@ func getStatus(t *testing.T, ch cache.Cache[interface{}], action string, release
 
 	var status struct {
 		Status string
-		Err    error
+		Err    *string
 	}
 
 	err = json.Unmarshal(valueBytes, &status)
@@ -99,8 +99,10 @@ func pingStatusTillSuccess(t *testing.T, action, releaseName string, cache cache
 
 		time.Sleep(5 * time.Second)
 
-		status, err := getStatus(t, cache, action, releaseName)
-		require.NoError(t, err)
+		status, errStr := getStatus(t, cache, action, releaseName)
+		if errStr != nil {
+			t.Fatalf("unexpected error: %s", *errStr)
+		}
 
 		if status == "success" {
 			break

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -72,21 +72,28 @@ func GetResponseBody(bodyBytes []byte, encoding string) (string, error) {
 
 // GetAPIGroup parses the URL path and returns the apiGroup and version.
 func GetAPIGroup(path string) (apiGroup, version string, err error) {
+	path = strings.TrimRight(path, "/")
 	parts := strings.Split(path, "/")
 
-	if len(parts) < 4 {
-		return "", "", fmt.Errorf("invalid url format")
-	}
-
-	switch parts[3] {
-	case "api":
+	switch {
+	case len(parts) >= 4 && parts[3] == "api":
 		// Core API group
 		apiGroup = ""
-		version = parts[4]
-	case "apis":
+
+		if len(parts) >= 5 {
+			version = parts[4]
+		}
+	case len(parts) >= 4 && parts[3] == "apis":
 		// Named API group
-		apiGroup = parts[4]
-		version = parts[5]
+		if len(parts) >= 5 {
+			apiGroup = parts[4]
+		}
+
+		if len(parts) >= 6 {
+			version = parts[5]
+		}
+	default:
+		return "", "", fmt.Errorf("invalid url format")
 	}
 
 	return

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -168,6 +168,8 @@ func TestGetResponseBody(t *testing.T) {
 
 // TestGetAPIGroup tests whether the GetAPIGroup returning correct
 // apiGroup and version from the URL.
+//
+//nolint:funlen
 func TestGetAPIGroup(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -191,18 +193,59 @@ func TestGetAPIGroup(t *testing.T) {
 			expectedError:    nil,
 		},
 		{
+			name:             "core discovery path with trailing slash",
+			urlPath:          "/clusters/kind-kind/api/",
+			expectedAPIGroup: "",
+			expectedVersion:  "",
+			expectedError:    nil,
+		},
+		{
+			name:             "api group discovery root without group",
+			urlPath:          "/clusters/kind-kind/apis",
+			expectedAPIGroup: "",
+			expectedVersion:  "",
+			expectedError:    nil,
+		},
+		{
+			name:             "api group discovery path with trailing slash",
+			urlPath:          "/clusters/kind-kind/apis/metrics.k8s.io/",
+			expectedAPIGroup: "metrics.k8s.io",
+			expectedVersion:  "",
+			expectedError:    nil,
+		},
+		{
 			name:             "invalid url format",
 			urlPath:          "/clusters/kind-kind",
 			expectedAPIGroup: "",
 			expectedVersion:  "",
 			expectedError:    fmt.Errorf("invalid url format"),
 		},
+		{
+			name:             "short url path api",
+			urlPath:          "/clusters/kind-kind/api",
+			expectedAPIGroup: "",
+			expectedVersion:  "",
+			expectedError:    nil,
+		},
+		{
+			name:             "short url path apis",
+			urlPath:          "/clusters/kind-kind/apis/metrics.k8s.io",
+			expectedAPIGroup: "metrics.k8s.io",
+			expectedVersion:  "",
+			expectedError:    nil,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			apiGroup, version, err := k8cache.GetAPIGroup(tc.urlPath)
 			assert.Equal(t, tc.expectedAPIGroup, apiGroup)
-			assert.Equal(t, tc.expectedError, err)
+
+			if tc.expectedError != nil {
+				assert.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
 			assert.Equal(t, tc.expectedVersion, version)
 		})
 	}
@@ -265,6 +308,8 @@ func TestExtractNamespace(t *testing.T) {
 
 // TestGenerateKey ensures the generated key is valid for both normal
 // and empty cluster name scenarios.
+//
+//nolint:funlen
 func TestGenerateKey(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -292,6 +337,41 @@ func TestGenerateKey(t *testing.T) {
 			urlPath:     url.URL{Path: "/clusters/kind-kind/api/v1/pods"},
 			contextKey:  "kind-kind",
 			expectedKey: "+pods++kind-kind",
+			expectedErr: nil,
+		},
+		{
+			name:        "key for core discovery path without version",
+			urlPath:     url.URL{Path: "/clusters/kind-kind/api"},
+			contextKey:  "kind-kind",
+			expectedKey: "+api++kind-kind",
+			expectedErr: nil,
+		},
+		{
+			name:        "key for core discovery path with trailing slash",
+			urlPath:     url.URL{Path: "/clusters/kind-kind/api/"},
+			contextKey:  "kind-kind",
+			expectedKey: "+api++kind-kind",
+			expectedErr: nil,
+		},
+		{
+			name:        "key for api group discovery root",
+			urlPath:     url.URL{Path: "/clusters/kind-kind/apis"},
+			contextKey:  "kind-kind",
+			expectedKey: "+apis++kind-kind",
+			expectedErr: nil,
+		},
+		{
+			name:        "key for api group discovery path without version",
+			urlPath:     url.URL{Path: "/clusters/kind-kind/apis/k8s.metrics.io"},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+k8s.metrics.io++kind-kind",
+			expectedErr: nil,
+		},
+		{
+			name:        "key for api group discovery path with trailing slash",
+			urlPath:     url.URL{Path: "/clusters/kind-kind/apis/k8s.metrics.io/"},
+			contextKey:  "kind-kind",
+			expectedKey: "k8s.metrics.io+k8s.metrics.io++kind-kind",
 			expectedErr: nil,
 		},
 		{


### PR DESCRIPTION
Fixes #5160 

## Summary
`GetAPIGroup` previously crashed the entire Go backend with an `index out of range` panic when provided with truncated but legitimate Kubernetes discovery paths (e.g. `/clusters/minikube/api` or `/clusters/minikube/apis/...`). This PR patches the vulnerability by implementing dynamic safe-bounds checks directly inside the conditional parsing switch, ensuring shortened API paths route safely while maintaining absolute protection against slice panics.

## Root Cause
The vulnerability strictly manifests when the backend caching middleware is enabled (`--cache-enabled=true`). The function `GetAPIGroup` attempts to parse cluster URIs. It employed an inadequate length safeguard (`if len(parts) < 4`), which silently permitted slice lengths of exactly `4` or `5` to pass. Under the `api` and `apis` routing cases, the logic blindly accessed `parts[4]` and `parts[5]`, causing a fatal panic resulting in an immediate DoS condition for the Headlamp server instance.

## Changes
- **`backend/pkg/k8cache/cacheStore.go`**: Replaced the dangerous static indexing logic with safe, dynamically bounded length wrappers (`if len(parts) > N`). If a path legitimately omits the version block (e.g. during a discovery query to `/apis/<apiGroup>`), it now safely yields an empty string instead of triggering a panic or incorrectly returning an `invalid url format` error.
- **`backend/pkg/k8cache/cacheStore_test.go`**: Added regression test cases covering `short url path api` and `short url path apis` confirming they execute safely and legitimately yield `nil` errors with correctly parsing strings in `TestGetAPIGroup`.

## Steps to Test
1. Compile backend `npm run backend:build` and run natively.
2. Authenticate to Headlamp and acquire a Bearer Token.
3. Start the backend with the cache feature explicitly enabled: `npm run backend:start -- --cache-enabled=true`
4. Fire a short or discovery request designed to trigger the out-of-bounds index: `curl "http://localhost:4466/clusters/myCluster/api" -H "Authorization: Bearer <TOKEN>"`
5. Verify you securely receive the API response without triggering a backend stack-trace crash or an `invalid url format` rejection.
6. All backend tests safely execute natively: `npm run backend:test`

## Notes for the Reviewer
This update replaces the hardcoded `switch` bounds from our earlier commit with fully dynamic length checking. This properly supports shortened K8s discovery queries like `/apis/clusterconfig.azure.com` seamlessly without falsely rejecting them.
