### PR TITLE
frontend: Log silently swallowed errors in catch blocks

### DIFF
--- a/frontend/src/components/App/themeSlice.ts
+++ b/frontend/src/components/App/themeSlice.ts
@@ -94,15 +94,18 @@ export const useCurrentAppTheme = () => {
     localStorage.setItem(currentThemeCacheKey, JSON.stringify(currentTheme));
   } else {
     // Try to load cached theme
-    try {
-      const cachedTheme = JSON.parse(localStorage.getItem(currentThemeCacheKey) ?? '') as
-        | AppTheme
-        | undefined;
+    const cachedThemeRaw = localStorage.getItem(currentThemeCacheKey);
+    if (cachedThemeRaw) {
+      try {
+        const cachedTheme = JSON.parse(cachedThemeRaw) as AppTheme | undefined;
 
-      if (cachedTheme && cachedTheme?.name === themeName) {
-        currentTheme = cachedTheme;
+        if (cachedTheme && cachedTheme?.name === themeName) {
+          currentTheme = cachedTheme;
+        }
+      } catch (e) {
+        console.debug('Failed to parse cached theme from localStorage:', e);
       }
-    } catch (e) {}
+    }
   }
 
   return currentTheme ?? defaultAppThemes[0];

--- a/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
+++ b/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
@@ -243,11 +243,19 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
                   );
                 }
               }
-            } catch (e) {}
+            } catch (e) {
+              console.debug(
+                `Failed to fetch group API resources for cluster ${cluster}:`,
+                { group: group?.name, version: group?.preferredVersion?.version },
+                e
+              );
+            }
           });
           await Promise.allSettled(groupResourceFetchPromises);
         }
-      } catch (legacyError) {}
+      } catch (legacyError) {
+        console.debug(`Failed to fetch legacy API resources for cluster ${cluster}:`, legacyError);
+      }
     }
   }
 

--- a/frontend/src/lib/k8s/api/v2/fetch.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.ts
@@ -54,7 +54,12 @@ export async function backendFetch(url: string | URL, init: RequestInit = {}) {
     try {
       const body = await response.json();
       maybeErrorMessage = typeof body === 'string' ? body : body.message;
-    } catch (e) {}
+    } catch (e) {
+      console.debug(
+        `Failed to parse error response body for ${url} (status ${response.status}):`,
+        e
+      );
+    }
 
     throw new ApiError(maybeErrorMessage ?? 'Unreachable', { status: response.status });
   }


### PR DESCRIPTION
## What this PR does / why we need it:
Adds `console.debug` to empty `catch` blocks across frontend components that previously swallowed errors silently, improving debuggability in developer consoles.

### Changes:
- **`apiDiscovery.tsx`**: Logs failures when fetching group and legacy API resources, including cluster name and group/version context for multi-cluster debugging.
- **`fetch.ts`**: Logs `JSON.parse` failures when reading HTTP error response bodies, including the request URL and HTTP status code.
- **`themeSlice.ts`**: Guards `JSON.parse` with a non-empty check to avoid noisy logs when the cache key is missing, and logs only when actual cached data fails to parse.

## Which issue(s) this PR fixes:
Proactive technical debt cleanup.
