### PR TITLE
backend: k8cache: Fix corrupted cache keys due to fragile ExtractNamespace logic

### DIFF
--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -35,6 +35,11 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 )
 
+const (
+	apiPathSegment  = "api"
+	apisPathSegment = "apis"
+)
+
 // CachedResponseData stores information such as StatusCode, Headers, and Body.
 // It helps cache responses efficiently and serve them from the cache.
 type CachedResponseData struct {
@@ -76,14 +81,14 @@ func GetAPIGroup(path string) (apiGroup, version string, err error) {
 	parts := strings.Split(path, "/")
 
 	switch {
-	case len(parts) >= 4 && parts[3] == "api":
+	case len(parts) >= 4 && parts[3] == apiPathSegment:
 		// Core API group
 		apiGroup = ""
 
 		if len(parts) >= 5 {
 			version = parts[4]
 		}
-	case len(parts) >= 4 && parts[3] == "apis":
+	case len(parts) >= 4 && parts[3] == apisPathSegment:
 		// Named API group
 		if len(parts) >= 5 {
 			apiGroup = parts[4]
@@ -111,7 +116,21 @@ func ExtractNamespace(rawURL string) (string, string) {
 	var namespace, kind string
 
 	urls := strings.Split(rawURL, "/")
+
 	n := len(urls)
+	apiIdx := -1
+
+	// Kubernetes API paths either start directly at /api (index 1)
+	// or are proxied via /clusters/{name}/api (index 3)
+	if n > 1 && (urls[1] == apiPathSegment || urls[1] == apisPathSegment) {
+		apiIdx = 1
+	} else if n > 3 && urls[1] == "clusters" && (urls[3] == apiPathSegment || urls[3] == apisPathSegment) {
+		apiIdx = 3
+	}
+
+	if apiIdx == -1 {
+		return "", ""
+	}
 
 	for i := 0; i < n-1; i++ {
 		if urls[i] == "namespaces" {
@@ -120,7 +139,7 @@ func ExtractNamespace(rawURL string) (string, string) {
 		}
 	}
 
-	if len(urls) > 2 {
+	if n > 2 {
 		kind = urls[n-1]
 	}
 

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -253,6 +253,8 @@ func TestGetAPIGroup(t *testing.T) {
 
 // TestExtractNamespace verifies namespace extraction from different kinds
 // of URLs, including valid, empty, and malformed ones.
+//
+//nolint:funlen
 func TestExtractNamespace(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -295,6 +297,24 @@ func TestExtractNamespace(t *testing.T) {
 			urlPath:    url.URL{Path: "/api/v1/namespaces/dev/services/"},
 			namespaces: "dev",
 			kind:       "services",
+		},
+		{
+			name:       "internal cluster URL without API group",
+			urlPath:    url.URL{Path: "/clusters/production-cluster"},
+			namespaces: "",
+			kind:       "",
+		},
+		{
+			name:       "internal cluster URL with literal api segment",
+			urlPath:    url.URL{Path: "/clusters/api/overview"},
+			namespaces: "",
+			kind:       "",
+		},
+		{
+			name:       "internal plugin URL without API group",
+			urlPath:    url.URL{Path: "/plugins/my-custom-plugin"},
+			namespaces: "",
+			kind:       "",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
### **Summary:** Fixes a bug where internal cluster and plugin URLs were being incorrectly parsed as Kubernetes resources, leading to cache pollution and potential cache key collisions with "garbage" resource kinds.

### **Fixes** #5287

### **Changes:**

1. `backend/pkg/k8cache/cacheStore.go (ExtractNamespace)`: Replaced the fragile len(urls) > 2 check with robust URL parsing logic. The function now ensures it only extracts a resource "Kind" if the URL is a valid Kubernetes API path (verifying it contains an "api" or "apis" segment). Non-API URLs now safely return empty values, preventing them from being improperly cached.
2. `backend/pkg/k8cache/cacheStore_test.go`: Added new unit tests to explicitly verify that ExtractNamespace correctly ignores internal cluster URLs and plugin URLs, confirming they return empty namespace and kind strings.

### **Steps to Test:**

1. Run the targeted backend unit tests to verify the new URL parsing logic: cd backend && go test -v ./pkg/k8cache/... -run TestExtractNamespace
2. Run the full backend test suite to ensure no regressions across the caching layer: cd backend && go test -v ./pkg/k8cache/...
3. (Optional) Start the application locally (npm start) and navigate between clusters and plugins in the UI. Ensure that the backend logs no longer show unexpected "Kinds" (like cluster names) being stored in the cache.