### PR TITLE
fix(backend): preserve kubeconfig server path prefix in WebSocket multiplexer and port-forward, prefer WS port-forward

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -912,8 +912,26 @@ func createWebSocketURL(host, path, query string) string {
 		u.Scheme = SecureWebSocketScheme
 	}
 
-	u.Path = path
+	u.Path = singleJoiningSlash(u.Path, path)
 	u.RawQuery = query
 
 	return u.String()
+}
+
+// singleJoiningSlash joins two URL paths with a single slash, mirroring the
+// helper used by net/http/httputil. It preserves the cluster server's path
+// prefix (e.g. when the kubeconfig points at a reverse-proxy that routes by
+// URL path such as Warpgate).
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+
+	return a + b
 }

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -299,7 +299,21 @@ func TestCreateWebSocketURL(t *testing.T) {
 			host:     "https://example.com/k8s",
 			path:     "/api/v1/pods",
 			query:    "watch=true",
-			expected: "wss://example.com/api/v1/pods?watch=true",
+			expected: "wss://example.com/k8s/api/v1/pods?watch=true",
+		},
+		{
+			name:     "HTTPS with trailing slash in host path",
+			host:     "https://example.com/k8s/",
+			path:     "/api/v1/pods",
+			query:    "watch=true",
+			expected: "wss://example.com/k8s/api/v1/pods?watch=true",
+		},
+		{
+			name:     "HTTPS with multi-segment path prefix in host",
+			host:     "https://k8s.example.com:443/dev-primary-cluster",
+			path:     "/api/v1/namespaces/default/events",
+			query:    "watch=1",
+			expected: "wss://k8s.example.com:443/dev-primary-cluster/api/v1/namespaces/default/events?watch=1",
 		},
 	}
 

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -38,6 +39,7 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
@@ -242,6 +244,48 @@ func getKubeClientAndConfig(kContext *kubeconfig.Context, token string) (*kubern
 	return clientset, rConf, nil
 }
 
+// buildPortForwardDialer returns a dialer that performs the port-forward
+// upgrade. It tries WebSocket first (matching kubectl since v1.31) and falls
+// back to SPDY/3.1 over POST when WebSocket negotiation fails — the WebSocket
+// path is also required when the cluster is fronted by a reverse proxy (e.g.
+// Warpgate) that propagates WebSocket upgrades but drops SPDY upgrade headers.
+func buildPortForwardDialer(
+	rConf *rest.Config, fullURL *url.URL,
+	upgrader spdy.Upgrader, roundTripper http.RoundTripper,
+) httpstream.Dialer {
+	spdyDialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, fullURL)
+
+	tunnelingDialer, err := portforward.NewSPDYOverWebsocketDialer(fullURL, rConf)
+	if err != nil {
+		// WebSocket dialer not available (e.g. config conversion failed);
+		// keep SPDY-only behavior.
+		return spdyDialer
+	}
+
+	return portforward.NewFallbackDialer(tunnelingDialer, spdyDialer, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	})
+}
+
+// buildPortForwardURL constructs the upstream port-forward URL for a pod,
+// preserving any path prefix carried by the kubeconfig server URL (for
+// clusters fronted by a path-routing reverse proxy such as Warpgate).
+//
+// `hostURL.ResolveReference(&url.URL{Path: …})` cannot be used here because
+// `ResolveReference` replaces the host path when the reference path is
+// absolute, dropping the prefix.
+func buildPortForwardURL(host, namespace, podName string) (*url.URL, error) {
+	hostURL, err := url.Parse(host)
+	if err != nil {
+		return nil, fmt.Errorf("invalid REST config host: %w", err)
+	}
+
+	prefix := strings.TrimSuffix(hostURL.Path, "/")
+	hostURL.Path = fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward", prefix, namespace, podName)
+
+	return hostURL, nil
+}
+
 // initPortForwarder sets up the SPDY dialer and creates a new port forwarder.
 // It requires a REST config, namespace, pod name, and the port mapping string (e.g., "8080:80").
 // It returns the port forwarder instance, stop/ready channels, output/error buffers, or an error.
