### PR TITLE
backend: plugins: use errors.Is for cache error check

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -364,7 +364,7 @@ func addPluginListRoute(config *HeadlampConfig, r *mux.Router) {
 		w.Header().Set("Content-Type", "application/json")
 
 		pluginsList, err := config.Cache.Get(context.Background(), plugins.PluginListKey)
-		if err != nil && err == cache.ErrNotFound {
+		if err != nil && errors.Is(err, cache.ErrNotFound) {
 			pluginsList = []plugins.PluginMetadata{}
 
 			if config.Telemetry != nil {


### PR DESCRIPTION
## Summary
Fix the plugin list handler to use `errors.Is()` instead of direct `==` comparison for `cache.ErrNotFound`.
## Changes
- **Fixed**: `addPluginListRoute` in `backend/cmd/headlamp.go` used `err == cache.ErrNotFound` which fails to match wrapped errors. Replaced with `errors.Is(err, cache.ErrNotFound)` to correctly traverse the error chain.
## Why
Direct equality comparison (`==`) on sentinel errors breaks when errors are wrapped via `fmt.Errorf("...: %w", err)`. The Go standard library provides `errors.Is()` specifically for this purpose. The rest of the codebase already follows this convention (e.g., `plugins.go:390`).
## Steps to Test
1. `cd backend && go build ./cmd/...`
2. `go vet ./cmd/...`
3. `go test ./cmd/... -v -count=1`
4. `go test ./pkg/plugins/... -v -count=1`
All tests pass.
## Notes for the Reviewer
Single-line fix. No behavioral change for the current unwrapped error path, but hardens the code against future wrapping of `cache.ErrNotFound`.
