### PR TITLE
frontend: RollbackButton: move hook calls before early return to fix rules-of-hooks

### DIFF
--- a/frontend/src/components/common/Resource/RollbackButton.tsx
+++ b/frontend/src/components/common/Resource/RollbackButton.tsx
@@ -74,26 +74,26 @@ export function RollbackButton(props: RollbackButtonProps) {
   const dispatch: AppDispatch = useDispatch();
   const { item, buttonStyle, afterConfirm } = props;
 
-  if (!item || !isRollbackableResource(item)) {
+  const [openDialog, setOpenDialog] = useState(false);
+  const location = useLocation();
+  const { t } = useTranslation(['translation']);
+  const dispatchRollbackEvent = useEventCallback(HeadlampEventType.ROLLBACK_RESOURCE);
+
+  const resource = item && isRollbackableResource(item) ? item : null;
+
+  const getRevisionHistory = useCallback((): Promise<RevisionInfo[]> => {
+    return resource ? resource.getRevisionHistory() : Promise.resolve([]);
+  }, [resource]);
+
+  if (!resource) {
     return null;
   }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const [openDialog, setOpenDialog] = useState(false);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const location = useLocation();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { t } = useTranslation(['translation']);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const dispatchRollbackEvent = useEventCallback(HeadlampEventType.ROLLBACK_RESOURCE);
-
-  const resource = item;
-  const resourceKind = resource.kind;
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const getRevisionHistory = useCallback(() => resource.getRevisionHistory(), [resource]);
+  const rollbackResource = resource;
+  const resourceKind = rollbackResource.kind;
 
   async function performRollback(toRevision?: number) {
-    const result = await resource.rollback(toRevision);
+    const result = await rollbackResource.rollback(toRevision);
     if (!result.success) {
       throw new Error(result.message);
     }
@@ -101,7 +101,7 @@ export function RollbackButton(props: RollbackButtonProps) {
   }
 
   function handleConfirm(toRevision?: number) {
-    const itemName = resource.metadata.name;
+    const itemName = rollbackResource.metadata.name;
 
     dispatch(
       clusterAction(() => performRollback(toRevision), {
@@ -110,8 +110,8 @@ export function RollbackButton(props: RollbackButtonProps) {
         successMessage: t('Rolled back {{ itemName }} to previous version.', { itemName }),
         errorMessage: t('Failed to rollback {{ itemName }}.', { itemName }),
         cancelUrl: location.pathname,
-        startUrl: resource.getDetailsLink(),
-        errorUrl: resource.getDetailsLink(),
+        startUrl: rollbackResource.getDetailsLink(),
+        errorUrl: rollbackResource.getDetailsLink(),
       })
     );
 
@@ -119,7 +119,7 @@ export function RollbackButton(props: RollbackButtonProps) {
 
     // Dispatch event for plugins/tracking
     dispatchRollbackEvent({
-      resource: resource,
+      resource: rollbackResource,
       status: EventStatus.CONFIRMED,
     });
 
@@ -147,7 +147,7 @@ export function RollbackButton(props: RollbackButtonProps) {
       <RollbackDialog
         open={openDialog}
         resourceKind={resourceKind}
-        resourceName={resource.metadata.name}
+        resourceName={rollbackResource.metadata.name}
         getRevisionHistory={getRevisionHistory}
         onClose={() => setOpenDialog(false)}
         onConfirm={handleConfirm}


### PR DESCRIPTION
Fixes #5191

Moves all hook calls (`useState`, `useLocation`, `useTranslation`,
`useEventCallback`, `useCallback`) to the top of `RollbackButton`
before the early return guard clause, satisfying rules-of-hooks.

`resource` is now derived as `RollbackableResource | null` before the
guard, and TypeScript can narrow it correctly after.

Steps to test:
- Run `npx eslint src/components/common/Resource/RollbackButton.tsx` - no warnings