### PR TITLE
frontend: GraphView: Fix react-hooks/rules-of-hooks violations

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -54,6 +54,19 @@ export default {
                 { status: 404 }
               )
           ),
+          http.get('http://localhost:4466/apis/autoscaling.k8s.io/v1', () =>
+            HttpResponse.json(
+              {
+                kind: 'Status',
+                apiVersion: 'v1',
+                status: 'Failure',
+                reason: 'NotFound',
+                message: 'the server could not find the requested resource',
+                code: 404,
+              },
+              { status: 404 }
+            )
+          ),
         ],
       },
     },

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -124,10 +124,11 @@ const ChipGroup = styled(Box)({
 function GraphViewContent({
   height,
   defaultNodeSelection,
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  defaultSources = useGetAllSources(),
+  defaultSources,
   defaultFilters = defaultFiltersValue,
 }: GraphViewContentProps) {
+  const allSources = useGetAllSources();
+  const sources = defaultSources ?? allSources;
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
@@ -305,7 +306,7 @@ function GraphViewContent({
                 <NamespacesAutocomplete />
 
                 <GraphSourcesView
-                  sources={defaultSources}
+                  sources={sources}
                   selectedSources={selectedSources}
                   toggleSource={toggleSelection}
                   sourceData={sourceData ?? new Map()}
@@ -454,10 +455,11 @@ function CustomThemeProvider({ children }: { children: ReactNode }) {
  * @returns
  */
 export function GraphView(props: GraphViewContentProps) {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const propsSources = props.defaultSources ?? useGetAllSources();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const propsRelations = props.defaultRelations ?? useGetAllRelations();
+  const allSources = useGetAllSources();
+  const allRelations = useGetAllRelations();
+
+  const propsSources = props.defaultSources ?? allSources;
+  const propsRelations = props.defaultRelations ?? allRelations;
 
   // Load plugin defined sources
   const pluginGraphSources = useTypedSelector(state => state.graphView.graphSources);

--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -107,6 +107,10 @@ interface GraphViewContentProps {
 
 const defaultFiltersValue: GraphFilter[] = [];
 
+interface GraphViewInternalProps extends Omit<GraphViewContentProps, 'defaultSources'> {
+  sources: GraphSource[];
+}
+
 const ChipGroup = styled(Box)({
   display: 'flex',
 
@@ -124,11 +128,9 @@ const ChipGroup = styled(Box)({
 function GraphViewContent({
   height,
   defaultNodeSelection,
-  defaultSources,
+  sources,
   defaultFilters = defaultFiltersValue,
-}: GraphViewContentProps) {
-  const allSources = useGetAllSources();
-  const sources = defaultSources ?? allSources;
+}: GraphViewInternalProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
@@ -473,7 +475,7 @@ export function GraphView(props: GraphViewContentProps) {
     <StrictMode>
       <ReactFlowProvider>
         <GraphSourceManager sources={sources} relations={propsRelations}>
-          <GraphViewContent {...props} defaultSources={sources} />
+          <GraphViewContent {...props} sources={sources} />
         </GraphSourceManager>
       </ReactFlowProvider>
     </StrictMode>


### PR DESCRIPTION

## Summary

This PR fixes the `react-hooks/rules-of-hooks` violations in `GraphView.tsx` by moving hook calls into the function body unconditionally.

## Related Issue

Fixes #5240

## Changes

- Removed `useGetAllSources()` from the default parameter expression in `GraphViewContent` and moved it into the function body
- Removed `useGetAllSources()` and `useGetAllRelations()` from conditional `??` expressions in `GraphView` and moved them into unconditional hook calls
- Removed `// eslint-disable-next-line react-hooks/rules-of-hooks` suppressions that were masking these violations

## Steps to Test

1. Navigate to the Resource Map page in Headlamp
2. Verify the graph renders correctly with nodes and edges
3. Verify grouping (Namespace / Instance / Node) and filtering controls work
4. Run `npx eslint --rule '{"react-hooks/rules-of-hooks": "error"}' src/components/resourceMap/GraphView.tsx` — should produce no output (exit 0)

## Screenshots

<img width="1909" height="865" alt="image" src="https://github.com/user-attachments/assets/37e008cf-0224-430d-995f-2839abe6aaac" />


## Notes for the Reviewer

- No behavior change intended; hooks are now called unconditionally on every render as React requires.
- The `??` fallback logic is preserved — if `defaultSources`/`defaultRelations` props are provided they are still used, otherwise the full list is used.
