### PR TITLE
app: on macOS, use app toolbar as titlebar

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1498,6 +1498,22 @@ function startElectron() {
     }
   }
 
+  function getPlatformWindowOptions(): Partial<Electron.BrowserWindowConstructorOptions> {
+    if (process.platform === 'darwin') {
+      const trafficLightSize = 14; // px
+      return {
+        titleBarStyle: 'hidden',
+        trafficLightPosition: {
+          // Top toolbar is 64px tall
+          // Apple traffic light buttons are 14px tall
+          y: (64 - trafficLightSize) / 2,
+          x: trafficLightSize,
+        },
+      };
+    }
+    return {};
+  }
+
   async function createWindow() {
     // WSL has a problem with full size window placement, so make it smaller.
     const withMargin = await isWSL();
@@ -1506,6 +1522,7 @@ function startElectron() {
     mainWindow = new BrowserWindow({
       width,
       height,
+      ...getPlatformWindowOptions(),
       webPreferences: {
         nodeIntegration: false,
         contextIsolation: true,

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -496,6 +496,8 @@ export const PureTopBar = memo(
       );
     });
 
+    const isMacElectron = isElectron() && navigator.userAgent.indexOf('Mac') > -1;
+
     return (
       <>
         <AppBar
@@ -510,8 +512,7 @@ export const PureTopBar = memo(
             boxShadow: 'none',
             borderBottom: '1px solid #eee',
             borderColor: theme.palette.divider,
-            paddingLeft:
-              isElectron() && (window as any).process?.platform === 'darwin' ? '72px' : undefined,
+            paddingLeft: isMacElectron ? '72px' : undefined,
           })}
           elevation={1}
           component="nav"
@@ -523,6 +524,10 @@ export const PureTopBar = memo(
               [theme.breakpoints.down('sm')]: {
                 paddingLeft: 0,
                 paddingRight: 0,
+              },
+              appRegion: 'drag',
+              '> *': {
+                appRegion: 'no-drag',
               },
             }}
           >

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -34,6 +34,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { getProductName, getVersion } from '../../helpers/getProductInfo';
+import { isElectron } from '../../helpers/isElectron';
 import { logout } from '../../lib/auth';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
 import { ClusterUserInfo, getClusterUserInfo } from '../../lib/k8s/api/v1/clusterApi';
@@ -509,6 +510,8 @@ export const PureTopBar = memo(
             boxShadow: 'none',
             borderBottom: '1px solid #eee',
             borderColor: theme.palette.divider,
+            paddingLeft:
+              isElectron() && (window as any).process?.platform === 'darwin' ? '72px' : undefined,
           })}
           elevation={1}
           component="nav"


### PR DESCRIPTION
## Summary

Small UI tweak to make the toolbar look more native on macOS by replacing the native toolbar with the headlamp toolbar

Note that this currently doesn't correctly set `app-region: drag` to the toolbar and `app-region: no-drag` to its children yet, I don't know enough about MUI and claude isn't helpful either.

## Related Issue

## Changes

- Hide native titlebar on macOS and move traffic light controls (app/electron/main.ts)
- Pad top-bar logo on the left on macOS (frontend/TopBar.tsx)

## Steps to Test

1. Build app on macOS
2. Open it and observe

## Screenshots (if applicable)

For comparison, current UI:

<img width="575" height="195" alt="image" src="https://github.com/user-attachments/assets/72a640dc-7e38-4875-ab25-e5f12d8dc1e4" />

After this PR:

<img width="721" height="315" alt="image" src="https://github.com/user-attachments/assets/de9ad24e-55a3-4b2a-92ef-9f520a91197d" />
