### PR TITLE
frontend: ci: Fix npm run star and add check for it

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -108,6 +108,11 @@ jobs:
         run: |
           make frontend-build
 
+      # This is to check the rsbuild setup is still working, so "npm run star" still works.
+      - name: Build Frontend (rsbuild)
+        run: |
+          make frontend-build-rsbuild
+
   testplugins:
     name: test plugins
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,10 @@ frontend: frontend-install
 frontend-build:
 	cd frontend && npm run build
 
+.PHONY: frontend-build-rsbuild
+frontend-build-rsbuild:
+	cd frontend && npm run build:rsbuild
+
 .PHONY: frontend-build-storybook
 frontend-build-storybook:
 	cd frontend && npm run build-storybook

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -91,10 +91,10 @@
         "yaml": "^2.7.0"
       },
       "devDependencies": {
-        "@rsbuild/core": "^1.4.15",
-        "@rsbuild/plugin-node-polyfill": "^1.4.1",
-        "@rsbuild/plugin-react": "^1.3.5",
-        "@rsbuild/plugin-svgr": "^1.2.2",
+        "@rsbuild/core": "^2.0.1",
+        "@rsbuild/plugin-node-polyfill": "^1.4.4",
+        "@rsbuild/plugin-react": "^2.0.0",
+        "@rsbuild/plugin-svgr": "^2.0.1",
         "@storybook/addon-docs": "^9.1.19",
         "@storybook/addon-links": "^9.1.19",
         "@storybook/react-vite": "^9.1.19",
@@ -651,21 +651,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1833,65 +1833,6 @@
         "react": ">=16"
       }
     },
-    "node_modules/@module-federation/error-codes": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
-      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/runtime": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
-      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.22.0",
-        "@module-federation/runtime-core": "0.22.0",
-        "@module-federation/sdk": "0.22.0"
-      }
-    },
-    "node_modules/@module-federation/runtime-core": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
-      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.22.0",
-        "@module-federation/sdk": "0.22.0"
-      }
-    },
-    "node_modules/@module-federation/runtime-tools": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
-      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.22.0",
-        "@module-federation/webpack-bundler-runtime": "0.22.0"
-      }
-    },
-    "node_modules/@module-federation/sdk": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
-      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
-      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.22.0",
-        "@module-federation/sdk": "0.22.0"
-      }
-    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
@@ -2349,16 +2290,22 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
-      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.5.0",
-        "@emnapi/runtime": "^1.5.0",
         "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2844,23 +2791,28 @@
       ]
     },
     "node_modules/@rsbuild/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-i37urpoV4y9NSsGiUOuLdoI42KJ5h4gAZ8EG8Ilmsond3bxoAoOCu7YvC+1pJ7p+r16suVPW8cki891ZKHOoXQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-5TwUpb10Y+VYaYH8oLL/rfJGrhxrk16BiGzv101kzaMPT60MtOXgjEUTxztbjRuq0ifbtRJ/w7rsIZQ4VziWYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rspack/core": "~1.7.10",
-        "@rspack/lite-tapable": "~1.1.0",
-        "@swc/helpers": "^0.5.20",
-        "core-js": "~3.47.0",
-        "jiti": "^2.6.1"
+        "@rspack/core": "^2.0.0",
+        "@swc/helpers": "^0.5.21"
       },
       "bin": {
         "rsbuild": "bin/rsbuild.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "core-js": ">= 3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "core-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rsbuild/plugin-node-polyfill": {
@@ -2904,17 +2856,17 @@
       }
     },
     "node_modules/@rsbuild/plugin-react": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-react/-/plugin-react-1.4.6.tgz",
-      "integrity": "sha512-LAT6xHlEyZKA0VjF/ph5d50iyG+WSmBx+7g98HNZUwb94VeeTMZFB8qVptTkbIRMss3BNKOXmHOu71Lhsh9oEw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-react/-/plugin-react-2.0.0.tgz",
+      "integrity": "sha512-/1gzt39EGUSFEqB83g46QoOwsgv172HI18i6au1b6lgIaX4sv9stuX4ijdHbHCp8PqYEq+MyQ99jIQMO6I+etg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rspack/plugin-react-refresh": "^1.6.1",
+        "@rspack/plugin-react-refresh": "2.0.0",
         "react-refresh": "^0.18.0"
       },
       "peerDependencies": {
-        "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+        "@rsbuild/core": "^2.0.0-0"
       },
       "peerDependenciesMeta": {
         "@rsbuild/core": {
@@ -2923,13 +2875,13 @@
       }
     },
     "node_modules/@rsbuild/plugin-svgr": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-svgr/-/plugin-svgr-1.3.1.tgz",
