### PR TITLE
frontend: Dialog: move useCallback before early return to fix rules-of-hooks

### DIFF
--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -45,22 +45,20 @@ export interface OurDialogTitleProps extends DialogTitleProps {
  */
 export function DialogTitle(props: OurDialogTitleProps) {
   const { children, focusTitle, buttons, disableTypography = false, id, ...other } = props;
+  const focusedRef = React.useCallback(
+    (node: HTMLElement | null) => {
+      if (node !== null && focusTitle) {
+        node.setAttribute('tabindex', '-1');
+        node.focus();
+      }
+    },
+    [focusTitle]
+  );
 
   // Don't render heading if there's no content to avoid empty heading violations
   if (!children && (!buttons || buttons.length === 0)) {
     return null;
   }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const focusedRef = React.useCallback((node: HTMLElement) => {
-    if (node !== null) {
-      if (focusTitle) {
-        node.setAttribute('tabindex', '-1');
-        node.focus();
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <MuiDialogTitle style={{ display: 'flex' }} {...other}>


### PR DESCRIPTION
Fixes #5186

Moves `React.useCallback` in `DialogTitle` to before the early return
guard clause, satisfying rules-of-hooks. Also adds `focusTitle` to the
dependency array which was previously missing.

Steps to test:
- Run `npx eslint src/components/common/Dialog.tsx` - no rules-of-hooks warnings