### PR TITLE
frontend: UpdatePopup: Remove dead code

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
+++ b/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx
@@ -111,61 +111,6 @@ function UpdatePopup({
     return null;
   }
 
-  if (fetchingRelease && !releaseDownloadURL) {
-    return (
-      <ColoredSnackbar
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        autoHideDuration={5000}
-        message={t('translation|Fetching release information…')}
-        ContentProps={{
-          'aria-describedby': 'updatePopup',
-        }}
-        open={fetchingRelease && !closeSnackError}
-        onClose={() => {
-          setCloseSnackError(true);
-        }}
-        action={
-          <React.Fragment>
-            <Button
-              style={{
-                color: 'rgb(255, 242, 0)',
-              }}
-              onClick={() => {
-                skipUpdateHandler();
-              }}
-            >
-              {t('translation|Skip')}
-            </Button>
-          </React.Fragment>
-        }
-      />
-    );
-  }
-
-  if (releaseFetchFailed && !releaseDownloadURL) {
-    return (
-      <ColoredSnackbar
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        open={releaseFetchFailed}
-        message={t('translation|Failed to fetch release information')}
-        ContentProps={{
-          'aria-describedby': 'updatePopup',
-        }}
-        autoHideDuration={6000}
-      />
-    );
-  }
-
-  if (!releaseDownloadURL) {
-    return null;
-  }
-
   return (
     <ColoredSnackbar
       anchorOrigin={{
@@ -183,7 +128,7 @@ function UpdatePopup({
           <Box display={'flex'} alignItems="center">
             <Box ml={-1}>
               <Button
-                onClick={() => window.open(releaseDownloadURL)}
+                onClick={() => window.open(releaseDownloadURL, '_blank', 'noopener,noreferrer')}
                 style={{
                   color: 'inherit',
                   textTransform: 'none',


### PR DESCRIPTION
# PR Description

## What this PR does

Removes 54 lines of unreachable dead code from [UpdatePopup.tsx](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx) and hardens `window.open`.

## Why

The [UpdatePopup](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/common/ReleaseNotes/UpdatePopup.tsx#43-170) component had three conditional blocks (`fetchingRelease`, `releaseFetchFailed`, `!releaseDownloadURL`) **duplicated** after an early-return guard:

```tsx
// Line 110 — returns null when releaseDownloadURL is falsy
if (!releaseDownloadURL) {
  return null;
}

// Lines 114-167 — UNREACHABLE: releaseDownloadURL is guaranteed truthy here
if (fetchingRelease && !releaseDownloadURL) { ... }   // ❌ never true
if (releaseFetchFailed && !releaseDownloadURL) { ... } // ❌ never true
if (!releaseDownloadURL) { ... }                       // ❌ never true
```

Since line 110 already returns `null` when `releaseDownloadURL` is falsy, all subsequent checks involving `!releaseDownloadURL` can never execute.

Also added `'_blank', 'noopener,noreferrer'` to `window.open()` for the release download link, consistent with other `window.open()` calls in the codebase (e.g., [ResourceTable.tsx](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/common/Resource/ResourceTable.tsx)) and following security best practices to prevent reverse tabnapping.

## How to verify

- [x] `npx vitest run --reporter=verbose src/storybook.test.tsx -t 'UpdatePopup'` — all 3 snapshot tests pass
- [x] `npm run frontend:lint` — 0 errors
