### PR TITLE
frontend: resourceMap: Use apiGroup icons in breadcrumbs

### DIFF
--- a/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
+++ b/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
@@ -89,8 +89,13 @@ export function SelectionBreadcrumbs({
           return '';
         };
 
-        const icon = it?.kubeObject?.kind ? (
-          <KubeIcon kind={it.kubeObject.kind} width="24px" height="24px" />
+        const kubeObject = it.kubeObject;
+        const apiGroup =
+          kubeObject?.jsonData?.apiVersion && kubeObject.jsonData.apiVersion.includes('/')
+            ? kubeObject.jsonData.apiVersion.split('/')[0]
+            : 'core';
+        const icon = kubeObject?.kind ? (
+          <KubeIcon kind={kubeObject.kind} apiGroup={apiGroup} width="24px" height="24px" />
         ) : null;
 
         const subtitle = it.subtitle ?? it?.kubeObject?.kind;


### PR DESCRIPTION
## Summary
Fixes a resource map UI inconsistency where breadcrumb icons could fall back to the generic Pod/cube icon even when the selected resource had a more specific built-in icon.

This happened because map nodes already pass `apiGroup` to `KubeIcon`, but `SelectionBreadcrumbs` only passed `kind`. For resources whose icons are registered by `apiGroup/kind`, like `apps/ReplicaSet`, the breadcrumb could not resolve the same icon shown on the node itself.

## Changes
- Updated `SelectionBreadcrumbs` to derive `apiGroup` from the resource `apiVersion`
- Fixed breadcrumb icons falling back to the generic Pod icon for resources with `apiGroup/kind` icons
- Kept the existing kind-only fallback behavior through `KubeIcon`
## Steps to Test
1. Open the resource map.
2. Group resources by Namespace and select a resource with an API-group-specific icon, like a Deployment or ReplicaSet.
3. Observe that the breadcrumb icon matches the selected resource icon instead of showing the generic Pod icon.

## Screenshots (if applicable)
Before:
<img width="743" height="274" alt="image" src="https://github.com/user-attachments/assets/95f40ae6-1a8e-4379-aebf-77be937e252d" />

After:
<img width="778" height="302" alt="image" src="https://github.com/user-attachments/assets/3c3d60a1-a393-4db3-b304-c09b5f4c6edf" />
