### PR TITLE
backend: k8cache: Add tests for uncovered branches

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -17,16 +17,20 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	api "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestDeleteKeys(t *testing.T) { //nolint:funlen
@@ -430,4 +434,178 @@ func TestRunInformerToWatch_OldResource(t *testing.T) {
 	checkEviction("Delete")
 
 	close(stopCh)
+}
+
+// GetKindAndVerb — missing / empty mux "api" var  (0% branch today)
+
+// TestGetKindAndVerb_NoMuxVars exercises the early-return path where the
+// "api" mux variable is absent from the request context.
+func TestGetKindAndVerb_NoMuxVars(t *testing.T) {
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/api/v1/pods", nil,
+	)
+	// No mux.SetURLVars → mux.Vars returns empty map → ok==false branch.
+	kind, verb := k8cache.GetKindAndVerb(req)
+	assert.Equal(t, "", kind)
+	assert.Equal(t, "unknown", verb)
+}
+
+// TestGetKindAndVerb_EmptyAPIVar covers the branch where the "api" mux var
+// is present but set to an empty string.
+func TestGetKindAndVerb_EmptyAPIVar(t *testing.T) {
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/", nil,
+	)
+	req = mux.SetURLVars(req, map[string]string{"api": ""})
+
+	kind, verb := k8cache.GetKindAndVerb(req)
+	assert.Equal(t, "", kind)
+	assert.Equal(t, "unknown", verb)
+}
+
+// IsAllowed — "could not determine resource or verb" guard branch
+
+// TestIsAllowed_EmptyKind drives the `last == ""` guard inside IsAllowed
+// by sending a request with no mux "api" variable so that
+// GetKindAndVerb returns ("", "unknown").
+func TestIsAllowed_EmptyKind(t *testing.T) {
+	k := &kubeconfig.Context{
+		ClusterID: "/home/user/.kubeconfig+kind-auth-test",
+		Cluster:   &api.Cluster{Server: "https://127.0.0.1:19999"},
+		AuthInfo:  &api.AuthInfo{Token: "tok"},
+		KubeContext: &api.Context{
+			Cluster:  "kind-auth-test",
+			AuthInfo: "default",
+		},
+		Name: "kind-auth-test",
+	}
+
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/api/v1/pods", nil,
+	)
+	// No mux vars → GetKindAndVerb returns ("", "unknown") →
+	// IsAllowed must return (false, non-nil error).
+	allowed, err := k8cache.IsAllowed(k, req)
+	assert.False(t, allowed)
+	assert.Error(t, err)
+}
+
+// ServeFromCacheOrForwardToK8s — StoreK8sResponseInCache error path
+
+// errOnWriteCache wraps MockCache and makes SetWithTTL always return an
+// error, triggering the error-logging branch in ServeFromCacheOrForwardToK8s.
+type errOnWriteCache struct {
+	*MockCache
+}
+
+func (e *errOnWriteCache) SetWithTTL(_ context.Context, _, _ string, _ time.Duration) error {
+	return assert.AnError
+}
+
+// TestServeFromCacheOrForwardToK8s_StoreError ensures the function handles
+// a cache-write failure gracefully without panicking.
+func TestServeFromCacheOrForwardToK8s_StoreError(t *testing.T) {
+	badCache := &errOnWriteCache{MockCache: NewMockCache()}
+	nextCalls := 0
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalls++
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"PodList"}`))
+	})
+
+	requestPath := "/clusters/kind-kind/api/v1/pods"
+	cacheKey := "store-err-key"
+
+	w1 := httptest.NewRecorder()
+	rcw1 := k8cache.NewResponseCapture(w1)
+	r1 := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, requestPath, nil,
+	)
+
+	k8cache.ServeFromCacheOrForwardToK8s(badCache, false, next, cacheKey, w1, r1, rcw1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	w2 := httptest.NewRecorder()
+	rcw2 := k8cache.NewResponseCapture(w2)
+	r2 := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, requestPath, nil,
+	)
+
+	k8cache.ServeFromCacheOrForwardToK8s(badCache, false, next, cacheKey, w2, r2, rcw2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, 2, nextCalls, "next must be called each time when cache write fails")
+
+	_, err := badCache.Get(context.Background(), cacheKey)
+	assert.Error(t, err, "failed cache write must not persist the key")
+}
+
+// HandleNonGETCacheInvalidation — three branches currently at 0%
+
+// TestHandleNonGETCacheInvalidation_GETSkipped verifies that GET requests
+// return nil immediately without touching the cache or calling next.
+func TestHandleNonGETCacheInvalidation_GETSkipped(t *testing.T) {
+	mockCache := NewMockCache()
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet,
+		"/clusters/kind/api/v1/pods", nil,
+	)
+
+	err := k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx-key")
+	assert.NoError(t, err)
+	assert.False(t, called, "next must not be called for GET requests")
+}
+
+// TestHandleNonGETCacheInvalidation_BypassURLExcluded verifies that a POST
+// on a URL containing "/selfsubjectrulesreviews" is NOT invalidated because
+// IsAuthBypassURL returns false for those paths — the function returns nil.
+func TestHandleNonGETCacheInvalidation_BypassURLExcluded(t *testing.T) {
+	mockCache := NewMockCache()
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	targetURL := &url.URL{Path: "/clusters/kind/api/v1/selfsubjectrulesreviews"}
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodPost, targetURL.String(), nil,
+	)
+	r.URL = targetURL
+
+	err := k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx-key")
+	assert.NoError(t, err)
+	assert.False(t, called, "next must not be called for excluded URLs")
+}
+
+// TestHandleNonGETCacheInvalidation_PostOnNormalURL exercises the full
+// invalidation path: POST on a normal (non-excluded) URL →
+// IsAuthBypassURL returns true → delete stale keys → forward request →
+// cache fresh GET → return ErrHandled.
+func TestHandleNonGETCacheInvalidation_PostOnNormalURL(t *testing.T) {
+	mockCache := NewMockCache()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"PodList"}`))
+	})
+
+	w := httptest.NewRecorder()
+	targetURL := &url.URL{Path: "/clusters/kind/api/v1/pods"}
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodPost, targetURL.String(), nil,
+	)
+	r.URL = targetURL
+
+	// IsAuthBypassURL("/…/pods") == true → full invalidation → ErrHandled.
+	err := k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
+	assert.ErrorIs(t, err, k8cache.ErrHandled)
 }

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -536,3 +536,303 @@ func TestStoreK8sResponseInCache(t *testing.T) {
 		})
 	}
 }
