### PR TITLE
backend: telemetry: use structured logger instead of log.Printf

### DIFF
--- a/backend/pkg/telemetry/telemetry.go
+++ b/backend/pkg/telemetry/telemetry.go
@@ -3,9 +3,10 @@ package telemetry
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"go.opentelemetry.io/otel"
@@ -220,8 +221,10 @@ func createTracingExporter(cfg cfg.Config) (trace.SpanExporter, error) { //nolin
 	}
 
 	if enabledExporters > 1 {
-		log.Printf("Warning: Multiple trace exporters configured (%s). Using %s exporter based on priority.",
-			strings.Join(enabledTypes, ", "), enabledTypes[0])
+		logger.Log(logger.LevelWarn, map[string]string{
+			"configured": strings.Join(enabledTypes, ", "),
+			"selected":   enabledTypes[0],
+		}, nil, "Multiple trace exporters configured, using highest priority exporter")
 	}
 
 	if *cfg.StdoutTraceEnabled {


### PR DESCRIPTION
## What this PR does / why we need it:
Replaces `log.Printf` with the project's structured `logger.Log` in the telemetry package for logging consistency.

### Changes:
- Replaced `log.Printf("Warning: ...")` with `logger.Log(logger.LevelWarn, ...)` including structured fields (`configured`, `selected`) for the multiple trace exporters warning.
- Removed unused `"log"` stdlib import.
- Added `"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"` import.

### Why:
The rest of the backend consistently uses the structured `logger` package (zerolog-based), but this single call used the stdlib `log.Printf`, breaking structured logging and making it harder to filter/parse logs in production.
