### PR TITLE
backend: multiplexer: Fix lock-order inversion deadlock in sendDataMe…

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -739,6 +739,10 @@ func (m *Multiplexer) sendCompleteMessage(conn *Connection, clientConn *WSConnLo
 }
 
 // sendDataMessage sends the actual data message to the client.
+//
+// Lock ordering note: writeMu is released before acquiring mu to
+// maintain a consistent lock order (mu → writeMu) with updateStatus
+// and prevent a lock-order inversion deadlock.
 func (m *Multiplexer) sendDataMessage(
 	conn *Connection,
 	clientConn *WSConnLock,
@@ -748,9 +752,10 @@ func (m *Multiplexer) sendDataMessage(
 	dataMsg := m.createWrapperMessage(conn, messageType, message)
 
 	conn.writeMu.Lock()
-	defer conn.writeMu.Unlock()
+	err := clientConn.WriteJSON(dataMsg)
+	conn.writeMu.Unlock()
 
-	if err := clientConn.WriteJSON(dataMsg); err != nil {
+	if err != nil {
 		return err
 	}
 

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -1570,3 +1570,101 @@ func TestSendDataMessage(t *testing.T) {
 	err = m.sendDataMessage(conn, clientConn, websocket.TextMessage, textMsg)
 	assert.NoError(t, err) // Should return nil even for closed connection
 }
+
+// runConcurrentLockStress fires updateStatus and sendDataMessage
+// simultaneously for n iterations to surface lock-order deadlocks.
+func runConcurrentLockStress(
+	m *Multiplexer,
+	conn *Connection,
+	clientConn *WSConnLock,
+	iterations int,
+) <-chan struct{} {
+	finished := make(chan struct{})
+
+	go func() {
+		defer close(finished)
+
+		var start sync.WaitGroup
+
+		for i := 0; i < iterations; i++ {
+			start.Add(1)
+
+			var wg sync.WaitGroup
+
+			wg.Add(2)
+
+			go func() {
+				defer wg.Done()
+
+				start.Wait()
+
+				conn.updateStatus(StateConnected, nil)
+			}()
+
+			go func() {
+				defer wg.Done()
+
+				start.Wait()
+
+				_ = m.sendDataMessage(conn, clientConn, websocket.TextMessage, []byte("test"))
+			}()
+
+			// Release both goroutines simultaneously.
+			start.Done()
+
+			wg.Wait()
+		}
+	}()
+
+	return finished
+}
+
+// TestConcurrentUpdateStatusAndSendDataMessage is a regression test that verifies
+// updateStatus and sendDataMessage can run concurrently without deadlocking.
+//
+// Before the fix, sendDataMessage acquired writeMu then mu (nested), while
+// updateStatus acquired mu then writeMu, creating a lock-order inversion
+// (ABBA deadlock). The fix changed sendDataMessage to acquire each lock
+// sequentially (writeMu → unlock → mu → unlock), eliminating the nested
+// acquisition entirely.
+func TestConcurrentUpdateStatusAndSendDataMessage(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore())
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	conn := createTestConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn)
+
+	// Drain messages from the client side so writes don't block on a full buffer.
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for {
+			var msg json.RawMessage
+			if err := clientConn.ReadJSON(&msg); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Clean up the reader goroutine so it does not leak after the test.
+	t.Cleanup(func() {
+		_ = clientConn.conn.Close()
+
+		<-done
+	})
+
+	// Run updateStatus and sendDataMessage concurrently.
+	// If the lock order is inverted, this will deadlock and the test will
+	// exceed its timeout.
+	finished := runConcurrentLockStress(m, conn, clientConn, 50)
+
+	select {
+	case <-finished:
+		// Success: no deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock detected: concurrent updateStatus and sendDataMessage blocked for 5s")
+	}
+}


### PR DESCRIPTION


## Summary

Fix a lock-order inversion deadlock between `updateStatus` and `sendDataMessage` in `backend/cmd/multiplexer.go` that can freeze WebSocket connections under concurrent load.

## Related Issue

Fixes #5305

## Root Cause

The `Connection` struct uses two mutexes: `mu` (state) and `writeMu` (WebSocket writes). Two functions acquired them in opposite order, creating a circular wait:

| Function | Lock Order | Nested? |
|---|---|---|
| `updateStatus` | `mu.Lock()` → `writeMu.Lock()` | Yes |
| `sendDataMessage` | `writeMu.Lock()` → `mu.Lock()` | Yes (BUG) |

When a Kubernetes watch stream sends data (`sendDataMessage`) while a connection error triggers a status update (`updateStatus`), both goroutines block forever waiting for each other's held lock.

## Fix

Make `sendDataMessage`'s lock acquisitions sequential (non-nested) instead of nested. The `writeMu` is released before `mu` is acquired, eliminating the circular wait while preserving correct synchronization:

```diff
 func (m *Multiplexer) sendDataMessage(...) error {
     dataMsg := m.createWrapperMessage(conn, messageType, message)

     conn.writeMu.Lock()
-    defer conn.writeMu.Unlock()
-
-    if err := clientConn.WriteJSON(dataMsg); err != nil {
+    err := clientConn.WriteJSON(dataMsg)
+    conn.writeMu.Unlock()
+
+    if err != nil {
         return err
     }

     conn.mu.Lock()
     conn.Status.LastMsg = time.Now()
     conn.mu.Unlock()

     return nil
 }
```

This is safe because:
- `writeMu` only protects the WebSocket write operation
- `mu` only protects the `Status.LastMsg` update
- These two operations are logically independent

## Post-fix Lock Ordering (Verified)

| Function | Lock Order | Nested? | Deadlock Risk? |
|---|---|---|---|
| `updateStatus` | `mu` → `writeMu` | Yes | No |
| `sendDataMessage` (fixed) | `writeMu` → release → `mu` | **No** | **No** |
| `sendCompleteMessage` | `mu.RLock` → release → `writeMu` | No | No |
| `cleanupConnection` | `mu` only | N/A | No |

## Notes for the Reviewer

- This is a 3-line diff (excluding comment additions) — minimal and surgical.
- The fix follows the same pattern already used by `sendCompleteMessage` (lines 710-739), which correctly releases `mu.RLock()` before acquiring `writeMu.Lock()`.
- Existing tests (`TestSendDataMessage`) validate the function's behavior (text, binary, and closed connection cases). All `cmd` package tests and linters pass cleanly.
