### PR TITLE
frontend: Remove role=button from label in DropZoneBox usage

### DIFF
--- a/frontend/src/components/common/DropZoneBox.stories.tsx
+++ b/frontend/src/components/common/DropZoneBox.stories.tsx
@@ -18,6 +18,7 @@ import { InlineIcon } from '@iconify/react';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
 import { DropZoneBox } from './DropZoneBox';
 
 export default {
@@ -27,19 +28,25 @@ export default {
 
 const Template: StoryFn<typeof DropZoneBox> = args => <DropZoneBox {...args} />;
 
-export const UploadFiles = Template.bind({});
-UploadFiles.args = {
-  children: (
+const UploadFilesContent = () => {
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  return (
     <>
       <Typography sx={{ m: 2 }}>{'Select a file or drag and drop here'}</Typography>
+      <input type="file" hidden ref={fileInputRef} />
       <Button
         variant="contained"
-        component="label"
+        onClick={() => fileInputRef.current?.click()}
         startIcon={<InlineIcon icon="mdi:upload" width={32} />}
         sx={{ fontWeight: 500 }}
       >
         {'Select File'}
       </Button>
     </>
-  ),
+  );
+};
+
+export const UploadFiles = Template.bind({});
+UploadFiles.args = {
+  children: <UploadFilesContent />,
 };

--- a/frontend/src/components/common/Resource/UploadDialog.tsx
+++ b/frontend/src/components/common/Resource/UploadDialog.tsx
@@ -70,6 +70,7 @@ const UploadFromFilesystem = ({
   const [files, setFiles] = React.useState<File[]>([]);
   const [dragOver, setDragOver] = React.useState(false);
   const [error, setError] = React.useState('');
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const onFilesPicked = (picked: FileList | null) => {
     setError('');
@@ -121,20 +122,21 @@ const UploadFromFilesystem = ({
             ? t('translation|Drop the file here...')
             : t('translation|Select a file or drag and drop here')}
         </Typography>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".yaml,.yml,application/yaml"
+          multiple
+          hidden
+          onChange={e => onFilesPicked(e.target.files)}
+        />
         <Button
           variant="contained"
-          component="label"
+          onClick={() => fileInputRef.current?.click()}
           startIcon={<InlineIcon icon="mdi:upload" width={32} />}
           sx={{ fontWeight: 500 }}
         >
           {t('translation|Select File')}
-          <input
-            type="file"
-            accept=".yaml,.yml,application/yaml"
-            multiple
-            hidden
-            onChange={e => onFilesPicked(e.target.files)}
-          />
         </Button>
       </DropZoneBox>
       {!!files.length && (

--- a/frontend/src/components/common/__snapshots__/DropZoneBox.UploadFiles.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/DropZoneBox.UploadFiles.stories.storyshot
@@ -8,10 +8,14 @@
       >
         Select a file or drag and drop here
       </p>
-      <label
+      <input
+        hidden=""
+        type="file"
+      />
+      <button
         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-17g4n8r-MuiButtonBase-root-MuiButton-root"
-        role="button"
         tabindex="0"
+        type="button"
       >
         <span
           class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
@@ -20,7 +24,7 @@
         <span
           class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </label>
+      </button>
     </div>
   </div>
 </body>


### PR DESCRIPTION
This change replaces `<Button component="label">` with a standard `<Button>` that programatically triggers a hidden file input via a ref, eliminating the `role="button"` on `<label>` a11y violation.

Fixes: #4612 

### Changes

- Replace `component="label"` pattern with a ref-based file input trigger in `UploadDialog.tsx`
- Apply the same fix to the `UploadFiles` story in `DropZoneBox.stories.tsx`

### Testing

- [x] Verified no `role="button"` is rendered on a `<label>` element
- [x] No TypeScript errors introduced  