### PR TITLE
frontend: AppContainer.stories: rename withEnv to WithEnv to fix rules-of-hooks

### DIFF
--- a/frontend/src/components/App/AppContainer.stories.tsx
+++ b/frontend/src/components/App/AppContainer.stories.tsx
@@ -23,7 +23,7 @@ import i18n from '../../i18n/config';
 import store from '../../redux/stores/store';
 import AppContainer from './AppContainer';
 
-const withEnv = (Story: React.ComponentType) => {
+const WithEnv = (Story: React.ComponentType) => {
   const prev = (window as any).desktopApi;
   (window as any).desktopApi = {
     send: () => {},
@@ -52,7 +52,7 @@ const withEnv = (Story: React.ComponentType) => {
 export default {
   title: 'App/AppContainer',
   component: AppContainer,
-  decorators: [withEnv],
+  decorators: [WithEnv],
   parameters: {
     layout: 'fullscreen',
     storyshots: { disable: true },


### PR DESCRIPTION
Fixes #5184

Renames `withEnv` decorator to `WithEnv` (PascalCase) so React
recognises it as a component and hooks are valid per rules-of-hooks.

Steps to test:
- Run `npx eslint src/components/App/AppContainer.stories.tsx` - no warnings