### PR TITLE
backend: k8cache: Add background janitor to evict expired clientsets

### DIFF
--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -37,6 +37,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// clientsetTTL is how long an idle clientset stays in the cache before
+// it becomes eligible for eviction.
+const clientsetTTL = 10 * time.Minute
+
+// janitorInterval is how often the background goroutine sweeps the
+// cache for expired entries.
+const janitorInterval = 5 * time.Minute
+
 type CachedClientSet struct {
 	clientset *kubernetes.Clientset
 	lastUsed  time.Time
@@ -45,17 +53,63 @@ type CachedClientSet struct {
 var (
 	clientsetCache = make(map[string]*CachedClientSet)
 	mu             sync.Mutex
+	janitorOnce    sync.Once
 )
 
-// GetClientSet return *kubernetes.ClientSet and error which further used for creating
+// startJanitor launches a background goroutine (exactly once) that
+// periodically scans clientsetCache and removes entries whose lastUsed
+// timestamp exceeds clientsetTTL. This prevents unbounded memory growth
+// when users with unique tokens never revisit the same cache key.
+func startJanitor() {
+	janitorOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(janitorInterval)
+			defer ticker.Stop()
+
+			for range ticker.C {
+				evictExpiredClientsets()
+			}
+		}()
+	})
+}
+
+// evictExpiredClientsets walks the cache under the lock and deletes
+// every entry older than clientsetTTL.
+func evictExpiredClientsets() {
+	mu.Lock()
+
+	now := time.Now()
+	evicted := 0
+
+	for key, cs := range clientsetCache {
+		if now.Sub(cs.lastUsed) > clientsetTTL {
+			delete(clientsetCache, key)
+
+			evicted++
+		}
+	}
+
+	remaining := len(clientsetCache)
+
+	mu.Unlock()
+
+	if evicted > 0 {
+		logger.Log(logger.LevelInfo, nil, nil,
+			fmt.Sprintf("janitor: evicted %d expired clientset(s), %d remaining", evicted, remaining))
+	}
+}
+
+// GetClientSet returns *kubernetes.ClientSet and error which is further used for creating
 // SSAR requests to k8s server to authorize user. GetClientSet uses kubeconfig.Context and
