### PR TITLE
frontend: Add delete button to plugin list

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../../lib/themes';
+import { PluginInfo } from '../../../plugin/pluginsSlice';
+import { TestContext } from '../../../test';
+import { PluginSettingsPure } from './PluginSettings';
+
+vi.mock('../../../helpers/isElectron', () => ({
+  isElectron: () => true,
+}));
+
+const theme = createMuiTheme({ name: 'light', base: 'light' });
+
+function createPlugins(count: number): PluginInfo[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `plugin-${i}`,
+    description: `Description for plugin ${i}`,
+    isEnabled: true,
+    isCompatible: true,
+    isLoaded: true,
+    type: 'user' as const,
+    homepage: '',
+  }));
+}
+
+function renderPluginSettings(
+  props: Partial<React.ComponentProps<typeof PluginSettingsPure>> = {}
+) {
+  const defaultProps = {
+    plugins: createPlugins(3),
+    onSave: vi.fn(),
+    onDelete: vi.fn(),
+    ...props,
+  };
+
+  return render(
+    <TestContext>
+      <ThemeProvider theme={theme}>
+        <PluginSettingsPure {...defaultProps} />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+describe('PluginSettingsPure', () => {
+  let confirmSpy: { mockRestore: () => void } | undefined;
+
+  afterEach(() => {
+    confirmSpy?.mockRestore();
+    confirmSpy = undefined;
+  });
+
+  it('renders the delete button for each plugin', () => {
+    renderPluginSettings();
+
+    const deleteButtons = screen.getAllByLabelText('Delete Plugin');
+    expect(deleteButtons).toHaveLength(3);
+  });
+
+  it('calls onDelete when delete is confirmed', () => {
+    const onDelete = vi.fn();
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderPluginSettings({ plugins: createPlugins(2), onDelete });
+
+    const deleteButtons = screen.getAllByLabelText('Delete Plugin');
+    fireEvent.click(deleteButtons[0]);
+
+    expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ name: 'plugin-0' }));
+  });
+
+  it('does not call onDelete when delete is cancelled', () => {
+    const onDelete = vi.fn();
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    renderPluginSettings({ plugins: createPlugins(2), onDelete });
+
+    const deleteButtons = screen.getAllByLabelText('Delete Plugin');
+    fireEvent.click(deleteButtons[0]);
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('removes the plugin from the list after deletion', () => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderPluginSettings();
+
+    expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(3);
+
+    fireEvent.click(screen.getAllByLabelText('Delete Plugin')[0]);
+
+    expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(2);
+  });
+
+  it('can delete multiple plugins consecutively', () => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderPluginSettings();
+
+    fireEvent.click(screen.getAllByLabelText('Delete Plugin')[0]);
+    expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByLabelText('Delete Plugin')[0]);
+    expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(1);
+  });
+
+  it('does not show delete button for shipped plugins', () => {
+    const plugins: PluginInfo[] = [
+      {
+        name: 'shipped-plugin',
+        description: 'A shipped plugin',
+        isEnabled: true,
+        isCompatible: true,
+        isLoaded: true,
+        type: 'shipped',
+        homepage: '',
+      },
+      {
+        name: 'user-plugin',
+        description: 'A user plugin',
+        isEnabled: true,
+        isCompatible: true,
+        isLoaded: true,
+        type: 'user',
+        homepage: '',
+      },
+    ];
+
+    renderPluginSettings({ plugins });
+
+    const deleteButtons = screen.getAllByLabelText('Delete Plugin');
+    expect(deleteButtons).toHaveLength(1);
+  });
+
+  it('only removes the matching version when plugins share a name', () => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const plugins: PluginInfo[] = [
+      {
+        name: 'shared-name',
+        description: 'User version',
+        isEnabled: true,
+        isCompatible: true,
+        isLoaded: true,
+        type: 'user',
+        homepage: '',
+      },
+      {
+        name: 'shared-name',
+        description: 'Development version',
+        isEnabled: true,
+        isCompatible: true,
+        isLoaded: true,
+        type: 'development',
+        homepage: '',
+      },
+    ];
+
+    renderPluginSettings({ plugins });
+
+    expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByLabelText('Delete Plugin')[0]);
+
+    expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(1);
+  });
+
+  it('restores the row when onDelete fails', async () => {
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onDelete = vi.fn().mockRejectedValue(new Error('boom'));
+
+    renderPluginSettings({ plugins: createPlugins(2), onDelete });
+
+    expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByLabelText('Delete Plugin')[0]);
+
+    // Wait for the async onDelete rejection to be handled and the row to be restored.
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Delete Plugin')).toHaveLength(2);
+    });
+  });
+});

--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -32,9 +32,11 @@ import { useFilterFunc } from '../../../lib/util';
 import { PluginInfo, reloadPage, setPluginSettings } from '../../../plugin/pluginsSlice';
 import { useTypedSelector } from '../../../redux/hooks';
 import { Link as HeadlampLink } from '../../common/';
+import ActionButton from '../../common/ActionButton';
 import SectionBox from '../../common/SectionBox';
 import SectionFilterHeader from '../../common/SectionFilterHeader';
 import Table from '../../common/Table';
+import { usePluginDelete } from './usePluginDelete';
 
 /**
  * Interface of the component's props structure.
@@ -48,6 +50,7 @@ import Table from '../../common/Table';
 export interface PluginSettingsPureProps {
   plugins: PluginInfo[];
   onSave: (plugins: PluginInfo[]) => void;
+  onDelete?: (plugin: PluginInfo) => Promise<void> | void;
   saveAlwaysEnable?: boolean;
 }
 
@@ -162,7 +165,9 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
      * If both arrays are identical in this scope, then no changes need to be saved.
      * If they do not match, there are changes in the pluginChanges array that can be saved and thus enableSave should be enabled.
      */
-    const arrayComp = props.plugins.every((val, key) => matcher(val, pluginChanges[key]));
+    const arrayComp =
+      props.plugins.length === pluginChanges.length &&
+      props.plugins.every((val, key) => matcher(val, pluginChanges[key]));
 
     /** For storybook usage, determines if the save button should be enabled by default */
     if (props.saveAlwaysEnable) {
@@ -184,6 +189,30 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
    */
   function onSaveButtonHandler() {
     props.onSave(pluginChanges);
+  }
+
+  /**
+   * Confirm with the user, optimistically remove the plugin row, and call onDelete.
+   * Restores the row if onDelete rejects so the list stays in sync with the backend.
+   */
+  async function handleDeleteClick(plugin: PluginInfo) {
+    if (!window.confirm(t('translation|Are you sure you want to delete this plugin?'))) return;
+
+    // Optimistic update: remove the row immediately so the user gets feedback.
+    // Match by both name and type so we don't remove other versions of the same plugin.
+    const previous = pluginChanges;
+    setPluginChanges((current: any[]) =>
+      current.filter((p: any) => !(p.name === plugin.name && p.type === plugin.type))
+    );
+
+    if (!props.onDelete) return;
+
+    try {
+      await props.onDelete(plugin);
+    } catch {
+      // Restore the row if deletion fails.
+      setPluginChanges(previous);
+    }
   }
 
   /**
@@ -383,10 +412,25 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                 );
               },
             },
+            {
+              header: t('translation|Delete'),
+              accessorKey: 'delete',
+              enableSorting: false,
+              Cell: ({ row: { original: plugin } }: { row: MRT_Row<PluginInfo> }) =>
+                plugin.type === 'shipped' ? null : (
+                  <ActionButton
+                    description={t('translation|Delete Plugin')}
+                    icon="mdi:delete"
+                    onClick={() => handleDeleteClick(plugin)}
+                  />
+                ),
+            },
           ]
-            // remove the enable column if we're not in app mode
-            .filter(el => !(el.header === t('translation|Enable') && !isElectron()))}
+            // remove the enable and delete columns if we're not in app mode
+            .filter(el => !(el.header === t('translation|Enable') && !isElectron()))
+            .filter(el => !(el.header === t('translation|Delete') && !isElectron()))}
           data={pluginChanges}
+          getRowId={(row: PluginInfo) => `${row.name}-${row.type}`}
           filterFunction={useFilterFunc<PluginInfo>(['.name'])}
           muiTableBodyRowProps={({ row }) => {
             const plugin = row.original as PluginInfo;
@@ -447,8 +491,8 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
 /** Container function for the PluginSettingsPure, onSave prop returns plugins */
 export default function PluginSettings() {
   const dispatch = useDispatch();
-
   const pluginSettings = useTypedSelector(state => state.plugins.pluginSettings);
+  const handleDelete = usePluginDelete();
 
   return (
     <PluginSettingsPure
@@ -457,6 +501,7 @@ export default function PluginSettings() {
         dispatch(setPluginSettings(plugins));
         dispatch(reloadPage());
       }}
+      onDelete={handleDelete}
     />
   );
 }

