### PR TITLE
backend: k8cache: Fix watcherRegistry poisoning preventing cache invalidation

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -152,15 +152,13 @@ func CheckForChanges(
 	contextKey string,
 	kContext kubeconfig.Context,
 ) {
-	if _, loaded := watcherRegistry.Load(contextKey); loaded {
+	if _, loaded := watcherRegistry.LoadOrStore(contextKey, struct{}{}); loaded {
 		return
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	contextCancel.Store(contextKey, cancel)
-
-	watcherRegistry.Store(contextKey, struct{}{})
 
 	go runWatcher(ctx, k8scache, contextKey, kContext)
 }
@@ -174,6 +172,11 @@ func runWatcher(
 	contextKey string,
 	kContext kubeconfig.Context,
 ) {
+	defer func() {
+		watcherRegistry.Delete(contextKey)
+		contextCancel.Delete(contextKey)
+	}()
+
 	logger.Log(logger.LevelInfo, nil, nil, "running runWatcher for watching k8s resource: "+contextKey)
 
 	config, err := kContext.RESTConfig()

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -1,0 +1,54 @@
+package k8cache
+
+import (
+	"context"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+)
+
+// ExportedRunWatcher exposes runWatcher for testing.
+func ExportedRunWatcher(
+	ctx context.Context,
+	k8scache cache.Cache[string],
+	contextKey string,
+	kContext kubeconfig.Context,
+) {
+	runWatcher(ctx, k8scache, contextKey, kContext)
+}
+
+// ResetRegistries clears both registries for test isolation.
+// If no keys are provided, it clears all entries.
+func ResetRegistries(keys ...string) {
+	if len(keys) == 0 {
+		watcherRegistry.Range(func(key, _ interface{}) bool {
+			watcherRegistry.Delete(key)
+			return true
+		})
+		contextCancel.Range(func(key, _ interface{}) bool {
+			contextCancel.Delete(key)
+			return true
+		})
+
+		return
+	}
+
+	for _, k := range keys {
+		watcherRegistry.Delete(k)
+		contextCancel.Delete(k)
+	}
+}
+
+// StoreTestRegistry populates both registries for test setup.
+func StoreTestRegistry(key string, cancel func()) {
+	watcherRegistry.Store(key, struct{}{})
+	contextCancel.Store(key, cancel)
+}
+
+// RegistryLoaded checks if a key exists in both registries.
+func RegistryLoaded(key string) (watcher, cancel bool) {
+	_, watcher = watcherRegistry.Load(key)
+	_, cancel = contextCancel.Load(key)
+
+	return
+}

--- a/backend/pkg/k8cache/registry_cleanup_test.go
+++ b/backend/pkg/k8cache/registry_cleanup_test.go
@@ -1,0 +1,33 @@
+package k8cache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunWatcherCleansUpRegistryOnFailure(t *testing.T) {
+	key := t.Name()
+	// Ensure clean state before and after the test.
+	k8cache.ResetRegistries(key)
+	defer k8cache.ResetRegistries(key)
+
+	// Simulate what CheckForChanges does before launching the goroutine.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	k8cache.StoreTestRegistry(key, cancel)
+
+	// An empty Context causes RESTConfig() to return an error,
+	// which makes runWatcher exit on its first error path.
+	k8cache.ExportedRunWatcher(ctx, nil, key, kubeconfig.Context{})
+
+	// After the early return, both registry entries must be cleaned up
+	// so that a subsequent CheckForChanges call can start a new watcher.
+	watcherLoaded, cancelLoaded := k8cache.RegistryLoaded(key)
+	assert.False(t, watcherLoaded, "watcherRegistry entry should be removed after early exit")
+	assert.False(t, cancelLoaded, "contextCancel entry should be removed after early exit")
+}


### PR DESCRIPTION

Fixes #5162 

## Summary
Resolves a silent cache desync bug where the UI cluster data permanently stagnates. The issue originates from the `watcherRegistry` becoming locked by the `runWatcher` thread that has actually returned early and died due to internal connectivity exceptions. This PR adds lifecycle release logic natively to un poison the queue. 

## Root Cause
Inside `backend/pkg/k8cache/cacheInvalidation.go`, `CheckForChanges` stores the `contextKey` into the thread-safe mechanism `watcherRegistry` before executing `go runWatcher()`. The system depends on `watcherRegistry` to ensure duplicates are not spun up. 
If `runWatcher` fails safely mid-setup (e.g. `kContext.RESTConfig()` errs out)—it correctly yields a return branch. But it previously overlooked calling `watcherRegistry.Delete(contextKey)`. This left a dead key lingering permanently in the map, tricking subsequent HTTP checks into skipping watcher instantiation because `loaded == true`. The backend then silently serves an infinitely aging cache.

## Changes
- **`backend/pkg/k8cache/cacheInvalidation.go`**: Prepended a `defer watcherRegistry.Delete(contextKey)` logic block aggressively at the top of the `runWatcher` function signature. Because it sits on the stack deferral, Go guarantees it cleans up the cluster ID tracking regardless of any internal `err return`, `ctx.Done()`, or runtime panics taking out the specific connection scope. 

## Steps to Test
1. Compile backend `npm run backend:build` and run natively.
2. Fire off a background Kubernetes instance with simulated network hiccups or discovery issues affecting a loaded RESTConfig during startup.
3. Reload your Headlamp cluster. It will seamlessly spawn a new retry `runWatcher` connection instead of returning infinitely stale information on cache.
4. Execute `npm run backend:test` safely asserting no regression on native pointer assignments or concurrency.
