### PR TITLE
frontend: router: Fix hooks called in inline component function

### DIFF
--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -138,6 +138,18 @@ const LazyGraphView = React.lazy(() =>
   import('../../components/resourceMap/GraphView').then(it => ({ default: it.GraphView }))
 );
 
+function SettingsClusterRedirect() {
+  const cluster = useCluster();
+  const history = useHistory();
+
+  React.useEffect(() => {
+    history.replace(`/settings/cluster?c=${cluster}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <></>;
+}
+
 /** @private */
 const defaultRoutes: { [routeName: string]: Route } = {
   projectCreateYaml: {
@@ -882,20 +894,7 @@ const defaultRoutes: { [routeName: string]: Route } = {
     },
     useClusterURL: true,
     noAuthRequired: true,
-    component: () => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const cluster = useCluster();
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const history = useHistory();
-
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      React.useEffect(() => {
-        history.replace(`/settings/cluster?c=${cluster}`);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, []);
-
-      return <></>;
-    },
+    component: SettingsClusterRedirect,
   },
   settingsClusterHomeContext: {
     path: '/settings/cluster',


### PR DESCRIPTION
## Summary

This PR fixes a \`react-hooks/rules-of-hooks\` violation in the router where \`useCluster\`, \`useHistory\`, and \`React.useEffect\` were called inside an anonymous arrow function used as a route component. React does not recognize unnamed functions as components, causing the hooks rule violation.

## Related Issue

Fixes #5247

## Changes

- Extracted the inline arrow function from the \`settingsCluster\` route into a named \`SettingsClusterRedirect\` component
- Removed three \`// eslint-disable-next-line react-hooks/rules-of-hooks\` suppressions

## Steps to Test

1. Run \`npm run lint\` in \`frontend/\` — confirmed no \`react-hooks/rules-of-hooks\` errors (exit 0)
2. Navigate to \`/settings\` — should redirect to \`/settings/cluster?c=<cluster>\` as before

## Notes for the Reviewer

- Behavior is identical; only the function naming changed to satisfy React's component detection." \
  --repo kubernetes-sigs/headlamp
