### PR TITLE
backend: serviceproxy: propagate request context to Kubernetes API calls

### DIFF
--- a/backend/pkg/serviceproxy/handler.go
+++ b/backend/pkg/serviceproxy/handler.go
@@ -1,6 +1,7 @@
 package serviceproxy
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -46,7 +47,7 @@ func RequestHandler(kubeConfigStore kubeconfig.ContextStore, w http.ResponseWrit
 	}
 
 	// Get the service
-	ps, status, err := getServiceFromCluster(cs, namespace, name)
+	ps, status, err := getServiceFromCluster(r.Context(), cs, namespace, name)
 	if err != nil {
 		w.WriteHeader(status)
 		return
@@ -88,8 +89,10 @@ func getAuthToken(r *http.Request, clusterName string) (string, error) {
 	return bearerToken, nil
 }
 
-func getServiceFromCluster(cs kubernetes.Interface, namespace string, name string) (*proxyService, int, error) {
-	ps, err := GetService(cs, namespace, name)
+func getServiceFromCluster(
+	ctx context.Context, cs kubernetes.Interface, namespace string, name string,
+) (*proxyService, int, error) {
+	ps, err := GetService(ctx, cs, namespace, name)
 	if err != nil {
 		if errors.IsUnauthorized(err) {
 			return nil, http.StatusUnauthorized, err

--- a/backend/pkg/serviceproxy/handler_test.go
+++ b/backend/pkg/serviceproxy/handler_test.go
@@ -382,7 +382,7 @@ func TestGetServiceFromCluster(t *testing.T) {
 				cs = fake.NewClientset()
 			}
 
-			ps, status, err := getServiceFromCluster(cs, tt.namespace, tt.serviceName)
+			ps, status, err := getServiceFromCluster(context.Background(), cs, tt.namespace, tt.serviceName)
 
 			assert.Equal(t, tt.expectedStatus, status)
 

--- a/backend/pkg/serviceproxy/service.go
+++ b/backend/pkg/serviceproxy/service.go
@@ -26,8 +26,8 @@ type proxyService struct {
 }
 
 // GetService returns the requested service based on the provided name and namespace.
-func GetService(cs kubernetes.Interface, namespace string, name string) (*proxyService, error) {
-	service, err := cs.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func GetService(ctx context.Context, cs kubernetes.Interface, namespace string, name string) (*proxyService, error) {
+	service, err := cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/serviceproxy/service_test.go
+++ b/backend/pkg/serviceproxy/service_test.go
@@ -33,7 +33,7 @@ func TestGetServiceInternal(t *testing.T) {
 		t.Errorf("Failed to create test service: %v", err)
 	}
 
-	ps, err := serviceproxy.GetService(cs, "default", "my-service")
+	ps, err := serviceproxy.GetService(context.Background(), cs, "default", "my-service")
 	if err != nil {
 		t.Errorf("GetService() error = %v", err)
 	}
@@ -67,7 +67,7 @@ func TestGetServiceExternal(t *testing.T) {
 		t.Errorf("Failed to create test service: %v", err)
 	}
 
-	ps, err := serviceproxy.GetService(cs, "default", "my-service")
+	ps, err := serviceproxy.GetService(context.Background(), cs, "default", "my-service")
 	if err != nil {
 		t.Errorf("GetService() error = %v", err)
 	}
@@ -81,7 +81,7 @@ func TestGetServiceNonExistent(t *testing.T) {
 	// Test GetService() for non-existent services
 	cs := fake.NewClientset()
 
-	_, err := serviceproxy.GetService(cs, "default", "non-existent-service")
+	_, err := serviceproxy.GetService(context.Background(), cs, "default", "non-existent-service")
 	if err == nil {
 		t.Errorf("GetService() error = nil, wantErr not nil")
 	}


### PR DESCRIPTION
## What this PR does

Replaces the hardcoded `context.TODO()` in the `serviceproxy` package with proper request-scoped context propagation.

### Changes
- **[GetService](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/serviceproxy/service.go:27:0-59:1)** now accepts a `ctx context.Context` parameter instead of using `context.TODO()` internally.
- **[getServiceFromCluster](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/serviceproxy/handler.go:91:0-102:1)** accepts a `ctx` parameter and passes it to [GetService](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/serviceproxy/service.go:27:0-59:1).
- **[RequestHandler](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/serviceproxy/handler.go:17:0-59:1)** propagates the HTTP request context (`r.Context()`) through the call chain.
- Updated all unit tests to pass `context.Background()`.

### Why
Using `context.TODO()` is intended as a temporary placeholder per Go conventions. By propagating the actual HTTP request context, the underlying Kubernetes API call will be automatically cancelled if the client disconnects, improving resource utilization and aligning with Go best practices for context propagation.

### Testing
All existing unit tests pass:
