### PR TITLE
frontend: common/ReleaseNotes/ReleaseNotesModal: Fix h3 appearing wit…

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
@@ -24,7 +24,7 @@ export default {
 
 export const Show = {
   args: {
-    releaseNotes: '### Hello\n\nworld',
+    releaseNotes: '# Release Notes\n\n## Hello\n\n### Sub-heading\n\nworld',
     appVersion: '1.9.9',
   },
 };

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
@@ -70,8 +70,18 @@
           <div
             class="MuiBox-root css-fm9d3m"
           >
-            <h3>
+            <h1>
+              Release Notes
+            </h1>
+            
+
+            <h2>
               Hello
+            </h2>
+            
+
+            <h3>
+              Sub-heading
             </h3>
             
 


### PR DESCRIPTION
## Summary

This PR fixes the heading hierarchy violation in the `ReleaseNotesModal` Show story by replacing the `### Hello` fixture (h3 with no preceding h1/h2) with a proper `# Release Notes → ## Hello → ### Sub-heading` hierarchy, and updates the storyshot snapshot to match.

## Related Issue

Fixes #4590

## Changes

- Updated `releaseNotes` fixture in `Show` story from `'### Hello\n\nworld'` to `'# Release Notes\n\n## Hello\n\n### Sub-heading\n\nworld'`
- Updated `ReleaseNotesModal.Show.stories.storyshot` snapshot to reflect the corrected heading hierarchy

## Steps to Test

1. Run `cd frontend && npx vitest run src/storybook.test.tsx` — all tests pass
2. Run `npm run storybook` and navigate to `common/ReleaseNotes/ReleaseNotesModal → Show`
3. Observe the modal renders with correct heading hierarchy: h1 → h2 → h3

## Screenshots 

<img width="1918" height="857" alt="image" src="https://github.com/user-attachments/assets/3b58ad99-2eca-4b81-9f5e-cd6dd89ed0d8" />
>


## Notes for the Reviewer

- No component logic was changed; only the story fixture and its snapshot were updated.
- Follows the same pattern used in other story files across the codebase.