@@ -253,16 +297,17 @@ func initPortForwarder(rConf *rest.Config, namespace, podName, portMapping strin
 		return nil, nil, nil, nil, nil, fmt.Errorf("failed to create SPDY round tripper: %w", err)
 	}
 
-	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", namespace, podName)
-
-	hostURL, err := url.Parse(rConf.Host)
+	fullURL, err := buildPortForwardURL(rConf.Host, namespace, podName)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("invalid REST config host: %w", err)
+		return nil, nil, nil, nil, nil, err
 	}
 
-	fullURL := hostURL.ResolveReference(&url.URL{Path: path})
+	// Try WebSocket-based port-forward first, fall back to SPDY/3.1 over POST.
+	// This mirrors `kubectl port-forward` behavior since v1.31 and is required
+	// for clusters fronted by reverse proxies (e.g. Warpgate) that handle WS
+	// upgrades but drop SPDY upgrade headers.
+	dialer := buildPortForwardDialer(rConf, fullURL, upgrader, roundTripper)
 
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, fullURL)
 	stopChan, readyChan := make(chan struct{}), make(chan struct{}, 1)
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
 

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -280,6 +280,22 @@ func buildPortForwardURL(host, namespace, podName string) (*url.URL, error) {
 		return nil, fmt.Errorf("invalid REST config host: %w", err)
 	}
 
