### PR TITLE
backend: serviceproxy: Prevent path traversal in proxy URIs

### DIFF
--- a/backend/pkg/serviceproxy/connection.go
+++ b/backend/pkg/serviceproxy/connection.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"path"
+	"strings"
 )
 
 // ServiceConnection represents a connection to a service.
@@ -35,8 +37,17 @@ func (c *Connection) Get(requestURI string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid request uri: %w", err)
 	}
 
-	if rel.IsAbs() {
+	if rel.IsAbs() || rel.Host != "" || rel.User != nil {
 		return nil, fmt.Errorf("request uri must be a relative path")
+	}
+
+	if rel.Path != "" {
+		cleaned := path.Clean(rel.Path)
+		if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+			return nil, fmt.Errorf("request uri must not traverse above base path")
+		}
+
+		rel.Path = cleaned
 	}
 
 	fullURL := base.ResolveReference(rel)

--- a/backend/pkg/serviceproxy/connection_test.go
+++ b/backend/pkg/serviceproxy/connection_test.go
@@ -76,6 +76,27 @@ var getTests = []struct {
 		wantBody:   nil,
 		wantErr:    true,
 	},
+	{
+		name:       "protocol-relative URI rejected",
+		uri:        "http://example.com",
+		requestURI: "//evil.example/path",
+		wantBody:   nil,
+		wantErr:    true,
+	},
+	{
+		name:       "path traversal with ../ rejected",
+		uri:        "http://example.com",
+		requestURI: "../secret",
+		wantBody:   nil,
+		wantErr:    true,
+	},
+	{
+		name:       "empty path resolves without error",
+		uri:        "http://example.com",
+		requestURI: "",
+		wantBody:   []byte("Hello, World!"),
+		wantErr:    false,
+	},
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
This change hardens the service proxy URI validation. It rejects protocol-relative URLs (`//host/path`) that could redirect requests to arbitrary hosts, blocks `..` path traversal, and safely handles empty-path requests. Tests are added for the new security checks.