-      "integrity": "sha512-HQupp4ubDgoPg0VHva68BZKNEb2GM/bZfQP/Pit2tV7vu/SnOO8MZFdiFbjyK/VXCdQktIMbkNREG7xDgpo/ww==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-svgr/-/plugin-svgr-2.0.1.tgz",
+      "integrity": "sha512-cnBGmwtuhj1ltPBScsQVAvsF29m9xmtKXM3sjWWpDfPISkSTxR/jIRvFOf5qYVY37bJIs41Rxfd+PgrGazIgag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rsbuild/plugin-react": "^1.4.6",
+        "@rsbuild/plugin-react": "^2.0.0",
         "@svgr/core": "8.1.0",
         "@svgr/plugin-jsx": "8.1.0",
         "@svgr/plugin-svgo": "8.1.0",
@@ -2937,7 +2889,7 @@
         "loader-utils": "^3.3.1"
       },
       "peerDependencies": {
-        "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+        "@rsbuild/core": "^2.0.0-0"
       },
       "peerDependenciesMeta": {
         "@rsbuild/core": {
@@ -2946,28 +2898,28 @@
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.11.tgz",
-      "integrity": "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-2.0.0.tgz",
+      "integrity": "sha512-WA2f9eQpejkvf5Vrnf6wNCn1m8RT1p08NjgOZpKhsCzr0uBjWeRvGduawlrFFHZh/jPnWZTVaVdQ08FEAWbwGw==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.7.11",
-        "@rspack/binding-darwin-x64": "1.7.11",
-        "@rspack/binding-linux-arm64-gnu": "1.7.11",
-        "@rspack/binding-linux-arm64-musl": "1.7.11",
-        "@rspack/binding-linux-x64-gnu": "1.7.11",
-        "@rspack/binding-linux-x64-musl": "1.7.11",
-        "@rspack/binding-wasm32-wasi": "1.7.11",
-        "@rspack/binding-win32-arm64-msvc": "1.7.11",
-        "@rspack/binding-win32-ia32-msvc": "1.7.11",
-        "@rspack/binding-win32-x64-msvc": "1.7.11"
+        "@rspack/binding-darwin-arm64": "2.0.0",
+        "@rspack/binding-darwin-x64": "2.0.0",
+        "@rspack/binding-linux-arm64-gnu": "2.0.0",
+        "@rspack/binding-linux-arm64-musl": "2.0.0",
+        "@rspack/binding-linux-x64-gnu": "2.0.0",
+        "@rspack/binding-linux-x64-musl": "2.0.0",
+        "@rspack/binding-wasm32-wasi": "2.0.0",
+        "@rspack/binding-win32-arm64-msvc": "2.0.0",
+        "@rspack/binding-win32-ia32-msvc": "2.0.0",
+        "@rspack/binding-win32-x64-msvc": "2.0.0"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.11.tgz",
-      "integrity": "sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-2.0.0.tgz",
+      "integrity": "sha512-ICBHDKYyndFqljLhjxvKfWWZu39RJSH2jkSmbceXl0kmptLSE0cLWpvk+eGSzLqtxKN0jVchwCw+5P5mWCzwAw==",
       "cpu": [
         "arm64"
       ],
@@ -2979,9 +2931,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.11.tgz",
-      "integrity": "sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-2.0.0.tgz",
+      "integrity": "sha512-YQ96LMmzIzhZt9cZWUDWXSxS9UWWHWoLxJyZ5f42DSaVPVelBg5ThbVORDwOP5QDA2xFXj60rVnmmcZLzg/aDA==",
       "cpu": [
         "x64"
       ],
@@ -2993,9 +2945,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.11.tgz",
-      "integrity": "sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-2.0.0.tgz",
+      "integrity": "sha512-Ufn33gzkIV7JY69k6vJQEdOzRvBqThIgH46pwXksHSMwRZp8IbJhXfyYIAVsRWCk8fXpr9t1nAvCDvJXT2EeyA==",
       "cpu": [
         "arm64"
       ],
@@ -3007,9 +2959,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.11.tgz",
-      "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-2.0.0.tgz",
+      "integrity": "sha512-CZbvFKlNY9UC0C+Czz6i8JFCzGpuL9oX8gEqcJA1+84Y6eEEBH50UiTzeCewxKW3dOofkZdvT5vgNMXz6aMUmg==",
       "cpu": [
         "arm64"
       ],
@@ -3021,9 +2973,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.11.tgz",
-      "integrity": "sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-2.0.0.tgz",
+      "integrity": "sha512-dPjFGpoCvZfFpJBsWAUR+PR7mWYxpou6L026qIOpAVkz7WiTzErwKD3P1jVrpP4dM9yLb3fVE+PHHjTglhTJ4g==",
       "cpu": [
         "x64"
       ],
@@ -3035,9 +2987,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.11.tgz",
-      "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-2.0.0.tgz",
+      "integrity": "sha512-4fgDTMWt0mJDiugdia2mdOjTbnm7yM1Drzl1JpPqlUlOr113byOhc+qgN57LURSGypz2yz/h/Zad7/UnVAxYJw==",
       "cpu": [
         "x64"
       ],
@@ -3049,9 +3001,9 @@
       ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.11.tgz",
-      "integrity": "sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-2.0.0.tgz",
+      "integrity": "sha512-ANk73ZKtPrZf9gdtyRK2nQUfhi1uXoC5P2KF89pyVAE8+zcoLBnYtZGYpWa/cmNi5BcO5g4Z+v2l1UA3bUPLQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -3059,13 +3011,15 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "1.0.7"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "1.1.4"
       }
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.11.tgz",
-      "integrity": "sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-2.0.0.tgz",
+      "integrity": "sha512-IHZFRtJ85ONbM+BCtF4TeYXS2Fu9X0IJS2phX1rPibYq9iEtHGfBt4cNlnsJPhbPAXVvi4Oli/yiLRJ1zxtCIg==",
       "cpu": [
         "arm64"
       ],
@@ -3077,9 +3031,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.11.tgz",
-      "integrity": "sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-2.0.0.tgz",
+      "integrity": "sha512-n4tbIqacq/FhNJflMlgZV50AeQFTLh5hnDS3v4W+rJWa3IW1VfgB0+XppdeW+Dqhw7QcMIsCmro01kwNdlXZDQ==",
       "cpu": [
         "ia32"
       ],
@@ -3091,9 +3045,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.11.tgz",
-      "integrity": "sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-2.0.0.tgz",
+      "integrity": "sha512-cJOgikIW2t3S+42TQZsv+DJriJt2m6lnUk+pUFu/fO93rrMvNrx8gfMxR8W5zDTreBX0cfMx2pw6EVmyi/YzsQ==",
       "cpu": [
         "x64"
       ],
@@ -3105,51 +3059,42 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.11.tgz",
-      "integrity": "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-WD1mJM9LbZ7Z399Rbv9dE3BNEV0+3sE5OzDdzV8hOxUb3mX++ynK5n9kil8w60B6nGdcKeV9ly5aN4PgqiwWUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime-tools": "0.22.0",
-        "@rspack/binding": "1.7.11",
-        "@rspack/lite-tapable": "1.1.0"
+        "@rspack/binding": "2.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
+        "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0",
         "@swc/helpers": ">=0.5.1"
       },
       "peerDependenciesMeta": {
+        "@module-federation/runtime-tools": {
+          "optional": true
+        },
         "@swc/helpers": {
           "optional": true
         }
       }
     },
