### PR TITLE
frontend: event: Refactor hooks out of Event class

### DIFF
--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -25,7 +25,7 @@ import { isBackstage } from '../../../helpers/isBackstage';
 import { isElectron } from '../../../helpers/isElectron';
 import { useClustersConf, useClustersVersion } from '../../../lib/k8s';
 import { Cluster } from '../../../lib/k8s/cluster';
-import Event from '../../../lib/k8s/event';
+import { useEventWarningList } from '../../../lib/k8s/event';
 import { createRouteURL } from '../../../lib/router/createRouteURL';
 import { PageGrid } from '../../common/Resource';
 import SectionBox from '../../common/SectionBox';
@@ -58,7 +58,7 @@ interface HomeComponentProps {
 }
 
 function useWarningSettingsPerCluster(clusterNames: string[]) {
-  const warningsMap = Event.useWarningList(clusterNames);
+  const warningsMap = useEventWarningList(clusterNames);
   const [warningLabels, setWarningLabels] = React.useState<{ [cluster: string]: string }>({});
   const maxWarnings = 50;
 

--- a/frontend/src/components/App/Notifications/Notifications.tsx
+++ b/frontend/src/components/App/Notifications/Notifications.tsx
@@ -32,7 +32,7 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { useClustersConf } from '../../../lib/k8s';
-import Event from '../../../lib/k8s/event';
+import Event, { useEventWarningList } from '../../../lib/k8s/event';
 import { createRouteURL } from '../../../lib/router/createRouteURL';
 import { useTypedSelector } from '../../../redux/hooks';
 import Empty from '../../common/EmptyContent';
@@ -158,7 +158,7 @@ export default function Notifications() {
   const notifications = useTypedSelector(state => state.notifications.notifications);
   const dispatch = useDispatch();
   const clusters = useClustersConf();
-  const warnings = Event.useWarningList(
+  const warnings = useEventWarningList(
     Object.values(clusters ?? {})?.map(c => c.name, {
       queryParams: {
         limit: defaultMaxNotificationsStored,

--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import _ from 'lodash';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { ResourceClasses } from '.';
 import { request } from './api/v1/clusterRequests';
 import type { QueryParameters } from './api/v1/queryParameters';
@@ -195,93 +194,78 @@ class Event extends KubeObject<KubeEvent> {
 
     return objInstance;
   }
-
-  /**
-   * Fetch events for given clusters
-   *
-   * Important! Make sure to have the parent component have clusters as a key
-   * so that component remounts when clusters change, instead of rerendering
-   * with different number of clusters
-   */
-  static useListForClusters(
-    clusterNames: string[],
-    options: { queryParams?: QueryParameters } = {}
-  ) {
-    // Calling hooks in a loop is usually forbidden
-    // But if we make sure that clusters don't change between renders it's fine
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const queries = Event.useList({
-      clusters: clusterNames,
-      ...options.queryParams,
-    });
-
-    type EventsPerCluster = {
-      [cluster: string]: {
-        warnings: Event[];
-        error?: ApiError | null;
-      };
-    };
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const result = useMemo(() => {
-      const res: EventsPerCluster = {};
-
-      queries.errors?.forEach(error => {
-        if (error.cluster) {
-          res[error.cluster] ??= { warnings: [] };
-          res[error.cluster].error = error;
-        }
-      });
-
-      Object.entries(queries.clusterResults ?? {}).forEach(([cluster, result]) => {
-        if (!res[cluster]) {
-          res[cluster] = { warnings: [] };
-        }
-
-        res[cluster].warnings = result.items ?? [];
-      });
-
-      return res;
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [queries, clusterNames]);
-
-    return result;
-  }
-
-  /**
-   * Fetch warning events for given clusters
-   * Amount is limited to {@link Event.maxEventsLimit}
-   *
-   * Important! Make sure to have the parent component have clusters as a key
-   * so that component remounts when clusters change, instead of rerendering
-   * with different number of clusters
-   */
-  static useWarningList(clusters: string[], options?: { queryParams?: QueryParameters }) {
-    const queryParameters = Object.assign(
-      {
-        limit: this.maxEventsLimit,
-        fieldSelector: 'type!=Normal',
-      },
-      options?.queryParams ?? {}
-    );
-
-    const newWarningsList = this.useListForClusters(clusters, { queryParams: queryParameters });
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [warningList, setWarningList] = React.useState<typeof newWarningsList>(newWarningsList);
-
-    // Only update the warnings if they actually differ
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (_.isEqual(warningList, newWarningsList)) {
-        return;
-      }
-
-      setWarningList(newWarningsList);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [newWarningsList]);
-
-    return warningList;
-  }
 }
 
 export default Event;
+
+/**
+ * Fetch events for given clusters
+ *
+ * Important! Make sure to have the parent component have clusters as a key
+ * so that component remounts when clusters change, instead of rerendering
+ * with different number of clusters
+ */
+export function useEventListForClusters(
+  clusterNames: string[],
+  options: { queryParams?: QueryParameters } = {}
+) {
+  const queries = Event.useList({
+    clusters: clusterNames,
+    ...options.queryParams,
+  });
+
+  type EventsPerCluster = {
+    [cluster: string]: {
+      warnings: Event[];
+      error?: ApiError | null;
+    };
+  };
+
+  const result = useMemo(() => {
+    const res: EventsPerCluster = {};
+
+    queries.errors?.forEach(error => {
+      if (error.cluster) {
+        res[error.cluster] ??= { warnings: [] };
+        res[error.cluster].error = error;
+      }
+    });
+
+    Object.entries(queries.clusterResults ?? {}).forEach(([cluster, result]) => {
+      if (!res[cluster]) {
+        res[cluster] = { warnings: [] };
+      }
+
+      res[cluster].warnings = result.items ?? [];
+    });
+
+    return res;
+  }, [queries.clusterResults, queries.errors]);
+
+  return result;
+}
+
+/**
+ * Fetch warning events for given clusters
+ * Amount is limited to {@link Event.maxLimit}
+ *
+ * Important! Make sure to have the parent component have clusters as a key
+ * so that component remounts when clusters change, instead of rerendering
+ * with different number of clusters
+ */
+export function useEventWarningList(
+  clusters: string[],
+  options?: { queryParams?: QueryParameters }
+) {
+  const queryParameters = Object.assign(
+    {
+      limit: Event.maxLimit,
+      fieldSelector: 'type!=Normal',
+    },
+    options?.queryParams ?? {}
+  );
+
+  const warningsList = useEventListForClusters(clusters, { queryParams: queryParameters });
+
+  return warningsList;
+}

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -363,6 +363,8 @@
     },
     "event": {
       "default": [Function],
+      "useEventListForClusters": [Function],
+      "useEventWarningList": [Function],
     },
     "getVersion": [Function],
     "ingress": {


### PR DESCRIPTION
## What this PR does

Extracts `useListForClusters` and `useWarningList` from static methods on the
`Event` class into standalone exported hook functions (`useEventListForClusters`,
`useEventWarningList`).

React hooks (`useList`, `useMemo`, `useState`, `useEffect`) cannot be called
inside class methods. Moving them to standalone custom hook functions fixes the
`react-hooks/rules-of-hooks` lint violation properly, instead of suppressing it
with `eslint-disable` comments.

## Changes

- **`frontend/src/lib/k8s/event.ts`**: Removed `static useListForClusters()`
  and `static useWarningList()` from the `Event` class. Added
  `useEventListForClusters()` and `useEventWarningList()` as standalone exported
  hook functions. Updated imports. Changed `this.maxEventsLimit` →
  `Event.maxLimit` (public getter).
- **`frontend/src/components/App/Notifications/Notifications.tsx`**: Import and
  use `useEventWarningList` instead of `Event.useWarningList`.
- **`frontend/src/components/App/Home/index.tsx`**: Import and use
  `useEventWarningList` instead of `Event.useWarningList`.

## Which issue(s) this PR fixes

Fixes #5245
