### PR TITLE
frontend: node details: add ephemeral storage in node detail view

### DIFF
--- a/frontend/src/components/cluster/Charts/ResourceCharts.tsx
+++ b/frontend/src/components/cluster/Charts/ResourceCharts.tsx
@@ -16,10 +16,12 @@
 
 import '../../../i18n/config';
 import { useTranslation } from 'react-i18next';
+import type { ApiError } from '../../../lib/k8s/api/v2/ApiError';
+import type { KubeNodeSummaryStats } from '../../../lib/k8s/api/v2/nodeSummaryApi';
 import { KubeMetrics } from '../../../lib/k8s/cluster';
 import Node from '../../../lib/k8s/node';
 import Pod from '../../../lib/k8s/pod';
-import { parseCpu, parseRam, TO_GB, TO_ONE_CPU } from '../../../lib/units';
+import { parseCpu, parseDiskSpace, parseRam, TO_GB, TO_ONE_CPU } from '../../../lib/units';
 import ResourceCircularChart, {
   CircularChartProps as ResourceCircularChartProps,
 } from '../../common/Resource/CircularChart';
@@ -138,6 +140,51 @@ export function PodCapacityCircularChart(props: { node: Node | null; pods: Pod[]
       label={getLabel()}
       legend={getLegend()}
       total={isLoading ? -1 : total}
+    />
+  );
+}
+
+interface EphemeralStorageCircularChartProps {
+  node: Node | null;
+  summaryStats: KubeNodeSummaryStats | null;
+  summaryError: ApiError | null;
+}
+
+export function EphemeralStorageCircularChart(props: EphemeralStorageCircularChartProps) {
+  const { node, summaryStats, summaryError } = props;
+  const { t } = useTranslation(['translation', 'glossary']);
+  const allocatable = (node?.status?.allocatable || {}) as Record<string, string | undefined>;
+  const capacity = (node?.status?.capacity || {}) as Record<string, string | undefined>;
+  const rawTotal =
+    allocatable.ephemeralStorage ||
+    allocatable['ephemeral-storage'] ||
+    capacity.ephemeralStorage ||
+    capacity['ephemeral-storage'] ||
+    '';
+  const totalBytes = parseDiskSpace(rawTotal);
+  const fs = summaryStats?.node?.fs;
+  const usedBytes =
+    typeof fs?.usedBytes === 'number'
+      ? fs.usedBytes
+      : typeof fs?.capacityBytes === 'number' && typeof fs?.availableBytes === 'number'
+      ? fs.capacityBytes - fs.availableBytes
+      : -1;
+
+  const hasData = totalBytes > 0 && usedBytes >= 0;
+  const usedGB = usedBytes / TO_GB;
+  const totalGB = totalBytes / TO_GB;
+  const usagePercent = hasData ? (usedBytes / totalBytes) * 100 : 0;
+
+  return (
+    <TileChart
+      title={t('translation|Ephemeral Storage Usage')}
+      data={hasData ? [{ name: 'used', value: usedBytes }] : null}
+      total={hasData ? totalBytes : -1}
+      label={hasData ? `${usagePercent.toFixed(1)} %` : '…'}
+      legend={hasData ? `${usedGB.toFixed(2)} / ${totalGB.toFixed(2)} GB` : ''}
+      infoTooltip={
+        summaryError ? t('translation|Unable to fetch ephemeral storage usage from kubelet.') : null
+      }
     />
   );
 }

--- a/frontend/src/components/cluster/Charts/index.ts
+++ b/frontend/src/components/cluster/Charts/index.ts
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-import { CpuCircularChart, MemoryCircularChart, PodCapacityCircularChart } from './ResourceCharts';
+import {
+  CpuCircularChart,
+  EphemeralStorageCircularChart,
+  MemoryCircularChart,
+  PodCapacityCircularChart,
+} from './ResourceCharts';
 import { NodesStatusCircleChart, PodsStatusCircleChart } from './StatusCharts';
 
 export {
   MemoryCircularChart,
   CpuCircularChart,
   PodCapacityCircularChart,
+  EphemeralStorageCircularChart,
   PodsStatusCircleChart,
   NodesStatusCircleChart,
 };

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -26,7 +26,9 @@ import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { apply } from '../../lib/k8s/api/v1/apply';
 import { drainNode, drainNodeStatus } from '../../lib/k8s/api/v1/drainNode';
-import type { KubeContainer, KubeMetrics } from '../../lib/k8s/cluster';
+import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
+import type { KubeNodeSummaryStats } from '../../lib/k8s/api/v2/nodeSummaryApi';
+import { KubeContainer, KubeMetrics } from '../../lib/k8s/cluster';
 import Node from '../../lib/k8s/node';
 import type { KubePod } from '../../lib/k8s/pod';
 import Pod from '../../lib/k8s/pod';
@@ -35,7 +37,12 @@ import { getCluster, timeAgo } from '../../lib/util';
 import { DefaultHeaderAction } from '../../redux/actionButtonsSlice';
 import { clusterAction } from '../../redux/clusterActionSlice';
 import { AppDispatch } from '../../redux/stores/store';