--- a/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettingsDetails.tsx
@@ -20,23 +20,20 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import _ from 'lodash';
-import { isValidElement, useEffect, useMemo, useRef, useState } from 'react';
+import { isValidElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 import { isElectron } from '../../../helpers/isElectron';
-import { deletePlugin } from '../../../lib/k8s/api/v1/pluginsApi';
 import { ConfigStore } from '../../../plugin/configStore';
-import { PluginInfo, reloadPage } from '../../../plugin/pluginsSlice';
-import { clusterAction } from '../../../redux/clusterActionSlice';
+import { PluginInfo } from '../../../plugin/pluginsSlice';
 import { useTypedSelector } from '../../../redux/hooks';
-import type { AppDispatch } from '../../../redux/stores/store';
 import NotFoundComponent from '../../404';
 import { SectionHeader } from '../../common';
 import ActionButton from '../../common/ActionButton';
 import { ConfirmDialog } from '../../common/Dialog';
 import ErrorBoundary from '../../common/ErrorBoundary';
 import { SectionBox } from '../../common/SectionBox';
+import { usePluginDelete } from './usePluginDelete';
 
 // Helper function to open plugin folder in file explorer (Electron only)
 function openPluginFolder(plugin: PluginInfo) {
@@ -70,63 +67,19 @@ function canOpenPluginFolder(plugin: PluginInfo): boolean {
 
 const PluginSettingsDetailsInitializer = (props: { plugin: PluginInfo }) => {
   const { plugin } = props;
-  const { t } = useTranslation(['translation']);
   const store = new ConfigStore(plugin.name);
   const pluginConf = store.useConfig();
   const config = pluginConf() as { [key: string]: any };
-  const dispatch: AppDispatch = useDispatch();
-  const history = useHistory();
-  const deleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (deleteTimeoutRef.current) {
-        clearTimeout(deleteTimeoutRef.current);
-      }
-    };
-  }, []);
+  const deletePluginAction = usePluginDelete();
 
   function handleSave(data: { [key: string]: any }) {
     store.set(data);
   }
 
   function handleDeleteConfirm() {
-    // Use folderName if available (the actual folder name on disk),
-    // otherwise fall back to extracting from the name
-    const pluginFolderName = plugin.folderName || plugin.name.split('/').splice(-1)[0];
-
-    // Determine plugin type for deletion - only allow deletion of user and development plugins
-    const pluginType =
-      plugin.type === 'development' || plugin.type === 'user' ? plugin.type : undefined;
-
-    let deleteSucceeded = false;
-
-    dispatch(
-      clusterAction(
-        () =>
-          deletePlugin(pluginFolderName, pluginType).then(() => {
-            deleteSucceeded = true;
-          }),
-        {
-          startMessage: t('Deleting plugin {{ itemName }}...', { itemName: pluginFolderName }),
-          cancelledMessage: t('Cancelled deletion of {{ itemName }}.', {
-            itemName: pluginFolderName,
-          }),
-          successMessage: t('Deleted plugin {{ itemName }}.', { itemName: pluginFolderName }),
-          errorMessage: t('Error deleting plugin {{ itemName }}.', { itemName: pluginFolderName }),
-        }
-      )
-    ).then(() => {
-      // Delay to let user see the snackbar notification before full page reload.
-      // The timeout is stored in a ref so it can be cleared if the component unmounts.
-      deleteTimeoutRef.current = setTimeout(() => {
-        if (deleteSucceeded) {
-          history.push('/settings/plugins');
-          dispatch(reloadPage());
-        }
-        // On error, don't reload - let user read the error message
-      }, 2000);
-    });
+    // The hook handles the snackbar, navigation, and reload. The promise rejects
+    // on failure but we ignore it here since the user stays on the detail page.
+    deletePluginAction(plugin).catch(() => {});
   }
 
   return (

--- a/frontend/src/components/App/PluginSettings/usePluginDelete.ts
+++ b/frontend/src/components/App/PluginSettings/usePluginDelete.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { deletePlugin } from '../../../lib/k8s/api/v1/pluginsApi';
+import { PluginInfo, reloadPage } from '../../../plugin/pluginsSlice';
+import { clusterAction } from '../../../redux/clusterActionSlice';
+import type { AppDispatch } from '../../../redux/stores/store';
+
+/**
+ * Returns a function that deletes a plugin via the backend API, dispatches
+ * a clusterAction (which surfaces the start/success/error snackbars), and
+ * navigates back to the plugin list before reloading.
+ *
+ * The returned promise resolves on success and rejects when the deletion
+ * fails, so callers can roll back optimistic UI updates if needed.
+ */
+export function usePluginDelete() {
+  const dispatch: AppDispatch = useDispatch();
+  const history = useHistory();
+  const { t } = useTranslation(['translation']);
+  const deleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (deleteTimeoutRef.current) {
+        clearTimeout(deleteTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return useCallback(
+    (plugin: PluginInfo): Promise<void> => {
+      // Use folderName when present (the actual folder name on disk),
+      // otherwise fall back to extracting from the name.
+      const pluginFolderName = plugin.folderName || plugin.name.split('/').splice(-1)[0];
+
+      // Only user and development plugins can be deleted.
+      const pluginType =
+        plugin.type === 'development' || plugin.type === 'user' ? plugin.type : undefined;
+
+      let deleteSucceeded = false;
+
+      return dispatch(
+        clusterAction(
+          () =>
+            deletePlugin(pluginFolderName, pluginType).then(() => {
+              deleteSucceeded = true;
+            }),
+          {
+            startMessage: t('Deleting plugin {{ itemName }}...', { itemName: pluginFolderName }),
+            cancelledMessage: t('Cancelled deletion of {{ itemName }}.', {
+              itemName: pluginFolderName,
+            }),
+            successMessage: t('Deleted plugin {{ itemName }}.', { itemName: pluginFolderName }),
+            errorMessage: t('Error deleting plugin {{ itemName }}.', {
+              itemName: pluginFolderName,
+            }),
+          }
+        )
+      ).then(() => {
+        if (!deleteSucceeded) {
+          // Reject so callers can roll back optimistic UI updates.
+          throw new Error('Plugin deletion failed');
+        }
+        // Delay so the user can read the success snackbar before reload.
+        deleteTimeoutRef.current = setTimeout(() => {
+          history.push('/settings/plugins');
+          dispatch(reloadPage());
+        }, 2000);
+      });
+    },
+    [dispatch, history, t]
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds a delete button to the plugin list page (Settings > Plugins), allowing users to delete plugins directly from the table without having to navigate to the plugin detail page first.

## Related Issue

Fixes #5275

## Changes

- Added a delete column with a trash icon (`mdi:delete`) to the plugin table in `PluginSettings.tsx`

## Steps to Test

1. Navigate to Settings > Plugins
2. Click the trash icon on any plugin row
3. Confirm the browser dialog
4. Observe the plugin is removed from the list
5. Repeat step 2-4 on the new top row to verify consecutive deletes work

## Screenshots (if applicable)

Plugins list:

<img width="1556" height="347" alt="image" src="https://github.com/user-attachments/assets/58dc151b-b211-4a00-bebb-71e3e43f7875" />

Button:

<img width="168" height="170" alt="image" src="https://github.com/user-attachments/assets/32351c29-4d56-4ba0-ad9a-0c71301df030" />

Confirm:

<img width="314" height="139" alt="image" src="https://github.com/user-attachments/assets/056ea4a7-125c-47a5-b3e7-03d0ea18789a" />

## Notes for the Reviewer

It is up to you to decide whether you want this option. Personally, I cannot find the delete button at first without consulting the documentation. I find this option more intuitive, just like enabling/disabling the plugin.