### PR TITLE
backend/helm: Fix fatal nil-pointer dereferences on invalid chart type install

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-playground/validator/v10"
@@ -640,8 +641,10 @@ func (h *Handler) getChart(
 
 	// chart is installable only if it is of type application or empty
 	if chart.Metadata.Type != "" && chart.Metadata.Type != "application" {
-		h.logActionState(zlog.Error(), err, actionName, reqChart, reqName, failed, "chart is not installable")
-		return nil, err
+		typeErr := fmt.Errorf("chart type %q is not installable", chart.Metadata.Type)
+		h.logActionState(zlog.Error(), typeErr, actionName, reqChart, reqName, failed, "chart is not installable")
+
+		return nil, typeErr
 	}
 
 	// Update chart dependencies
@@ -924,7 +927,12 @@ func (h *Handler) GetActionStatus(clientConfig clientcmd.ClientConfig, w http.Re
 	}
 
 	if stat.Status == failed {
-		response["message"] = "action failed with error: " + *stat.Err
+		errMsg := "unknown error"
+		if stat.Err != nil {
+			errMsg = *stat.Err
+		}
+
+		response["message"] = "action failed with error: " + errMsg
 	}
 
 	w.WriteHeader(http.StatusAccepted)

--- a/backend/pkg/helm/release_internal_test.go
+++ b/backend/pkg/helm/release_internal_test.go
@@ -1,0 +1,76 @@
+package helm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+)
+
+func TestGetActionStatus_NilErr(t *testing.T) {
+	h := &Handler{
+		Cache: cache.New[interface{}](),
+	}
+
+	// Set a failed status in the cache with a nil Err pointer
+	statusVal := stat{
+		Status: "failed",
+		Err:    nil,
+	}
+	err := h.Cache.Set(context.Background(), "helm_install_test-release", statusVal)
+	require.NoError(t, err)
+
+	url := "/clusters/minikube/helm/releases/status?action=install&name=test-release"
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	// GetActionStatus panics if it dereferences a nil pointer.
+	// This call should not panic.
+	h.GetActionStatus(nil, rr, req)
+
+	assert.Equal(t, http.StatusAccepted, rr.Code)
+
+	// The response should indicate "unknown error"
+	assert.Contains(t, rr.Body.String(), "action failed with error: unknown error")
+}
+
+func TestGetChart_InvalidType(t *testing.T) {
+	h := &Handler{
+		Cache:       cache.New[interface{}](),
+		EnvSettings: cli.New(),
+	}
+
+	// Create a temp directory for the fake chart
+	chartDir := t.TempDir()
+	chartYaml := filepath.Join(chartDir, "Chart.yaml")
+
+	chartContent := []byte("apiVersion: v2\nname: test-lib\nversion: 1.0.0\ntype: library\n")
+	err := os.WriteFile(chartYaml, chartContent, 0o600)
+	require.NoError(t, err)
+
+	opts := action.ChartPathOptions{}
+	loadedChart, err := h.getChart("install", chartDir, "test-release", opts, false, h.EnvSettings)
+
+	assert.Nil(t, loadedChart)
+	require.Error(t, err)
+	assert.Equal(t, "chart type \"library\" is not installable", err.Error())
+
+	// Verify that the failed status was logged to the cache
+	statusVal, err := h.Cache.Get(context.Background(), "helm_install_test-release")
+	require.NoError(t, err)
+
+	statusMap := statusVal.(stat)
+	assert.Equal(t, "failed", statusMap.Status)
+	assert.NotNil(t, statusMap.Err)
+	assert.Contains(t, *statusMap.Err, "chart type \"library\" is not installable")
+}


### PR DESCRIPTION


**Summary:** 
Fixes a critical P1 server crash (nil-pointer dereference) that occurs when users attempt to install or upgrade a Helm chart of an unsupported type (such as a `"library"` chart).

 Fixes #5216 

**Changes:**
- **`backend/pkg/helm/release.go` (`getChart`)**: Fixed a semantic bug where `getChart` returned `(nil, nil)` and passed a nil error to `logActionState` upon failing the chart type validation. It now generates and returns an explicit `fmt.Errorf`, preventing the caller (`installRelease` / `upgradeRelease`) from passing a nil chart into the Helm client.
- **`backend/pkg/helm/release.go` (`GetActionStatus`)**: Added a defensive nil-guard before dereferencing `*stat.Err` when `stat.Status == failed`. This prevents HTTP handler panics in edge cases where a failed state was cached without an accompanying error.

**Steps to Test:**
1. Run the backend server (`npm run backend:start`).
2. Attempt to install a Helm chart configured with `type: library` via the UI or by sending a raw `POST` request to `/helm/release/install`.
3. Verify that the server **does not crash**.
4. Verify that the action status properly reports the error: "chart type 'library' is not installable".
5. Run the backend tests (`npm run backend:test`) to confirm no regressions.

**Notes for the Reviewer:**
The core issue was that `loader.Load` succeeded (`err = nil`), but the type validation failed right after. The code then logged and returned the `nil` error, causing the background goroutine to execute `installClient.Run(nil, values)`, which triggers an unrecovered panic in the Helm library.