+
+// TestGetResponseBody_PlainEncoding verifies that non-gzip bodies are
+// returned as-is without any decompression.
+func TestGetResponseBody_PlainEncoding(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         []byte
+		encoding     string
+		expectedBody string
+	}{
+		{
+			name:         "plain text body with no encoding",
+			body:         []byte("hello world"),
+			encoding:     "",
+			expectedBody: "hello world",
+		},
+		{
+			name:         "json body with identity encoding",
+			body:         []byte(`{"kind":"PodList"}`),
+			encoding:     "identity",
+			expectedBody: `{"kind":"PodList"}`,
+		},
+		{
+			name:         "empty body with no encoding",
+			body:         []byte{},
+			encoding:     "",
+			expectedBody: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := k8cache.GetResponseBody(tc.body, tc.encoding)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedBody, body)
+		})
+	}
+}
+
+// TestFilterHeaderForCache_NonGzip verifies that when encoding is not gzip,
+// all headers (including Content-Encoding) are passed through unchanged.
+func TestFilterHeaderForCache_NonGzip(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseHeader http.Header
+		encoding       string
+		expectedHeader http.Header
+	}{
+		{
+			name: "non-gzip encoding keeps all headers intact",
+			responseHeader: http.Header{
+				"Content-Type":     {"application/json"},
+				"Content-Encoding": {"identity"},
+				"X-Custom-Header":  {"value1"},
+			},
+			encoding: "identity",
+			expectedHeader: http.Header{
+				"Content-Type":     {"application/json"},
+				"Content-Encoding": {"identity"},
+				"X-Custom-Header":  {"value1"},
+			},
+		},
+		{
+			name: "no encoding keeps all headers intact",
+			responseHeader: http.Header{
+				"Content-Type": {"text/plain"},
+				"X-Request-Id": {"abc-123"},
+			},
+			encoding: "",
+			expectedHeader: http.Header{
+				"Content-Type": {"text/plain"},
+				"X-Request-Id": {"abc-123"},
+			},
+		},
+		{
+			name:           "empty headers with no encoding",
+			responseHeader: http.Header{},
+			encoding:       "",
+			expectedHeader: http.Header{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := k8cache.FilterHeaderForCache(tc.responseHeader, tc.encoding)
+			assert.Equal(t, tc.expectedHeader, result)
+		})
+	}
+}
+
+// TestLoadFromCache_Misses covers cache-miss and permission-denied paths
+// that are absent from the existing tests.
+func TestLoadFromCache_Misses(t *testing.T) {
+	tests := []struct {
+		name         string
+		seedKey      string
+		seedValue    string
+		lookupKey    string
+		isAllowed    bool
+		expectLoaded bool
+	}{
+		{
+			name:         "cache miss returns false with no error",
+			seedKey:      "other-key",
+			seedValue:    `{"Body":"data","StatusCode":200}`,
+			lookupKey:    "missing-key",
+			isAllowed:    true,
+			expectLoaded: false,
+		},
+		{
+			name:         "cache hit but isAllowed=false returns false",
+			seedKey:      "my-key",
+			seedValue:    `{"Body":"secret","StatusCode":200}`,
+			lookupKey:    "my-key",
+			isAllowed:    false,
+			expectLoaded: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCache := NewMockCache()
+			err := mockCache.Set(context.Background(), tc.seedKey, tc.seedValue)
+			assert.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/api/v1/pods", nil,
+			)
+
+			loaded, err := k8cache.LoadFromCache(mockCache, tc.isAllowed, tc.lookupKey, w, r)
+			assert.Equal(t, tc.expectLoaded, loaded)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestLoadFromCache_MissesEdgeCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		seedKey      string
+		seedValue    string
+		lookupKey    string
+		expectLoaded bool
+		expectError  bool
+	}{
+		{
+			name:         "cache hit with whitespace-only body returns false",
+			seedKey:      "blank-key",
+			seedValue:    "   ",
+			lookupKey:    "blank-key",
+			expectLoaded: false,
+			expectError:  false,
+		},
+		{
+			name:         "cache hit with invalid JSON returns error",
+			seedKey:      "bad-json",
+			seedValue:    `not-valid-json`,
+			lookupKey:    "bad-json",
+			expectLoaded: false,
+			expectError:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCache := NewMockCache()
+			err := mockCache.Set(context.Background(), tc.seedKey, tc.seedValue)
+			assert.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/api/v1/pods", nil,
+			)
+
+			loaded, err := k8cache.LoadFromCache(mockCache, true, tc.lookupKey, w, r)
+			assert.Equal(t, tc.expectLoaded, loaded)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestStoreK8sResponseInCache_SkipSelfSubjectRulesReview verifies that
+// responses for selfsubjectrulesreviews are never written to the cache.
+func TestStoreK8sResponseInCache_SkipSelfSubjectRulesReview(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/api/v1/selfsubjectrulesreviews"}
+
+	rw := httptest.NewRecorder()
+	rcw := k8cache.NewResponseCapture(rw)
+
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, targetURL.Path, nil,
+	)
+
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "skip-key")
+	assert.NoError(t, err)
+
+	// Key must NOT have been written to the cache.
+	_, getErr := mockCache.Get(context.Background(), "skip-key")
+	assert.Error(t, getErr, "selfsubjectrulesreviews response should never be cached")
+}
+
+// TestStoreK8sResponseInCache_GzipBody verifies that a gzip-compressed
+// response body is correctly decompressed before being stored.
+func TestStoreK8sResponseInCache_GzipBody(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/api/v1/pods"}
+
+	rw := httptest.NewRecorder()
+	rcw := k8cache.NewResponseCapture(rw)
+
+	// Write a gzip-compressed body into the capture writer.
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	_, _ = gz.Write([]byte(`{"kind":"PodList","items":[]}`))
+	_ = gz.Close()
+
+	rcw.Header().Set("Content-Encoding", "gzip")
+	rcw.WriteHeader(http.StatusOK)
+	_, _ = rcw.Write(buf.Bytes())
+
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, targetURL.Path, nil,
+	)
+
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "gzip-key")
+	assert.NoError(t, err)
+
+	// The stored value must exist and must NOT contain the Content-Encoding header.
+	stored, getErr := mockCache.Get(context.Background(), "gzip-key")
+	assert.NoError(t, getErr)
+	assert.NotEmpty(t, stored)
+	assert.NotContains(t, stored, "Content-Encoding")
+}
+
+// TestStoreK8sResponseInCache_FailureBodyNotCached ensures responses
+// whose JSON body contains "Failure" (e.g. k8s error objects) are
+// not written to cache.
+func TestStoreK8sResponseInCache_FailureBodyNotCached(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/api/v1/pods"}
+
+	rw := httptest.NewRecorder()
+	rcw := k8cache.NewResponseCapture(rw)
+
+	failureBody := `{"kind":"Status","status":"Failure","message":"Forbidden"}`
+
+	rcw.WriteHeader(http.StatusForbidden)
+	_, _ = rcw.Write([]byte(failureBody))
+
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, targetURL.Path, nil,
+	)
+
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "failure-key")
+	assert.NoError(t, err)
+
+	// Key must NOT have been written to the cache.
+	_, getErr := mockCache.Get(context.Background(), "failure-key")
+	assert.Error(t, getErr, "Failure responses should never be cached")
+}
+
+// TestExtractNamespace_QueryStringOnNamespacedURL verifies that query
+// parameters are stripped correctly even when a namespace is present.
+func TestExtractNamespace_QueryStringOnNamespacedURL(t *testing.T) {
+	tests := []struct {
+		name              string
+		rawURL            string
+		expectedNamespace string
+		expectedKind      string
+	}{
+		{
+			name:              "namespaced resource with query string",
+			rawURL:            "/api/v1/namespaces/prod/pods?labelSelector=app%3Dnginx",
+			expectedNamespace: "prod",
+			expectedKind:      "pods",
+		},
+		{
+			name:              "cluster-scoped resource with multiple query params",
+			rawURL:            "/api/v1/nodes?limit=500&continue=token123",
+			expectedNamespace: "",
+			expectedKind:      "nodes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			namespace, kind := k8cache.ExtractNamespace(tc.rawURL)
+			assert.Equal(t, tc.expectedNamespace, namespace)
+			assert.Equal(t, tc.expectedKind, kind)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR increases test coverage of the `k8cache` package by adding tests for previously uncovered branches in `cacheStore_test.go` and `cacheInvalidation_test.go`.

## Related Issue
N/A

## Changes
- Added tests for plain-encoding path in `GetResponseBody`
- Added tests for non-gzip header filtering in `FilterHeaderForCache`
- Added tests for cache miss, permission-denied, whitespace body and invalid JSON paths in `LoadFromCache`
- Added tests for `selfsubjectrulesreviews` skip logic, gzip body store and `Failure` response guard in `StoreK8sResponseInCache`
- Added tests for missing/empty mux var branches in `GetKindAndVerb`
- Added tests for empty kind/verb guard in `IsAllowed`
- Added tests for store error path in `ServeFromCacheOrForwardToK8s`
- Added tests for GET skip, excluded URL and full POST invalidation path in `HandleNonGETCacheInvalidation`

## Steps to Test
1. Navigate to `backend/pkg/k8cache`
2. Run `go test -cover`
3. Observe coverage increase from 63.5% to 71.0%

## Screenshots (if applicable)
<img width="1447" height="96" alt="image" src="https://github.com/user-attachments/assets/86dce230-6ea0-4c50-8b9e-6c31f26575a8" />


## Notes for the Reviewer
- No production code was modified, only test files
- All new tests follow the existing table-driven test style used in the package
- `MockCache` and helper types are reused from existing test files