### PR TITLE
docs: Update platforms.md to include NKP

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -30,6 +30,8 @@ The "works" column refers to the overall Kubernetes-related functionality when r
 | [Talos Linux](https://www.talos.dev/) |  ✔️   | - Simple to install / expose with the regular [in-cluster instructions](https://headlamp.dev/docs/latest/installation/in-cluster/).  
 | [Oracle Kubernetes Engine (OKE)](https://www.oracle.com/in/cloud/cloud-native/kubernetes-engine/)    |  ✔️   | - As reported [here](https://github.com/kubernetes-sigs/headlamp/pull/4666).
 | [Linode Kubernetes Engine (LKE)](https://techdocs.akamai.com/cloud-computing/docs/linode-kubernetes-engine)    |  ✔️   | - Simple to install / expose with the regular [in-cluster instructions](https://headlamp.dev/docs/latest/installation/in-cluster/).                                                                                                                              
+| [Nutanix Kubernetes Platform (NKP)](https://www.nutanix.com/products/kubernetes-management-platform)    |  ✔️   | - Simple to install / expose with the regular [in-cluster instructions](https://headlamp.dev/docs/latest/installation/in-cluster/).    
+
 ## Tested Browsers
 
 We mostly test with 'modern browsers' defined as the latest version and two older versions. But we try to make Headlamp work with web standards, so it's quite likely other standards-conforming browsers will also work.


### PR DESCRIPTION
I've thoroughly tested headlamp with NKP clusters, and I'm pleased to report it is functioning well without any workarounds, since NKP is based on kubeadm.