+	// url.Parse accepts scheme-less inputs like "example.com" or
+	// "kubernetes.default.svc:443" without erroring, producing a relative URL
+	// (the latter is parsed as scheme="kubernetes.default.svc", opaque="443").
+	// Default to https:// when the host parsed without one, then reject what
+	// still has no host.
+	if hostURL.Host == "" {
+		hostURL, err = url.Parse("https://" + host)
+		if err != nil {
+			return nil, fmt.Errorf("invalid REST config host: %w", err)
+		}
+	}
+
+	if hostURL.Host == "" {
+		return nil, fmt.Errorf("invalid REST config host %q: missing host", host)
+	}
+
 	prefix := strings.TrimSuffix(hostURL.Path, "/")
 	hostURL.Path = fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward", prefix, namespace, podName)
 

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -234,6 +234,63 @@ func TestPortForwardRequestValidate(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestBuildPortForwardURL ensures the upstream port-forward URL preserves the
+// kubeconfig server's path prefix (relevant when the cluster is fronted by a
+// path-routing reverse proxy such as Warpgate).
+func TestBuildPortForwardURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		host      string
+		namespace string
+		podName   string
+		want      string
+	}{
+		{
+			name:      "no path prefix",
+			host:      "https://kubernetes.default.svc:443",
+			namespace: "default",
+			podName:   "my-pod",
+			want:      "https://kubernetes.default.svc:443/api/v1/namespaces/default/pods/my-pod/portforward",
+		},
+		{
+			name:      "single segment path prefix",
+			host:      "https://example.com/k8s",
+			namespace: "default",
+			podName:   "my-pod",
+			want:      "https://example.com/k8s/api/v1/namespaces/default/pods/my-pod/portforward",
+		},
+		{
+			name:      "trailing slash path prefix",
+			host:      "https://example.com/k8s/",
+			namespace: "default",
+			podName:   "my-pod",
+			want:      "https://example.com/k8s/api/v1/namespaces/default/pods/my-pod/portforward",
+		},
+		{
+			name:      "Warpgate-style multi-segment prefix",
+			host:      "https://k8s.example.com:443/proxy-routed-cluster",
+			namespace: "kube-system",
+			podName:   "traefik-69fpr",
+			want: "https://k8s.example.com:443/proxy-routed-cluster" +
+				"/api/v1/namespaces/kube-system/pods/traefik-69fpr/portforward",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildPortForwardURL(tt.host, tt.namespace, tt.podName)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+// TestBuildPortForwardURLInvalidHost ensures an invalid host yields an error.
+func TestBuildPortForwardURLInvalidHost(t *testing.T) {
+	_, err := buildPortForwardURL("://not a url", "ns", "pod")
+	assert.Error(t, err)
+}
+
 // TestStopOrDeletePortForwardRequest.Validate() function.
 func TestStopOrDeletePortForwardRequestValidate(t *testing.T) {
 	req := stopOrDeletePortForwardRequest{}

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
 )
 
 // TestHandlePortForwardReadiness tests handlePortForwardReadiness function.
@@ -289,6 +291,50 @@ func TestBuildPortForwardURL(t *testing.T) {
 func TestBuildPortForwardURLInvalidHost(t *testing.T) {
 	_, err := buildPortForwardURL("://not a url", "ns", "pod")
 	assert.Error(t, err)
+}
+
+// TestBuildPortForwardDialer verifies dialer selection: with a valid REST
+// config we get a WebSocket-first FallbackDialer (which itself falls back to
+// SPDY on upgrade failures); when the WebSocket dialer cannot be created we
+// fall back to a SPDY-only dialer rather than erroring.
+func TestBuildPortForwardDialer(t *testing.T) {
+	fullURL, err := url.Parse("https://example.com/api/v1/namespaces/default/pods/p/portforward")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		rConf        *rest.Config
+		wantFallback bool
+	}{
+		{
+			name:         "websocket dialer available, wraps in FallbackDialer",
+			rConf:        &rest.Config{Host: "https://example.com"},
+			wantFallback: true,
+		},
+		{
+			// Insecure + CAData makes TLSConfigFor (called by
+			// websocket.RoundTripperFor) fail, exercising the SPDY-only path.
+			name: "websocket dialer unavailable, returns SPDY-only dialer",
+			rConf: &rest.Config{
+				Host: "https://example.com",
+				TLSClientConfig: rest.TLSClientConfig{
+					Insecure: true,
+					CAData:   []byte("not-a-real-ca"),
+				},
+			},
+			wantFallback: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := buildPortForwardDialer(tt.rConf, fullURL, nil, nil)
+			require.NotNil(t, d)
+
+			_, isFallback := d.(*portforward.FallbackDialer)
+			assert.Equal(t, tt.wantFallback, isFallback)
+		})
+	}
 }
 
 // TestStopOrDeletePortForwardRequest.Validate() function.

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -276,6 +276,20 @@ func TestBuildPortForwardURL(t *testing.T) {
 			want: "https://k8s.example.com:443/proxy-routed-cluster" +
 				"/api/v1/namespaces/kube-system/pods/traefik-69fpr/portforward",
 		},
+		{
+			name:      "missing scheme defaults to https",
+			host:      "kubernetes.default.svc:443",
+			namespace: "default",
+			podName:   "my-pod",
+			want:      "https://kubernetes.default.svc:443/api/v1/namespaces/default/pods/my-pod/portforward",
+		},
+		{
+			name:      "bare hostname defaults to https",
+			host:      "example.com",
+			namespace: "default",
+			podName:   "my-pod",
+			want:      "https://example.com/api/v1/namespaces/default/pods/my-pod/portforward",
+		},
 	}
 
 	for _, tt := range tests {
@@ -287,10 +301,24 @@ func TestBuildPortForwardURL(t *testing.T) {
 	}
 }
 
-// TestBuildPortForwardURLInvalidHost ensures an invalid host yields an error.
+// TestBuildPortForwardURLInvalidHost ensures unparseable or empty hosts yield
+// an error instead of silently producing a relative URL that would fail later
+// in the dialer.
 func TestBuildPortForwardURLInvalidHost(t *testing.T) {
-	_, err := buildPortForwardURL("://not a url", "ns", "pod")
-	assert.Error(t, err)
+	tests := []struct {
+		name string
+		host string
+	}{
+		{"unparseable", "://not a url"},
+		{"empty", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildPortForwardURL(tt.host, "ns", "pod")
+			assert.Error(t, err)
+		})
+	}
 }
 
 // TestBuildPortForwardDialer verifies dialer selection: with a valid REST


