### PR TITLE
frontend: pod: Show container resource requests and limits in Pod details

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1338,6 +1338,48 @@ export function VolumeMounts(props: VolumeMountsProps) {
   );
 }
 
+export function ContainerResources(props: { resources: KubeContainer['resources'] }) {
+  const { resources } = props;
+  const { t } = useTranslation('glossary');
+
+  if (!resources) {
+    return null;
+  }
+
+  const rows = [
+    {
+      type: t('CPU'),
+      requests: resources.requests?.cpu ?? '-',
+      limits: resources.limits?.cpu ?? '-',
+    },
+    {
+      type: t('Memory'),
+      requests: resources.requests?.memory ?? '-',
+      limits: resources.limits?.memory ?? '-',
+    },
+  ];
+
+  return (
+    <InnerTable
+      columns={[
+        {
+          label: '',
+          getter: (data: any) => data.type,
+        },
+        {
+          label: t('Request'),
+          getter: (data: any) => data.requests,
+        },
+        {
+          label: t('Limit'),
+          getter: (data: any) => data.limits,
+        },
+      ]}
+      data={rows}
+    />
+  );
+}
+
 export function LivenessProbes(props: { liveness: KubeContainer['livenessProbe'] }) {
   const { liveness } = props;
 
@@ -1637,6 +1679,12 @@ export function ContainerInfo(props: ContainerInfoProps) {
         name: t('glossary|Environment'),
         value: <ContainerEnvironmentVariables pod={resource as KubePod} container={container} />,
         hide: _.isEmpty(container?.env) && _.isEmpty(container?.envFrom),
+      },
+      {
+        name: t('Resources'),
+        value: <ContainerResources resources={container.resources} />,
+        valueFullRow: true,
+        hide: _.isEmpty(container.resources),
       },
       {
         name: t('Liveness Probes'),


### PR DESCRIPTION
## What

Fixes #4727.

Container resource requests and limits (CPU/memory) were not displayed anywhere in the Pod details page. This PR adds a `ContainerResources` component that shows them in a table within each container's info section.

## How

- Added `ContainerResources` exported component in `Resource.tsx` that renders an `InnerTable` with CPU and Memory rows, each showing the configured request and limit values.
- Added a `Resources` row to `containerRows()` in `ContainerInfo`, placed after Environment and before Liveness Probes. The row is hidden when `container.resources` is empty or undefined, so existing pods without resource specs are unaffected.
- Uses existing i18n keys (`Resources`, `CPU`, `Memory`, `Request`, `Limit`) from `glossary.json` — no new translation strings needed.

## Screenshots

The Resources row appears in the container section of the Pod details page when requests/limits are defined:

| | Request | Limit |
|--|--|--|
| CPU | 100m | 200m |
| Memory | 128Mi | 256Mi |

## Testing

- Pods without resource specs: the Resources row is hidden (no change to existing snapshots, since story fixtures use `resources: {}`).
- Pods with resource specs: the Resources row is visible with the correct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)