### PR TITLE
frontend: fix conditional useTranslation hook in VolumeDetails

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -422,10 +422,13 @@ export interface VolumeDetailsProps {
 
 export function VolumeDetails(props: VolumeDetailsProps) {
   const { volumes } = props;
+
+  const { t } = useTranslation();
+
   if (!volumes) {
     return null;
   }
-  const { t } = useTranslation();
+
   return (
     <SectionBox title={t('translation|Volumes')}>
       <SimpleTable


### PR DESCRIPTION
## Summary

This PR fixes a "Rules of Hooks" violation in the `VolumeDetails` component where `useTranslation` was being called after a conditional early return.

Fixes#5195

## Changes

- Moved the `useTranslation()` hook call to the top level of the `VolumeDetails` component in `frontend/src/components/pod/Details.tsx` to ensure it always executes in the same order.

## Steps to Test

1. Navigate to a **Pod Details** page.
2. Verify that the **Volumes** section title and content are still correctly translated.
3. Ensure no React hook warnings appear in the console when viewing pods with or without volumes.

## Notes for the Reviewer

This is a straightforward fix to adhere to React's requirement that hooks must be called at the top level and not conditionally.
