### PR TITLE
frontend: Fix useEvict setting not persisting as false

### DIFF
--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -89,7 +89,7 @@ export const initialState: ConfigState = {
       storedSettings.tableRowsPerPageOptions || defaultTableRowsPerPageOptions,
     timezone: storedSettings.timezone || defaultTimezone(),
     sidebarSortAlphabetically: storedSettings.sidebarSortAlphabetically || false,
-    useEvict: storedSettings.useEvict || true,
+    useEvict: storedSettings.useEvict ?? true,
   },
 };
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where the "Use evict for pod deletion" setting could not be persisted as disabled across page reloads.

## Related Issue

Fixes #5325 

## Changes

- Fixed a logical OR (`||`) bug in `frontend/src/redux/configSlice.ts` by replacing it with the nullish coalescing operator (`??`). This ensures that an explicit `false` value from `localStorage` is preserved instead of falling through to the default `true`.

## Steps to Test

1. Navigate to Settings (gear icon in the top right).
2. Under "General Settings", toggle **OFF** "Use evict for pod deletion".
3. Refresh the browser page (F5 or Cmd+R).
4. Navigate back to Settings and verify that the toggle is still **OFF**.
5. Navigate to a Pod details page and click the Delete icon. Verify the confirmation dialog says "Delete" instead of "Evict".

## Notes for the Reviewer

- The `||` operator treats `false` as falsy, which caused the setting to always revert to `true` upon initialization from localStorage. The `??` operator correctly only falls back to `true` when the stored value is `null` or `undefined`.
