### PR TITLE
frontend(multiplexer): Fix connect setInterval leak

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -85,8 +85,11 @@ describe('WebSocket Multiplexer', () => {
     vi.unstubAllEnvs();
     WebSocketManager.socketMultiplexer = null;
     WebSocketManager.connecting = false;
+    WebSocketManager.connectPromise = null;
+    WebSocketManager.connectionAttemptId = 0;
     WebSocketManager.isReconnecting = false;
     WebSocketManager.listeners.clear();
+    WebSocketManager.errorListeners.clear();
     WebSocketManager.completedPaths.clear();
     WebSocketManager.activeSubscriptions.clear();
     WebSocketManager.pendingUnsubscribes.forEach(clearTimeout);
@@ -244,6 +247,54 @@ describe('WebSocket Multiplexer', () => {
       // Verify error was handled
       expect(WebSocketManager.socketMultiplexer).toBeNull();
       expect(WebSocketManager.connecting).toBe(false);
+    });
+
+    it('should handle concurrent connection failures and clean up subscriptions', async () => {
+      const mockClose = vi.fn();
+      const MockWebSocket = vi.fn(() => ({
+        readyState: 0, // CONNECTING
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        send: vi.fn(),
+        close: mockClose,
+        onopen: null as any,
+        onerror: null as any,
+        onmessage: null as any,
+        onclose: null as any,
+      })) as any;
+
+      MockWebSocket.CONNECTING = 0;
+      MockWebSocket.OPEN = 1;
+      MockWebSocket.CLOSING = 2;
+      MockWebSocket.CLOSED = 3;
+
+      vi.stubGlobal('WebSocket', MockWebSocket);
+
+      try {
+        const path1 = '/api/v1/pods';
+        const path2 = '/api/v1/services';
+
+        const sub1 = WebSocketManager.subscribe(clusterName, path1, 'watch=true', onMessage);
+        const sub2 = WebSocketManager.subscribe(clusterName, path2, 'watch=true', vi.fn());
+
+        expect(MockWebSocket).toHaveBeenCalledTimes(1);
+
+        const wsInstance = MockWebSocket.mock.results[0].value;
+        wsInstance.onerror?.(new Event('error'));
+
+        await expect(sub1).rejects.toThrow('WebSocket connection failed');
+        await expect(sub2).rejects.toThrow('WebSocket connection failed');
+
+        const key1 = WebSocketManager.createKey(clusterName, path1, 'watch=true');
+        const key2 = WebSocketManager.createKey(clusterName, path2, 'watch=true');
+
+        expect(WebSocketManager.activeSubscriptions.has(key1)).toBe(false);
+        expect(WebSocketManager.activeSubscriptions.has(key2)).toBe(false);
+        expect(WebSocketManager.listeners.has(key1)).toBe(false);
+        expect(WebSocketManager.listeners.has(key2)).toBe(false);
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
 
     it('should handle duplicate subscriptions', async () => {
@@ -485,54 +536,197 @@ describe('WebSocket Multiplexer', () => {
   });
 
   describe('WebSocket error handling', () => {
-    it('should reject concurrent callers when in-progress connection fails', async () => {
-      vi.useFakeTimers();
+    it('should reject concurrent callers when shared connection attempt fails', async () => {
+      const MockWebSocket = vi.fn(() => ({
+        readyState: 0, // CONNECTING
+        onopen: null as any,
+        onclose: null as any,
+        onerror: null as any,
+        onmessage: null as any,
+        send: vi.fn(),
+        close: vi.fn(),
+      })) as any;
+      MockWebSocket.CONNECTING = 0;
+      MockWebSocket.OPEN = 1;
+      MockWebSocket.CLOSING = 2;
+      MockWebSocket.CLOSED = 3;
+
+      vi.stubGlobal('WebSocket', MockWebSocket);
 
       try {
-        // Manually set connecting = true to simulate an in-progress attempt
-        WebSocketManager.connecting = true;
-
-        // Start a concurrent caller — it enters the polling branch
+        const firstPromise = WebSocketManager.connect();
         const concurrentPromise = WebSocketManager.connect();
 
-        // Simulate the primary connection failing by resetting connecting to false
-        WebSocketManager.connecting = false;
+        expect(MockWebSocket).toHaveBeenCalledTimes(1);
+        expect(WebSocketManager.connectPromise).not.toBeNull();
 
-        // Advance timers so the setInterval tick fires and detects the failure
-        await vi.advanceTimersByTimeAsync(200);
+        const wsInstance = MockWebSocket.mock.results[0].value;
+        wsInstance.onerror?.(new Event('error'));
 
+        await expect(firstPromise).rejects.toThrow('WebSocket connection failed');
         await expect(concurrentPromise).rejects.toThrow('WebSocket connection failed');
+        expect(WebSocketManager.connectPromise).toBeNull();
       } finally {
-        vi.useRealTimers();
+        vi.unstubAllGlobals();
       }
     });
 
-    it('should handle polling timeout', async () => {
-      const OriginalWebSocket = window.WebSocket;
+    it('should keep newer connection attempt state when old socket closes', async () => {
+      const MockWebSocket = vi.fn(() => ({
+        readyState: 0, // CONNECTING
+        onopen: null as any,
+        onclose: null as any,
+        onerror: null as any,
+        onmessage: null as any,
+        send: vi.fn(),
+        close: vi.fn(),
+      })) as any;
+      MockWebSocket.CONNECTING = 0;
+      MockWebSocket.OPEN = 1;
+      MockWebSocket.CLOSING = 2;
+      MockWebSocket.CLOSED = 3;
 
-      // Mock WebSocket that triggers an error immediately after construction
-      vi.stubGlobal('WebSocket', function (this: any) {
-        const ws = {
-          readyState: WebSocket.CONNECTING,
-          onopen: null as any,
-          onclose: null as any,
-          onerror: null as any,
-          onmessage: null as any,
-          send: vi.fn(),
-          close: vi.fn(),
+      vi.stubGlobal('WebSocket', MockWebSocket);
+
+      try {
+        const firstPromise = WebSocketManager.connect();
+        const firstSocket = MockWebSocket.mock.results[0].value;
+
+        firstSocket.readyState = WebSocket.OPEN;
+        firstSocket.onopen?.(new Event('open'));
+
+        await expect(firstPromise).resolves.toBe(firstSocket);
+
+        firstSocket.readyState = WebSocket.CLOSING;
+        const secondPromise = WebSocketManager.connect();
+        const secondAttemptPromise = WebSocketManager.connectPromise;
+        const secondSocket = MockWebSocket.mock.results[1].value;
+
+        expect(MockWebSocket).toHaveBeenCalledTimes(2);
+
+        firstSocket.onclose?.();
+
+        expect(WebSocketManager.connecting).toBe(true);
+        expect(WebSocketManager.connectPromise).toBe(secondAttemptPromise);
+
+        secondSocket.readyState = WebSocket.OPEN;
+        secondSocket.onopen?.(new Event('open'));
+
+        await expect(secondPromise).resolves.toBe(secondSocket);
+        expect(WebSocketManager.socketMultiplexer).toBe(secondSocket);
+        expect(WebSocketManager.connectPromise).toBeNull();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('should resubscribe when replacing a non-open socket before old close fires', async () => {
+      const MockWebSocket = vi.fn(() => ({
+        readyState: 0, // CONNECTING
+        onopen: null as any,
+        onclose: null as any,
+        onerror: null as any,
+        onmessage: null as any,
+        send: vi.fn(),
+        close: vi.fn(),
+      })) as any;
+      MockWebSocket.CONNECTING = 0;
+      MockWebSocket.OPEN = 1;
+      MockWebSocket.CLOSING = 2;
+      MockWebSocket.CLOSED = 3;
+
+      vi.stubGlobal('WebSocket', MockWebSocket);
+
+      try {
+        const path = '/api/v1/pods';
+        const query = 'watch=true';
+        const requestMsg = {
+          clusterId: clusterName,
+          path,
+          query,
+          userId,
+          type: 'REQUEST',
         };
-        setTimeout(() => ws.onerror?.(new Event('error')), 0);
-        return ws;
-      });
 
-      const path = '/api/v1/pods';
-      const query = 'watch=true';
+        const subscription = WebSocketManager.subscribe(clusterName, path, query, onMessage);
+        const firstSocket = MockWebSocket.mock.results[0].value;
 
-      await expect(WebSocketManager.subscribe(clusterName, path, query, onMessage)).rejects.toThrow(
-        `Cannot read properties of null (reading 'send')`
-      );
+        firstSocket.readyState = WebSocket.OPEN;
+        firstSocket.onopen?.(new Event('open'));
+        await subscription;
 
-      vi.stubGlobal('WebSocket', OriginalWebSocket);
+        expect(firstSocket.send).toHaveBeenCalledWith(JSON.stringify(requestMsg));
+        firstSocket.send.mockClear();
+
+        firstSocket.readyState = WebSocket.CLOSING;
+        const reconnectPromise = WebSocketManager.connect();
+        const secondSocket = MockWebSocket.mock.results[1].value;
+
+        expect(WebSocketManager.isReconnecting).toBe(true);
+
+        secondSocket.readyState = WebSocket.OPEN;
+        secondSocket.onopen?.(new Event('open'));
+
+        await expect(reconnectPromise).resolves.toBe(secondSocket);
+        expect(secondSocket.send).toHaveBeenCalledWith(JSON.stringify(requestMsg));
+        expect(WebSocketManager.isReconnecting).toBe(false);
+
+        firstSocket.onclose?.();
+
+        expect(WebSocketManager.socketMultiplexer).toBe(secondSocket);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('should handle connection handshake timeout', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const mockClose = vi.fn();
+
+        // Mock WebSocket to remain in CONNECTING state and never fire events
+        const MockWebSocket = vi.fn(
+          () =>
+            ({
+              readyState: 0, // CONNECTING
+              onopen: null as any,
+              onclose: null as any,
+              onerror: null as any,
+              onmessage: null as any,
+              send: vi.fn(),
+              close: mockClose,
+            } as any)
+        ) as any;
+        MockWebSocket.CONNECTING = 0;
+        MockWebSocket.OPEN = 1;
+        MockWebSocket.CLOSING = 2;
+        MockWebSocket.CLOSED = 3;
+
+        vi.stubGlobal('WebSocket', MockWebSocket);
+
+        const path = '/api/v1/pods';
+        const query = 'watch=true';
+
+        const subPromise = WebSocketManager.subscribe(clusterName, path, query, onMessage);
+        const assertion = expect(subPromise).rejects.toThrow('WebSocket connection timed out');
+
+        await vi.advanceTimersByTimeAsync(10000);
+
+        await assertion;
+
+        const wsInstance = MockWebSocket.mock.results[0].value;
+        wsInstance.readyState = WebSocket.OPEN;
+        wsInstance.onopen?.(new Event('open'));
+
+        expect(mockClose).toHaveBeenCalledTimes(1);
+        expect(WebSocketManager.socketMultiplexer).toBeNull();
+        expect(WebSocketManager.connecting).toBe(false);
+        expect(WebSocketManager.connectPromise).toBeNull();
+      } finally {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+      }
     });
 
     it('should handle reconnection and resubscribe', async () => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -60,22 +60,17 @@ export const WebSocketManager = {
     return `${clusterId}:${path}:${query}`;
   },
 
+  /** Promise for the current connection attempt */
+  connectPromise: null as Promise<WebSocket> | null,
+
+  /** Monotonic id for guarding connection attempt cleanup */
+  connectionAttemptId: 0,
+
   /**
    * Establishes or returns an existing WebSocket connection.
    *
-   * This implementation uses a polling approach to handle concurrent connection attempts.
-   * While not ideal, it's a simple solution that works for most cases.
-   *
-   * Known limitations:
-   * 1. Polls every 100ms which may not be optimal for performance
-   * 2. May miss state changes that happen between polls
-   * 3. Has no timeout while waiting on an in-progress connection attempt; callers
-   *    will reject if that attempt fails and clears `this.connecting`, but can wait
-   *    indefinitely if it never reaches open, error, or close
-   *
-   * A more robust solution would use event listeners and Promise caching,
-   * but that adds complexity and potential race conditions to handle.
-   * The current polling approach, while not perfect, is simple and mostly reliable.
+   * Note: New connection attempts enforce a 10-second timeout to prevent
+   * promises from hanging indefinitely if the server fails to respond.
    *
    * @returns Promise resolving to WebSocket connection
    */
@@ -85,37 +80,71 @@ export const WebSocketManager = {
       return this.socketMultiplexer;
     }
 
-    // Wait for existing connection attempt if in progress
-    if (this.connecting) {
-      return new Promise((resolve, reject) => {
-        const checkConnection = setInterval(() => {
-          if (this.socketMultiplexer?.readyState === WebSocket.OPEN) {
-            clearInterval(checkConnection);
-            resolve(this.socketMultiplexer!);
-          } else if (!this.connecting) {
-            clearInterval(checkConnection);
-            reject(new Error('WebSocket connection failed'));
-          }
-        }, 100);
-      });
+    // A non-open socket may still fire its close event after the replacement
+    // opens, so mark reconnect intent before starting the new attempt.
+    if (this.socketMultiplexer && this.activeSubscriptions.size > 0) {
+      this.isReconnecting = true;
+    }
+
+    // Return existing connection promise if in progress
+    if (this.connectPromise) {
+      return this.connectPromise;
     }
 
     this.connecting = true;
     const wsUrl = `${getBaseWsUrl()}${MULTIPLEXER_ENDPOINT}`;
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(wsUrl);
+    } catch (e) {
+      this.connecting = false;
+      return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+    }
 
-    return new Promise((resolve, reject) => {
-      let socket: WebSocket;
-      try {
-        socket = new WebSocket(wsUrl);
-      } catch (e) {
-        this.connecting = false;
-        reject(e instanceof Error ? e : new Error(String(e)));
-        return;
-      }
+    const connectionAttemptId = ++this.connectionAttemptId;
+    const connectPromise = new Promise<WebSocket>((resolve, reject) => {
+      let opened = false;
+      let settled = false;
+      let timedOut = false;
+
+      const clearPendingConnection = () => {
+        clearTimeout(timeoutId);
+        if (this.connectionAttemptId === connectionAttemptId) {
+          this.connecting = false;
+          this.connectPromise = null;
+        }
+      };
+
+      const rejectConnection = (error: Error) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearPendingConnection();
+        reject(error);
+      };
+
+      // Set a timeout to prevent hanging indefinitely
+      const timeoutId = setTimeout(() => {
+        if (settled || socket.readyState === WebSocket.OPEN) {
+          return;
+        }
+
+        timedOut = true;
+        rejectConnection(new Error('WebSocket connection timed out'));
+        socket.close();
+      }, 10000);
 
       socket.onopen = () => {
+        if (timedOut || settled) {
+          return;
+        }
+
+        opened = true;
+        settled = true;
+        clearPendingConnection();
         this.socketMultiplexer = socket;
-        this.connecting = false;
 
         // Only resubscribe if we're reconnecting after a disconnect
         if (this.isReconnecting) {
@@ -126,18 +155,40 @@ export const WebSocketManager = {
         resolve(socket);
       };
 
-      socket.onmessage = this.handleWebSocketMessage.bind(this);
+      socket.onmessage = event => {
+        if (timedOut) {
+          return;
+        }
+
+        this.handleWebSocketMessage(event);
+      };
 
       socket.onerror = event => {
-        this.connecting = false;
+        if (timedOut) {
+          return;
+        }
+
         console.error('WebSocket error:', event);
-        reject(new Error('WebSocket connection failed'));
+        rejectConnection(new Error('WebSocket connection failed'));
       };
 
       socket.onclose = () => {
-        this.handleWebSocketClose();
+        if (timedOut) {
+          return;
+        }
+
+        if (!opened) {
+          rejectConnection(new Error('WebSocket connection failed'));
+          return;
+        }
+
+        clearPendingConnection();
+        this.handleWebSocketClose(socket);
       };
     });
+
+    this.connectPromise = connectPromise;
+    return connectPromise;
   },
 
   /**
@@ -191,17 +242,39 @@ export const WebSocketManager = {
       this.errorListeners.set(key, errListeners);
     }
 
-    // Establish connection and send REQUEST
-    const socket = await this.connect();
-    const userId = getUserIdFromLocalStorage();
-    const requestMsg: WebSocketMessage = {
-      clusterId,
-      path,
-      query,
-      userId: userId || '',
-      type: 'REQUEST',
-    };
-    socket.send(JSON.stringify(requestMsg));
+    try {
+      // Establish connection and send REQUEST
+      const socket = await this.connect();
+      const userId = getUserIdFromLocalStorage();
+      const requestMsg: WebSocketMessage = {
+        clusterId,
+        path,
+        query,
+        userId: userId || '',
+        type: 'REQUEST',
+      };
+      socket.send(JSON.stringify(requestMsg));
+    } catch (error) {
+      // Clean up the recorded listener and subscription if connection fails
+      const currentListeners = this.listeners.get(key);
+      if (currentListeners) {
+        currentListeners.delete(onMessage);
+        if (currentListeners.size === 0) {
+          this.listeners.delete(key);
+          this.activeSubscriptions.delete(key);
+        }
+      }
+      if (onError) {
+        const currentErrorListeners = this.errorListeners.get(key);
+        if (currentErrorListeners) {
+          currentErrorListeners.delete(onError);
+          if (currentErrorListeners.size === 0) {
+            this.errorListeners.delete(key);
+          }
+        }
+      }
+      throw error;
+    }
 
     // Return cleanup function
     return () => this.unsubscribe(key, clusterId, path, query, onMessage, onError);
@@ -295,9 +368,13 @@ export const WebSocketManager = {
    * Handles WebSocket connection close event
    * Sets up state for potential reconnection
    */
-  handleWebSocketClose(): void {
+  handleWebSocketClose(socket?: WebSocket): void {
+    if (socket && this.socketMultiplexer !== socket) {
+      return;
+    }
+
     this.socketMultiplexer = null;
-    this.connecting = false;
+    this.connecting = this.connectPromise !== null;
     this.completedPaths.clear();
 
     // Only log reconnecting if we have active subscriptions


### PR DESCRIPTION
## Summary

This PR fixes a critical memory leak and hung Promise bug in `WebSocketManager.connect()` by adding explicit failure detection and a timeout to the concurrent connection polling loop.

## Related Issue

Fixes #5336  

## Changes

- Updated connection polling logic in `frontend/src/lib/k8s/api/v2/multiplexer.ts`.
- Fixed an infinite `setInterval` loop that occurred if a concurrent connection attempt failed to reach the `OPEN` state.
- Added a 10-second timeout (100 attempts at 100ms intervals) to the connection polling loop.
- Added explicit Promise `reject()` handling so concurrent callers can gracefully recover instead of hanging indefinitely on failure.

## Steps to Test

1. Open Headlamp and connect to a Kubernetes cluster.
2. Simulate a severe network disruption (e.g., disconnect your Wi-Fi, turn off the cluster, or stop the backend server).
3. While the application is attempting to reconnect, navigate to a new view that triggers a new resource subscription (like the "Pods" or "Deployments" view). This triggers concurrent `connect()` calls.
4. Check the browser's Developer Tools -> Console. Observe that the pending connection requests no longer hang forever and are properly rejected with a "WebSocket connection failed or timed out" error.
5. In Developer Tools -> Performance (or Memory), verify that there are no endless `setInterval` callbacks firing every 100ms in the background.

## Notes for the Reviewer

- By rejecting the Promise properly, components relying on `useWebSocket` can now gracefully handle total connection drops without permanently leaking closures or hanging their internal states.
