### PR TITLE
frontend: node: Extract useMetrics into standalone hook

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 import Event from '../../lib/k8s/event';
-import Node from '../../lib/k8s/node';
+import Node, { useNodeMetrics } from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
 import { useFilterFunc } from '../../lib/util';
 import { useNamespaces } from '../../redux/filterSlice';
@@ -48,7 +48,7 @@ export default function Overview() {
   const { t } = useTranslation(['translation']);
   const [pods] = Pod.useList();
   const [nodes] = Node.useList();
-  const [nodeMetrics, metricsError] = Node.useMetrics();
+  const [nodeMetrics, metricsError] = useNodeMetrics();
   const chartProcessors = useTypedSelector(state => state.overviewCharts.processors);
 
   const noMetrics = metricsError?.status === 404;

--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -29,7 +29,7 @@ import { drainNode, drainNodeStatus } from '../../lib/k8s/api/v1/drainNode';
 import type { ApiError } from '../../lib/k8s/api/v2/ApiError';
 import type { KubeNodeSummaryStats } from '../../lib/k8s/api/v2/nodeSummaryApi';
 import { KubeContainer, KubeMetrics } from '../../lib/k8s/cluster';
-import Node from '../../lib/k8s/node';
+import Node, { useNodeMetrics, useNodeSummaryStats } from '../../lib/k8s/node';
 import type { KubePod } from '../../lib/k8s/pod';
 import Pod from '../../lib/k8s/pod';
 import * as units from '../../lib/units';
@@ -72,8 +72,8 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
   const dispatch: AppDispatch = useDispatch();
 
   const { enqueueSnackbar } = useSnackbar();
-  const [nodeMetrics, metricsError] = Node.useMetrics();
-  const [nodeSummaryStats, nodeSummaryError] = Node.useNodeSummaryStats(name, cluster);
+  const [nodeMetrics, metricsError] = useNodeMetrics();
+  const [nodeSummaryStats, nodeSummaryError] = useNodeSummaryStats(name, cluster);
   const [isupdatingNodeScheduleProperty, setisUpdatingNodeScheduleProperty] = React.useState(false);
   const [isNodeDrainInProgress, setisNodeDrainInProgress] = React.useState(false);
   const [nodeFromAPI, nodeError] = Node.useGet(name);

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import Node from '../../lib/k8s/node';
+import Node, { useNodeMetrics } from '../../lib/k8s/node';
 import { getResourceMetrics } from '../../lib/util';
 import { HoverInfoLabel } from '../common/Label';
 import ResourceListView from '../common/Resource/ResourceListView';
@@ -24,7 +24,7 @@ import { NodeReadyLabel } from './Details';
 import { formatTaint, NodeTaintsLabel } from './utils';
 
 export default function NodeList() {
-  const [nodeMetrics, metricsError] = Node.useMetrics();
+  const [nodeMetrics, metricsError] = useNodeMetrics();
   const { t } = useTranslation(['glossary', 'translation']);
 
   const noMetrics = metricsError?.status === 404;

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -73,6 +73,37 @@ export interface KubeNode extends KubeObjectInterface {
   };
 }
 
+export function useNodeMetrics(): [KubeMetrics[] | null, ApiError | null] {
+  const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
+  const [error, setError] = useErrorState(setNodeMetrics);
+
+  function setMetrics(metrics: KubeMetrics[]) {
+    setNodeMetrics(metrics);
+    setError(null);
+  }
+
+  useConnectApi(metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError));
+
+  return [nodeMetrics, error];
+}
+
+export function useNodeSummaryStats(
+  nodeName?: string,
+  cluster?: string
+): [KubeNodeSummaryStats | null, ApiError | null] {
+  const [summaryStats, setSummaryStats] = React.useState<KubeNodeSummaryStats | null>(null);
+  const [error, setError] = useErrorState(setSummaryStats);
+
+  function setStats(stats: KubeNodeSummaryStats) {
+    setSummaryStats(stats);
+    setError(null);
+  }
+
+  useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
+
+  return [summaryStats, error];
+}
+
 class Node extends KubeObject<KubeNode> {
   static kind = 'Node';
   static apiName = 'nodes';
@@ -85,49 +116,6 @@ class Node extends KubeObject<KubeNode> {
 
   get spec(): KubeNode['spec'] {
     return this.jsonData.spec;
-  }
-
-  static useMetrics(): [KubeMetrics[] | null, ApiError | null] {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [error, setError] = useErrorState(setNodeMetrics);
-
-    function setMetrics(metrics: KubeMetrics[]) {
-      setNodeMetrics(metrics);
-
-      if (metrics !== null) {
-        setError(null);
-      }
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError));
-
-    return [nodeMetrics, error];
-  }
-
-  static useNodeSummaryStats(
-    nodeName?: string,
-    cluster?: string
-  ): [KubeNodeSummaryStats | null, ApiError | null] {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [summaryStats, setSummaryStats] = React.useState<KubeNodeSummaryStats | null>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [error, setError] = useErrorState(setSummaryStats);
-
-    function setStats(stats: KubeNodeSummaryStats) {
-      setSummaryStats(stats);
-
-      if (stats !== null) {
-        setError(null);
-      }
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
-
-    return [summaryStats, error];
   }
 
   getExternalIP(): string {

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -382,6 +382,8 @@
     },
     "node": {
       "default": [Function],
+      "useNodeMetrics": [Function],
+      "useNodeSummaryStats": [Function],
     },
     "persistentVolume": {
       "default": [Function],


### PR DESCRIPTION
## Summary

Fixes a `react-hooks/rules-of-hooks` violation by extracting the `Node.useMetrics()` static class method into a standalone exported hook `useNodeMetrics()`, and updating all call sites to use it directly.

## Related Issue

Fixes #5246

## Changes

- Extracted `static useMetrics()` and `static useNodeSummaryStats()` from the `Node` class in `frontend/src/lib/k8s/node.ts` into standalone exported hooks `useNodeMetrics()` and `useNodeSummaryStats()`
- Updated `frontend/src/components/node/Details.tsx` to import and call both hooks directly
- Updated `frontend/src/components/node/List.tsx` to use `useNodeMetrics()`
- Updated `frontend/src/components/cluster/Overview.tsx` to use `useNodeMetrics()`
- Updated the plugin library snapshot to reflect the two new named exports

## Steps to Test

1. Run `npm run lint` in `frontend/` — should pass with no `react-hooks/rules-of-hooks` errors

## Notes for the Reviewer
- The extracted `useNodeMetrics` function is behaviour-identical to the original static method; only the call site syntax changes.
