### PR TITLE
frontend: Sidebar: Fix TypeScript Typecast bypass in VersionButton

### DIFF
--- a/frontend/src/components/Sidebar/VersionButton.tsx
+++ b/frontend/src/components/Sidebar/VersionButton.tsx
@@ -78,8 +78,8 @@ export default function VersionButton() {
     ];
   }
 
-  const { data: clusterVersion } = useQuery({
-    placeholderData: null as any,
+  const { data: clusterVersion } = useQuery<StringDict | null>({
+    placeholderData: null,
     queryKey: ['version', cluster ?? ''],
     queryFn: () => {
       return getVersion()
@@ -111,7 +111,10 @@ export default function VersionButton() {
 
           return results;
         })
-        .catch((error: Error) => console.error('Getting the cluster version:', error));
+        .catch((error: Error) => {
+          console.error('Getting the cluster version:', error);
+          return null;
+        });
     },
     refetchInterval: versionFetchInterval,
   });


### PR DESCRIPTION
**Summary:** 
Fixes a technical debt item where `useQuery` was missing its generic type argument and instead bypassing the type checker using `placeholderData: null as any`.

**Changes:**
- Provided explicit generic type `<StringDict | null>` to `useQuery` in `VersionButton.tsx`.
- Removed the unsafe `as any` cast from `placeholderData`.
- Updated the `.catch()` block to explicitly return `null` upon failure, respecting the strict return type instead of bleeding a `void` return type.

**Steps to Test:**
1. Run `npm run frontend:tsc` to ensure no type errors have been introduced.
2. Compile and run the frontend (`cd frontend && npm start`).
3. Ensure the Sidebar's version button behaves exactly as before successfully resolving cluster version data.
