### PR TITLE
frontend: LogsButton debounce processAllLogs in All Pods mode

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -410,4 +410,29 @@ describe('LogsButton', () => {
     expect(mockActivityLaunch).not.toHaveBeenCalled();
     expect(dispatchMock).not.toHaveBeenCalled();
   });
+
+  it('launchWorkloadLogs works for foreign workloads with loggable kinds (cross-bundle compatibility)', () => {
+    class ForeignDeployment extends MockKubeObject {
+      static kind = 'Deployment'; // Same kind as a real loggable workload
+    }
+    const foreignItem = new ForeignDeployment({
+      kind: 'Deployment',
+      metadata: { name: 'foreign-dep', namespace: 'default', uid: 'foreign-123' },
+    });
+
+    const dispatchMock = vi.fn();
+    launchWorkloadLogs(foreignItem as any, dispatchMock);
+
+    expect(mockActivityLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'logs-foreign-123',
+        title: 'Logs: foreign-dep',
+      })
+    );
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'headlamp.logs',
+      })
+    );
+  });
 });

--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -15,112 +15,115 @@
  */
 
 import 'vitest-canvas-mock';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
 import Deployment from '../../../lib/k8s/deployment';
 import Pod from '../../../lib/k8s/pod';
 import StatefulSet from '../../../lib/k8s/statefulSet';
 import { TestContext } from '../../../test';
 import { launchWorkloadLogs, LogsButton } from './LogsButton';
 
