### PR TITLE
frontend: plugin: Re-initialize plugins when cluster becomes availabl…

### DIFF
--- a/frontend/src/plugin/Plugins.test.tsx
+++ b/frontend/src/plugin/Plugins.test.tsx
@@ -16,16 +16,20 @@
 
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestContext } from '../test';
-import Plugins from './Plugins';
 
-const { mockFetchAndExecutePlugins, mockEnqueueSnackbar } = vi.hoisted(() => ({
-  mockFetchAndExecutePlugins: vi.fn(),
-  mockEnqueueSnackbar: vi.fn(),
-}));
+const { mockFetchAndExecutePlugins, mockInitializePlugins, mockEnqueueSnackbar } = vi.hoisted(
+  () => ({
+    mockFetchAndExecutePlugins: vi.fn(),
+    mockInitializePlugins: vi.fn(),
+    mockEnqueueSnackbar: vi.fn(),
+  })
+);
 
 vi.mock('./index', () => ({
   fetchAndExecutePlugins: mockFetchAndExecutePlugins,
+  initializePlugins: mockInitializePlugins,
 }));
 
 vi.mock('notistack', () => ({
@@ -36,14 +40,25 @@ vi.mock('notistack', () => ({
   SnackbarProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+let mockClusterValue: string | null = null;
+vi.mock('../lib/k8s', () => ({
+  useCluster: () => mockClusterValue,
+}));
+
+import Plugins from './Plugins';
+
 // Silence expected console.error calls in tests
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
   vi.clearAllMocks();
+  mockClusterValue = null;
+  mockFetchAndExecutePlugins.mockResolvedValue(undefined);
+  mockInitializePlugins.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  mockClusterValue = null;
 });
 
 describe('Plugins', () => {
@@ -82,5 +97,87 @@ describe('Plugins', () => {
       expect.anything(),
       expect.objectContaining({ variant: 'error' })
     );
+  });
+
+  it('calls initializePlugins when cluster becomes available after no-cluster initial load', async () => {
+    // Initial render: no cluster in URL
+    mockClusterValue = null;
+
+    const { rerender } = render(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    expect(mockInitializePlugins).not.toHaveBeenCalled();
+
+    // Cluster becomes available (user logs in, URL changes to /c/main/...)
+    mockClusterValue = 'main';
+    rerender(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    // pluginsReady is set asynchronously once fetchAndExecutePlugins resolves,
+    // so we wait for initializePlugins to be called.
+    await waitFor(() => expect(mockInitializePlugins).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not call initializePlugins when cluster is already available at mount', async () => {
+    // When the cluster is in the URL from the start, loadedWithoutCluster stays false
+    // so the re-initialization effect must not fire.
+    mockClusterValue = 'my-cluster';
+
+    const { rerender } = render(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    // Wait for pluginsReady to settle (fetchAndExecutePlugins mock resolves)
+    await waitFor(() => expect(mockFetchAndExecutePlugins).toHaveBeenCalledTimes(1));
+
+    expect(mockInitializePlugins).not.toHaveBeenCalled();
+
+    // Cluster changes (e.g. user switches cluster) — should still NOT call
+    mockClusterValue = 'other-cluster';
+    rerender(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    expect(mockInitializePlugins).not.toHaveBeenCalled();
+  });
+
+  it('only initializes once even if cluster value changes multiple times', async () => {
+    mockClusterValue = null;
+
+    const { rerender } = render(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    mockClusterValue = 'main';
+    rerender(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    // Wait for the one expected call (triggered after pluginsReady becomes true)
+    await waitFor(() => expect(mockInitializePlugins).toHaveBeenCalledTimes(1));
+
+    // Subsequent re-renders with a different cluster must not call initializePlugins again
+    mockClusterValue = 'other-cluster';
+    rerender(
+      <TestContext>
+        <Plugins />
+      </TestContext>
+    );
+
+    expect(mockInitializePlugins).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/plugin/Plugins.tsx
+++ b/frontend/src/plugin/Plugins.tsx
@@ -16,13 +16,14 @@
 
 import Button from '@mui/material/Button';
 import { SnackbarKey, useSnackbar } from 'notistack';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { isElectron } from '../helpers/isElectron';
+import { useCluster } from '../lib/k8s';
 import { useTypedSelector } from '../redux/hooks';
-import { fetchAndExecutePlugins } from './index';
+import { fetchAndExecutePlugins, initializePlugins } from './index';
 import { pluginsLoaded, setPluginSettings } from './pluginsSlice';
 
 /**
@@ -40,11 +41,18 @@ export default function Plugins() {
   const { closeSnackbar, enqueueSnackbar } = useSnackbar();
   const history = useHistory();
   const { t } = useTranslation();
-
+  const cluster = useCluster();
   const settingsPlugins = useTypedSelector(state => state.plugins.pluginSettings);
+  // True once fetchAndExecutePlugins (and its internal initializePlugins call) has finished.
+  const [pluginsReady, setPluginsReady] = useState(false);
+  // True when the first plugin load happened without a cluster in the URL.
+  const loadedWithoutCluster = useRef(false);
 
   // only run on first load
   useEffect(() => {
+    if (!cluster) {
+      loadedWithoutCluster.current = true;
+    }
     fetchAndExecutePlugins(
       settingsPlugins,
       updatedSettingsPackages => {
@@ -91,6 +99,7 @@ export default function Plugins() {
       .finally(() => {
         try {
           dispatch(pluginsLoaded());
+          setPluginsReady(true);
           // Warn the app (if we're in app mode).
           window.desktopApi?.send('pluginsLoaded');
         } catch (err) {
@@ -99,5 +108,15 @@ export default function Plugins() {
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Re-initialize plugins once the cluster becomes available after a no-cluster initial load.
+  // Gated on pluginsReady so we never race with the fetchAndExecutePlugins call, which
+  // already calls initializePlugins() internally via afterPluginsRun.
+  useEffect(() => {
+    if (!cluster || !pluginsReady || !loadedWithoutCluster.current) return;
+    loadedWithoutCluster.current = false;
+    void initializePlugins();
+  }, [cluster, pluginsReady]);
+
   return null;
 }


### PR DESCRIPTION
## Summary

This PR fixes the app-catalog sidebar entry not appearing after login by re-calling `initializePlugins()` once the cluster first becomes available after a no-cluster initial load.

## Related Issue

Fixes #4787

## Changes

- Added `loadedWithoutCluster` ref in `Plugins.tsx` to track whether initial plugin load happened without a cluster in the URL
- Added second `useEffect([cluster])` that calls `initializePlugins()` when cluster first becomes available after a no-cluster load
- Added `Plugins.test.tsx` with unit tests covering the re-initialization behavior

## Steps to Test

1. Install the app-catalog plugin in Headlamp
2. Start Headlamp and log in (so the app redirects from `/` to `/c/<cluster>/...`)
3. Observe that the app-catalog sidebar entry now appears after login without requiring a page refresh

## Notes for the Reviewer

- The fix only re-calls `initializePlugins()` (which iterates already-loaded `window.plugins`) — it does not re-fetch plugin JS, so there is no double-download
- The `loadedWithoutCluster` ref is reset to `false` after the first re-initialization, so subsequent cluster changes do not trigger it again
- Full E2E testing requires the Go backend; unit tests cover the race-condition logic directly