### PR TITLE
frontend: createResourceForm for deployments

### DIFF
--- a/frontend/src/components/common/Resource/CreateButton.tsx
+++ b/frontend/src/components/common/Resource/CreateButton.tsx
@@ -26,14 +26,17 @@ import * as yaml from 'js-yaml';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelectedClusters } from '../../../lib/k8s';
+import Deployment from '../../../lib/k8s/deployment';
 import Pod from '../../../lib/k8s/pod';
 import { Activity } from '../../activity/Activity';
+import CreateDeploymentForm from '../../deployments/CreateDeploymentForm';
 import CreatePodForm from '../../pod/CreatePodForm';
 import ActionButton from '../ActionButton';
 import EditorDialog from './EditorDialog';
 
 export const RESOURCE_DEFINITIONS = {
   Pod: { class: Pod, form: CreatePodForm },
+  Deployment: { class: Deployment, form: CreateDeploymentForm },
 };
 
 export type ResourceType = keyof typeof RESOURCE_DEFINITIONS;

--- a/frontend/src/components/deployments/CreateDeploymentForm.stories.tsx
+++ b/frontend/src/components/deployments/CreateDeploymentForm.stories.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { TestContext } from '../../test';
+import CreateDeploymentForm, { CreateDeploymentFormProps } from './CreateDeploymentForm';
+
+export default {
+  title: 'deployment/CreateDeploymentForm',
+  component: CreateDeploymentForm,
+  argTypes: { onChange: { action: 'changed' } },
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<CreateDeploymentFormProps> = args => <CreateDeploymentForm {...args} />;
+
+export const Empty = Template.bind({});
+Empty.args = {
+  resource: {},
+};
+
+export const Prefilled = Template.bind({});
+Prefilled.args = {
+  resource: {
+    metadata: {
+      name: 'nginx-deployment',
+      namespace: 'default',
+      labels: { app: 'nginx' },
+    },
+    spec: {
+      selector: {
+        matchLabels: { app: 'nginx' },
+      },
+      template: {
+        metadata: {
+          labels: { app: 'nginx' },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nginx',
+              image: 'nginx:1.27',
+              ports: [{ containerPort: 80 }],
+              imagePullPolicy: 'IfNotPresent',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+export const MultipleContainers = Template.bind({});
+MultipleContainers.args = {
+  resource: {
+    metadata: {
+      name: 'multi-container-deployment',
+      namespace: 'apps',
+    },
+    spec: {
+      selector: {
+        matchLabels: { app: 'myapp' },
+      },
+      template: {
+        metadata: {
+          labels: { app: 'myapp' },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'app',
+              image: 'myapp:latest',
+              ports: [{ containerPort: 8080 }],
+              imagePullPolicy: 'Always',
+            },
+            {
+              name: 'sidecar',
+              image: 'envoyproxy/envoy:v1.30',
+              ports: [{ containerPort: 9901 }],
+              imagePullPolicy: 'IfNotPresent',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+export const WithNodeName = Template.bind({});
+WithNodeName.args = {
+  resource: {
+    metadata: {
+      name: 'pinned-deployment',
+    },
+    spec: {
+      selector: {
+        matchLabels: { app: 'worker' },
+      },
+      template: {
+        metadata: {
+          labels: { app: 'worker' },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'worker',
+              image: 'busybox:latest',
+              ports: [{ containerPort: 8080 }],
+              imagePullPolicy: 'Never',
+            },
+          ],
+          nodeName: 'node-01',
+        },
+      },
+    },
+  },
+};

--- a/frontend/src/components/deployments/CreateDeploymentForm.tsx
+++ b/frontend/src/components/deployments/CreateDeploymentForm.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import CreateResourceForm, { FormSection } from '../common/Resource/CreateResourceForm';
+
+export interface CreateDeploymentFormProps {
+  resource?: Record<string, any>;
+  onChange: (resource: Record<string, any>) => void;
+}
+
+export default function CreateDeploymentForm(props: CreateDeploymentFormProps) {
+  const { resource, onChange } = props;
+  const { t } = useTranslation(['translation', 'glossary']);
+
+  const normalizedResource = resource ?? {};
+
+  const sections: FormSection[] = [
+    {
+      title: t('translation|Metadata'),
+      fields: [
+        {
+          key: 'name',
+          path: 'metadata.name',
+          label: t('translation|Name'),
+          required: true,
+        },
+        {
+          key: 'namespace',
+          path: 'metadata.namespace',
+          label: t('glossary|Namespace'),
+          type: 'namespace' as const,
+        },
+        {
+          key: 'labels',
+          path: 'metadata.labels',
+          label: t('translation|Labels'),
+          type: 'labels' as const,
+        },
+      ],
+    },
+    {
+      title: t('translation|Selector'),
+      fields: [
+        {
+          key: 'matchLabels',
+          path: 'spec.selector.matchLabels',
+          label: t('translation|Match Labels'),
+          type: 'labels' as const,
+        },
+      ],
+    },
+    {
+      title: t('translation|Pod Template'),
+      fields: [
+        {
+          key: 'templateLabels',
+          path: 'spec.template.metadata.labels',
+          label: t('translation|Template Labels'),
+          type: 'labels' as const,
+        },
+        {
+          key: 'containers',
+          path: 'spec.template.spec.containers',
+          label: t('translation|Containers'),
+          type: 'containers' as const,
+        },
+      ],
+    },
+    {
+      title: t('translation|Node'),
+      fields: [
+        {
+          key: 'nodeName',
+          path: 'spec.template.spec.nodeName',
+          label: t('translation|Node Name'),
+          helperText: t('translation|Optional: schedule the pod on a specific node'),
+        },
+      ],
+    },
+  ];
+
+  return (
+    <CreateResourceForm sections={sections} resource={normalizedResource} onChange={onChange} />
+  );
+}

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -783,5 +783,9 @@
   "Toggle Table Filters": "",
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
-  "Toggle search in log viewer": ""
+  "Toggle search in log viewer": "",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -783,5 +783,9 @@
   "Toggle Table Filters": "Toggle Table Filters",
   "Toggle column filters in tables": "Toggle column filters in tables",
   "Log Viewer Search": "Log Viewer Search",
-  "Toggle search in log viewer": "Toggle search in log viewer"
+  "Toggle search in log viewer": "Toggle search in log viewer",
+  "Selector": "Selector",
+  "Pod Template": "Pod Template",
+  "Match Labels": "Match Labels",
+  "Template Labels": "Template Labels"
 }

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -788,5 +788,9 @@
   "Toggle Table Filters": "",
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
-  "Toggle search in log viewer": ""
+  "Toggle search in log viewer": "",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -788,5 +788,9 @@
   "Toggle Table Filters": "",
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
-  "Toggle search in log viewer": ""
+  "Toggle search in log viewer": "",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -783,5 +783,9 @@
   "Toggle Table Filters": "",
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
-  "Toggle search in log viewer": ""
+  "Toggle search in log viewer": "",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -788,5 +788,9 @@
   "Toggle Table Filters": "",
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
-  "Toggle search in log viewer": ""
+  "Toggle search in log viewer": "",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -779,5 +779,9 @@
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
   "Toggle search in log viewer": "",
-  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ eventDate }} ({{ firstEventDate }} 以来 {{ count }} 回)"
+  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ eventDate }} ({{ firstEventDate }} 以来 {{ count }} 回)",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -779,5 +779,9 @@
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
   "Toggle search in log viewer": "",
-  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ firstEventDate }} 이후 {{ count }}회 발생 ({{ eventDate }})"
+  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ firstEventDate }} 이후 {{ count }}회 발생 ({{ eventDate }})",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -788,5 +788,9 @@
   "Toggle Table Filters": "",
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
-  "Toggle search in log viewer": ""
+  "Toggle search in log viewer": "",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -783,5 +783,9 @@
   "Toggle Table Filters": "",
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
-  "Toggle search in log viewer": ""
+  "Toggle search in log viewer": "",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -779,5 +779,9 @@
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
   "Toggle search in log viewer": "",
