### PR TITLE
app: Makefile: ci: Add i18n-check to catch translation regressions

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -42,6 +42,8 @@ jobs:
       run: make app-test
     - name: Run tsc type checker
       run: make app-tsc
+    - name: Run app-i18n-check
+      run: make app-i18n-check
     - name: App linux
       run: |
         make app-linux

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,14 @@ app-tsc:
 	cd app && npm install
 	cd app && npm run tsc
 
+app/node_modules/.package-lock.json: app/package-lock.json
+	cd app && npm ci
+
+.PHONY: app-i18n-check
+app-i18n-check: app/node_modules/.package-lock.json
+	@echo "Checking app translations. If this fails use: 'npm run i18n' in the app/ folder"
+	cd app && npm run i18n-check
+
 .PHONY: backend
 backend:
 	cd backend && go build $(BUILD_VERSION_FLAGS) -o ./headlamp-server${SERVER_EXE_EXT} ./cmd

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "dev-only-app": "npm run compile-electron -- --dev && cross-env ELECTRON_DEV=1 ELECTRON_START_URL=http://localhost:3000 EXTERNAL_SERVER=true electron .",
     "format": "cd .. && npm run frontend:format",
     "i18n": "npx --no-install i18next ./electron/main.ts -c ./electron/i18next-parser.config.ts",
+    "i18n-check": "npm run i18n -- --fail-on-update",
     "lint": "cd .. && npm run frontend:lint",
     "lint-fix": "cd .. && npm run frontend:lint:fix",
     "package": "npm run build && electron-builder build --publish never",

--- a/docs/development/app.md
+++ b/docs/development/app.md
@@ -91,6 +91,24 @@ To check TypeScript types:
 npm run app:tsc
 ```
 
+## Translations (i18n)
+
+The app uses [i18next](https://www.i18next.com/) for translations. Translation keys are extracted from `app/electron/main.ts` using i18next-parser.
+
+To regenerate translation files after changing translatable strings:
+
+```bash
+cd app && npm run i18n
+```
+
+To check that translation files are up to date (exits with an error if any file would change):
+
+```bash
+npm run app:i18n-check
+```
+
+This check runs automatically in CI to prevent translation regressions when code or dependencies change.
+
 ## Packaging
 
 To package the app for all platforms:
@@ -115,8 +133,9 @@ The typical development workflow for the desktop app:
 1. Make changes to the app code in `app/electron/`
 2. Run linting and formatting: `npm run app:lint:fix && npm run app:format`
 3. Run type checking: `npm run app:tsc`
-4. Test your changes: `npm run app:test`
-5. Build and run: `npm run app:start`
+4. If you added or changed translatable strings, regenerate translations: `cd app && npm run i18n`
+5. Test your changes: `npm run app:test`
+6. Build and run: `npm run app:start`
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "app:test:unit": "cd app && npm run test",
     "app:test:e2e": "cd app/e2e-tests && npm run test",
     "app:tsc": "cd app && npm run tsc",
+    "app:i18n-check": "cd app && npm run i18n-check",
     "app:format": "cd app && npm run format",
     "app:lint": "cd app && npm run lint",
     "app:lint:fix": "cd app && npm run lint-fix",


### PR DESCRIPTION
Added a "app:i18n-check" which is run in CI.

- To check that i18n files don't need updating.
- The CI check helps us catch regressions as dependencies/code is updated.