### PR TITLE
cloudbuild: Pin gcb-docker-gcloud image by digest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 3000s
 # For each build step, cloudbuild executes a docker container.
 steps:
   # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:8d6a3a5b895e6776dbe9115b75db1412fbe57299b8db329d45cb54680e462b0b' # v20251211-4c812d4cd8
     entrypoint: make
     args:
       - image


### PR DESCRIPTION
This change pins the `gcb-docker-gcloud` Cloud Build image by digest to fix the `post-headlamp-push-images` Prow job, which fails on every merge because the previous tag was garbage-collected from the registry.

Fixes: #5228

### Changes

- Pin image by digest instead of tag to prevent future tag GC breakage
- Align with the pattern used by other kubernetes-sigs projects (e.g. cluster-api)

### Testing
- [x] Verified current tag `v20250513-9264efb079` returns "no such manifest" via `docker manifest inspect`
- [x] Verified replacement digest `sha256:8d6a3a5b...` exists and is pullable
- [x] Verified `cloudbuild.yaml` is the only file referencing this image
- [x] Prow `post-headlamp-push-images` job should pass after merge 