### PR TITLE
frontend: auth: Fix potential crash during JWT decoding

### DIFF
--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -14,19 +14,31 @@
  * limitations under the License.
  */
 
+import { Base64 } from 'js-base64';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { setToken } from './auth';
+import store from '../redux/stores/store';
+import { getUserInfo, setToken } from './auth';
 import { backendFetch } from './k8s/api/v2/fetch';
 
 // Mock the dependencies
 vi.mock('./k8s/api/v2/fetch');
 vi.mock('../helpers/getHeadlampAPIHeaders');
+vi.mock('../redux/stores/store', () => ({
+  default: {
+    getState: vi.fn(),
+  },
+}));
 
 const mockBackendFetch = vi.mocked(backendFetch);
+const mockStore = vi.mocked(store);
 
 describe('auth', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockStore.getState.mockReturnValue({
+      ui: { functionsToOverride: {} },
+      config: { allClusters: {} },
+    } as any);
   });
 
   describe('setToken', () => {
@@ -85,6 +97,70 @@ describe('auth', () => {
       mockBackendFetch.mockResolvedValue(mockResponse as Response);
 
       await expect(setToken(cluster, token)).rejects.toThrow('Failed to set cookie token');
+    });
+  });
+
+  describe('getUserInfo', () => {
+    it('should return null when no token exists', () => {
+      mockStore.getState.mockReturnValue({
+        ui: { functionsToOverride: {} },
+      } as any);
+
+      expect(getUserInfo('test-cluster')).toBeNull();
+    });
+
+    it('should return decoded info for a valid base64url token', () => {
+      const userData = { name: 'test-user', email: 'test@example.com' };
+      // Base64.encodeURI produces base64url (no padding, url-safe chars) as real JWTs do
+      const validToken = `header.${Base64.encodeURI(JSON.stringify(userData))}.signature`;
+
+      mockStore.getState.mockReturnValue({
+        ui: {
+          functionsToOverride: {
+            getToken: () => validToken,
+          },
+        },
+      } as any);
+
+      expect(getUserInfo('test-cluster')).toEqual(userData);
+    });
+
+    it('should return null and not crash for a malformed token', () => {
+      const malformedToken = 'header.malformed_payload.signature';
+
+      mockStore.getState.mockReturnValue({
+        ui: {
+          functionsToOverride: {
+            getToken: () => malformedToken,
+          },
+        },
+      } as any);
+
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(getUserInfo('test-cluster')).toBeNull();
+      expect(spy).toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+
+    it('should return null for valid base64 but invalid JSON', () => {
+      const invalidJsonToken = `header.${Base64.encode('not-json')}.signature`;
+
+      mockStore.getState.mockReturnValue({
+        ui: {
+          functionsToOverride: {
+            getToken: () => invalidJsonToken,
+          },
+        },
+      } as any);
+
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(getUserInfo('test-cluster')).toBeNull();
+      expect(spy).toHaveBeenCalled();
+
+      spy.mockRestore();
     });
   });
 });

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -18,6 +18,7 @@
  * This module was taken from the k8dash project.
  */
 
+import { Base64 } from 'js-base64';
 import { getHeadlampAPIHeaders } from '../helpers/getHeadlampAPIHeaders';
 import store from '../redux/stores/store';
 import { backendFetch } from './k8s/api/v2/fetch';
@@ -47,13 +48,21 @@ export function getToken(cluster: string) {
  * By default tokens are stored in httpOnly cookies and not available from JS
  *
  * @param cluster - The name of the cluster.
- * @returns The decoded user information from the token's payload.
+ * @returns The decoded user information from the token's payload, or null if the token is invalid or missing.
  */
-export function getUserInfo(cluster: string) {
+export function getUserInfo(cluster: string): Record<string, unknown> | null {
   const user = getToken(cluster)?.split('.')[1];
   if (user) {
-    return JSON.parse(atob(user));
+    try {
+      const parsed = JSON.parse(Base64.decode(user));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch (e) {
+      console.error('Error parsing user info:', e);
+    }
   }
+  return null;
 }
 
 /**


### PR DESCRIPTION
### **Summary:** Fixes a critical vulnerability in the authentication utility where a malformed or corrupted JWT could trigger an unhandled exception, resulting in a "White Screen of Death" (total UI crash). This is particularly important for plugin stability, as getUserInfo is an exported utility used by extensions to retrieve user details.

### **Fixes:** #5264 

### **Changes:**

1. frontend/src/lib/auth.ts: Wrapped the atob() and JSON.parse() logic in getUserInfo within a try/catch block. The function now logs a graceful error and returns null instead of throwing an exception when encountering invalid token data.
2. frontend/src/lib/auth.test.ts: Added a comprehensive test suite for getUserInfo to verify its behavior with:
3. Valid, well-formed JWT tokens (successful decoding).
4. Malformed/corrupted tokens (graceful error handling).
5. Missing tokens (returns null).

### **Steps to Test:**

Verify the fix by running the new unit tests: `cmd /c "npm run frontend:test -- src/lib/auth.test.ts"`
(Optional) If you want to see it "not crash" live, you can temporarily call getUserInfo in any component with a dummy string like getUserInfo("test"). Previously this would crash the page; now it will simply log an error to the console and keep the app running.