### PR TITLE
Update node version to 22.x LTS

### DIFF
--- a/.github/workflows/app-artifacts-embedded.yml
+++ b/.github/workflows/app-artifacts-embedded.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
-        node-version: 20.x
+        node-version: 22.x
         cache: 'npm'
         cache-dependency-path: |
           frontend/package-lock.json

--- a/.github/workflows/app-artifacts-linux.yml
+++ b/.github/workflows/app-artifacts-linux.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
-        node-version: 20.x
+        node-version: 22.x
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: '1.25.*'

--- a/.github/workflows/app-artifacts-mac.yml
+++ b/.github/workflows/app-artifacts-mac.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
-        node-version: 20.x
+        node-version: 22.x
         cache: 'npm'
         cache-dependency-path: |
           app/package-lock.json
@@ -84,7 +84,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
-        node-version: 18.x
+        node-version: 22.x
         cache: 'npm'
         cache-dependency-path: |
           app/package-lock.json

--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
-        node-version: 20.x
+        node-version: 22.x
         cache: 'npm'
         cache-dependency-path: |
           headlamp/app/package-lock.json

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Use Node.js ${{ matrix.node-version }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Use Node.js ${{ matrix.node-version }}
@@ -78,7 +78,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/backend-embed-test.yml
+++ b/.github/workflows/backend-embed-test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
-        node-version: 20.x
+        node-version: 22.x
     - name: Check if sha256 lines changed in this PR for verifying image digest changes
       id: check-sha
       if: github.event_name == 'pull_request'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
@@ -113,7 +113,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
@@ -135,7 +135,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
@@ -157,7 +157,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/pr-to-update-choco.yml
+++ b/.github/workflows/pr-to-update-choco.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Create node.js environment
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '21'
+          node-version: '22'
       # Install the app dependencies for the choco script
       - name: Install app dependencies
         run: |

--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Create artifacts directory
         run: mkdir -p ./artifacts

--- a/app/package.json
+++ b/app/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://github.com/kubernetes-sigs/headlamp/#readme",
   "productName": "Headlamp",
   "engines": {
-    "npm": ">=10.0.0",
-    "node": ">=20.11.1"
+    "npm": ">=11.0.0",
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "npm run copy-icons && npm run copy-plugins && npm run compile-electron && electron-builder --dir --publish never",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "productName": "Headlamp",
   "engines": {
-    "npm": ">=10.0.0",
-    "node": ">=20.11.1"
+    "npm": ">=11.0.0",
+    "node": ">=22.0.0"
   },
   "type": "module",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.11.1",
-    "npm": ">=10.0.0"
+    "npm": ">=11.0.0",
+    "node": ">=22.0.0"
   },
   "scripts": {
     "install:all": "npm run frontend:install && npm run backend:build && npm run app:install && npm run tools:install",


### PR DESCRIPTION
Node 20 will be EOL by the  end of this month so let's update all our ci workflows to use 22.x LTS
24.x was causing too many issues, so for now upgrading just to 22.x

## Changes

- Updated all workflows to use Node 22.x
- Updated "engines" fields in all package.json 

## Steps to Test

1. Check if CI workflows pass