-  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ eventDate }} (自 {{ firstEventDate }} 起 {{ count }} 次)"
+  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ eventDate }} (自 {{ firstEventDate }} 起 {{ count }} 次)",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -779,5 +779,9 @@
   "Toggle column filters in tables": "",
   "Log Viewer Search": "",
   "Toggle search in log viewer": "",
-  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ eventDate }} (自 {{ firstEventDate }} 起 {{ count }} 次)"
+  "{{ eventDate }} ({{ count }} times since {{ firstEventDate }})_one": "{{ eventDate }} (自 {{ firstEventDate }} 起 {{ count }} 次)",
+  "Selector": "",
+  "Pod Template": "",
+  "Match Labels": "",
+  "Template Labels": ""
 }


### PR DESCRIPTION
## Summary

This PR is a continuation of #5044 by @vyncent-t to add form based UI for kubernetes resource creation. 

This PR introduces form based UI for Deployment creation.

## Changes

1. Created `CreateDeploymentForm` component and added its stories

## How to test?

1. Navigate to the Pod list page
2. Click the "Create Deployment" (+) button in the header
3. Click "Form" in the editor toolbar
4. Fill in the required fields
5. Click "Apply" 

Repeat from the sidebar "Create" button (click "Create Form", select "Deployment" from the resource picker, fill the form, and verify the same behavior)

## Screenshots

<img width="1417" height="728" alt="Screenshot 2026-04-29 at 10 47 33 PM" src="https://github.com/user-attachments/assets/344284bf-671e-4f12-9199-9ced2c4b4d26" />