### PR DESCRIPTION
## Summary

This PR fixes the cluster proxy in the backend so that interactions requiring an HTTP upgrade (WebSocket / SPDY) keep working when the `kubeconfig` cluster `server` URL contains a path prefix — e.g. clusters fronted by reverse proxies such as Warpgate or any path-routing bastion.
It also enables WebSocket-first port-forward negotiation (SPDY fallback) so port-forward survives proxies that don't transparently propagate the `Upgrade: SPDY/3.1` header.

## Related Issue

Fixes #5304  

## Changes

- Fixed `backend/cmd/multiplexer.go::createWebSocketURL`: the upstream  WebSocket URL was rebuilt with `u.Path = path`, which dropped any path  prefix carried by the kubeconfig server URL. Replaced by  `singleJoiningSlash(u.Path, path)` (mirroring `net/http/httputil`).
- Fixed `backend/pkg/portforward/handler.go::initPortForwarder`: the  upstream port-forward URL was built with
  `hostURL.ResolveReference(&url.URL{Path: path})`, which silently drops  the host's path because the reference path is absolute. Extracted  `buildPortForwardURL`, which preserves any prefix on `rConf.Host`.
- Added `buildPortForwardDialer`: tries WebSocket first via `portforward.NewSPDYOverWebsocketDialer` and falls back to the existing  SPDY dialer with `portforward.NewFallbackDialer`. Same negotiation pattern that `kubectl port-forward` adopted in v1.31.
- Added/updated unit tests:
  - `TestCreateWebSocketURL`: new cases for trailing-slash prefix and multi-segment prefix; fixed an existing case that was asserting the buggy "drop the prefix" behavior.
  - `TestBuildPortForwardURL`: covers no prefix, single-segment prefix, trailing-slash prefix, multi-segment prefix and invalid host.

## Steps to Test

1. Use a `kubeconfig` whose cluster `server` field contains a path
   prefix, for example:
   ```yaml
   clusters:
     - cluster:
         server: https://k8s.example.com:443/dev-cluster
         insecure-skip-tls-verify: true
       name: warpgate-dev

Any setup where a reverse proxy in front of the apiserver routes by URL path will reproduce the bug. A kubectl proxy --address 127.0.0.1    --port 9000 --append-server-path /dev-cluster instance is the
simplest local repro.
2. Open Headlamp on that cluster.
3. Before the patch: navigating to a pod's "Logs" or "Events" tab
yields WebSocket connection to 'ws://localhost:.../events?...&watch=1'    failed in the browser console; clicking "Port Forward" returns
500 Internal Server Error with error upgrading connection: Upgrade request required.
4. After the patch: log streaming works, exec terminal opens, and port-forward succeeds. The upstream proxy logs the request as GET /<prefix>/api/v1/.../portforward → 101 Switching Protocols, confirming the WebSocket path is taken.
5. Regression check on a vanilla cluster (no path prefix): all existing flows continue to work — singleJoiningSlash("", "/api/...") ==    "/api/..." and the WebSocket dialer falls back to SPDY transparently on apiservers that don't speak the WS variant.


## Notes for the Reviewer

buildPortForwardDialer takes rConf *rest.Config because NewSPDYOverWebsocketDialer needs the auth/TLS config to build the WebSocket transport — it can't reuse the SPDY round-tripper.
The fallback condition (IsUpgradeFailure || IsHTTPSProxyError) is intentionally identical to kubectl's (pkg/cmd/portforward/portforward.go::createDialer) so we benefit from the same upstream behavior and bug fixes.
For setups where the cluster server URL contains characters that need URL-encoding (uncommon in practice), url.Parse already returns the decoded Path; the constructed URL is then re-encoded by Go's net/url and request writers, so no double-encoding occurs.
No public API or CLI surface changes; the multiplexer and port-forward routes accept the exact same payloads as before.

