### PR TITLE
backend: helm: Add authentication support for repositories

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -44,11 +44,15 @@ var errRepositoryNotFound = errors.New("repository not found")
 
 // add repository.
 type AddUpdateRepoRequest struct {
-	Name string `json:"name"`
-	URL  string `json:"url"`
-	// TODO: Figure out how to support auth
-	// like username, password, certfile etc
-	// https://github.com/helm/helm/blob/39ca699ca790e02ba36753dec6ba4177cc68d417/cmd/helm/repo_add.go#L169
+	Name                  string  `json:"name"`
+	URL                   string  `json:"url"`
+	Username              *string `json:"username,omitempty"`
+	Password              *string `json:"password,omitempty"`
+	CertFile              *string `json:"certFile,omitempty"`
+	KeyFile               *string `json:"keyFile,omitempty"`
+	CAFile                *string `json:"caFile,omitempty"`
+	InsecureSkipTLSVerify *bool   `json:"insecureSkipTLSVerify,omitempty"`
+	PassCredentialsAll    *bool   `json:"passCredentialsAll,omitempty"`
 }
 
 func (r AddUpdateRepoRequest) Validate() error {
@@ -97,7 +101,7 @@ func lockRepositoryFile(lockCtx context.Context, repositoryConfig string) (bool,
 const timeoutForLock = 30 * time.Second
 
 // Adds a repository with name, url to the helm config. Returns error if there is one.
-func addRepository(name string, url string, settings *cli.EnvSettings) error {
+func addRepository(req *AddUpdateRepoRequest, settings *cli.EnvSettings) error {
 	err := createFileIfNotThere(settings.RepositoryConfig)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "creating empty RepositoryConfig file")
@@ -131,8 +135,30 @@ func addRepository(name string, url string, settings *cli.EnvSettings) error {
 
 	// add repo
 	newRepo := &repo.Entry{
-		Name: name,
-		URL:  url,
+		Name: req.Name,
+		URL:  req.URL,
+	}
+
+	if req.Username != nil {
+		newRepo.Username = *req.Username
+	}
+	if req.Password != nil {
+		newRepo.Password = *req.Password
+	}
+	if req.CertFile != nil {
+		newRepo.CertFile = *req.CertFile
+	}
+	if req.KeyFile != nil {
+		newRepo.KeyFile = *req.KeyFile
+	}
+	if req.CAFile != nil {
+		newRepo.CAFile = *req.CAFile
+	}
+	if req.InsecureSkipTLSVerify != nil {
+		newRepo.InsecureSkipTLSverify = *req.InsecureSkipTLSVerify
+	}
+	if req.PassCredentialsAll != nil {
+		newRepo.PassCredentialsAll = *req.PassCredentialsAll
 	}
 
 	repo, err := repo.NewChartRepository(newRepo, getter.All(settings))
@@ -180,7 +206,7 @@ func (h *Handler) AddRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = addRepository(request.Name, request.URL, h.EnvSettings)
+	err = addRepository(&request, h.EnvSettings)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -347,7 +373,7 @@ func (h *Handler) RemoveRepo(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func UpdateRepository(name, url string, settings *cli.EnvSettings) error {
+func UpdateRepository(req *AddUpdateRepoRequest, settings *cli.EnvSettings) error {
 	err := createFileIfNotThere(settings.RepositoryConfig)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "creating empty RepositoryConfig file")
@@ -378,11 +404,53 @@ func UpdateRepository(name, url string, settings *cli.EnvSettings) error {
 		return err
 	}
 
+	var existingEntry *repo.Entry
+	for _, e := range repoFile.Repositories {
+		if e.Name == req.Name {
+			existingEntry = e
+			break
+		}
+	}
+
+	newEntry := &repo.Entry{Name: req.Name}
+	if existingEntry != nil {
+		newEntry.URL = existingEntry.URL
+		newEntry.Username = existingEntry.Username
+		newEntry.Password = existingEntry.Password
+		newEntry.CertFile = existingEntry.CertFile
+		newEntry.KeyFile = existingEntry.KeyFile
+		newEntry.CAFile = existingEntry.CAFile
+		newEntry.InsecureSkipTLSverify = existingEntry.InsecureSkipTLSverify
+		newEntry.PassCredentialsAll = existingEntry.PassCredentialsAll
+	}
+
+	if req.URL != "" {
+		newEntry.URL = req.URL
+	}
+	if req.Username != nil {
+		newEntry.Username = *req.Username
+	}
+	if req.Password != nil {
+		newEntry.Password = *req.Password
+	}
+	if req.CertFile != nil {
+		newEntry.CertFile = *req.CertFile
+	}
+	if req.KeyFile != nil {
+		newEntry.KeyFile = *req.KeyFile
+	}
+	if req.CAFile != nil {
+		newEntry.CAFile = *req.CAFile
+	}
+	if req.InsecureSkipTLSVerify != nil {
+		newEntry.InsecureSkipTLSverify = *req.InsecureSkipTLSVerify
+	}
+	if req.PassCredentialsAll != nil {
+		newEntry.PassCredentialsAll = *req.PassCredentialsAll
+	}
+
 	// update repo
-	repoFile.Update(&repo.Entry{
-		Name: name,
-		URL:  url,
-	})
+	repoFile.Update(newEntry)
 
 	err = repoFile.WriteFile(settings.RepositoryConfig, defaultNewConfigFileMode)
 	if err != nil {
@@ -414,7 +482,7 @@ func (h *Handler) UpdateRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = UpdateRepository(request.Name, request.URL, h.EnvSettings)
+	err = UpdateRepository(&request, h.EnvSettings)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -146,6 +146,46 @@ func TestAddRepository(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 		assert.Contains(t, rr.Body.String(), "url is required")
 	})
+
+	t.Run("add_repo_with_auth", func(t *testing.T) {
+		username := "testuser"
+		password := "testpass"
+		skipTLS := true
+		addRepo := helm.AddUpdateRepoRequest{
+			Name:                  "auth_test_repo",
+			URL:                   "https://kubernetes-sigs.github.io/headlamp/",
+			Username:              &username,
+			Password:              &password,
+			InsecureSkipTLSVerify: &skipTLS,
+		}
+
+		addRepoRequestJSON, err := json.Marshal(addRepo)
+		require.NoError(t, err)
+
+		addRepoRequest, err := http.NewRequestWithContext(context.Background(), "POST",
+			"/clusters/minikube/helm/repositories/charts", bytes.NewBuffer(addRepoRequestJSON))
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		helmHandler.AddRepo(rr, addRepoRequest)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		assert.True(t, checkRepoExists(t, helmHandler, "auth_test_repo"))
+
+		repoFile, err := repo.LoadFile(helmHandler.EnvSettings.RepositoryConfig)
+		require.NoError(t, err)
+		var found *repo.Entry
+		for _, e := range repoFile.Repositories {
+			if e.Name == "auth_test_repo" {
+				found = e
+				break
+			}
+		}
+		require.NotNil(t, found)
+		assert.Equal(t, "testuser", found.Username)
+		assert.Equal(t, "testpass", found.Password)
+		assert.True(t, found.InsecureSkipTLSverify)
+	})
 }
 
 // TestRemoveRepository.


### PR DESCRIPTION
## Summary
This PR implements authentication support for adding and updating Helm repositories in the backend, resolving an existing `TODO` in `backend/pkg/helm/repository.go`.

## Related Issue
N/A

## Changes
- **`backend/pkg/helm/repository.go`**: Updated the `AddUpdateRepoRequest` struct to include authentication fields mapping directly to `helm.sh/helm/v3/pkg/repo.Entry` (such as `Username`, `Password`, `CertFile`, `KeyFile`, `CAFile`, `InsecureSkipTLSverify`). Refactored `addRepository`, `UpdateRepository`, and their HTTP handlers to safely parse and persist these credentials.
- **`backend/pkg/helm/repository_test.go`**: Added `TestAddRepository/add_repo_with_auth` to ensure the authentication fields are properly parsed and passed through the Helm repository backend logic.

## Steps to Test
1. Make sure you are in the project root directory.
2. Run backend code formatting: `npm run backend:format`
3. Run the backend unit tests and ensure they pass successfully:
   ```bash
   cd backend && go test -v ./pkg/helm/...
4. Verify the CI workflows pass on the Pull Request.
## Screenshots
N/A - Backend API enhancement only.
## Notes for the Reviewer
The auth fields added map directly to the `repo.Entry` parameters in `helm.sh/helm/v3`. For the time being, this PR strictly implements the backend API support for parsing these credentials.