### PR TITLE
backend/helm: fix double-write in InstallRelease

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -602,6 +602,8 @@ func (h *Handler) InstallRelease(clientConfig clientcmd.ClientConfig, w http.Res
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "setting status")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
 	}
 
 	go func(h *Handler) {


### PR DESCRIPTION
## What does this PR do?

Adds a missing [return](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#557-571) statement after `http.Error` in the [InstallRelease](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#572-615) handler.

When `setReleaseStatus` fails, the handler sends a 500 error but does not return. Execution falls through to:

1. Launch the [installRelease](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#703-752) goroutine unnecessarily
2. Call [returnResponse](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#557-571) → writes 202 Accepted on the same `ResponseWriter` → **superfluous `WriteHeader` panic**

### Before

```go
if err != nil {
    logger.Log(logger.LevelError, nil, err, "setting status")
    http.Error(w, err.Error(), http.StatusInternalServerError)
}
// falls through ↓
```

### After

```go
if err != nil {
    logger.Log(logger.LevelError, nil, err, "setting status")
    http.Error(w, err.Error(), http.StatusInternalServerError)

    return
}
```

## Which issue(s) is this PR related to?

Fixes #5276 

## Verification

- [x] `go vet ./pkg/helm/...` — pass
- [x] `go fmt ./pkg/helm/...` — pass
- [x] `go test ./pkg/helm/... -v` — all pass
