### PR TITLE
frontend: App: Fix react-hooks lint warnings

### DIFF
--- a/frontend/src/components/App/CreateCluster/AddCluster.stories.tsx
+++ b/frontend/src/components/App/CreateCluster/AddCluster.stories.tsx
@@ -110,22 +110,17 @@ export const WithPluginCatalog: Story = {
   decorators: [
     Story => {
       function ElectronStoryDecorator() {
-        const originalProcess = React.useRef((window as any).process);
-
-        const didSetProcess = React.useRef(false);
-        if (!didSetProcess.current) {
+        React.useEffect(() => {
+          const original = (window as any).process;
           (window as any).process = {
-            ...(originalProcess.current ?? {}),
+            ...(original ?? {}),
             type: 'renderer',
           };
-          didSetProcess.current = true;
-        }
-        React.useEffect(() => {
           return () => {
-            if (originalProcess.current === undefined) {
+            if (original === undefined) {
               delete (window as any).process;
             } else {
-              (window as any).process = originalProcess.current;
+              (window as any).process = original;
             }
           };
         }, []);

--- a/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.WithPluginCatalog.stories.storyshot
+++ b/frontend/src/components/App/CreateCluster/__snapshots__/AddCluster.WithPluginCatalog.stories.storyshot
@@ -99,23 +99,6 @@
                     Providers
                   </h4>
                 </div>
-                <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
-                >
-                  <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-5534ty-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <span
-                      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
-                    />
-                    Add Local Cluster Provider
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
These changes fix two `react-hooks` lint warnings in `AddCluster.stories.tsx` decorator by moving the `window.process` mutation into a `useEffect` and capturing the original value in a local variable rather than a ref. The related storyshot snapshot is updated accordingly.

### Testing

- Run `cd frontend && npm run ci-lint` and ensure it passes
