### PR TITLE
backend/helm: use errors.Is for release-not-found checks

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -233,7 +233,7 @@ func (h *Handler) GetRelease(clientConfig clientcmd.ClientConfig, w http.Respons
 
 	// check if release exists
 	_, err = actionConfig.Releases.Deployed(req.Name)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "request": "get_release"},
 			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -300,7 +300,7 @@ func (h *Handler) GetReleaseHistory(clientConfig clientcmd.ClientConfig, w http.
 
 	// check if release exists
 	_, err = actionConfig.Releases.Deployed(req.Name)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "request": "get_release_history"},
 			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -379,7 +379,7 @@ func (h *Handler) UninstallRelease(clientConfig clientcmd.ClientConfig, w http.R
 
 	// check if release exists
 	_, err = actionConfig.Releases.Deployed(req.Name)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name, "request": "uninstall_release"},
 			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -476,7 +476,7 @@ func (h *Handler) RollbackRelease(clientConfig clientcmd.ClientConfig, w http.Re
 
 	// check if release exists
 	_, err = actionConfig.Releases.Deployed(req.Name)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		logger.Log(logger.LevelError, map[string]string{"releaseName": req.Name},
 			err, "release not found")
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -785,7 +785,7 @@ func (h *Handler) UpgradeRelease(clientConfig clientcmd.ClientConfig, w http.Res
 
 	// check if release exists
 	_, err = actionConfig.Releases.Deployed(req.Name)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		handleError(w, req.Name, err, "release not found", http.StatusNotFound)
 		return
 	}


### PR DESCRIPTION
# PR Description
## What does this PR do?

Replaces 5 direct equality checks (`err == driver.ErrReleaseNotFound`) with `errors.Is(err, driver.ErrReleaseNotFound)` in the helm release handlers.

Since Go 1.13, `errors.Is` is the idiomatic way to compare sentinel errors. It correctly traverses wrapped error chains, making the checks forward-compatible if the Helm SDK ever wraps `ErrReleaseNotFound`.

The `errors` package is already imported in the file — no new dependencies.

### Affected handlers

- [GetRelease](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#214-267)
- [GetReleaseHistory](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#277-338)
- [UninstallRelease](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#360-419)
- [RollbackRelease](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#458-514)
- [UpgradeRelease](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/backend/pkg/helm/release.go#761-805)

## Which issue(s) is this PR related to?

Fixes #5279

## Verification

- [x] `go vet ./pkg/helm/...` — pass
- [x] `go fmt ./pkg/helm/...` — pass
- [x] `go test ./pkg/helm/... -count=1` — all pass
