### PR TITLE
frontend: log silently swallowed errors in terminal components

### DIFF
--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -381,7 +381,13 @@ export default function Terminal(props: TerminalProps) {
         if (_.isEmpty(error.metadata) && error.status === 'Success') {
           return true;
         }
-      } catch {}
+      } catch (e) {
+        console.debug('Terminal: failed to parse server error channel data', {
+          channel,
+          text,
+          error: e,
+        });
+      }
     }
     return false;
   }
@@ -394,7 +400,13 @@ export default function Terminal(props: TerminalProps) {
         if (error.code === 500 && error.status === 'Failure' && error.reason === 'InternalError') {
           return true;
         }
-      } catch {}
+      } catch (e) {
+        console.debug('Terminal: failed to parse server error channel data', {
+          channel,
+          text,
+          error: e,
+        });
+      }
     }
     // Windows container Error
     if (channel === 1) {

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -204,7 +204,13 @@ export function NodeShellTerminal(props: NodeShellTerminalProps) {
           }
           return true;
         }
-      } catch {}
+      } catch (e) {
+        console.debug('NodeShellTerminal: failed to parse server error channel data', {
+          channel,
+          text,
+          error: e,
+        });
+      }
     }
     return false;
   }
@@ -217,7 +223,13 @@ export function NodeShellTerminal(props: NodeShellTerminalProps) {
         if (error.code === 500 && error.status === 'Failure' && error.reason === 'InternalError') {
           return true;
         }
-      } catch {}
+      } catch (e) {
+        console.debug('NodeShellTerminal: failed to parse server error channel data', {
+          channel,
+          text,
+          error: e,
+        });
+      }
     }
     // Windows container Error
     if (channel === Channel.StdOut) {

--- a/frontend/src/components/pod/PodDebugTerminal.tsx
+++ b/frontend/src/components/pod/PodDebugTerminal.tsx
@@ -301,7 +301,13 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
           }
           return true;
         }
-      } catch {}
+      } catch (e) {
+        console.debug('PodDebugTerminal: failed to parse server error channel data', {
+          channel,
+          text,
+          error: e,
+        });
+      }
     }
     return false;
   }
@@ -314,7 +320,13 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
         if (error.code === 500 && error.status === 'Failure' && error.reason === 'InternalError') {
           return true;
         }
-      } catch {}
+      } catch (e) {
+        console.debug('PodDebugTerminal: failed to parse server error channel data', {
+          channel,
+          text,
+          error: e,
+        });
+      }
     }
     // Windows container Error
     if (channel === Channel.StdOut) {


### PR DESCRIPTION
# PR Description
## What does this PR do?

Adds `console.debug` logging to 6 empty `catch {}` blocks in [isSuccessfulExitError()](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/node/NodeShellTerminal.tsx#196-216) and [isShellNotFoundError()](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/node/NodeShellTerminal.tsx#217-240) across three terminal components.

When `JSON.parse(text)` fails on server error channel data, the error was completely swallowed with no logging — making terminal connection issues invisible. Each catch now logs the `channel` and `text` for operational observability.

### Files changed

- [Terminal.tsx](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/common/Terminal.tsx) - 2 catch blocks
- [PodDebugTerminal.tsx](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/pod/PodDebugTerminal.tsx) - 2 catch blocks
- [NodeShellTerminal.tsx](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/node/NodeShellTerminal.tsx) -2 catch blocks

## Which issue(s) is this PR related to?

Fixes #5281

## Verification

- [x] All catch blocks now log with `console.debug`
- [x] Uses operational `console.debug` (not `console.log`) per project standards