-// authentication bearer token  which will help to create clientSet based on the user's
+// authentication bearer token which will help to create clientSet based on the user's
 // identity.
 func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, error) {
 	contextKey := strings.Split(k.ClusterID, "+")
 	if len(contextKey) < 2 {
 		return nil, fmt.Errorf("unexpected ClusterID format in getClientSet: %q", k.ClusterID)
 	}
+
+	startJanitor()
 
 	cacheKey := fmt.Sprintf("%s-%s", contextKey[1], token)
 
@@ -65,18 +119,20 @@ func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, e
 	if cs, found := clientsetCache[cacheKey]; found {
 		now := time.Now()
 
-		if now.Sub(cs.lastUsed) > 10*time.Minute { // If the clientset was expired then delete
-			// the existing clientset resulting only fresh clientset.
+		// If the clientset was expired then delete the existing clientset resulting only fresh clientset.
+		if now.Sub(cs.lastUsed) > clientsetTTL {
 			delete(clientsetCache, cacheKey)
-			logger.Log(logger.LevelInfo, nil, nil, "clientset "+cacheKey+" was deleted")
+			logger.Log(logger.LevelInfo, nil, nil, fmt.Sprintf("expired clientset for cluster %s was deleted", contextKey[1]))
 		} else {
-			return cs.clientset, nil // If the clientset is not expired then return directly.
+			// If the clientset is not expired then refresh its last-used time and return it.
+			cs.lastUsed = now
+			return cs.clientset, nil
 		}
 	}
 
 	cs, err := k.ClientSetWithToken(token)
 	if err != nil {
-		return nil, fmt.Errorf("error while creating clientset for key %s: %w", cacheKey, err)
+		return nil, fmt.Errorf("error while creating clientset for cluster %s: %w", contextKey[1], err)
 	}
 
 	clientsetCache[cacheKey] = &CachedClientSet{

--- a/backend/pkg/k8cache/eviction_test.go
+++ b/backend/pkg/k8cache/eviction_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/stretchr/testify/assert"
+)
+
+var testKeyCounter int
+
+func seedCache(n int, lastUsed time.Time) {
+	for i := 0; i < n; i++ {
+		testKeyCounter++
+		key := fmt.Sprintf("test-token-%d-%d", time.Now().UnixNano(), testKeyCounter)
+		k8cache.SeedClientsetCache(key, lastUsed)
+	}
+}
+
+func TestEvictExpiredClientsets_AllExpired(t *testing.T) {
+	k8cache.ResetClientsetCache()
+
+	// Seed 5 expired entries
+	expiredTime := time.Now().Add(-20 * time.Minute)
+	seedCache(5, expiredTime)
+
+	assert.Equal(t, 5, k8cache.ClientsetCacheLen())
+
+	// Run eviction
+	k8cache.ManualEvictExpiredClientsets()
+
+	assert.Equal(t, 0, k8cache.ClientsetCacheLen(), "all expired entries should be removed")
+}
+
+func TestEvictExpiredClientsets_AllActive(t *testing.T) {
+	k8cache.ResetClientsetCache()
+
+	// Seed 5 active entries
+	activeTime := time.Now().Add(-2 * time.Minute)
+	seedCache(5, activeTime)
+
+	assert.Equal(t, 5, k8cache.ClientsetCacheLen())
+
+	// Run eviction
+	k8cache.ManualEvictExpiredClientsets()
+
+	assert.Equal(t, 5, k8cache.ClientsetCacheLen(), "all active entries should be preserved")
+}
+
+func TestEvictExpiredClientsets_Mixed(t *testing.T) {
+	k8cache.ResetClientsetCache()
+
+	// 3 expired
+	seedCache(3, time.Now().Add(-15*time.Minute))
+	// 2 active
+	seedCache(2, time.Now().Add(-1*time.Minute))
+
+	assert.Equal(t, 5, k8cache.ClientsetCacheLen())
+
+	// Run eviction
+	k8cache.ManualEvictExpiredClientsets()
+
+	assert.Equal(t, 2, k8cache.ClientsetCacheLen(), "only active entries should remain")
+}
+
+func TestEvictExpiredClientsets_Empty(t *testing.T) {
+	k8cache.ResetClientsetCache()
+
+	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
+
+	// Run eviction on empty cache
+	assert.NotPanics(t, func() {
+		k8cache.ManualEvictExpiredClientsets()
+	})
+
+	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
+}
+
+func TestEvictExpiredClientsets_BoundaryTTL(t *testing.T) {
+	k8cache.ResetClientsetCache()
+
+	// Nearly 10 minutes ago (should stay)
+	k8cache.SeedClientsetCache("at-boundary", time.Now().Add(-10*time.Minute+5*time.Second))
+
+	// Well over 10 minutes ago (should be evicted)
+	k8cache.SeedClientsetCache("past-boundary", time.Now().Add(-10*time.Minute-5*time.Second))
+
+	assert.Equal(t, 2, k8cache.ClientsetCacheLen())
+
+	// Run eviction
+	k8cache.ManualEvictExpiredClientsets()
+
+	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
+}
+
+func TestClientsetCacheLen_Accuracy(t *testing.T) {
+	k8cache.ResetClientsetCache()
+
+	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
+
+	k8cache.SeedClientsetCache("one", time.Now())
+	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
+
+	k8cache.SeedClientsetCache("two", time.Now())
+	assert.Equal(t, 2, k8cache.ClientsetCacheLen())
+}

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -2,9 +2,11 @@ package k8cache
 
 import (
 	"context"
+	"time"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"k8s.io/client-go/kubernetes"
 )
 
 // ExportedRunWatcher exposes runWatcher for testing.
@@ -51,4 +53,37 @@ func RegistryLoaded(key string) (watcher, cancel bool) {
 	_, cancel = contextCancel.Load(key)
 
 	return
+}
+
+// ResetClientsetCache clears the clientset cache for test isolation.
+func ResetClientsetCache() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	clientsetCache = make(map[string]*CachedClientSet)
+}
+
+// SeedClientsetCache populates the clientset cache with dummy entries for testing.
+func SeedClientsetCache(key string, lastUsed time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	clientsetCache[key] = &CachedClientSet{
+		clientset: &kubernetes.Clientset{},
+		lastUsed:  lastUsed,
+	}
+}
+
+// ManualEvictExpiredClientsets triggers the eviction logic immediately for testing.
+func ManualEvictExpiredClientsets() {
+	evictExpiredClientsets()
+}
+
+// ClientsetCacheLen returns the current number of entries in the
+// clientset cache. It is intended for use in tests.
+func ClientsetCacheLen() int {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return len(clientsetCache)
 }


### PR DESCRIPTION
### **Summary:** Fixes a progressive memory leak in the backend where expired Kubernetes Clientset objects are never actively evicted from the in-memory clientsetCache map, causing unbounded memory growth and eventual OOM crashes on busy clusters.

### **Fixes** #5285 

### **Changes:**

1. `backend/pkg/k8cache/authorization.go:` Added a background "janitor" goroutine that periodically sweeps the clientsetCache map and deletes entries whose lastUsed timestamp exceeds the 10-minute TTL. The janitor starts lazily on the first call to GetClientSet() using sync.Once, ensuring exactly one goroutine is ever spawned. Extracted the hardcoded 10*time.Minute into a named constant (clientsetTTL) for clarity. Added an exported ClientsetCacheLen() helper for test observability. The existing passive eviction inside GetClientSet is preserved as a belt-and-suspenders measure.
2. `backend/pkg/k8cache/eviction_test.go:` Added a comprehensive unit test suite with 6 test cases covering: all-expired entries are removed, all-active entries are preserved, mixed expired/active entries are handled correctly, empty cache does not panic, boundary TTL behavior (strict greater-than check), and ClientsetCacheLen accuracy.

### **Steps to Test:**

1. Run the new unit tests: cd backend && go test -v ./pkg/k8cache -run "TestEvict|TestClientsetCacheLen"
2. Verify all 6 tests pass.
3. Run the full package test suite to confirm no regressions: cd backend && go test -v ./pkg/k8cache/...
4. Verify the janitor log message appears in server logs after 5 minutes of uptime with expired sessions: "janitor: evicted N expired clientset(s), M remaining".