### PR TITLE
frontend: AuthChooser: Fix empty DialogTitle h1 in AnError story

### DIFF
--- a/frontend/src/components/authchooser/AuthChooser.stories.tsx
+++ b/frontend/src/components/authchooser/AuthChooser.stories.tsx
@@ -77,5 +77,6 @@ AuthTypeoidc.args = {
 export const AnError = Template.bind({});
 AnError.args = {
   ...argFixture,
+  title: 'Authentication',
   error: Error('Oh no! Some error happened?!?'),
 };

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -94,7 +94,7 @@
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >
-                    some title
+                    Authentication
                   </h1>
                 </div>
               </div>


### PR DESCRIPTION

## Summary

This PR fixes the AnError Storybook story for AuthChooser to ensure that the DialogTitle always renders meaningful text and does not produce an empty h1 element.

## Related Issue

Fixes #4600

## Changes

- Updated `AnError` story args to use `title: 'Authentication'`
- Regenerated `AuthChooser.AnError.stories.storyshot` snapshot

## Steps to Test

1. Run `npm run storybook` inside the `frontend` directory
2. Navigate to **AuthChooser → An Error** story in the sidebar
3. Observe the dialog title now shows **"Authentication"** instead of **"some title"**
4. Run `npx vitest run src/storybook.test.tsx -t "AuthChooser"` — all 5 stories pass

## Screenshots

<img width="1918" height="869" alt="image" src="https://github.com/user-attachments/assets/d324dc63-1706-432f-ad52-91ef9983c19c" />


## Notes for the Reviewer
Ensures the DialogTitle does not render an empty heading
No functional changes, only Storybook and snapshot update