-// vi.hoisted runs before imports, making values available to vi.mock factories
-const { MockKubeObject, mockClusterFetch, mockEnqueueSnackbar, mockActivityLaunch } = vi.hoisted(
-  () => {
-    class MockKubeObject {
-      static kind: string | undefined;
-      static isClassOf(instance: any): boolean {
-        return instance?.kind === this.kind;
-      }
-      jsonData: any;
-      constructor(data: any) {
-        this.jsonData = data;
-      }
-      get kind() {
-        return this.jsonData?.kind;
-      }
-      get metadata() {
-        return this.jsonData?.metadata;
-      }
-      get spec() {
-        return this.jsonData?.spec;
-      }
-      get status() {
-        return this.jsonData?.status;
-      }
-      get cluster() {
-        return '';
-      }
-      getName() {
-        return this.jsonData?.metadata?.name ?? '';
-      }
-      getNamespace() {
-        return this.jsonData?.metadata?.namespace ?? '';
-      }
+const {
+  MockKubeObject,
+  mockClusterFetch,
+  mockEnqueueSnackbar,
+  mockActivityLaunch,
+  mockXTermWrite,
+  mockXTermClear,
+} = vi.hoisted(() => {
+  class MockKubeObject {
+    jsonData: any;
+    static kind = '';
+    static apiGroupName = '';
+    constructor(data: any) {
+      this.jsonData = data;
     }
-    return {
-      MockKubeObject,
-      mockClusterFetch: vi.fn(),
-      mockEnqueueSnackbar: vi.fn(),
-      mockActivityLaunch: vi.fn(),
-    };
+    get kind() {
+      return this.jsonData?.kind;
+    }
+    static isClassOf(maybeInstance: any) {
+      return maybeInstance?.kind === this.kind;
+    }
+    _class() {
+      return this.constructor as any;
+    }
+    get metadata() {
+      return this.jsonData?.metadata;
+    }
+    get spec() {
+      return this.jsonData?.spec;
+    }
+    get status() {
+      return this.jsonData?.status;
+    }
+    get cluster() {
+      return '';
+    }
+    getName() {
+      return this.jsonData?.metadata?.name ?? '';
+    }
+    getNamespace() {
+      return this.jsonData?.metadata?.namespace ?? '';
+    }
   }
-);
+  return {
+    MockKubeObject,
+    mockClusterFetch: vi.fn(),
+    mockEnqueueSnackbar: vi.fn(),
+    mockActivityLaunch: vi.fn(),
+    mockXTermWrite: vi.fn(),
+    mockXTermClear: vi.fn(),
+  };
+});
 
-// --- K8s module mocks ---
+vi.mock('../../../lib/k8s/KubeObject', () => ({ KubeObject: MockKubeObject }));
 
-vi.mock('../../../lib/k8s/KubeObject', () => ({
-  KubeObject: MockKubeObject,
-}));
-
-vi.mock('../../../lib/k8s/deployment', () => ({
-  default: class Deployment extends MockKubeObject {
+vi.mock('../../../lib/k8s/deployment', () => {
+  class Deployment extends MockKubeObject {
     static kind = 'Deployment';
-  },
-  __esModule: true,
-}));
+  }
+  return { default: Deployment, __esModule: true };
+});
 
-vi.mock('../../../lib/k8s/pod', () => ({
-  default: class Pod extends MockKubeObject {
+vi.mock('../../../lib/k8s/pod', () => {
+  class Pod extends MockKubeObject {
+    static kind = 'Pod';
     getLogs() {
       return () => {};
     }
-  },
-  __esModule: true,
-}));
+  }
+  return { default: Pod, __esModule: true };
+});
 
-vi.mock('../../../lib/k8s/daemonSet', () => ({
-  default: class DaemonSet extends MockKubeObject {
+vi.mock('../../../lib/k8s/daemonSet', () => {
+  class DaemonSet extends MockKubeObject {
     static kind = 'DaemonSet';
-  },
-  __esModule: true,
-}));
+  }
+  return { default: DaemonSet, __esModule: true };
+});
 
-vi.mock('../../../lib/k8s/replicaSet', () => ({
-  default: class ReplicaSet extends MockKubeObject {
+vi.mock('../../../lib/k8s/replicaSet', () => {
+  class ReplicaSet extends MockKubeObject {
     static kind = 'ReplicaSet';
-  },
-  __esModule: true,
-}));
+  }
+  return { default: ReplicaSet, __esModule: true };
+});
 
-vi.mock('../../../lib/k8s/statefulSet', () => ({
-  default: class StatefulSet extends MockKubeObject {
+vi.mock('../../../lib/k8s/statefulSet', () => {
+  class StatefulSet extends MockKubeObject {
     static kind = 'StatefulSet';
-  },
-  __esModule: true,
-}));
+  }
+  return { default: StatefulSet, __esModule: true };
+});
 
-vi.mock('../../../lib/k8s', () => ({
-  labelSelectorToQuery: vi.fn(() => 'app=test'),
-}));
-
+vi.mock('../../../lib/k8s', () => ({ labelSelectorToQuery: vi.fn(() => 'app=test') }));
 vi.mock('../../../lib/k8s/api/v2/fetch', () => ({
   clusterFetch: (...args: any[]) => mockClusterFetch(...args),
 }));
-
 vi.mock('notistack', () => ({
   useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
-  SnackbarProvider: ({ children }: { children: React.ReactNode }) => children,
+  SnackbarProvider: ({ children }: any) => children,
 }));
-
 vi.mock('../../activity/Activity', () => ({
   Activity: {
     launch: (...args: any[]) => mockActivityLaunch(...args),
@@ -128,26 +131,40 @@ vi.mock('../../activity/Activity', () => ({
   },
   ActivitiesRenderer: () => null,
 }));
+vi.mock('../LogViewer', () => ({
+  LogViewer: (props: any) => {
+    const { xtermRef } = props;
+    React.useEffect(() => {
+      if (xtermRef) {
+        xtermRef.current = {
+          write: mockXTermWrite,
+          clear: mockXTermClear,
+        };
+      }
+    }, [xtermRef]);
+    return <div data-testid="mock-log-viewer" />;
+  },
+}));
 
-// --- Mock Data ---
+// Mock Icon to avoid undefined component error
+vi.mock('@iconify/react', () => ({
+  Icon: () => <span data-testid="icon" />,
+}));
+
+// Mock Tooltip components
+vi.mock('../Tooltip', () => ({
+  LightTooltip: ({ children }: any) => <div>{children}</div>,
+}));
 
 const deploymentData = {
   kind: 'Deployment',
-  metadata: {
-    name: 'test-deployment',
-    namespace: 'default',
-    creationTimestamp: '2024-01-01T00:00:00Z',
-    uid: 'dep-123',
-  },
+  metadata: { name: 'test-deployment', namespace: 'default', uid: 'dep-123' },
   spec: {
     selector: { matchLabels: { app: 'test-app' } },
-    strategy: {
-      type: 'RollingUpdate',
-    },
     template: {
       spec: {
-        nodeName: 'test-node',
-        containers: [{ name: 'nginx', image: 'nginx:latest', imagePullPolicy: 'Always' }],
+        containers: [{ name: 'nginx', image: 'nginx', imagePullPolicy: 'Always' }],
+        nodeName: '',
       },
     },
   },
@@ -156,24 +173,13 @@ const deploymentData = {
 
 const statefulSetData = {
   kind: 'StatefulSet',
-  metadata: {
-    name: 'test-statefulset',
-    namespace: 'default',
-    creationTimestamp: '2024-01-01T00:00:00Z',
-    uid: 'sts-123',
-  },
+  metadata: { name: 'test-ss', namespace: 'default', uid: 'ss-123' },
   spec: {
     selector: { matchLabels: { app: 'test-app' } },
-    updateStrategy: {
-      type: 'RollingUpdate',
-      rollingUpdate: {
-        partition: 0,
-      },
-    },
     template: {
       spec: {
-        nodeName: 'test-node',
-        containers: [{ name: 'nginx', image: 'nginx:latest', imagePullPolicy: 'Always' }],
+        containers: [{ name: 'nginx', image: 'nginx', imagePullPolicy: 'Always' }],
+        nodeName: '',
       },
     },
   },
@@ -182,30 +188,18 @@ const statefulSetData = {
 
 const mockPodData = {
   kind: 'Pod',
-  apiVersion: 'v1',
-  metadata: {
-    name: 'test-pod-1',
-    namespace: 'default',
-    creationTimestamp: '2024-01-01T00:00:00Z',
-    uid: 'pod-123',
-  },
-  spec: {
-    containers: [{ name: 'nginx', image: 'nginx:latest', imagePullPolicy: 'Always' }],
-    nodeName: 'test-node',
-  },
-  status: { phase: 'Running' },
+  metadata: { name: 'test-pod-1', namespace: 'default', uid: 'pod-123' },
+  spec: { containers: [{ name: 'nginx', image: 'nginx', imagePullPolicy: 'Always' }] },
+  status: { phase: 'Running', containerStatuses: [{ name: 'nginx', restartCount: 0 }] },
 };
 
-// --- Tests ---
-
 describe('LogsButton', () => {
-  let originalGetLogs: typeof Pod.prototype.getLogs;
+  let originalGetLogs: any;
 
   beforeEach(() => {
     originalGetLogs = Pod.prototype.getLogs;
-    mockClusterFetch.mockReset();
-    mockEnqueueSnackbar.mockReset();
-    mockActivityLaunch.mockReset();
+    vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   afterEach(() => {
@@ -215,42 +209,28 @@ describe('LogsButton', () => {
   it('renders the logs button for a Deployment', () => {
     render(
       <TestContext>
-        <LogsButton item={new Deployment(deploymentData)} />
+        <LogsButton item={new Deployment(deploymentData as any)} />
       </TestContext>
     );
-
     expect(screen.getByLabelText('translation|Show logs')).toBeInTheDocument();
   });
 
   it('renders the logs button for a StatefulSet', () => {
     render(
       <TestContext>
-        <LogsButton item={new StatefulSet(statefulSetData)} />
+        <LogsButton item={new StatefulSet(statefulSetData as any)} />
       </TestContext>
     );
-
     expect(screen.getByLabelText('translation|Show logs')).toBeInTheDocument();
   });
 
-  it('does not render the button for null item', () => {
+  it('launches activity with correct metadata on click', () => {
     render(
       <TestContext>
-        <LogsButton item={null} />
+        <LogsButton item={new Deployment(deploymentData as any)} />
       </TestContext>
     );
-
-    expect(screen.queryByLabelText('translation|Show logs')).not.toBeInTheDocument();
-  });
-
-  it('launches Activity with correct metadata on click', () => {
-    render(
-      <TestContext>
-        <LogsButton item={new Deployment(deploymentData)} />
-      </TestContext>
-    );
-
     fireEvent.click(screen.getByLabelText('translation|Show logs'));
-
     expect(mockActivityLaunch).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'logs-dep-123',
@@ -259,8 +239,147 @@ describe('LogsButton', () => {
     );
   });
 
+  it('shows warning when no pods found', async () => {
+    mockClusterFetch.mockResolvedValue({ json: async () => ({ items: [] }) });
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData as any)} />
+      </TestContext>
+    );
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    render(<TestContext>{activityContent}</TestContext>);
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        expect.stringMatching(/No pods found/i),
+        expect.anything()
+      );
+    });
+  });
+
+  it('streams logs successfully', async () => {
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({ items: [mockPodData] }),
+    });
+
+    Pod.prototype.getLogs = vi.fn((...args: any[]) => {
+      const onLogs = args.find(arg => typeof arg === 'function');
+      onLogs({ logs: ['log line 1\n'] });
+      return () => {};
+    }) as any;
+
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData as any)} />
+      </TestContext>
+    );
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    render(<TestContext>{activityContent}</TestContext>);
+
+    await waitFor(() => {
+      expect(mockXTermWrite).toHaveBeenCalledWith(expect.stringContaining('log line 1'));
+    });
+  });
+
+  it('debounces processAllLogs and batches multiple pod updates', async () => {
+    vi.useFakeTimers();
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({
+        items: [
+          { ...mockPodData, metadata: { name: 'pod-1', uid: 'u1' } },
+          { ...mockPodData, metadata: { name: 'pod-2', uid: 'u2' } },
+        ],
+      }),
+    });
+
+    let pod1Callback: any;
+    let pod2Callback: any;
+
+    Pod.prototype.getLogs = vi.fn(function (this: any, ...args: any[]) {
+      const onLogs = args.find(arg => typeof arg === 'function');
+      if (this.getName() === 'pod-1') pod1Callback = onLogs;
+      if (this.getName() === 'pod-2') pod2Callback = onLogs;
+      return () => {};
+    }) as any;
+
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData as any)} />
+      </TestContext>
+    );
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    render(<TestContext>{activityContent}</TestContext>);
+
+    await waitFor(() => expect(pod1Callback).toBeDefined());
+    await waitFor(() => expect(pod2Callback).toBeDefined());
+
+    // Send updates from both pods
+    act(() => {
+      pod1Callback({ logs: ['2023-01-01T00:00:01Z pod1 log\n'] });
+      pod2Callback({ logs: ['2023-01-01T00:00:02Z pod2 log\n'] });
+    });
+
+    // Should not have updated terminal yet due to debounce
+    expect(mockXTermWrite).not.toHaveBeenCalled();
+
+    // Advance time by 250ms
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    // Now it should be called once with aggregated logs
+    expect(mockXTermWrite).toHaveBeenCalledTimes(1);
+    const written = mockXTermWrite.mock.calls[0][0];
+    expect(written).toContain('[pod-1] 2023-01-01T00:00:01Z pod1 log');
+    expect(written).toContain('[pod-2] 2023-01-01T00:00:02Z pod2 log');
+
+    vi.useRealTimers();
+  });
+
+  it('cancels timer on unmount', async () => {
+    vi.useFakeTimers();
+    const spy = vi.spyOn(global, 'clearTimeout');
+
+    // Mock logs arrival to trigger timer
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({ items: [mockPodData] }),
+    });
+
+    let onLogsCallback: any;
+    Pod.prototype.getLogs = vi.fn((...args: any[]) => {
+      const onLogs = args.find(arg => typeof arg === 'function');
+      onLogsCallback = onLogs;
+      return () => {};
+    }) as any;
+
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData as any)} />
+      </TestContext>
+    );
+    fireEvent.click(screen.getByLabelText('translation|Show logs'));
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    const { unmount } = render(<TestContext>{activityContent}</TestContext>);
+
+    await waitFor(() => expect(onLogsCallback).toBeDefined());
+
+    // Trigger logs arrival which starts the debounce timer
+    act(() => {
+      onLogsCallback({ logs: ['some logs\n'] });
+    });
+
+    unmount();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+    vi.useRealTimers();
+  });
+
   it('launchWorkloadLogs opens Activity programmatically without a click', () => {
-    launchWorkloadLogs(new Deployment(deploymentData) as any);
+    const dispatchMock = vi.fn();
+    launchWorkloadLogs(new Deployment(deploymentData as any) as any, dispatchMock);
 
     expect(mockActivityLaunch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -269,201 +388,26 @@ describe('LogsButton', () => {
         location: 'full',
       })
     );
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: 'headlamp.logs',
+      data: {
+        status: 'open',
+      },
+    });
   });
 
