### PR TITLE
frontend: LogViewer: Add i18n support for Reconnect button

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -217,7 +217,7 @@ export function LogViewer(props: LogViewerProps) {
       >
         {showReconnectButton && (
           <Button onClick={handleReconnect} color="info" variant="contained">
-            Reconnect
+            {t('translation|Reconnect')}
           </Button>
         )}
         <div

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "Finden",
   "Download": "Herunterladen",
+  "Reconnect": "",
   "No results": "Keine Ergebnisse",
   "Too many matches": "Zu viele Treffer",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} von {{ totalResults }}",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "Open Issue on GitHub",
   "Find": "Find",
   "Download": "Download",
+  "Reconnect": "Reconnect",
   "No results": "No results",
   "Too many matches": "Too many matches",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} of {{ totalResults }}",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "Buscar",
   "Download": "Descargar",
+  "Reconnect": "",
   "No results": "Sin resultados",
   "Too many matches": "Demasiadas búsquedas",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} de {{ totalResults }}",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "Ouvrir un ticket sur GitHub",
   "Find": "Trouver",
   "Download": "Télécharger",
+  "Reconnect": "",
   "No results": "Aucun résultat",
   "Too many matches": "Trop de correspondances",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} sur {{ totalResults }}",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "खोजें",
   "Download": "डाउनलोड करें",
+  "Reconnect": "",
   "No results": "कोई परिणाम नहीं",
   "Too many matches": "बहुत अधिक मिलान",
   "{{ currentIndex }} of {{ totalResults }}": "{{ totalResults }} में से {{ currentIndex }}",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "Trova",
   "Download": "Scarica",
+  "Reconnect": "",
   "No results": "Nessun risultato",
   "Too many matches": "Troppi risultati",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} di {{ totalResults }}",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "検索",
   "Download": "ダウンロード",
+  "Reconnect": "",
   "No results": "結果なし",
   "Too many matches": "一致が多すぎます",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} / {{ totalResults }}",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "찾기",
   "Download": "다운로드",
+  "Reconnect": "",
   "No results": "결과 없음",
   "Too many matches": "일치 항목이 너무 많습니다",
   "{{ currentIndex }} of {{ totalResults }}": "{{ totalResults }} 중 {{ currentIndex }}",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "Pesquisar",
   "Download": "Descarregar",
+  "Reconnect": "",
   "No results": "Sem resultados",
   "Too many matches": "Demasiados resultados",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} de {{ totalResults }}",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "",
   "Find": "கண்டுபிடி",
   "Download": "பதிவிறக்கு",
+  "Reconnect": "",
   "No results": "முடிவுகள் இல்லை",
   "Too many matches": "அதிக பொருத்தங்கள்",
   "{{ currentIndex }} of {{ totalResults }}": "{{ totalResults }}-இல் {{ currentIndex }}",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "在 GitHub 上開啟 Issue",
   "Find": "查詢",
   "Download": "下載",
+  "Reconnect": "",
   "No results": "無結果",
   "Too many matches": "符合過多",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} / {{ totalResults }}",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -265,6 +265,7 @@
   "Open Issue on GitHub": "在 GitHub 上创建 Issue",
   "Find": "查找",
   "Download": "下载",
+  "Reconnect": "",
   "No results": "暂无结果",
   "Too many matches": "匹配结果过多",
   "{{ currentIndex }} of {{ totalResults }}": "{{ currentIndex }} / {{ totalResults }}",


### PR DESCRIPTION
## What this PR does

Wraps the hardcoded `"Reconnect"` string in the `LogViewer` component with
the `t()` translation function and registers the key in all 12 locale files.

## Why

The `Reconnect` button label was the only user-facing string in `LogViewer.tsx`
not going through `react-i18next`. This caused the button to remain in English
regardless of the user's selected language, breaking localization for all
non-English locales.

## Changes

- **`LogViewer.tsx`** - replaced hardcoded `"Reconnect"` with `t('translation|Reconnect')`
- **`en/translation.json`** - added `"Reconnect": "Reconnect"` as the source string
- **All other locale files** (`de`, `es`, `fr`, `hi`, `it`, `ja`, `ko`, `pt`, `ta`, `zh`, `zh-tw`) -added the `"Reconnect"` key with an empty string (ready for translators)

## How to verify

1. Run `npm run frontend:lint` -0 errors
2. Switch the app language to any non-English locale
3. Open a pod's log view and trigger a disconnect -the Reconnect button should now
   fall back gracefully and be translatable