### PR TITLE
frontend: RestartButton: move hook calls before early return to fix rules-of-hooks

### DIFF
--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -55,6 +55,7 @@ export function DialogTitle(props: OurDialogTitleProps) {
     [focusTitle]
   );
 
+  // Don't render heading if there's no content to avoid empty heading violations
   if (!children && (!buttons || buttons.length === 0)) {
     return null;
   }

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -55,7 +55,6 @@ export function DialogTitle(props: OurDialogTitleProps) {
     [focusTitle]
   );
 
-  // Don't render heading if there's no content to avoid empty heading violations
   if (!children && (!buttons || buttons.length === 0)) {
     return null;
   }

--- a/frontend/src/components/common/Resource/RestartButton.tsx
+++ b/frontend/src/components/common/Resource/RestartButton.tsx
@@ -48,19 +48,14 @@ interface RestartButtonProps {
 export function RestartButton(props: RestartButtonProps) {
   const dispatch: AppDispatch = useDispatch();
   const { item, buttonStyle, afterConfirm } = props;
+  const [openDialog, setOpenDialog] = useState(false);
+  const location = useLocation();
+  const { t } = useTranslation(['translation']);
+  const dispatchRestartEvent = useEventCallback(HeadlampEventType.RESTART_RESOURCE);
 
   if (!item || !isRestartableResource(item)) {
     return null;
   }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const [openDialog, setOpenDialog] = useState(false);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const location = useLocation();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { t } = useTranslation(['translation']);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const dispatchRestartEvent = useEventCallback(HeadlampEventType.RESTART_RESOURCE);
 
   async function restartResource() {
     const patchData = {


### PR DESCRIPTION
Fixes #5190

Moves all hook calls (`useState`, `useLocation`, `useTranslation`,
`useEventCallback`) to the top of `RestartButton` before the early
return guard clause, satisfying rules-of-hooks.

Steps to test:
- Run `npx eslint src/components/common/Resource/RestartButton.tsx` - no warnings