### PR TITLE
frontend: fix Rules of Hooks violation in AuthVisible

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -56,22 +56,18 @@ export interface AuthVisibleProps extends React.PropsWithChildren<{}> {
 export default function AuthVisible(props: AuthVisibleProps) {
   const { item, authVerb, subresource, namespace, onError, onAuthResult, children } = props;
 
-  if (!VALID_AUTH_VERBS.includes(authVerb)) {
-    console.warn(`Invalid authVerb provided: "${authVerb}". Skipping authorization check.`);
-    return null;
-  }
+  const isValidAuthVerb = VALID_AUTH_VERBS.includes(authVerb);
 
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { data } = useQuery<any>({
-    enabled: !!item,
+    enabled: !!item && isValidAuthVerb,
     queryKey: [
       'authVisible',
       itemName,
-      itemClass.apiName,
-      itemClass.apiVersion,
+      itemClass?.apiName,
+      itemClass?.apiVersion,
       authVerb,
       subresource,
       namespace,
@@ -86,13 +82,13 @@ export default function AuthVisible(props: AuthVisibleProps) {
         return res;
       } catch (e: any) {
         onError?.(e);
+        return null;
       }
     },
   });
 
   const visible = data?.status?.allowed ?? false;
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (data) {
       onAuthResult?.({
@@ -100,8 +96,12 @@ export default function AuthVisible(props: AuthVisibleProps) {
         reason: data.status?.reason ?? '',
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
+
+  if (!isValidAuthVerb) {
+    console.warn(`Invalid authVerb provided: "${authVerb}". Skipping authorization check.`);
+    return null;
+  }
 
   if (!visible) {
     return null;


### PR DESCRIPTION
## Summary

This PR fixes a "Rules of Hooks" violation in the `AuthVisible` component where `useQuery` and `useEffect` were being called after an early return statement.

## Related Issue

Fixes #5187

## Changes

- Moved `useQuery` and `useEffect` hook calls to the top level of the `AuthVisible` component, above all early returns.
- Updated the `useQuery` `enabled` property to include the `isValidAuthVerb` check, ensuring authorization checks are still skipped for invalid verbs without violating hook rules.
- Added optional chaining to `itemClass` properties in the `queryKey` for safer access when `item` might be null.
- Relocated the invalid verb warning and early return to occur after the hook initializations.

## Steps to Test

1. Navigate to a resource that uses `AuthVisible` (e.g., viewing logs or executing commands in a Pod).
2. Verify that permissions are still correctly identified and that UI elements (like buttons or tabs) appear/disappear based on the user's RBAC.
3. Verify that the console still shows a warning if an invalid `authVerb` is passed, and that the component correctly returns `null`.

## Notes for the Reviewer

This change ensures that hooks are called in the same order every render, adhering to React's core requirements while preserving the component's original logic and safety checks.