-import { CpuCircularChart, MemoryCircularChart, PodCapacityCircularChart } from '../cluster/Charts';
+import {
+  CpuCircularChart,
+  EphemeralStorageCircularChart,
+  MemoryCircularChart,
+  PodCapacityCircularChart,
+} from '../cluster/Charts';
 import ActionButton from '../common/ActionButton';
 import ConfirmDialog from '../common/ConfirmDialog';
 import { StatusLabelProps } from '../common/Label';
@@ -66,6 +73,7 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
 
   const { enqueueSnackbar } = useSnackbar();
   const [nodeMetrics, metricsError] = Node.useMetrics();
+  const [nodeSummaryStats, nodeSummaryError] = Node.useNodeSummaryStats(name, cluster);
   const [isupdatingNodeScheduleProperty, setisUpdatingNodeScheduleProperty] = React.useState(false);
   const [isNodeDrainInProgress, setisNodeDrainInProgress] = React.useState(false);
   const [nodeFromAPI, nodeError] = Node.useGet(name);
@@ -218,7 +226,14 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
         cluster={cluster}
         error={nodeError}
         headerSection={item => (
-          <ChartsSection node={item} pods={nodePods} metrics={nodeMetrics} noMetrics={noMetrics} />
+          <ChartsSection
+            node={item}
+            pods={nodePods}
+            metrics={nodeMetrics}
+            noMetrics={noMetrics}
+            summaryStats={nodeSummaryStats}
+            summaryError={nodeSummaryError}
+          />
         )}
         withEvents
         actions={item => {
@@ -312,11 +327,13 @@ interface ChartsSectionProps {
   node: Node | null;
   pods: Pod[] | null;
   metrics: KubeMetrics[] | null;
+  summaryStats: KubeNodeSummaryStats | null;
+  summaryError: ApiError | null;
   noMetrics?: boolean;
 }
 
 function ChartsSection(props: ChartsSectionProps) {
-  const { node, pods, metrics, noMetrics } = props;
+  const { node, pods, metrics, summaryStats, summaryError, noMetrics } = props;
   const { t } = useTranslation('glossary');
 
   function getUptime() {
@@ -368,6 +385,13 @@ function ChartsSection(props: ChartsSectionProps) {
         </Box>
         <Box>
           <PodCapacityCircularChart node={node} pods={pods} />
+        </Box>
+        <Box>
+          <EphemeralStorageCircularChart
+            node={node}
+            summaryStats={summaryStats}
+            summaryError={summaryError}
+          />
         </Box>
       </Box>
     </Box>

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU-Nutzung",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Angefordert",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Bereit",
   "Recent clusters": "Aktuelle Cluster",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU Usage",
   "{{ used }} / {{ total }} Pods": "{{ used }} / {{ total }} Pods",
   "Pod Usage": "Pod Usage",
+  "Ephemeral Storage Usage": "Ephemeral Storage Usage",
+  "Unable to fetch ephemeral storage usage from kubelet.": "Unable to fetch ephemeral storage usage from kubelet.",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Requested",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Recent clusters",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "Uso de la CPU",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} requeridos",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Clusters recientes",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "Utilisation du CPU",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Demandé(s)",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Groupes récents",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU उपयोग",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} अनुरोधित",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} तैयार",
   "Recent clusters": "हाल के क्लस्टर",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "Utilizzo CPU",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} Richiesti",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Pronti",
   "Recent clusters": "Cluster recenti",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU 使用量",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} リクエスト済み",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} 準備完了",
   "Recent clusters": "最近のクラスター",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU 사용량",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "요청됨: {{ numReady }} / {{ numItems }}",
   "{{ numReady }} / {{ numItems }} Ready": "준비됨: {{ numReady }} / {{ numItems }}",
   "Recent clusters": "최근 클러스터",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "Uso do CPU",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} requeridos",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} Ready",
   "Recent clusters": "Clusters recentes",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU பயன்பாடு",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} கோரப்பட்டது",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} தயார்",
   "Recent clusters": "சமீபத்திய க்ளஸ்டர்கள்",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU 使用",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} 已請求",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} 已準備好",
   "Recent clusters": "最近的叢集",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -213,6 +213,8 @@
   "CPU Usage": "CPU 使用",
   "{{ used }} / {{ total }} Pods": "",
   "Pod Usage": "",
+  "Ephemeral Storage Usage": "",
+  "Unable to fetch ephemeral storage usage from kubelet.": "",
   "{{ numReady }} / {{ numItems }} Requested": "{{ numReady }} / {{ numItems }} 已请求",
   "{{ numReady }} / {{ numItems }} Ready": "{{ numReady }} / {{ numItems }} 已准备好",
   "Recent clusters": "最近的集群",