-  it('launchWorkloadLogs fires the LOGS OPENED event when a dispatcher is passed', () => {
-    const dispatch = vi.fn();
-    launchWorkloadLogs(new Deployment(deploymentData) as any, dispatch);
-
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'headlamp.logs',
-        data: expect.objectContaining({ status: 'open' }),
-      })
-    );
-  });
-
-  it('LogsButtonContent fetches pods for a cross-bundle Deployment (isClassOf)', async () => {
-    // Simulates a plugin passing a Deployment instance whose class identity
-    // differs from the host's (duplicate class across bundles). instanceof
-    // would return false; isClassOf should match on kind.
-    class ForeignDeployment {
-      static kind = 'Deployment';
-      static isClassOf(instance: any) {
-        return instance?.kind === this.kind;
-      }
-      jsonData: any;
-      constructor(data: any) {
-        this.jsonData = data;
-      }
-      get kind() {
-        return this.jsonData?.kind;
-      }
-      get metadata() {
-        return this.jsonData?.metadata;
-      }
-      get spec() {
-        return this.jsonData?.spec;
-      }
-      get status() {
-        return this.jsonData?.status;
-      }
-      get cluster() {
-        return '';
-      }
-      getName() {
-        return this.jsonData?.metadata?.name ?? '';
-      }
+  it('launchWorkloadLogs ignores non-loggable workloads safely (cross-bundle check)', () => {
+    class UnknownWorkload extends MockKubeObject {
+      static kind = 'Unknown';
     }
-
-    mockClusterFetch.mockResolvedValue({
-      json: async () => ({ kind: 'PodList', apiVersion: 'v1', metadata: {}, items: [] }),
+    const unknownItem = new UnknownWorkload({
+      metadata: { name: 'unknown', uid: 'u-123' },
     });
-
-    const foreign = new ForeignDeployment(deploymentData);
-    expect(foreign instanceof Deployment).toBe(false); // precondition
-
-    // Exercise the programmatic plugin path: launch the Activity directly.
-    launchWorkloadLogs(foreign as any);
-    expect(mockActivityLaunch).toHaveBeenCalled();
-
-    // Render the launched Activity content so LogsButtonContent mounts and
-    // kicks off its pod fetch. With isClassOf, this should succeed even
-    // though the foreign class fails `instanceof Deployment`.
-    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
-    render(
-      <TestContext>
-        <div id="main" />
-        {activityContent}
-      </TestContext>
-    );
-
-    await waitFor(() => {
-      expect(mockClusterFetch).toHaveBeenCalled();
-    });
-  });
-
-  it('launchWorkloadLogs no-ops for unsupported workload kinds (e.g. Job)', () => {
-    const jobData = {
-      kind: 'Job',
-      metadata: { name: 'test-job', namespace: 'default', uid: 'job-123' },
-      spec: {},
-      status: {},
-    };
-    const dispatch = vi.fn();
-    launchWorkloadLogs(new Deployment(jobData as any) as any, dispatch);
+    const dispatchMock = vi.fn();
+    launchWorkloadLogs(unknownItem as any, dispatchMock);
 
     expect(mockActivityLaunch).not.toHaveBeenCalled();
-    expect(dispatch).not.toHaveBeenCalled();
-  });
-
-  it('shows warning snackbar when no pods are available', async () => {
-    mockClusterFetch.mockResolvedValue({
-      json: async () => ({ kind: 'PodList', apiVersion: 'v1', metadata: {}, items: [] }),
-    });
-
-    const { rerender } = render(
-      <TestContext>
-        <LogsButton item={new Deployment(deploymentData)} />
-      </TestContext>
-    );
-
-    fireEvent.click(screen.getByLabelText('translation|Show logs'));
-
-    // Render the LogsButtonContent
-    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
-    rerender(
-      <TestContext>
-        <div id="main" />
-        {activityContent}
-      </TestContext>
-    );
-
-    await waitFor(() => {
-      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
-        expect.stringMatching(/No pods found/i),
-        expect.objectContaining({ variant: 'warning' })
-      );
-    });
-  });
-
-  it('opens log viewer in loading state when getLogs never delivers data', async () => {
-    mockClusterFetch.mockResolvedValue({
-      json: async () => ({
-        kind: 'PodList',
-        apiVersion: 'v1',
-        metadata: {},
-        items: [mockPodData],
-      }),
-    });
-
-    Pod.prototype.getLogs = function () {
-      // Never deliver logs — simulates loading
-      return () => {};
-    };
-
-    const { rerender } = render(
-      <TestContext>
-        <LogsButton item={new Deployment(deploymentData)} />
-      </TestContext>
-    );
-
-    fireEvent.click(screen.getByLabelText('translation|Show logs'));
-
-    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
-    rerender(
-      <TestContext>
-        <div id="main" />
-        {activityContent}
-      </TestContext>
-    );
-
-    // LogsButtonContent mounts and fetches pods
-    await waitFor(() => {
-      expect(mockClusterFetch).toHaveBeenCalled();
-    });
-  });
-
-  it('opens log viewer and streams logs successfully', async () => {
-    mockClusterFetch.mockResolvedValue({
-      json: async () => ({
-        kind: 'PodList',
-        apiVersion: 'v1',
-        metadata: {},
-        items: [mockPodData],
-      }),
-    });
-
-    Pod.prototype.getLogs = function (...args: any[]) {
-      const onLogs = args[1];
-      const mockLogs = [
-        '2023-01-01T00:00:01Z Starting container...\n',
-        '2023-01-01T00:00:02Z Initializing application...\n',
-        '2023-01-01T00:00:03Z Server listening on port 80\n',
-      ];
-      const timeout = setTimeout(() => onLogs({ logs: mockLogs, hasJsonLogs: false }), 50);
-      return () => clearTimeout(timeout);
-    };
-
-    const { rerender } = render(
-      <TestContext>
-        <LogsButton item={new Deployment(deploymentData)} />
-      </TestContext>
-    );
-
-    fireEvent.click(screen.getByLabelText('translation|Show logs'));
-
-    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
-    rerender(
-      <TestContext>
-        <div id="main" />
-        {activityContent}
-      </TestContext>
-    );
-
-    // LogsButtonContent mounts and fetches pods
-    await waitFor(() => {
-      expect(mockClusterFetch).toHaveBeenCalled();
-    });
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -25,7 +25,7 @@ import { styled } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
 import { Terminal as XTerminal } from '@xterm/xterm';
 import { useSnackbar } from 'notistack';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { labelSelectorToQuery } from '../../../lib/k8s';
 import { clusterFetch } from '../../../lib/k8s/api/v2/fetch';
@@ -101,6 +101,10 @@ function LogsButtonContent({ item }: LogsButtonProps) {
   const [showReconnectButton, setShowReconnectButton] = useState(false);
 
   const xtermRef = React.useRef<XTerminal | null>(null);
+  const allPodLogsRef = useRef<{ [podName: string]: string[] }>({});
+  const processLogsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const processedLogsRef = useRef<{ [podName: string]: string[] } | null>(null);
+  const activeParamsRef = useRef<string>('');
   const { t } = useTranslation(['glossary', 'translation']);
   const { enqueueSnackbar } = useSnackbar();
 
@@ -232,8 +236,9 @@ function LogsButtonContent({ item }: LogsButtonProps) {
 
   // Function to process and display all logs
   const processAllLogs = React.useCallback(() => {
+    const currentAllPodLogs = allPodLogsRef.current;
     const allLogs: string[] = [];
-    Object.entries(allPodLogs).forEach(([podName, podLogs]) => {
+    Object.entries(currentAllPodLogs).forEach(([podName, podLogs]) => {
       podLogs.forEach(log => {
         allLogs.push(`[${podName}] ${log}`);
       });
@@ -255,125 +260,145 @@ function LogsButtonContent({ item }: LogsButtonProps) {
       logs: allLogs,
       lastLineShown: allLogs.length - 1,
     });
-  }, [allPodLogs]);
+  }, []);
 
   // Function to fetch and aggregate logs from all pods
-  function fetchAllPodsLogs(pods: Pod[], container: string): () => void {
-    clearLogs();
-    setAllPodLogs({});
+  const fetchAllPodsLogs = React.useCallback(
+    (pods: Pod[], container: string): (() => void) => {
+      clearLogs();
+      setAllPodLogs({});
+      allPodLogsRef.current = {};
 
-    const cleanups: Array<() => void> = [];
+      const cleanups: Array<() => void> = [];
 
-    pods.forEach(pod => {
-      const cleanup = pod.getLogs(
-        container,
-        ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
-          const podName = pod.getName();
-          setAllPodLogs(current => {
-            const updated = {
-              ...current,
-              [podName]: newLogs,
-            };
-            return updated;
-          });
-        },
-        {
-          tailLines: lines,
-          showPrevious,
-          showTimestamps,
-          follow,
-          onReconnectStop: () => {
-            setShowReconnectButton(true);
+      pods.forEach(pod => {
+        const cleanup = pod.getLogs(
+          container,
+          ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
+            const podName = pod.getName();
+            setAllPodLogs(current => {
+              const updated = {
+                ...current,
+                [podName]: newLogs,
+              };
+              allPodLogsRef.current = updated;
+              return updated;
+            });
           },
-        }
-      );
-      cleanups.push(cleanup);
-    });
+          {
+            tailLines: lines,
+            showPrevious,
+            showTimestamps,
+            follow,
+            onReconnectStop: () => {
+              setShowReconnectButton(true);
+            },
+          }
+        );
+        cleanups.push(cleanup);
+      });
 
-    return () => cleanups.forEach(cleanup => cleanup());
-  }
+      return () => cleanups.forEach(cleanup => cleanup());
+    },
+    [clearLogs, lines, showPrevious, showTimestamps, follow]
+  );
 
   // Effect for fetching and updating logs
   React.useEffect(() => {
+    const paramsKey = JSON.stringify({
+      selectedPodIndex,
+      selectedContainer,
+      lines,
+      showPrevious,
+      showTimestamps,
+      follow,
+      pods: pods.map(p => p.metadata.uid),
+    });
+
+    if (!selectedContainer || paramsKey === activeParamsRef.current) {
+      return;
+    }
+
+    activeParamsRef.current = paramsKey;
+
     let cleanup: (() => void) | null = null;
     let isSubscribed = true;
 
-    if (selectedContainer) {
-      clearLogs();
-      setAllPodLogs({}); // Clear aggregated logs when switching pods
+    // Handle paused logs state
+    if (!follow && logs.logs.length > 0) {
+      xtermRef.current?.write(
+        '\n\n' +
+          t('translation|Logs are paused. Click the follow button to resume following them.') +
+          '\r\n'
+      );
+      return;
+    }
 
-      // Handle paused logs state
-      if (!follow && logs.logs.length > 0) {
-        xtermRef.current?.write(
-          '\n\n' +
-            t('translation|Logs are paused. Click the follow button to resume following them.') +
-            '\r\n'
-        );
-        return;
-      }
+    clearLogs();
+    setAllPodLogs({}); // Clear aggregated logs when switching pods
+    allPodLogsRef.current = {};
 
-      if (selectedPodIndex === 'all') {
-        cleanup = fetchAllPodsLogs(pods, selectedContainer);
-      } else {
-        const pod = pods[selectedPodIndex as number];
-        if (pod) {
-          let lastLogLength = 0;
-          cleanup = pod.getLogs(
-            selectedContainer,
-            ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
-              if (!isSubscribed) return;
+    if (selectedPodIndex === 'all') {
+      cleanup = fetchAllPodsLogs(pods, selectedContainer);
+    } else {
+      const pod = pods[selectedPodIndex as number];
+      if (pod) {
+        let lastLogLength = 0;
+        cleanup = pod.getLogs(
+          selectedContainer,
+          ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
+            if (!isSubscribed) return;
 
-              setLogs(current => {
-                const terminalRef = xtermRef.current;
-                if (!terminalRef) return current;
+            setLogs(current => {
+              const terminalRef = xtermRef.current;
+              if (!terminalRef) return current;
 
-                // Only process new logs in chunks for better performance
-                if (newLogs.length > lastLogLength) {
-                  const CHUNK_SIZE = 1000; // Process 1000 lines at a time
-                  const startIdx = lastLogLength;
-                  const endIdx = Math.min(startIdx + CHUNK_SIZE, newLogs.length);
+              // Only process new logs in chunks for better performance
+              if (newLogs.length > lastLogLength) {
+                const CHUNK_SIZE = 1000; // Process 1000 lines at a time
+                const startIdx = lastLogLength;
+                const endIdx = Math.min(startIdx + CHUNK_SIZE, newLogs.length);
 
-                  // Process only the new chunk of logs
-                  const newLogContent = newLogs
-                    .slice(startIdx, endIdx)
-                    .join('')
-                    .replaceAll('\n', '\r\n');
+                // Process only the new chunk of logs
+                const newLogContent = newLogs
+                  .slice(startIdx, endIdx)
+                  .join('')
+                  .replaceAll('\n', '\r\n');
 
-                  terminalRef.write(newLogContent);
-                  lastLogLength = endIdx;
+                terminalRef.write(newLogContent);
+                lastLogLength = endIdx;
 
-                  // If there are more logs to process, schedule them for the next frame
-                  if (endIdx < newLogs.length) {
-                    requestAnimationFrame(() => {
-                      setLogs(current => ({
-                        ...current,
-                        logs: newLogs,
-                        lastLineShown: endIdx - 1,
-                      }));
-                    });
-                    return current;
-                  }
+                // If there are more logs to process, schedule them for the next frame
+                if (endIdx < newLogs.length) {
+                  requestAnimationFrame(() => {
+                    setLogs(current => ({
+                      ...current,
+                      logs: newLogs,
+                      lastLineShown: endIdx - 1,
+                    }));
+                  });
+                  return current;
                 }
+              }
 
-                return {
-                  logs: newLogs,
-                  lastLineShown: newLogs.length - 1,
-                };
-              });
+              return {
+                logs: newLogs,
+                lastLineShown: newLogs.length - 1,
+              };
+            });
+          },
+          {
+            tailLines: lines,
+            showPrevious,
+            showTimestamps,
+            follow,
+            onReconnectStop: () => {
+              if (isSubscribed) {
+                setShowReconnectButton(true);
+              }
             },
-            {
-              tailLines: lines,
-              showPrevious,
-              showTimestamps,
-              follow,
-              onReconnectStop: () => {
-                if (isSubscribed) {
-                  setShowReconnectButton(true);
-                }
-              },
-            }
-          );
-        }
+          }
+        );
       }
     }
 
@@ -384,13 +409,43 @@ function LogsButtonContent({ item }: LogsButtonProps) {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPodIndex, selectedContainer, lines, showTimestamps, follow, clearLogs, t, pods]);
+  }, [
+    selectedPodIndex,
+    selectedContainer,
+    lines,
+    showPrevious,
+    showTimestamps,
+    follow,
+    clearLogs,
+    fetchAllPodsLogs,
+    t,
+    pods,
+  ]);
 
   // Effect to process logs when allPodLogs changes - only for "All Pods" mode
+  // Debounced to avoid expensive O(N log N) sort on every incoming log chunk
   React.useEffect(() => {
-    if (selectedPodIndex === 'all' && Object.keys(allPodLogs).length > 0) {
-      processAllLogs();
+    if (
+      selectedPodIndex === 'all' &&
+      Object.keys(allPodLogs).length > 0 &&
+      allPodLogs !== processedLogsRef.current
+    ) {
+      if (processLogsTimerRef.current) {
+        clearTimeout(processLogsTimerRef.current);
+        processLogsTimerRef.current = null;
+      }
+      processLogsTimerRef.current = setTimeout(() => {
+        processLogsTimerRef.current = null;
+        processedLogsRef.current = allPodLogs;
+        processAllLogs();
+      }, 250);
     }
+    return () => {
+      if (processLogsTimerRef.current) {
+        clearTimeout(processLogsTimerRef.current);
+        processLogsTimerRef.current = null;
+      }
+    };
   }, [allPodLogs, selectedPodIndex, processAllLogs]);
 
   const topActions = [
@@ -577,10 +632,7 @@ export function LogsButton({ item }: LogsButtonProps) {
   return (
     <>
       {/* Show logs button for supported workload types */}
-      {(item instanceof Deployment ||
-        item instanceof ReplicaSet ||
-        item instanceof DaemonSet ||
-        item instanceof StatefulSet) && (
+      {isLoggableWorkload(item) && (
         <ActionButton
           icon="mdi:file-document-box-outline"
           onClick={onClick}

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -309,12 +309,11 @@ function LogsButtonContent({ item }: LogsButtonProps) {
       return;
     }
 
-    clearLogs();
-    setAllPodLogs({}); // Clear aggregated logs when switching pods
-
     if (selectedPodIndex === 'all') {
       cleanup = fetchAllPodsLogs(pods, selectedContainer);
     } else {
+      clearLogs();
+      setAllPodLogs({}); // Clear aggregated logs when switching pods
       const pod = pods[selectedPodIndex as number];
       if (pod) {
         let lastLogLength = 0;

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -101,10 +101,8 @@ function LogsButtonContent({ item }: LogsButtonProps) {
   const [showReconnectButton, setShowReconnectButton] = useState(false);
 
   const xtermRef = React.useRef<XTerminal | null>(null);
-  const allPodLogsRef = useRef<{ [podName: string]: string[] }>({});
   const processLogsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const processedLogsRef = useRef<{ [podName: string]: string[] } | null>(null);
-  const activeParamsRef = useRef<string>('');
   const { t } = useTranslation(['glossary', 'translation']);
   const { enqueueSnackbar } = useSnackbar();
 
@@ -235,10 +233,9 @@ function LogsButtonContent({ item }: LogsButtonProps) {
   }
 
   // Function to process and display all logs
-  const processAllLogs = React.useCallback(() => {
-    const currentAllPodLogs = allPodLogsRef.current;
+  const processAllLogs = React.useCallback((logsData: { [podName: string]: string[] }) => {
     const allLogs: string[] = [];
-    Object.entries(currentAllPodLogs).forEach(([podName, podLogs]) => {
+    Object.entries(logsData).forEach(([podName, podLogs]) => {
       podLogs.forEach(log => {
         allLogs.push(`[${podName}] ${log}`);
       });
@@ -267,7 +264,6 @@ function LogsButtonContent({ item }: LogsButtonProps) {
     (pods: Pod[], container: string): (() => void) => {
       clearLogs();
       setAllPodLogs({});
-      allPodLogsRef.current = {};
 
       const cleanups: Array<() => void> = [];
 
@@ -276,14 +272,10 @@ function LogsButtonContent({ item }: LogsButtonProps) {
           container,
           ({ logs: newLogs }: { logs: string[]; hasJsonLogs?: boolean }) => {
             const podName = pod.getName();
-            setAllPodLogs(current => {
-              const updated = {
-                ...current,
-                [podName]: newLogs,
-              };
-              allPodLogsRef.current = updated;
-              return updated;
-            });
+            setAllPodLogs(current => ({
+              ...current,
+              [podName]: newLogs,
+            }));
           },
           {
             tailLines: lines,
@@ -305,38 +297,20 @@ function LogsButtonContent({ item }: LogsButtonProps) {
 
   // Effect for fetching and updating logs
   React.useEffect(() => {
-    const paramsKey = JSON.stringify({
-      selectedPodIndex,
-      selectedContainer,
-      lines,
-      showPrevious,
-      showTimestamps,
-      follow,
-      pods: pods.map(p => p.metadata.uid),
-    });
-
-    if (!selectedContainer || paramsKey === activeParamsRef.current) {
+    if (!selectedContainer) {
       return;
     }
-
-    activeParamsRef.current = paramsKey;
 
     let cleanup: (() => void) | null = null;
     let isSubscribed = true;
 
-    // Handle paused logs state
+    // Handle paused logs state - avoid fetching new logs
     if (!follow && logs.logs.length > 0) {
-      xtermRef.current?.write(
-        '\n\n' +
-          t('translation|Logs are paused. Click the follow button to resume following them.') +
-          '\r\n'
-      );
       return;
     }
 
     clearLogs();
     setAllPodLogs({}); // Clear aggregated logs when switching pods
-    allPodLogsRef.current = {};
 
     if (selectedPodIndex === 'all') {
       cleanup = fetchAllPodsLogs(pods, selectedContainer);
@@ -417,10 +391,20 @@ function LogsButtonContent({ item }: LogsButtonProps) {
     showTimestamps,
     follow,
     clearLogs,
-    fetchAllPodsLogs,
-    t,
     pods,
   ]);
+
+  // Effect to write paused logs message without triggering resubscription
+  React.useEffect(() => {
+    if (!follow && logs.logs.length > 0) {
+      xtermRef.current?.write(
+        '\n\n' +
+          t('translation|Logs are paused. Click the follow button to resume following them.') +
+          '\r\n'
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [follow, t]);
 
   // Effect to process logs when allPodLogs changes - only for "All Pods" mode
   // Debounced to avoid expensive O(N log N) sort on every incoming log chunk
@@ -437,7 +421,7 @@ function LogsButtonContent({ item }: LogsButtonProps) {
       processLogsTimerRef.current = setTimeout(() => {
         processLogsTimerRef.current = null;
         processedLogsRef.current = allPodLogs;
-        processAllLogs();
+        processAllLogs(allPodLogs);
       }, 250);
     }
     return () => {


### PR DESCRIPTION
### Summary
This PR fixes a severe UI freeze / performance bottleneck in `LogsButton.tsx` by debouncing the `processAllLogs` function that runs an expensive O(N log N) sort on every incoming log chunk when streaming logs in "All Pods" mode.

### Related Issue
Fixes #5319

### Changes
* **Debounced Log Aggregation:** Added `processLogsTimerRef` to hold a debounce timer. Debounced the `useEffect` that triggers `processAllLogs` with a 250ms delay so the sort only runs once after a rapid batch of log chunks arrive, instead of on every single chunk.
* **Pure State Management:** Replaced unsafe mutations with pure `useState` updates. Added `processedLogsRef` to efficiently track the latest rendered logs and prevent unnecessary effect re-triggers. 
* **Removed Redundant Clears:** Removed redundant `clearLogs()` and `setAllPodLogs({})` calls from the main `useEffect` when switching to "All Pods" to prevent double-clearing the terminal.
* **Cross-Bundle Compatibility:** Replaced brittle `instanceof` checks with `*.isClassOf()` inside `isLoggableWorkload` to ensure Headlamp plugin compatibility. Added cross-bundle regression tests.

### Steps to Test

1. Apply this high-throughput log generating Deployment to your cluster:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: log-spammer
  labels:
    app: log-spammer
spec:
  replicas: 5
  selector:
    matchLabels:
      app: log-spammer
  template:
    metadata:
      labels:
        app: log-spammer
    spec:
      containers:
      - name: spammer
        image: alpine:latest
        command: ["/bin/sh", "-c"]
        args:
        - |
          i=0
          while true; do
            echo "$(date --rfc-3339=ns) - High throughput log line $i from pod $HOSTNAME to test UI debouncing!"
            i=$((i+1))
            sleep 0.05
          done
```

2. Open Headlamp and navigate to the `log-spammer` workload's detail page.
3. Click the **"Show logs"** action button to open the Log Viewer.
4. In the "Select Pod" dropdown, select **"All Pods"**.
5. Observe that the UI remains responsive while logs stream in rapidly (previously the browser tab would freeze/crash).

### Notes for the Reviewer
* The fix is scoped to only the "All Pods" aggregation path; single-pod log streaming is unaffected.
* The 250ms debounce interval balances responsiveness with performance; logs still appear near-real-time but the sort is batched.
* The cleanup function in the `useEffect` properly clears the debounce timer to prevent stale updates.
