### PR TITLE
backend: portforward: Fix orphaned process leaks on deletion and timeout

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -437,8 +437,6 @@ func runAndMonitorPortForward(
 			case forwardErrChan <- err:
 			default:
 			}
-
-			safeCloseChan(pfDetails.closeChan)
 		} else {
 			logger.Log(logger.LevelInfo, logParams, nil, "ForwardPorts() exited.")
 
@@ -452,6 +450,7 @@ func runAndMonitorPortForward(
 			}
 		}
 
+		safeCloseChan(pfDetails.closeChan)
 		close(forwardErrChan)
 	}()
 

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -68,10 +68,11 @@ func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id 
 		return err
 	}
 
-	if isStopRequest {
-		// close the channel to stop the portforward
-		portforward.closeChan <- struct{}{}
+	// Always signal the portforward to stop, whether it's a stop or delete request.
+	// This prevents orphaned goroutines and leaked ports.
+	safeCloseChan(portforward.closeChan)
 
+	if isStopRequest {
 		portforward.Status = STOPPED
 		portforwardstore(cache, portforward)
 	} else {


### PR DESCRIPTION
### **Summary:** Fixes a reliability issue in the port-forwarding module where background goroutines and network listeners were not properly terminated during failed connections or upon deletion of the port-forward record. This prevents orphaned processes from leaking memory and keeping local ports occupied after their management record has been removed from the UI.

### **Fixes:** #5313

### **Changes:**

1. backend/pkg/portforward/store.go: Updated stopOrDeletePortForward to always signal the background task to stop (via safeCloseChan) before deleting the cache record. This ensures the lifecycle of the process is strictly tied to the record in the cache.
2. backend/pkg/portforward/store.go: Replaced the potentially blocking channel send <- struct{}{} with a non-blocking close() signal (via safeCloseChan) to prevent backend hangs if the receiver is no longer active.
3. backend/pkg/portforward/handler.go: Updated runAndMonitorPortForward to ensure the background task is stopped if the readiness check fails or times out. Previously, a failed start could leave a hidden process running in the background.

### **Steps to Test:**

1. Verify the fix by running the existing test suite: go test -v ./pkg/portforward/...
2. (Optional) To see the fix "live":
3. Start a port-forward in Headlamp to a local port (e.g., 8080).
4. Delete the entry from the UI.
5. Verify that the local port is actually released (e.g., using netstat -an or by successfully starting a new service on that same port). Previously, the port would remain blocked by an orphaned process.