### PR TITLE
frontend: lib: Fix unit comparison blindness and decimal CPU truncation

### DIFF
--- a/frontend/src/components/resourceQuota/Details.tsx
+++ b/frontend/src/components/resourceQuota/Details.tsx
@@ -44,7 +44,7 @@ export function ResourceQuotaTable({
           label: t('translation|Used'),
           getter: item => {
             const normalizedUnit = normalizeUnit(item.name, item.used);
-            return compareUnits(item.used, normalizedUnit)
+            return compareUnits(item.used, normalizedUnit, item.name)
               ? normalizedUnit
               : `${item.used} (${normalizedUnit})`;
           },
@@ -53,7 +53,7 @@ export function ResourceQuotaTable({
           label: t('translation|Hard'),
           getter: item => {
             const normalizedUnit = normalizeUnit(item.name, item.hard);
-            return compareUnits(item.hard, normalizedUnit)
+            return compareUnits(item.hard, normalizedUnit, item.name)
               ? normalizedUnit
               : `${item.hard} (${normalizedUnit})`;
           },

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -262,7 +262,7 @@
                             <td
                               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                             >
-                              300m (0.3 cores)
+                              0.3 cores
                             </td>
                           </tr>
                           <tr
@@ -276,12 +276,12 @@
                             <td
                               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                             >
-                              500m (0.5 cores)
+                              0.5 cores
                             </td>
                             <td
                               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                             >
-                              200m (0.2 cores)
+                              0.2 cores
                             </td>
                           </tr>
                         </tbody>

--- a/frontend/src/lib/units.test.ts
+++ b/frontend/src/lib/units.test.ts
@@ -23,6 +23,13 @@ describe('parseRam', () => {
     expect(parseRam('')).toBe(0);
   });
 
+  it('should reject invalid inputs with trailing digits or signs', () => {
+    expect(parseRam('1Ki3')).toBeNaN();
+    expect(parseRam('1+6')).toBeNaN();
+    expect(parseRam('1Ki-3')).toBeNaN();
+    expect(parseRam('1M+2')).toBeNaN();
+  });
+
   it('should parse binary units', () => {
     expect(parseRam('1Ki')).toBe(1024);
     expect(parseRam('1Mi')).toBe(1024 * 1024);
@@ -31,6 +38,8 @@ describe('parseRam', () => {
 
   it('should parse decimal units', () => {
     expect(parseRam('1K')).toBe(1000);
+    expect(parseRam('1k')).toBe(1000);
+    expect(parseRam('1ki')).toBe(1024);
     expect(parseRam('1M')).toBe(1000000);
     expect(parseRam('1G')).toBe(1000000000);
   });
@@ -38,6 +47,17 @@ describe('parseRam', () => {
   it('should parse exponential notation', () => {
     expect(parseRam('1e3')).toBe(1000);
     expect(parseRam('1e6')).toBe(1000000);
+    expect(parseRam('1E3')).toBe(1000);
+    expect(parseRam('1E6')).toBe(1000000);
+    expect(parseRam('1e-3')).toBe(0.001);
+    expect(parseRam('1.5e-3')).toBe(0.0015);
+    expect(parseRam('1E+6')).toBe(1000000);
+    expect(parseRam('1e')).toBeNaN();
+  });
+
+  it('should parse exabytes correctly', () => {
+    expect(parseRam('1E')).toBe(1000 ** 6);
+    expect(parseRam('1Ei')).toBe(1024 ** 6);
   });
 
   it('should parse decimal values with binary units', () => {
@@ -91,6 +111,12 @@ describe('parseRam', () => {
         expect(result).toBeGreaterThanOrEqual(0);
       })
     );
+  });
+
+  it('should trim surrounding whitespace', () => {
+    expect(parseRam(' 1000 ')).toBe(1000);
+    expect(parseRam(' 1Ki\n')).toBe(1024);
+    expect(parseRam('\t1Mi ')).toBe(1024 * 1024);
   });
 });
 
@@ -168,6 +194,25 @@ describe('parseCpu', () => {
         expect(result).toBeGreaterThanOrEqual(0);
       })
     );
+  });
+
+  it('should trim surrounding whitespace', () => {
+    expect(parseCpu(' 1n ')).toBe(1);
+    expect(parseCpu(' 1u\n')).toBe(1000);
+    expect(parseCpu('\t1m ')).toBe(1000000);
+    expect(parseCpu(' 1 ')).toBe(1000000000);
+  });
+
+  it('should handle fractional CPU values', () => {
+    expect(parseCpu('0.5')).toBe(500000000);
+    expect(parseCpu('0.1')).toBe(100000000);
+    expect(parseCpu('1.5')).toBe(1500000000);
+  });
+
+  it('should avoid floating-point artifacts', () => {
+    expect(parseCpu('0.3')).toBe(300000000);
+    expect(parseCpu('0.1')).toBe(100000000);
+    expect(parseCpu('0.000000001')).toBe(1);
   });
 });
 

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -38,20 +38,64 @@ export function parseRam(value: string) {
 function parseUnitsOfBytes(value: string): number {
   if (!value) return 0;
 
-  const groups = value.match(/(\d+(?:\.\d+)?)([BKMGTPEe])?(i)?(\d+)?/) || [];
+  const trimmedValue = value.trim();
+
+  const fractionalUnits: Record<string, number> = {
+    m: 1e-3,
+    u: 1e-6,
+    n: 1e-9,
+    p: 1e-12,
+    f: 1e-15,
+    a: 1e-18,
+  };
+
+  const groups =
+    trimmedValue.match(/^([+-]?(?:\d+\.\d*|\.\d+|\d+))([BKMGTPEek])?(i)?([+-]?\d+)?$/) || [];
+  if (groups.length === 0) {
+    // Check for fractional units like 'm' (millibytes/units - unlikely but spec allows it for generic Quantity)
+    const fractionalGroups = trimmedValue.match(/^([+-]?(?:\d+\.\d*|\.\d+|\d+))([munpfa])$/) || [];
+    if (fractionalGroups.length > 0) {
+      const num = parseFloat(fractionalGroups[1]);
+      const unit = fractionalGroups[2];
+      return num * fractionalUnits[unit];
+    }
+    return Number.NaN;
+  }
   const number = parseFloat(groups[1]);
+
+  // We treat the value as scientific notation only when the unit marker is 'e' or 'E',
+  // an exponent is present in groups[4], and there is no binary suffix marker in groups[3].
+  // Without an exponent (for example, '1E'), 'E' is treated as the Exabytes unit.
+  const isScientific =
+    (groups[2] === 'e' || groups[2] === 'E') && groups[4] !== undefined && groups[3] === undefined;
+
+  // An exponent-like trailing match is only allowed as part of scientific notation.
+  // Otherwise, inputs like "1Ki3" or "1+6" must be rejected.
+  if (groups[4] !== undefined && !isScientific) {
+    return Number.NaN;
+  }
 
   // number ex. 1000
   if (groups[2] === undefined) {
     return number;
   }
 
-  // number with exponent ex. 1e3
-  if (groups[4] !== undefined) {
-    return number * 10 ** parseInt(groups[4], 10);
+  if (isScientific) {
+    const exponent = groups[4] ? parseInt(groups[4], 10) : 0;
+    return number * 10 ** exponent;
   }
 
-  const unitIndex = _.indexOf(UNITS, groups[2]);
+  const unit = groups[2];
+  const unitIndex = _.indexOf(UNITS, unit);
+
+  if (unitIndex === -1) {
+    // Handle lowercase 'k' which is common but not in our uppercase UNITS list.
+    // If it is followed by the binary suffix marker ('ki'), treat it like 'Ki'.
+    if (groups[2] === 'k') {
+      return groups[3] !== undefined ? number * 1024 : number * 1000;
+    }
+    return Number.NaN;
+  }
 
   // Unit + i ex. 1Ki
   if (groups[3] !== undefined) {
@@ -78,11 +122,12 @@ export function unparseRam(value: number) {
 export function parseCpu(value: string) {
   if (!value) return 0;
 
-  const number = parseInt(value, 10);
-  if (value.endsWith('n')) return number;
-  if (value.endsWith('u')) return number * 1000;
-  if (value.endsWith('m')) return number * 1000 * 1000;
-  return number * 1000 * 1000 * 1000;
+  const trimmedValue = value.trim();
+  const number = parseFloat(trimmedValue);
+  if (trimmedValue.endsWith('n')) return Math.round(number);
+  if (trimmedValue.endsWith('u')) return Math.round(number * 1000);
+  if (trimmedValue.endsWith('m')) return Math.round(number * 1000 * 1000);
+  return Math.round(number * 1000 * 1000 * 1000);
 }
 
 export function unparseCpu(value: string) {

--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -16,6 +16,7 @@
 
 import {
   combineClusterListErrors,
+  compareUnits,
   flattenClusterListItems,
   formatDuration,
   normalizeUnit,
@@ -197,6 +198,51 @@ describe('formatDuration (Kubernetes apimachinery parity)', () => {
   });
 });
 
+describe('compareUnits', () => {
+  it('should return true for equal quantities with different suffixes', () => {
+    expect(compareUnits('1Gi', '1024Mi')).toBe(true);
+    expect(compareUnits('1Mi', '1024Ki')).toBe(true);
+    expect(compareUnits('1', '1000m')).toBe(true);
+  });
+
+  it('should return false for different quantities', () => {
+    expect(compareUnits('1Gi', '1Mi')).toBe(false);
+    expect(compareUnits('1', '0.5')).toBe(false);
+  });
+
+  it('should handle nanocores and microcores', () => {
+    expect(compareUnits('1u', '1000n')).toBe(true);
+    expect(compareUnits('1m', '1000u')).toBe(true);
+  });
+
+  it('should handle decimal CPU values without suffix', () => {
+    expect(compareUnits('0.5', '500m')).toBe(true);
+    expect(compareUnits('0.5', '0.6')).toBe(false);
+  });
+
+  it('should not misclassify memory SI units as CPU', () => {
+    // '1M' (memory megabyte) must not be lowercased into '1m' (CPU millicores)
+    expect(compareUnits('1M', '1m')).toBe(false);
+    expect(compareUnits('1Gi', '1Gi')).toBe(true);
+  });
+
+  it('should handle memory decimal SI prefixes including lowercase k', () => {
+    expect(compareUnits('1M', '1000k')).toBe(true);
+    expect(compareUnits('1G', '1000M')).toBe(true);
+    expect(compareUnits('1k', '1000')).toBe(true);
+  });
+
+  it('should use resourceType to disambiguate when provided', () => {
+    expect(compareUnits('500m', '0.5', 'cpu')).toBe(true);
+    expect(compareUnits('1024', '1Ki', 'memory')).toBe(true);
+    expect(compareUnits('1.5Gi', '1536Mi', 'memory')).toBe(true);
+    expect(compareUnits('1000m', '1', 'memory')).toBe(true);
+    expect(compareUnits('1000000u', '1', 'memory')).toBe(true);
+    expect(compareUnits('1000000000n', '1', 'memory')).toBe(true);
+    expect(compareUnits('2Mi', '2048Ki', 'requests.hugepages-2Mi')).toBe(true);
+  });
+});
+
 describe('timeAgo', () => {
   it('matches formatDuration for the fixed test clock offset (UNDER_TEST)', () => {
     const start = new Date('2020-06-15T12:00:00.000Z');
@@ -302,6 +348,15 @@ describe('normalizeUnit', () => {
     it('handles empty string gracefully', () => {
       expect(normalizeUnit('memory', '')).toBe('');
     });
+
+    it('returns the original quantity if parsing fails (NaN guard)', () => {
+      expect(normalizeUnit('cpu', 'invalid')).toBe('invalid');
+      expect(normalizeUnit('memory', 'not-a-number')).toBe('not-a-number');
+    });
+
+    it('returns the original quantity for non-finite values (Infinity guard)', () => {
+      expect(normalizeUnit('cpu', '1e309')).toBe('1e309');
+    });
   });
 
   describe('cpu', () => {
@@ -315,6 +370,19 @@ describe('normalizeUnit', () => {
 
     it('shows plural cores', () => {
       expect(normalizeUnit('cpu', '2')).toBe('2 cores');
+    });
+
+    it('converts microcores', () => {
+      expect(normalizeUnit('cpu', '1000u')).toBe('0.001 cores');
+    });
+
+    it('converts nanocores', () => {
+      expect(normalizeUnit('cpu', '1000000n')).toBe('0.001 cores');
+    });
+
+    it('formats very small nanocores without scientific notation', () => {
+      expect(normalizeUnit('cpu', '1n')).toBe('0.000000001 cores');
+      expect(normalizeUnit('cpu', '10n')).toBe('0.00000001 cores');
     });
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -466,14 +466,48 @@ export function useURLState<T extends string | number | undefined = string>(
   return [value, setValue] as [T, React.Dispatch<React.SetStateAction<T>>];
 }
 
-// compareUnits compares two units and returns true if they are equal
-export function compareUnits(quantity1: string, quantity2: string) {
-  // strip whitespace and convert to lowercase
-  const qty1 = quantity1.replace(/\s/g, '').toLowerCase();
-  const qty2 = quantity2.replace(/\s/g, '').toLowerCase();
+/**
+ * Compares two Kubernetes resource quantities and returns true if they are equal.
+ * Known call site: ResourceQuota/Details.tsx.
+ * When possible, callers should pass resourceType (e.g. 'cpu', 'memory') for unambiguous comparison.
+ */
+export function compareUnits(quantity1: string, quantity2: string, resourceType?: string) {
+  // strip whitespace
+  const qty1 = quantity1.replace(/\s/g, '');
+  const qty2 = quantity2.replace(/\s/g, '');
 
-  // compare numbers
-  return parseInt(qty1) === parseInt(qty2);
+  const type = resourceType?.toLowerCase() || '';
+  const lastToken = type.split('.').pop() || '';
+  const isExplicitCpu = lastToken === 'cpu';
+  const isExplicitMemory =
+    lastToken === 'memory' ||
+    lastToken === 'storage' ||
+    lastToken === 'ephemeral-storage' ||
+    lastToken.startsWith('hugepages-');
+
+  // Match CPU suffixes case-sensitively to avoid misclassifying memory 'M' as CPU 'm'
+  const hasCpuSuffix = (val: string) => /[mun]$/.test(val);
+  // Plain decimal values (e.g. '0.5') without any suffix are CPU cores
+  const isPlainDecimalCpu = (val: string) => /^[+-]?(?:\d+\.\d*|\.\d+)$/.test(val);
+
+  if (isExplicitCpu) {
+    return parseCpu(qty1) === parseCpu(qty2);
+  }
+  if (isExplicitMemory) {
+    return parseRam(qty1) === parseRam(qty2);
+  }
+
+  // Fallback to heuristic if type is unknown
+  if (
+    hasCpuSuffix(qty1) ||
+    hasCpuSuffix(qty2) ||
+    isPlainDecimalCpu(qty1) ||
+    isPlainDecimalCpu(qty2)
+  ) {
+    return parseCpu(qty1) === parseCpu(qty2);
+  }
+
+  return parseRam(qty1) === parseRam(qty2);
 }
 
 export function normalizeUnit(resourceType: string, quantity: string) {
@@ -486,16 +520,23 @@ export function normalizeUnit(resourceType: string, quantity: string) {
   let normalizedQuantity = '';
   let bytes = 0;
   switch (type) {
-    case 'cpu':
-      normalizedQuantity = quantity?.endsWith('m')
-        ? `${Number(quantity.substring(0, quantity.length - 1)) / 1000}`
-        : `${quantity}`;
+    case 'cpu': {
+      const cpuValue = parseCpu(quantity);
+      if (!Number.isFinite(cpuValue)) {
+        return quantity;
+      }
+      const cores = cpuValue / 1000000000;
+      normalizedQuantity = cores
+        .toFixed(9)
+        .replace(/(\.\d*?[1-9])0+$/, '$1')
+        .replace(/\.0+$/, '');
       if (normalizedQuantity === '1') {
         normalizedQuantity = normalizedQuantity + ' ' + 'core';
       } else {
         normalizedQuantity = normalizedQuantity + ' ' + 'cores';
       }
       break;
+    }
 
     case 'memory':
       /**


### PR DESCRIPTION
### **Summary:** Fixes a critical P1 frontend logic bug where resource quantities with different units (e.g., 1Gi vs 1Mi) were incorrectly compared as equal due to `parseInt` usage. Also fixes decimal truncation where fractional CPU values (e.g., 0.5) were parsed as 0.

### **Fixes:** #5297 

### **Changes:**

1. `frontend/src/lib/units.ts (parseCpu):` Replaced `parseInt` with `parseFloat` to ensure decimal CPU values (like 0.5) are accurately converted instead of truncated to zero.
2. `frontend/src/lib/util.ts (compareUnits):` Removed the incorrect `toLowerCase()` which broke case-sensitive unit parsing (like `Gi`), and upgraded the comparison to use the robust `parseRam` and `parseCpu` functions instead of `parseInt`.
3. `frontend/src/lib/util.ts (normalizeUnit):` Added missing support for standard Kubernetes CPU units: nanocores (`n`) and microcores (`u`).
4. `frontend/src/lib/units.test.ts:` Added unit tests to explicitly verify that fractional CPU values are calculated correctly.
5. `frontend/src/lib/util.test.ts:` Added new unit tests covering cross-unit comparisons (e.g., 1Gi vs 1024Mi) and nano/micro-core normalization.

### **Steps to Test:**
1. Run the frontend unit tests to verify the new comparison and parsing logic: `npm run frontend:test -- src/lib/units.test.ts src/lib/util.test.ts`
2. Run the full frontend test suite to ensure no regressions: `npm run frontend:test`
3. (Optional) Start the application locally (`npm start`), edit a Deployment, change its memory from 1Gi to 1Mi, and observe that the "Apply" button now correctly lights up because it detects the change.