### PR TITLE
frontend: RollbackButton: move hook calls before early return to fix rules-of-hooks

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.stories.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.stories.tsx
@@ -20,12 +20,11 @@ import React from 'react';
 import { PluginInfo, PluginSettingsDetailsProps } from '../../../plugin/pluginsSlice';
 import { PluginSettingsDetailsPure, PluginSettingsDetailsPureProps } from './PluginSettingsDetails';
 
-const testAutoSaveComponent: React.FC<PluginSettingsDetailsProps> = () => {
+const TestAutoSaveComponent: React.FC<PluginSettingsDetailsProps> = () => {
   const [data, setData] = React.useState<{ [key: string]: any }>({});
   const onChange = (value: string) => {
     setData({ works: value });
   };
-
   return (
     <TextField
       value={data?.works || ''}
@@ -37,15 +36,13 @@ const testAutoSaveComponent: React.FC<PluginSettingsDetailsProps> = () => {
   );
 };
 
-const testNormalComponent: React.FC<PluginSettingsDetailsProps> = props => {
+const TestNormalComponent: React.FC<PluginSettingsDetailsProps> = props => {
   const { data, onDataChange } = props;
-
   function onChange(value: string) {
     if (onDataChange) {
       onDataChange({ works: value });
     }
   }
-
   return (
     <TextField
       value={data?.works || ''}
@@ -63,7 +60,7 @@ const mockPluginInfoAutoSave: PluginInfo = {
   description: 'This is an example plugin with auto-save enabled.',
   version: '0.0.1',
   homepage: 'https://example.com/plugin-auto-save',
-  settingsComponent: testAutoSaveComponent,
+  settingsComponent: TestAutoSaveComponent,
   displaySettingsComponentWithSaveButton: false,
 };
 
@@ -72,7 +69,7 @@ const mockPluginInfoNormal: PluginInfo = {
   description: 'This is an example plugin with normal save.',
   version: '0.0.1',
   homepage: 'https://example.com/plugin-normal',
-  settingsComponent: testNormalComponent,
+  settingsComponent: TestNormalComponent,
   displaySettingsComponentWithSaveButton: true,
 };
 

--- a/frontend/src/components/common/Resource/RollbackButton.tsx
+++ b/frontend/src/components/common/Resource/RollbackButton.tsx
@@ -74,18 +74,18 @@ export function RollbackButton(props: RollbackButtonProps) {
   const dispatch: AppDispatch = useDispatch();
   const { item, buttonStyle, afterConfirm } = props;
 
-  if (!item || !isRollbackableResource(item)) {
-    return null;
-  }
-
   const [openDialog, setOpenDialog] = useState(false);
   const location = useLocation();
   const { t } = useTranslation(['translation']);
   const dispatchRollbackEvent = useEventCallback(HeadlampEventType.ROLLBACK_RESOURCE);
 
-  const resource = item;
-  const resourceKind = resource.kind;
-  const getRevisionHistory = useCallback(() => resource.getRevisionHistory(), [resource]);
+  const resource = isRollbackableResource(item) ? item : null;
+  const resourceKind = resource?.kind;
+  const getRevisionHistory = useCallback(() => resource?.getRevisionHistory(), [resource]);
+
+  if (!item || !isRollbackableResource(item)) {
+    return null;
+  }
 
   async function performRollback(toRevision?: number) {
     const result = await resource.rollback(toRevision);

--- a/frontend/src/components/configmap/Details.tsx
+++ b/frontend/src/components/configmap/Details.tsx
@@ -29,6 +29,79 @@ import { DataField, DetailsGrid } from '../common/Resource';
 import { SectionBox } from '../common/SectionBox';
 import { NameValueTable, NameValueTableRow } from '../common/SimpleTable';
 
+function ConfigMapDataSection({ item }: { item: ConfigMap }) {
+  const { t } = useTranslation(['translation']);
+  const dispatch: AppDispatch = useDispatch();
+
+  const [data, setData] = React.useState(() => _.cloneDeep(item.data));
+  const [isDirty, setIsDirty] = React.useState(false);
+  const lastDataRef = React.useRef(_.cloneDeep(item.data));
+
+  const handleFieldChange = (key: string, newValue: string) => {
+    setData(prev => ({ ...prev, [key]: newValue }));
+    setIsDirty(true);
+  };
+
+  React.useEffect(() => {
+    const newData = _.cloneDeep(item.data);
+    if (!isDirty && !_.isEqual(newData, lastDataRef.current)) {
+      setData(newData);
+      lastDataRef.current = newData;
+    }
+  }, [item.data, isDirty]);
+
+  const handleSave = () => {
+    const updatedConfigMap = { ...item.jsonData, data };
+    dispatch(
+      clusterAction(() => item.update(updatedConfigMap), {
+        startMessage: t('translation|Applying changes to {{ itemName }}…', {
+          itemName: item.metadata.name,
+        }),
+        cancelledMessage: t('translation|Cancelled changes to {{ itemName }}.', {
+          itemName: item.metadata.name,
+        }),
+        successMessage: t('translation|Applied changes to {{ itemName }}.', {
+          itemName: item.metadata.name,
+        }),
+        errorMessage: t('translation|Failed to apply changes to {{ itemName }}.', {
+          itemName: item.metadata.name,
+        }),
+      })
+    );
+    lastDataRef.current = _.cloneDeep(data);
+    setIsDirty(false);
+  };
+
+  const mainRows: NameValueTableRow[] = Object.entries(data).map(([key, value]) => ({
+    name: key as string,
+    value: (
+      <DataField
+        label={key as string}
+        disableLabel
+        value={value}
+        onChange={(newValue: string) => handleFieldChange(key as string, newValue)}
+      />
+    ),
+  }));
+
+  return (
+    <SectionBox title={t('translation|Data')}>
+      {mainRows.length === 0 ? (
+        <EmptyContent>{t('No data in this config map')}</EmptyContent>
+      ) : (
+        <>
+          <NameValueTable rows={mainRows} />
+          <Box mt={2} display="flex" justifyContent="flex-end">
+            <Button variant="contained" color="primary" onClick={handleSave}>
+              {t('translation|Save')}
+            </Button>
+          </Box>
+        </>
+      )}
+    </SectionBox>
+  );
+}
+
 export default function ConfigDetails(props: {
   name?: string;
   namespace?: string;
@@ -36,8 +109,6 @@ export default function ConfigDetails(props: {
 }) {
   const params = useParams<{ namespace: string; name: string }>();
   const { name = params.name, namespace = params.namespace, cluster } = props;
-  const { t } = useTranslation(['translation']);
-  const dispatch: AppDispatch = useDispatch();
 
   return (
     <DetailsGrid
@@ -50,75 +121,7 @@ export default function ConfigDetails(props: {
         item && [
           {
             id: 'headlamp.configmap-data',
-            section: () => {
-              const [data, setData] = React.useState(() => _.cloneDeep(item.data));
-              const [isDirty, setIsDirty] = React.useState(false);
-              const lastDataRef = React.useRef(_.cloneDeep(item.data));
-
-              const handleFieldChange = (key: string, newValue: string) => {
-                setData(prev => ({ ...prev, [key]: newValue }));
-                setIsDirty(true);
-              };
-
-              React.useEffect(() => {
-                const newData = _.cloneDeep(item.data);
-                if (!isDirty && !_.isEqual(newData, lastDataRef.current)) {
-                  setData(newData);
-                  lastDataRef.current = newData;
-                }
-              }, [item.data, isDirty]);
-
-              const handleSave = () => {
-                const updatedConfigMap = { ...item.jsonData, data };
-                dispatch(
-                  clusterAction(() => item.update(updatedConfigMap), {
-                    startMessage: t('translation|Applying changes to {{ itemName }}…', {
-                      itemName: item.metadata.name,
-                    }),
-                    cancelledMessage: t('translation|Cancelled changes to {{ itemName }}.', {
-                      itemName: item.metadata.name,
-                    }),
-                    successMessage: t('translation|Applied changes to {{ itemName }}.', {
-                      itemName: item.metadata.name,
-                    }),
-                    errorMessage: t('translation|Failed to apply changes to {{ itemName }}.', {
-                      itemName: item.metadata.name,
-                    }),
-                  })
-                );
-                lastDataRef.current = _.cloneDeep(data);
-                setIsDirty(false);
-              };
-
-              const mainRows: NameValueTableRow[] = Object.entries(data).map((item: unknown[]) => ({
-                name: item[0] as string,
-                value: (
-                  <DataField
-                    label={item[0] as string}
-                    disableLabel
-                    value={item[1]}
-                    onChange={(newValue: string) => handleFieldChange(item[0] as string, newValue)}
-                  />
-                ),
-              }));
-
-              return (
-                <SectionBox title={t('translation|Data')}>
-                  {mainRows.length === 0 ? (
-                    <EmptyContent>{t('No data in this config map')}</EmptyContent>
-                  ) : (
-                    <>
-                      <NameValueTable rows={mainRows} />
-                      <Box mt={2} display="flex" justifyContent="flex-end">
-                        <Button variant="contained" color="primary" onClick={handleSave}>
-                          {t('translation|Save')}
-                        </Button>
-                      </Box>
-                    </>
-                  )}
-                </SectionBox>
-              );
-            },
+            section: () => <ConfigMapDataSection item={item} />,
           },
         ]
       }


### PR DESCRIPTION
Fixes #5191

Moves all hook calls (`useState`, `useLocation`, `useTranslation`,
`useEventCallback`, `useCallback`) to the top of `RollbackButton`
before the early return guard clause, satisfying rules-of-hooks.

`resource` is now derived as `RollbackableResource | null` before the
guard, and TypeScript can narrow it correctly after.

Steps to test:
- Run `npx eslint src/components/common/Resource/RollbackButton.tsx` - no warnings