### PR TITLE
frontend: pod: Fix useTranslation called conditionally in VolumeDetails

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -422,10 +422,10 @@ export interface VolumeDetailsProps {
 
 export function VolumeDetails(props: VolumeDetailsProps) {
   const { volumes } = props;
+  const { t } = useTranslation();
   if (!volumes) {
     return null;
   }
-  const { t } = useTranslation();
   return (
     <SectionBox title={t('translation|Volumes')}>
       <SimpleTable


### PR DESCRIPTION
## Summary
This PR fixes a `react-hooks/rules-of-hooks` violation in the `VolumeDetails` component. The `useTranslation` hook was being called after an early-return guard (`if (!volumes) return null`), which is against React best practices.

## Related Issue
Fixes #5195

## Changes
- Moved the `useTranslation` hook call to the top of the `VolumeDetails` component in `frontend/src/components/pod/Details.tsx`.

## Steps to Test
1. Open Headlamp and navigate to any Pod's details page.
2. Ensure the "Volumes" section is displayed correctly.
3. Verify that no new runtime errors appear in the console.
