### PR TITLE
frontend: log silently swallowed errors in advanced search

### DIFF
--- a/frontend/src/components/advancedSearch/utils/searchWithQuery.tsx
+++ b/frontend/src/components/advancedSearch/utils/searchWithQuery.tsx
@@ -38,7 +38,9 @@ export async function searchWithQuery<T extends { jsonData: any }>(
   const functionBody = query;
   try {
     filterExpression = jsep(functionBody);
-  } catch (e) {}
+  } catch (e) {
+    // Intentionally empty: parse errors are expected as users type partial queries
+  }
 
   if (!filterExpression) return { results: [], searchTimeMs: 0 };
 
@@ -47,6 +49,10 @@ export async function searchWithQuery<T extends { jsonData: any }>(
   // Create object that contains all keys of all objects
   const dummyObject: any = {};
   getTopLevelKeys(items.map(it => it.jsonData)).forEach(key => (dummyObject[key] = undefined));
+
+  let evalErrorCount = 0;
+  let firstEvalError: unknown = null;
+  let firstFailedResource: T | null = null;
 
   for (let i = 0; i < items.length; i++) {
     const resource = items[i];
@@ -57,7 +63,13 @@ export async function searchWithQuery<T extends { jsonData: any }>(
       if (res === true) {
         results.push(resource);
       }
-    } catch (e) {}
+    } catch (e) {
+      evalErrorCount++;
+      if (!firstEvalError) {
+        firstEvalError = e;
+        firstFailedResource = resource;
+      }
+    }
 
     // After processing a batch or at the end, yield to the event loop
     if ((i + 1) % batchSize === 0 || i === items.length - 1) {
@@ -68,6 +80,14 @@ export async function searchWithQuery<T extends { jsonData: any }>(
         return { results: [], searchTimeMs: 0 };
       }
     }
+  }
+
+  if (evalErrorCount > 0) {
+    console.debug('searchWithQuery: failed to evaluate filter expression', {
+      errorCount: evalErrorCount,
+      firstError: firstEvalError,
+      firstFailedResource,
+    });
   }
 
   const searchTimeEnd = performance.now();


### PR DESCRIPTION
# PR Description

## What does this PR do?

Adds `console.debug` logging to 2 empty `catch (e) {}` blocks in [searchWithQuery.tsx](file://wsl.localhost/Ubuntu/home/ashwaniyadav/headlamp/frontend/src/components/advancedSearch/utils/searchWithQuery.tsx):

- Query parse failure (`jsep`) - logs the query string and error
- Filter evaluation failure (`evaluate`) -logs the error

Previously both errors were completely swallowed, making it impossible to debug why a search query returned zero results.

## Which issue(s) is this PR related to?

Fixes #5283

## Verification

- [x] Uses `console.debug` (not `console.log`) per project standards
