### PR TITLE
frontend: apiDiscovery: Log core API discovery failures

### DIFF
--- a/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
+++ b/frontend/src/lib/k8s/api/v2/apiDiscovery.tsx
@@ -204,7 +204,12 @@ export async function apiDiscovery(clusters: string[]): Promise<ApiResource[]> {
                 }
               }
             } catch (e) {
-              // This catch block intentionally left blank.
+              // Log failure to fetch core API resources for better observability.
+              console.debug(
+                `Failed to fetch core API resources for cluster ${cluster}:`,
+                { version: v },
+                e
+              );
             }
           });
           await Promise.allSettled(coreResourceFetchPromises);


### PR DESCRIPTION
### **Summary:** This PR addresses a "silent killer" observability issue in the API discovery component. Previously, if the request to fetch Core Resources (like Pods, Nodes, or Services) failed due to a timeout, network glitch, or RBAC permission issue, the error was completely swallowed by an intentionally empty catch block. This resulted in resources silently failing to appear in the UI without any indication of why.

### **Fixes:** #5327

### **Changes:**

1. frontend/src/lib/k8s/api/v2/apiDiscovery.tsx: Replaced the empty catch block in the core API discovery loop with a console.debug statement. Failures are now properly logged with the cluster name and API version details, improving diagnosability without spamming the main UI with error toasts.

### **Steps to Test:**

1. Run npm run frontend:test to ensure no regressions.
2. Verify logging: Temporarily block or simulate a network failure for a core API fetch request (e.g., block the /api/v1 request in the browser's network tab).
3. Open the browser's developer tools and verify that a helpful message (Failed to fetch core API resources for cluster...) appears in the console instead of the failure happening silently.
