### PR TITLE
frontend: stateless: Use console.debug for operational logs

### DIFF
--- a/frontend/src/stateless/deleteClusterKubeconfig.ts
+++ b/frontend/src/stateless/deleteClusterKubeconfig.ts
@@ -118,7 +118,7 @@ export async function deleteClusterKubeconfig(
           if (!parsed.contexts || parsed.contexts.length === 0) {
             const deleteRequest = store.delete(cursor.key);
             deleteRequest.onsuccess = () => {
-              console.log('Kubeconfig deleted from IndexedDB');
+              console.debug('Kubeconfig deleted from IndexedDB');
               resolve(kubeconfig64);
             };
             deleteRequest.onerror = () => {
@@ -134,7 +134,7 @@ export async function deleteClusterKubeconfig(
 
           const putRequest = store.put(updatedRow);
           putRequest.onsuccess = () => {
-            console.log('Kubeconfig updated in IndexedDB');
+            console.debug('Kubeconfig updated in IndexedDB');
             resolve(kubeconfig64);
           };
           putRequest.onerror = () => {

--- a/frontend/src/stateless/index.ts
+++ b/frontend/src/stateless/index.ts
@@ -149,7 +149,7 @@ export function storeStatelessClusterKubeconfig(kubeconfig: string): Promise<voi
         // The onsuccess event is fired when the request has succeeded.
         // This is where you handle the results of the request.
         addRequest.onsuccess = function requestSuccess() {
-          console.log('Kubeconfig added to IndexedDB');
+          console.debug('Kubeconfig added to IndexedDB');
           resolve(); // Resolve the promise when the kubeconfig is successfully added
         };
 


### PR DESCRIPTION
## What this PR does

Replaces `console.log` with `console.debug` for IndexedDB operational
messages in `deleteClusterKubeconfig.ts` and `stateless/index.ts`.

## Why

These messages (`Kubeconfig deleted/updated/added to IndexedDB`) are
informational success confirmations, not debug artifacts. Using
`console.debug` keeps them accessible during development but hides
them from the production console by default, reducing noise for users.
