### PR TITLE
frontend: sidebarSlice: Fix fatal UI crash on malformed local storage

### DIFF
--- a/frontend/src/components/Sidebar/sidebarSlice.test.ts
+++ b/frontend/src/components/Sidebar/sidebarSlice.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { vi } from 'vitest';
 import sidebarReducer, {
   DefaultSidebars,
   initialState,
@@ -167,5 +168,21 @@ describe('setInitialSidebarOpen', () => {
     (import.meta.env as any).REACT_APP_HEADLAMP_SIDEBAR_DEFAULT_OPEN = 'true';
 
     expect(setInitialSidebarOpen().isSidebarOpen).toBe(false);
+  });
+
+  it('should handle malformed or null localStorage values safely', () => {
+    // Suppress console.warn for this test to avoid polluting test output
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    localStorage.setItem('sidebar', 'null');
+    expect(() => setInitialSidebarOpen()).not.toThrow();
+
+    localStorage.setItem('sidebar', 'invalid json');
+    expect(() => setInitialSidebarOpen()).not.toThrow();
+
+    localStorage.setItem('sidebar', JSON.stringify({ shrink: 'not-a-boolean' }));
+    expect(() => setInitialSidebarOpen()).not.toThrow();
+
+    consoleSpy.mockRestore();
   });
 });

--- a/frontend/src/components/Sidebar/sidebarSlice.ts
+++ b/frontend/src/components/Sidebar/sidebarSlice.ts
@@ -95,9 +95,24 @@ export interface SidebarState {
 export function setInitialSidebarOpen() {
   let defaultOpen;
 
-  const openUserSelected = localStorage?.getItem('sidebar')
-    ? !JSON.parse(localStorage.getItem('sidebar')!).shrink
-    : undefined;
+  let openUserSelected: boolean | undefined = undefined;
+  const storedSidebar = localStorage?.getItem('sidebar');
+
+  if (storedSidebar) {
+    try {
+      const parsed = JSON.parse(storedSidebar);
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'shrink' in parsed &&
+        typeof parsed.shrink === 'boolean'
+      ) {
+        openUserSelected = !parsed.shrink;
+      }
+    } catch (e) {
+      console.warn('Failed to parse sidebar local storage', e);
+    }
+  }
 
   if (openUserSelected !== undefined) {
     defaultOpen = openUserSelected;


### PR DESCRIPTION
### **Summary:** Fixes a critical P1 frontend crash (TypeError) that occurs during Redux state initialization when the user's browser localStorage contains a malformed or empty sidebar key.

Fixes #5234

### **Changes:**

frontend/src/components/Sidebar/sidebarSlice.ts (setInitialSidebarOpen): Fixed a vulnerability where an unguarded JSON.parse was coupled with a non-null assertion operator. If localStorage parsing failed or returned null, the code blindly dereferenced !null.shrink, causing a fatal crash. The code now safely wraps parsing in a try/catch and verifies the object property exists before accessing it.

### **Steps to Test:**

1. Run the frontend (npm run frontend:start).
2. Open the application in your browser.
3. Open Developer Tools -> Console and inject a corrupted state: localStorage.setItem('sidebar', 'null') or localStorage.setItem('sidebar', 'invalid json').
4. Refresh the page.
5. Verify that the UI does not crash with a White Screen of Death.
6. Verify that the application falls back to the default sidebar open/close state gracefully.
7. Run the frontend tests (npm run frontend:test) to confirm no regressions.