--- a/frontend/src/lib/k8s/api/v2/nodeSummaryApi.ts
+++ b/frontend/src/lib/k8s/api/v2/nodeSummaryApi.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isDebugVerbose } from '../../../../helpers/debugVerbose';
+import { getCluster } from '../../../cluster';
+import type { ApiError } from './ApiError';
+import { clusterFetch } from './fetch';
+
+export interface KubeNodeSummaryStats {
+  node?: {
+    fs?: {
+      availableBytes?: number;
+      capacityBytes?: number;
+      usedBytes?: number;
+    };
+  };
+}
+
+/**
+ * Gets kubelet summary stats for a node. Fetches new stats every 10 seconds.
+ *
+ * @param nodeName - The node name.
+ * @param onStats - The function to call with the node summary stats.
+ * @param onError - The function to call if there's an error.
+ * @param cluster - The cluster to get stats for. By default uses the current cluster (URL defined).
+ *
+ * @returns A function to cancel the polling request.
+ */
+export async function nodeSummaryStats(
+  nodeName: string,
+  onStats: (arg: KubeNodeSummaryStats) => void,
+  onError?: (err: ApiError) => void,
+  cluster?: string
+) {
+  if (!nodeName) {
+    return () => {};
+  }
+
+  const handle = setInterval(getNodeSummaryStats, 10000);
+  const clusterName = cluster || getCluster() || '';
+
+  async function getNodeSummaryStats() {
+    try {
+      const summary: KubeNodeSummaryStats = await clusterFetch(
+        `/api/v1/nodes/${encodeURIComponent(nodeName)}/proxy/stats/summary`,
+        { cluster: clusterName }
+      ).then(response => response.json());
+      onStats(summary);
+    } catch (err) {
+      if (isDebugVerbose('k8s/apiProxy@nodeSummaryStats')) {
+        console.debug('k8s/apiProxy@nodeSummaryStats', { err, nodeName });
+      }
+
+      if (onError) {
+        onError(err as ApiError);
+      }
+    }
+  }
+
+  function cancel() {
+    clearInterval(handle);
+  }
+
+  getNodeSummaryStats();
+
+  return cancel;
+}

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -19,6 +19,7 @@ import { useErrorState } from '../util';
 import { useConnectApi } from '.';
 import { metrics } from './api/v1/metricsApi';
 import type { ApiError } from './api/v2/ApiError';
+import { KubeNodeSummaryStats, nodeSummaryStats } from './api/v2/nodeSummaryApi';
 import type { KubeCondition, KubeMetrics } from './cluster';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
@@ -104,6 +105,29 @@ class Node extends KubeObject<KubeNode> {
     useConnectApi(metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError));
 
     return [nodeMetrics, error];
+  }
+
+  static useNodeSummaryStats(
+    nodeName?: string,
+    cluster?: string
+  ): [KubeNodeSummaryStats | null, ApiError | null] {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [summaryStats, setSummaryStats] = React.useState<KubeNodeSummaryStats | null>(null);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [error, setError] = useErrorState(setSummaryStats);
+
+    function setStats(stats: KubeNodeSummaryStats) {
+      setSummaryStats(stats);
+
+      if (stats !== null) {
+        setError(null);
+      }
+    }
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
+
+    return [summaryStats, error];
   }
 
   getExternalIP(): string {


### PR DESCRIPTION
## Summary

This PR adds ephemeral storage usage visibility to the **Node Details** view by fetching kubelet summary stats and rendering a dedicated circular usage chart, including an initial/loading state and an error tooltip when stats cannot be fetched.

## Related Issue

Fixes #5168 

## Changes

- Added a new kubelet summary API client:
  - `frontend/src/lib/k8s/api/v1/nodeSummaryApi.ts`
  - Polls `/api/v1/nodes/{name}/proxy/stats/summary` every 10s.
- Added a new node hook in:
  - `frontend/src/lib/k8s/node.ts`
  - `Node.useNodeSummaryStats(nodeName, cluster)` for summary stats + error state.
- Added a new chart in:
  - `frontend/src/components/cluster/Charts/ResourceCharts.tsx`
  - `EphemeralStorageCircularChart` to show used/total ephemeral storage.
- Exported the new chart from:
  - `frontend/src/components/cluster/Charts/index.ts`
- Wired summary stats + chart into:
  - `frontend/src/components/node/Details.tsx`
- Added i18n keys for:
  - `Ephemeral Storage Usage`
  - `Unable to fetch ephemeral storage usage from kubelet.`
  - across locale files under `frontend/src/i18n/locales/*/translation.json`.

## Steps to Test

1. Navigate to **Nodes** and click any node to open **Node Details**.
2. Verify the new **Ephemeral Storage Usage** chart appears in the header charts section.
3. Confirm the chart shows percentage and `used / total GB` values when stats are available.


## Screenshots (if applicable)
<img width="3072" height="1728" alt="Screenshot from 2026-04-20 14-32-54" src="https://github.com/user-attachments/assets/5e5cb349-00e2-45f1-8b88-51d752acd880" />


## Notes for the Reviewer