-    "node_modules/@rspack/lite-tapable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
-      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@rspack/plugin-react-refresh": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-1.6.1.tgz",
-      "integrity": "sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-2.0.0.tgz",
+      "integrity": "sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "error-stack-parser": "^2.1.4",
-        "html-entities": "^2.6.0"
-      },
       "peerDependencies": {
-        "react-refresh": ">=0.10.0 <1.0.0",
-        "webpack-hot-middleware": "2.x"
+        "@rspack/core": "^2.0.0-0",
+        "react-refresh": ">=0.10.0 <1.0.0"
       },
       "peerDependenciesMeta": {
-        "webpack-hot-middleware": {
+        "@rspack/core": {
           "optional": true
         }
       }
@@ -3636,9 +3581,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.20.tgz",
-      "integrity": "sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6324,18 +6269,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -7262,16 +7195,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/error-stack-parser": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
-      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -9328,23 +9251,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10446,16 +10352,6 @@
       "dependencies": {
         "cssfontparser": "^1.2.1",
         "moo-color": "^1.0.2"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-base64": {
@@ -14840,13 +14736,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stackframe": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,7 +123,8 @@
     "i18n": "i18next 'src/**/*.{ts,tsx}' -c ./src/i18n/i18next-parser.config.js",
     "tsc": "tsc",
     "make-version": "node ./make-env.js",
-    "star": "cross-env REACT_APP_HEADLAMP_BACKEND_TOKEN=headlamp rsbuild dev"
+    "star": "cross-env REACT_APP_HEADLAMP_BACKEND_TOKEN=headlamp rsbuild dev",
+    "build:rsbuild": "rsbuild build"
   },
   "browserslist": {
     "production": [
@@ -221,10 +222,10 @@
   },
   "prettier": "@headlamp-k8s/eslint-config/prettier-config",
   "devDependencies": {
-    "@rsbuild/core": "^1.4.15",
-    "@rsbuild/plugin-node-polyfill": "^1.4.1",
-    "@rsbuild/plugin-react": "^1.3.5",
-    "@rsbuild/plugin-svgr": "^1.2.2",
+    "@rsbuild/core": "^2.0.1",
+    "@rsbuild/plugin-node-polyfill": "^1.4.4",
+    "@rsbuild/plugin-react": "^2.0.0",
+    "@rsbuild/plugin-svgr": "^2.0.1",
     "@storybook/addon-docs": "^9.1.19",
     "@storybook/addon-links": "^9.1.19",
     "@storybook/react-vite": "^9.1.19",

--- a/frontend/rsbuild.config.ts
+++ b/frontend/rsbuild.config.ts
@@ -11,6 +11,10 @@ const reactAppEnvVars = Object.entries(process.env)
     return env;
   }, { 'import.meta.env': '{}' });
 
+// Use environment variable for backend port, defaulting to 4466
+const backendPort = process.env.HEADLAMP_PORT || '4466';
+const backendTarget = `http://localhost:${backendPort}`;
+
 export default defineConfig({
   source: {
     entry: {
@@ -31,6 +35,22 @@ export default defineConfig({
   server: {
     port: 3000,
     cors: true,
+    proxy: {
+      '/api': { target: backendTarget, changeOrigin: true },
+      '/clusters': { target: backendTarget, changeOrigin: true },
+      '/plugins': { target: backendTarget, changeOrigin: true },
+      '/config': { target: backendTarget, changeOrigin: true },
+      '/auth': { target: backendTarget, changeOrigin: true },
+      '/oidc': { target: backendTarget, changeOrigin: true },
+      '/oidc-callback': { target: backendTarget, changeOrigin: true },
+      '/wsMultiplexer': { target: backendTarget, changeOrigin: true, ws: true },
+      '/externalproxy': { target: backendTarget, changeOrigin: true },
+      '/drain-node': { target: backendTarget, changeOrigin: true },
+      '/drain-node-status': { target: backendTarget, changeOrigin: true },
+      '/parseKubeConfig': { target: backendTarget, changeOrigin: true },
+      '/cluster': { target: backendTarget, changeOrigin: true },
+      '/metrics': { target: backendTarget, changeOrigin: true },
+    },
   },
   // dev: {
   //   hmr: false,
@@ -49,6 +69,15 @@ export default defineConfig({
   },
   tools: {
     rspack: {
+      module: {
+        rules: [
+          {
+            // Handle ?url imports (e.g. elkjs worker) as asset URLs, matching Vite's ?url behavior
+            resourceQuery: /url/,
+            type: 'asset/resource',
+          },
+        ],
+      },
       optimization: {
         splitChunks: {
           cacheGroups: {


### PR DESCRIPTION
## Summary


"cd frontend && npm run star" works again. Seems a package upgrade broke it at some point.

This is so I can load headlamp in dev mode on windows cmd (without having to wait minutes and reload until it works).


### How to test?

- In other terminal :`make run-backend`
- `cd frontend && npm install && npm run star`


## Changes

- Added `server.proxy` entries to `frontend/rsbuild.config.ts` matching `frontend/vite.config.ts` so API requests (`/api`, `/config`, `/clusters`, etc.) reach the backend instead of 404'ing
- Added an rspack `asset/resource` rule with `resourceQuery: /url/` to `frontend/rsbuild.config.ts` so `?url` imports (elkjs worker for Map View) work like Vite
- Updated rsbuild packages to stable 2.0.x: `@rsbuild/core` `^2.0.0-rc.0` → `^2.0.1`, `@rsbuild/plugin-react` `^1.4.6` → `^2.0.0`, `@rsbuild/plugin-svgr` `^1.3.1` → `^2.0.1`
- Added `build:rsbuild` npm script in `frontend/package.json` and `frontend-build-rsbuild` Makefile target
- Added `make frontend-build-rsbuild` step to the existing `build:` job in `.github/workflows/frontend.yml` (with an explanatory comment) so CI checks that the rsbuild setup keeps working and `npm run star` still works

## Steps to Test

1. `cd frontend && npm install`
2. Run `npm run star` and open the Home Screen — it should load the cluster overview, not a spinner
3. Navigate to Map — it should render
4. Run `make frontend-build-rsbuild` (or `cd frontend && npm run build:rsbuild`) — production build should succeed

## Screenshots (if applicable)

Home Screen under `npm run star`:

<img src="https://github.com/user-attachments/assets/30070e45-f508-427c-9700-0f950d4bfd02">

Map View with under `npm run star`:

<img src="https://github.com/user-attachments/assets/b3c9a2d9-c2d3-49ff-a8c3-0ce5ee8b5fe8">

