### PR TITLE
fix(crd): unconditionally call useMemo hooks in CustomResourceListTable

### DIFF
--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -114,11 +114,6 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
   const clusters = useSelectedClusters();
   const isMultiCluster = clusters.length > 1;
 
-  if (!CRClass) {
-    return <Empty>{t('translation|No custom resources found')}</Empty>;
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const additionalPrinterCols = React.useMemo(() => {
     const currentVersion = apiGroup[1];
     const colsFromSpec =
@@ -150,7 +145,6 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
     return cols;
   }, [crd, apiGroup]);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const cols = React.useMemo(() => {
     const colsToDisplay: ResourceTableProps<KubeObject<KubeCRD>>['columns'] = [
       {
@@ -171,6 +165,10 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
     return colsToDisplay;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [crd, additionalPrinterCols, isMultiCluster]);
+
+  if (!CRClass) {
+    return <Empty>{t('translation|No custom resources found')}</Empty>;
+  }
 
   return (
     <ResourceListView


### PR DESCRIPTION
## Summary

Fixes two `react-hooks/rules-of-hooks` violations in `CustomResourceListTable` where `React.useMemo` was being called after an early return, breaking React's rules of hooks.

## Related Issue

Fixes #5194

## Changes

- Moved `additionalPrinterCols` and `cols` `useMemo` hooks above the `if (!CRClass)` early return in `frontend/src/components/crd/CustomResourceList.tsx`
- Removed two `// eslint-disable-next-line react-hooks/rules-of-hooks` suppressions that are no longer needed

## Steps to Test

1. Navigate to a cluster with custom resource definitions
2. Open any CRD's custom resource list view
3. Verify the list renders correctly with all columns (name, namespace, labels, age, additional printer columns)
4. Verify no React hook order errors appear in the browser console

## Screenshots (if applicable)

N/A — no UI changes