### PR TITLE
frontend: pod: Do not show reconnect button for previous logs

### DIFF
--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -193,6 +193,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
         xtermRef.current?.clear();
         setLogs({ logs: [], lastLineShown: -1 });
         setHasJsonLogs(false);
+        setShowReconnectButton(false);
 
         callback = item.getLogs(container, debouncedSetState, {
           tailLines: lines,

--- a/frontend/src/components/pod/PodLogViewer.test.tsx
+++ b/frontend/src/components/pod/PodLogViewer.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { TestContext } from '../../test';
+import { PodLogViewer } from './Details';
+
+vi.mock('../../lib/k8s', () => ({}));
+vi.mock('../../lib/k8s/pod', () => ({ default: vi.fn(), __esModule: true }));
+vi.mock('../../lib/k8s/cluster', () => ({}));
+
+vi.mock('../globalSearch/useLocalStorageState', () => ({
+  useLocalStorageState: (key: string, defaultValue: any) => [defaultValue, vi.fn()],
+}));
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    open: vi.fn(),
+    clear: vi.fn(),
+    write: vi.fn(),
+    focus: vi.fn(),
+    onData: vi.fn(),
+    onResize: vi.fn(),
+    attachCustomKeyEventHandler: vi.fn(),
+    dispose: vi.fn(),
+    loadAddon: vi.fn(),
+  })),
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: vi.fn(),
+    activate: vi.fn(),
+  })),
+}));
+
+function makeMockPod(getLogs: (...args: any[]) => any) {
+  return {
+    metadata: { name: 'test-pod', namespace: 'default', uid: 'pod-uid-123' },
+    spec: { containers: [{ name: 'nginx' }] },
+    status: {
+      containerStatuses: [{ name: 'nginx', state: { running: {} }, restartCount: 1 }],
+    },
+    getName: () => 'test-pod',
+    getLogs,
+  } as any;
+}
+
+describe('PodLogViewer', () => {
+  describe('reconnect button', () => {
+    it('is cleared when switching to previous logs', async () => {
+      let capturedOnReconnectStop: (() => void) | undefined;
+      const getLogs = vi.fn((_container: string, _onLogs: any, options: any) => {
+        capturedOnReconnectStop = options.onReconnectStop;
+        return () => {};
+      });
+
+      render(
+        <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }}>
+          <PodLogViewer open item={makeMockPod(getLogs)} onClose={() => {}} />
+        </TestContext>
+      );
+
+      // trigger reconnect stop to show the button
+      act(() => {
+        capturedOnReconnectStop?.();
+      });
+      expect(screen.getByText('Reconnect')).toBeInTheDocument();
+
+      // switch to previous logs
+      act(() => {
+        fireEvent.click(screen.getByLabelText('Previous'));
+      });
+      expect(screen.queryByText('Reconnect')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/lib/k8s/pod.test.ts
+++ b/frontend/src/lib/k8s/pod.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockStream = vi.fn();
+vi.mock('./api/v1/streamingApi', () => ({
+  stream: (...args: any[]) => mockStream(...args),
+}));
+
+// Avoid pulling in the full `./index` barrel via KubeObject's imports.
+vi.mock('./KubeObject', () => {
+  class KubeObject<T = any> {
+    jsonData: T;
+    cluster?: string;
+    constructor(jsonData: T, cluster?: string) {
+      this.jsonData = jsonData;
+      this.cluster = cluster;
+    }
+    getName() {
+      return (this.jsonData as any)?.metadata?.name ?? '';
+    }
+    getNamespace() {
+      return (this.jsonData as any)?.metadata?.namespace ?? '';
+    }
+  }
+  return { KubeObject };
+});
+
+vi.mock('./api/v1/clusterRequests', () => ({
+  post: vi.fn(),
+  patch: vi.fn(),
+}));
+
+const { default: Pod } = await import('./pod');
+
+function makePod(): Pod {
+  return new Pod({
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'test-pod', namespace: 'default', uid: 'pod-uid-123' },
+    spec: { containers: [{ name: 'nginx' }], nodeName: 'test-node' },
+    status: { containerStatuses: [], phase: 'Running' },
+  } as any);
+}
+
+describe('Pod.getLogs', () => {
+  beforeEach(() => {
+    mockStream.mockReset();
+    mockStream.mockReturnValue({ cancel: () => {}, getSocket: () => null });
+  });
+
+  describe('failCb / onReconnectStop', () => {
+    it('does not call onReconnectStop when showPrevious is true', () => {
+      const onReconnectStop = vi.fn();
+      makePod().getLogs('nginx', () => {}, { showPrevious: true, follow: true, onReconnectStop });
+
+      const streamArgs = mockStream.mock.calls[0][2];
+      streamArgs.failCb();
+
+      expect(onReconnectStop).not.toHaveBeenCalled();
+    });
+
+    it('calls onReconnectStop when showPrevious is false', () => {
+      const onReconnectStop = vi.fn();
+      makePod().getLogs('nginx', () => {}, { showPrevious: false, follow: true, onReconnectStop });
+
+      const streamArgs = mockStream.mock.calls[0][2];
+      streamArgs.failCb();
+
+      expect(onReconnectStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onReconnectStop when follow is false', () => {
+      const onReconnectStop = vi.fn();
+      makePod().getLogs('nginx', () => {}, { showPrevious: false, follow: false, onReconnectStop });
+
+      const streamArgs = mockStream.mock.calls[0][2];
+      streamArgs.failCb();
+
+      expect(onReconnectStop).not.toHaveBeenCalled();
+    });
+
+    it('only calls onReconnectStop once across repeated failCb invocations', () => {
+      const onReconnectStop = vi.fn();
+      makePod().getLogs('nginx', () => {}, { showPrevious: false, follow: true, onReconnectStop });
+
+      const streamArgs = mockStream.mock.calls[0][2];
+      streamArgs.failCb();
+      streamArgs.failCb();
+
+      expect(onReconnectStop).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -242,7 +242,7 @@ class Pod extends KubeObject<KubePod> {
        */
       failCb: () => {
         // If it's a reconnection attempt, stop further reconnection attempts
-        if (follow && isReconnecting) {
+        if (!showPrevious && follow && isReconnecting) {
           isReconnecting = false;
 
           // If the onReconnectStop callback is provided, call it


### PR DESCRIPTION
## Summary

When looking at the previous logs for a container, there is always a "reconnect" button at the bottom. This can be confusing; the previous logs do not stream as the container has already terminated. Clicking on this button just refreshes the existing logs. The reconnect button will even persist even going back to the current logs (even though the current logs are streaming fine).

This PR hides the "reconnect" button when viewing the previous logs for a pod.

## Related Issue

No issue created.

## Changes

- Added/Updated [component/file/logic]
- Fixed [bug/issue/typo]
- Refactored [code/module] for clarity/performance

## Steps to Test

1. Navigate to a pod that has a previous container.
2. Check that the reconnect button does not appear when viewing previous container logs.

## Screenshots (if applicable)

Before:
<img width="1193" height="287" alt="image" src="https://github.com/user-attachments/assets/e5950873-7b3e-4c05-852e-dbaebfafb9b6" />

After:
<img width="1188" height="348" alt="image" src="https://github.com/user-attachments/assets/780aa029-fa7a-4670-9520-1219e42199d1" />

## Notes for the Reviewer

I'm a bit of a noob in this codebase. I wonder if there is a more involved fix around how the websocket closes for cases where we know we aren't streaming logs continuously (you see a warn log in console whenever you go to the previous log page about websocket closing unexpectedly).

This fix seems to fit the current pattern though.