### PR TITLE
backend: spa: Fix Windows path handling using path.Join

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -310,7 +310,7 @@ func addPluginDeleteRoute(config *HeadlampConfig, r *mux.Router) {
 		logger.Log(logger.LevelInfo, nil, nil, "Received DELETE request for plugin: "+mux.Vars(r)["name"])
 
 		if err := config.checkHeadlampBackendToken(w, r); err != nil {
-			config.TelemetryHandler.RecordError(span, err, " Invalid backend token")
+			config.TelemetryHandler.RecordError(span, err, "Invalid backend token")
 			logger.Log(logger.LevelWarn, nil, err, "Invalid backend token for DELETE /plugins/{name}")
 
 			return

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -50,8 +50,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -599,149 +597,6 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 	}
 }
 
-func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
-	podOk := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-ok",
-			Namespace: "default",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-		},
-	}
-	podDaemonset := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-daemonset",
-			Namespace: "default",
-			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-		},
-	}
-	podFail := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-fail",
-			Namespace: "kube-system",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-		},
-	}
-
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-node",
-		},
-	}
-
-	fakeClient := fake.NewClientset(node, podOk, podDaemonset, podFail)
-
-	// Inject error for deleting pod-fail
-	fakeClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
-		deleteAction := action.(k8stesting.DeleteAction)
-		if deleteAction.GetName() == "pod-fail" {
-			return true, nil, fmt.Errorf("pod is protected by PodDisruptionBudget")
-		}
-
-		return false, nil, nil
-	})
-
-	testCache := cache.New[interface{}]()
-	c := &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			Cache: testCache,
-		},
-	}
-
-	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
-	ctx := context.Background()
-
-	c.drainNode(fakeClient, "test-node", "test-cluster")
-
-	require.Eventually(t, func() bool {
-		cacheItem, err := testCache.Get(ctx, cacheKey)
-		if err != nil {
-			return false
-		}
-
-		status, ok := cacheItem.(string)
-
-		return ok && strings.HasPrefix(status, "error:")
-	}, 5*time.Second, 50*time.Millisecond)
-
-	cacheItem, err := testCache.Get(ctx, cacheKey)
-	require.NoError(t, err)
-
-	status, ok := cacheItem.(string)
-	require.True(t, ok)
-
-	assert.True(t, strings.HasPrefix(status, "error:"),
-		"expected error status, got: %s", status)
-	assert.Contains(t, status, "failed to delete")
-}
-
-func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
-	pod1 := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-1",
-			Namespace: "default",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-		},
-	}
-	podDaemonset := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-daemonset",
-			Namespace: "default",
-			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "test-node",
-		},
-	}
-
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-node",
-		},
-	}
-
-	fakeClient := fake.NewClientset(node, pod1, podDaemonset)
-
-	testCache := cache.New[interface{}]()
-	c := &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			Cache: testCache,
-		},
-	}
-
-	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
-	ctx := context.Background()
-
-	c.drainNode(fakeClient, "test-node", "test-cluster")
-
-	require.Eventually(t, func() bool {
-		cacheItem, err := testCache.Get(ctx, cacheKey)
-		if err != nil {
-			return false
-		}
-
-		status, ok := cacheItem.(string)
-
-		return ok && status == "success"
-	}, 2*time.Second, 50*time.Millisecond)
-
-	cacheItem, err := testCache.Get(ctx, cacheKey)
-	require.NoError(t, err)
-
-	status, ok := cacheItem.(string)
-	require.True(t, ok)
-
-	assert.Equal(t, "success", status)
-}
-
 func TestDeletePlugin(t *testing.T) {
 	// create temp dir for plugins
 	tempDir, err := os.MkdirTemp("", "plugins")
@@ -750,22 +605,22 @@ func TestDeletePlugin(t *testing.T) {
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// create user-plugins dir
-	userPluginDir := tempDir + "/user-plugins"
+	userPluginDir := filepath.Join(tempDir, "user-plugins")
 	err = os.Mkdir(userPluginDir, 0o750)
 	require.NoError(t, err)
 
 	// create dev plugins dir
-	devPluginDir := tempDir + "/plugins"
+	devPluginDir := filepath.Join(tempDir, "plugins")
 	err = os.Mkdir(devPluginDir, 0o750)
 	require.NoError(t, err)
 
 	// create plugin in dev dir
-	pluginDir := devPluginDir + "/test-plugin"
+	pluginDir := filepath.Join(devPluginDir, "test-plugin")
 	err = os.Mkdir(pluginDir, 0o750)
 	require.NoError(t, err)
 
 	// create plugin file
-	pluginFile := pluginDir + "/main.js"
+	pluginFile := filepath.Join(pluginDir, "main.js")
 	f, err := os.Create(pluginFile) //nolint:gosec
 	require.NoError(t, err)
 	require.NoError(t, f.Close())

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -50,6 +50,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -597,6 +599,149 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 	}
 }
 
+func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
+	podOk := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-ok",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	podDaemonset := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-daemonset",
+			Namespace: "default",
+			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	podFail := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-fail",
+			Namespace: "kube-system",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	fakeClient := fake.NewClientset(node, podOk, podDaemonset, podFail)
+
+	// Inject error for deleting pod-fail
+	fakeClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		deleteAction := action.(k8stesting.DeleteAction)
+		if deleteAction.GetName() == "pod-fail" {
+			return true, nil, fmt.Errorf("pod is protected by PodDisruptionBudget")
+		}
+
+		return false, nil, nil
+	})
+
+	testCache := cache.New[interface{}]()
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			Cache: testCache,
+		},
+	}
+
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
+	ctx := context.Background()
+
+	c.drainNode(fakeClient, "test-node", "test-cluster")
+
+	require.Eventually(t, func() bool {
+		cacheItem, err := testCache.Get(ctx, cacheKey)
+		if err != nil {
+			return false
+		}
+
+		status, ok := cacheItem.(string)
+
+		return ok && strings.HasPrefix(status, "error:")
+	}, 5*time.Second, 50*time.Millisecond)
+
+	cacheItem, err := testCache.Get(ctx, cacheKey)
+	require.NoError(t, err)
+
+	status, ok := cacheItem.(string)
+	require.True(t, ok)
+
+	assert.True(t, strings.HasPrefix(status, "error:"),
+		"expected error status, got: %s", status)
+	assert.Contains(t, status, "failed to delete")
+}
+
+func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	podDaemonset := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-daemonset",
+			Namespace: "default",
+			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	fakeClient := fake.NewClientset(node, pod1, podDaemonset)
+
+	testCache := cache.New[interface{}]()
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			Cache: testCache,
+		},
+	}
+
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
+	ctx := context.Background()
+
+	c.drainNode(fakeClient, "test-node", "test-cluster")
+
+	require.Eventually(t, func() bool {
+		cacheItem, err := testCache.Get(ctx, cacheKey)
+		if err != nil {
+			return false
+		}
+
+		status, ok := cacheItem.(string)
+
+		return ok && status == "success"
+	}, 2*time.Second, 50*time.Millisecond)
+
+	cacheItem, err := testCache.Get(ctx, cacheKey)
+	require.NoError(t, err)
+
+	status, ok := cacheItem.(string)
+	require.True(t, ok)
+
+	assert.Equal(t, "success", status)
+}
+
 func TestDeletePlugin(t *testing.T) {
 	// create temp dir for plugins
 	tempDir, err := os.MkdirTemp("", "plugins")
@@ -874,7 +1019,7 @@ func TestCustomNameToExtensions(t *testing.T) {
 			tmpFile, err := os.CreateTemp(t.TempDir(), "kubeconfig-*.yaml")
 			require.NoError(t, err)
 
-			_ = tmpFile.Close()
+			require.NoError(t, tmpFile.Close())
 
 			config := &api.Config{
 				Contexts: map[string]*api.Context{

--- a/backend/pkg/exec/exec_test.go
+++ b/backend/pkg/exec/exec_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -32,9 +33,8 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"reflect"
-	stdruntime "runtime"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -96,6 +96,39 @@ stR0Yiw0buV6DL/moUO0HIM9Bjh96HJp+LxiIS6UCdIhMPp5HoQa
 -----END RSA PRIVATE KEY-----`)
 	validCert *tls.Certificate
 )
+
+func setTestPluginCommand(config *api.ExecConfig) {
+	if goruntime.GOOS == "windows" {
+		config.Command = "cmd"
+		config.Args = append([]string{"/C", ".\\testdata\\test-plugin.bat"}, config.Args...)
+
+		return
+	}
+
+	config.Command = "./testdata/test-plugin.sh"
+}
+
+func testOutputEnv(output string) api.ExecEnvVar {
+	if goruntime.GOOS == "windows" {
+		return api.ExecEnvVar{
+			Name:  "TEST_OUTPUT_B64",
+			Value: base64.StdEncoding.EncodeToString([]byte(output)),
+		}
+	}
+
+	return api.ExecEnvVar{
+		Name:  "TEST_OUTPUT",
+		Value: output,
+	}
+}
+
+func testOutputEnvString(output string) string {
+	if goruntime.GOOS == "windows" {
+		return "TEST_OUTPUT_B64=" + base64.StdEncoding.EncodeToString([]byte(output))
+	}
+
+	return "TEST_OUTPUT=" + output
+}
 
 func init() {
 	cert, err := tls.X509KeyPair(certData, keyData)
@@ -796,11 +829,8 @@ func TestRefreshCreds(t *testing.T) {
 			c := test.config
 
 			if c.Command == "" {
-				c.Command, c.Args = getTestPluginCmd()
-				c.Env = append(c.Env, api.ExecEnvVar{
-					Name:  "TEST_OUTPUT",
-					Value: test.output,
-				})
+				setTestPluginCommand(&c)
+				c.Env = append(c.Env, testOutputEnv(test.output))
 				c.Env = append(c.Env, api.ExecEnvVar{
 					Name:  "TEST_EXIT_CODE",
 					Value: strconv.Itoa(test.exitCode),
@@ -862,7 +892,7 @@ func TestRoundTripper(t *testing.T) {
 	}
 
 	setOutput := func(s string) {
-		env[0] = "TEST_OUTPUT=" + s
+		env[0] = testOutputEnvString(s)
 	}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -880,13 +910,12 @@ func TestRoundTripper(t *testing.T) {
 	}
 	server := httptest.NewServer(http.HandlerFunc(handler))
 
-	cmd, args := getTestPluginCmd()
 	c := api.ExecConfig{
-		Command:         cmd,
-		Args:            args,
 		APIVersion:      "client.authentication.k8s.io/v1beta1",
 		InteractiveMode: api.IfAvailableExecInteractiveMode,
 	}
+	setTestPluginCommand(&c)
+
 	a, err := newAuthenticator(newCache(), func(_ int) bool { return false }, &c, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -996,13 +1025,13 @@ func TestAuthorizationHeaderPresentCancelsExecAction(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		cmd, args := getTestPluginCmd()
 		t.Run(test.name, func(t *testing.T) {
-			a, err := newAuthenticator(newCache(), func(_ int) bool { return false }, &api.ExecConfig{
-				Command:    cmd,
-				Args:       args,
+			c := api.ExecConfig{
 				APIVersion: "client.authentication.k8s.io/v1beta1",
-			}, nil)
+			}
+			setTestPluginCommand(&c)
+
+			a, err := newAuthenticator(newCache(), func(_ int) bool { return false }, &c, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1041,13 +1070,13 @@ func TestTLSCredentials(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	cmd, args := getTestPluginCmd()
-	a, err := newAuthenticator(newCache(), func(_ int) bool { return false }, &api.ExecConfig{
-		Command:         cmd,
-		Args:            args,
+	c := api.ExecConfig{
 		APIVersion:      "client.authentication.k8s.io/v1beta1",
 		InteractiveMode: api.IfAvailableExecInteractiveMode,
-	}, nil)
+	}
+	setTestPluginCommand(&c)
+
+	a, err := newAuthenticator(newCache(), func(_ int) bool { return false }, &c, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1057,7 +1086,7 @@ func TestTLSCredentials(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return []string{"TEST_OUTPUT=" + string(data)}
+		return []string{testOutputEnvString(string(data))}
 	}
 	a.now = func() time.Time { return now }
 	a.stderr = io.Discard
@@ -1133,12 +1162,11 @@ func TestConcurrentUpdateTransportConfig(t *testing.T) {
 		return s
 	}
 
-	cmd, args := getTestPluginCmd()
 	c := api.ExecConfig{
-		Command:    cmd,
-		Args:       args,
 		APIVersion: "client.authentication.k8s.io/v1beta1",
 	}
+	setTestPluginCommand(&c)
+
 	a, err := newAuthenticator(newCache(), func(_ int) bool { return false }, &c, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1272,11 +1300,4 @@ func genClientCert(t *testing.T) ([]byte, []byte) {
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certRaw}),
 		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyRaw})
-}
-
-func getTestPluginCmd() (string, []string) {
-	if stdruntime.GOOS == "windows" {
-		return "cmd.exe", []string{"/c", filepath.Join(".", "testdata", "test-plugin.bat")}
-	}
-	return filepath.Join(".", "testdata", "test-plugin.sh"), nil
 }

--- a/backend/pkg/exec/testdata/test-plugin.bat
+++ b/backend/pkg/exec/testdata/test-plugin.bat
@@ -1,9 +1,10 @@
 @echo off
 setlocal EnableDelayedExpansion
 if defined KUBERNETES_EXEC_INFO echo !KUBERNETES_EXEC_INFO! 1>&2
-if defined TEST_OUTPUT echo !TEST_OUTPUT!
-if defined TEST_EXIT_CODE (
-    exit /b !TEST_EXIT_CODE!
+if defined TEST_OUTPUT_B64 (
+  C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command "[Console]::Out.Write([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($env:TEST_OUTPUT_B64)))"
 ) else (
-    exit /b 0
+  echo !TEST_OUTPUT!
 )
+if defined TEST_EXIT_CODE exit /B !TEST_EXIT_CODE!
+exit /B 0

--- a/backend/pkg/exec/testdata/test-plugin.bat
+++ b/backend/pkg/exec/testdata/test-plugin.bat
@@ -2,7 +2,7 @@
 setlocal EnableDelayedExpansion
 if defined KUBERNETES_EXEC_INFO echo !KUBERNETES_EXEC_INFO! 1>&2
 if defined TEST_OUTPUT_B64 (
-  C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command "[Console]::Out.Write([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($env:TEST_OUTPUT_B64)))"
+  %SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command "[Console]::Out.Write([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($env:TEST_OUTPUT_B64)))"
 ) else (
   echo !TEST_OUTPUT!
 )

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -60,7 +60,7 @@ const (
 
 // Watch watches the given path for changes and sends the events to the notify channel.
 // It runs until the provided context is cancelled.
-func Watch(ctx context.Context, path string, notify chan<- string, ready ...chan<- struct{}) {
+func Watch(ctx context.Context, watchPath string, notify chan<- string, ready ...chan<- struct{}) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "creating watcher")
@@ -84,7 +84,7 @@ func Watch(ctx context.Context, path string, notify chan<- string, ready ...chan
 			r = ready[0]
 		}
 
-		periodicallyWatchSubfolders(ctx, watcher, path, subFolderWatchInterval, r)
+		periodicallyWatchSubfolders(ctx, watcher, notify, watchPath, subFolderWatchInterval, r)
 	}()
 
 	for {
@@ -94,7 +94,12 @@ func Watch(ctx context.Context, path string, notify chan<- string, ready ...chan
 
 			return
 		case event := <-watcher.Events:
-			notify <- event.Name + ":" + event.Op.String()
+			select {
+			case notify <- event.Name + ":" + event.Op.String():
+			case <-ctx.Done():
+				logger.Log(logger.LevelInfo, nil, nil, "watcher: shutting down plugin watcher during event notify")
+				return
+			}
 		case err := <-watcher.Errors:
 			logger.Log(logger.LevelError, nil, err, "Plugin watcher Error")
 		}
@@ -107,32 +112,43 @@ func Watch(ctx context.Context, path string, notify chan<- string, ready ...chan
 func periodicallyWatchSubfolders(
 	ctx context.Context,
 	watcher *fsnotify.Watcher,
-	path string,
+	notify chan<- string,
+	dirPath string,
 	interval time.Duration,
 	ready chan<- struct{},
 ) {
 	walk := func() {
 		// Walk the path and add any new directories to the watcher.
-		_ = filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
-			if d != nil && d.IsDir() && !slices.Contains(watcher.WatchList(), path) {
-				err := watcher.Add(path)
+		_ = filepath.WalkDir(dirPath, func(entryPath string, d fs.DirEntry, err error) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			if d != nil && d.IsDir() && !slices.Contains(watcher.WatchList(), entryPath) {
+				err := watcher.Add(entryPath)
 				if err != nil {
-					logger.Log(logger.LevelError, map[string]string{"path": path},
+					logger.Log(logger.LevelError, map[string]string{"path": entryPath},
 						err, "adding path to watcher")
 
 					return err
 				}
 				// when a folder is added, send events for all the files in the folder
-				entries, err := os.ReadDir(path)
+				entries, err := os.ReadDir(entryPath)
 				if err != nil {
-					logger.Log(logger.LevelError, map[string]string{"path": path},
+					logger.Log(logger.LevelError, map[string]string{"path": entryPath},
 						err, "reading dir")
 
 					return err
 				}
 
 				for _, entry := range entries {
-					watcher.Events <- fsnotify.Event{Name: filepath.Join(path, entry.Name()), Op: fsnotify.Create}
+					select {
+					case notify <- filepath.Join(entryPath, entry.Name()) + ":" + fsnotify.Create.String():
+					case <-ctx.Done():
+						return ctx.Err()
+					}
 				}
 			}
 
@@ -340,21 +356,24 @@ func ListPlugins(staticPluginDir, userPluginDir, pluginDir string) error {
 
 // pluginBasePathListForDir returns a list of valid plugin paths for the given directory.
 func pluginBasePathListForDir(pluginDir string, baseURL string) ([]string, error) {
+	if pluginDir == "" {
+		return nil, nil
+	}
+
 	info, err := os.Stat(pluginDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-
 		return nil, err
 	}
 
 	if !info.IsDir() {
-		return nil, fmt.Errorf("plugin path %s is not a directory", pluginDir)
+		return nil, fmt.Errorf("%q is not a directory", pluginDir)
 	}
 
 	files, err := os.ReadDir(pluginDir)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		logger.Log(logger.LevelError, map[string]string{"pluginDir": pluginDir},
 			err, "reading plugin directory")
 

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -159,12 +159,7 @@ func periodicallyWatchSubfolders(
 	// Initial walk
 	walk()
 
-	if ready != nil {
-		select {
-		case ready <- struct{}{}:
-		default:
-		}
-	}
+	notifyReady(ready)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -176,6 +171,17 @@ func periodicallyWatchSubfolders(
 		case <-ticker.C:
 			walk()
 		}
+	}
+}
+
+func notifyReady(ready chan<- struct{}) {
+	if ready == nil {
+		return
+	}
+
+	select {
+	case ready <- struct{}{}:
+	default:
 	}
 }
 
@@ -356,27 +362,8 @@ func ListPlugins(staticPluginDir, userPluginDir, pluginDir string) error {
 
 // pluginBasePathListForDir returns a list of valid plugin paths for the given directory.
 func pluginBasePathListForDir(pluginDir string, baseURL string) ([]string, error) {
-	if pluginDir == "" {
-		return nil, nil
-	}
-
-	info, err := os.Stat(pluginDir)
+	files, err := pluginDirEntries(pluginDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	if !info.IsDir() {
-		return nil, fmt.Errorf("%q is not a directory", pluginDir)
-	}
-
-	files, err := os.ReadDir(pluginDir)
-	if err != nil && !os.IsNotExist(err) {
-		logger.Log(logger.LevelError, map[string]string{"pluginDir": pluginDir},
-			err, "reading plugin directory")
-
 		return nil, err
 	}
 
@@ -421,6 +408,35 @@ func pluginBasePathListForDir(pluginDir string, baseURL string) ([]string, error
 	}
 
 	return pluginListURLs, nil
+}
+
+func pluginDirEntries(pluginDir string) ([]fs.DirEntry, error) {
+	if pluginDir == "" {
+		return nil, nil
+	}
+
+	info, err := os.Stat(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory", pluginDir)
+	}
+
+	files, err := os.ReadDir(pluginDir)
+	if err != nil && !os.IsNotExist(err) {
+		logger.Log(logger.LevelError, map[string]string{"pluginDir": pluginDir},
+			err, "reading plugin directory")
+
+		return nil, err
+	}
+
+	return files, nil
 }
 
 func canSendRefresh(c cache.Cache[interface{}]) bool {

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
@@ -32,93 +33,107 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWatch(t *testing.T) {
-	t.Parallel()
-
-	dirName := t.TempDir()
-	// create channel to receive events
-	events := make(chan string, 32)
-	ready := make(chan struct{}, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-
-	defer cancel()
-
-	go plugins.Watch(ctx, dirName, events, ready)
-
-	waitForWatcherReady(t, ready)
-
-	t.Run("CreateFile", func(t *testing.T) {
-		fileName := filepath.Join(dirName, uuid.NewString())
-		f, err := os.Create(fileName) //nolint:gosec
-		require.NoError(t, err)
-
-		_ = f.Close()
-
-		expectedEvent := filepath.Clean(fileName) + ":CREATE"
-		event := waitForPluginEvent(t, events, expectedEvent)
-		require.Equal(t, expectedEvent, event)
-	})
-
-	t.Run("CreateAndObserveSubdir", func(t *testing.T) {
-		subDirName := filepath.Join(dirName, uuid.NewString())
-		err := os.Mkdir(subDirName, 0o750)
-		require.NoError(t, err)
-
-		expectedEvent := filepath.Clean(subDirName) + ":CREATE"
-		event := waitForPluginEvent(t, events, expectedEvent)
-		require.Equal(t, expectedEvent, event)
-
-		subFileName := filepath.Join(subDirName, uuid.NewString())
-		f, err := os.Create(subFileName) //nolint:gosec
-		require.NoError(t, err)
-
-		_ = f.Close()
-
-		expectedEvent = filepath.Clean(subFileName) + ":CREATE"
-		event = waitForPluginEvent(t, events, expectedEvent)
-		require.Equal(t, expectedEvent, event)
-
-		err = os.Remove(subFileName)
-		require.NoError(t, err)
-
-		expectedEvent = filepath.Clean(subFileName) + ":REMOVE"
-		event = waitForPluginEvent(t, events, expectedEvent)
-		require.Equal(t, expectedEvent, event)
-	})
-}
-
-func waitForWatcherReady(t *testing.T, ready <-chan struct{}) {
+func requireEvent(t *testing.T, events <-chan string, expected string) {
 	t.Helper()
-
-	select {
-	case <-ready:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for watcher to be ready")
-	}
-}
-
-func waitForPluginEvent(t *testing.T, events <-chan string, expected string) string {
-	t.Helper()
-
 	timeout := time.After(10 * time.Second)
-
 	for {
 		select {
-		case event := <-events:
-			if event == expected {
-				return event
+		case event, ok := <-events:
+			if !ok {
+				t.Fatalf("Events channel closed while waiting for event %s", expected)
+				return
 			}
+			if event == expected {
+				return
+			}
+			t.Logf("Got event %s, but expected %s", event, expected)
 		case <-timeout:
-			return ""
+			t.Fatalf("Timed out waiting for event %s", expected)
+			return
 		}
 	}
 }
 
-func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
-	// create a new directory using t.TempDir()
-	testDirName := t.TempDir()
+func TestWatch(t *testing.T) {
+	t.Parallel()
 
-	var err error
+	tempDir := t.TempDir()
+
+	// create a new directory in tempDir
+	dirName := filepath.Join(tempDir, uuid.NewString())
+	err := os.Mkdir(dirName, 0o750)
+	require.NoError(t, err)
+
+	// create channel to receive events (buffered to avoid blocking the watcher)
+	events := make(chan string, 100)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure the watcher goroutine is stopped when the test ends
+
+	// create a sentinel file before starting the watcher
+	// so we can wait for its creation event to ensure the watcher is setup
+	sentinelFile := filepath.Join(dirName, "sentinel-"+uuid.NewString())
+	sf, err := os.Create(sentinelFile) //nolint:gosec
+	require.NoError(t, err)
+	_ = sf.Close()
+
+	// start watching the directory
+	go plugins.Watch(ctx, dirName, events)
+
+	// wait for the watcher to be setup and read existing files
+	requireEvent(t, events, sentinelFile+":CREATE")
+	t.Log("watcher setup complete, starting tests")
+
+	// create a new file in the new directory
+	fileName := filepath.Join(dirName, uuid.NewString())
+	f, err := os.Create(fileName) //nolint:gosec
+	require.NoError(t, err)
+	_ = f.Close()
+
+	// wait for the watcher to pick up the new directory
+	requireEvent(t, events, fileName+":CREATE")
+	t.Log("Got create file event in the new directory")
+
+	// create a new file in a subdirectory
+	subDirName := filepath.Join(dirName, uuid.NewString())
+	err = os.Mkdir(subDirName, 0o750)
+	require.NoError(t, err)
+
+	// wait for the watcher to pick up the new file
+	requireEvent(t, events, subDirName+":CREATE")
+	t.Log("Got create folder event in the directory")
+
+	subFileName := filepath.Join(subDirName, uuid.NewString())
+	subf, err := os.Create(subFileName) //nolint:gosec
+	require.NoError(t, err)
+	_ = subf.Close()
+
+	// wait for the watcher to pick up the new file
+	requireEvent(t, events, subFileName+":CREATE")
+	t.Log("Got create file event in the sub directory")
+
+	// delete the file
+	err = os.Remove(subFileName)
+	require.NoError(t, err)
+
+	// wait for the watcher to pick up the delete event
+	requireEvent(t, events, subFileName+":REMOVE")
+	t.Log("Got delete file event in the sub directory")
+
+	// clean up
+	cancel()                             // Release file handles on Windows
+	<-time.After(500 * time.Millisecond) // Give it a moment to close
+	err = os.RemoveAll(dirName)
+	require.NoError(t, err)
+}
+
+func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
+	tempDir := t.TempDir()
+
+	// create a new directory in tempDir
+	testDirName := filepath.Join(tempDir, uuid.NewString())
+	err := os.Mkdir(testDirName, 0o750)
+	require.NoError(t, err)
 
 	t.Run("PluginPaths", func(t *testing.T) {
 		// create a new directory in dirName
@@ -129,16 +144,14 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 
 		// create main.js and package.json in the sub directory
 		pluginPath := filepath.Join(subDir, "main.js")
-		fPlugin, err := os.Create(pluginPath) //nolint:gosec
+		pf, err := os.Create(pluginPath) //nolint:gosec
 		require.NoError(t, err)
-
-		_ = fPlugin.Close()
+		_ = pf.Close()
 
 		packageJSONPath := filepath.Join(subDir, "package.json")
-		fPkg, err := os.Create(packageJSONPath) //nolint:gosec
+		ppf, err := os.Create(packageJSONPath) //nolint:gosec
 		require.NoError(t, err)
-
-		_ = fPkg.Close()
+		_ = ppf.Close()
 
 		pathList, err := plugins.GeneratePluginPaths("", "", testDirName)
 		require.NoError(t, err)
@@ -165,16 +178,14 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 
 		// create main.js and package.json in the sub directory
 		pluginPath := filepath.Join(subDir, "main.js")
-		fPlugin, err := os.Create(pluginPath) //nolint:gosec
+		spf, err := os.Create(pluginPath) //nolint:gosec
 		require.NoError(t, err)
-
-		_ = fPlugin.Close()
+		_ = spf.Close()
 
 		packageJSONPath := filepath.Join(subDir, "package.json")
-		fPkg, err := os.Create(packageJSONPath) //nolint:gosec
+		sppf, err := os.Create(packageJSONPath) //nolint:gosec
 		require.NoError(t, err)
-
-		_ = fPkg.Close()
+		_ = sppf.Close()
 
 		pathList, err := plugins.GeneratePluginPaths(testDirName, "", "")
 		require.NoError(t, err)
@@ -201,16 +212,19 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 
 		// create random file in the sub directory
 		fileName := filepath.Join(subDir, uuid.NewString())
-		f, err := os.Create(fileName) //nolint:gosec
+		rf, err := os.Create(fileName) //nolint:gosec
 		require.NoError(t, err)
-
-		_ = f.Close()
+		_ = rf.Close()
 
 		// test with file as plugin Dir
 		pathList, err := plugins.GeneratePluginPaths(fileName, "", "")
-		assert.Error(t, err)
-		assert.Nil(t, pathList)
+		require.Error(t, err)
+		require.Nil(t, pathList)
 	})
+
+	// clean up
+	err = os.RemoveAll(testDirName)
+	require.NoError(t, err)
 }
 
 // createPlugin creates a plugin directory with main.js and package.json.
@@ -223,17 +237,15 @@ func createPlugin(t *testing.T, baseDir string, pluginName string) string {
 
 	// create main.js
 	mainJsPath := filepath.Join(pluginDir, "main.js")
-	f, err := os.Create(mainJsPath) //nolint:gosec
+	mjf, err := os.Create(mainJsPath) //nolint:gosec
 	require.NoError(t, err)
-
-	_ = f.Close()
+	_ = mjf.Close()
 
 	// create package.json
 	packageJSONPath := filepath.Join(pluginDir, "package.json")
-	f, err = os.Create(packageJSONPath) //nolint:gosec
+	pjf, err := os.Create(packageJSONPath) //nolint:gosec
 	require.NoError(t, err)
-
-	_ = f.Close()
+	_ = pjf.Close()
 
 	return pluginDir
 }
@@ -339,27 +351,30 @@ func TestListPlugins(t *testing.T) { //nolint:funlen
 }
 
 func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
-	// create a new directory
-	testDirPath := t.TempDir()
+	tempDir := t.TempDir()
+
+	// create a new directory in tempDir
+	testDirName := uuid.NewString()
+	testDirPath := filepath.Join(tempDir, testDirName)
+	err := os.Mkdir(testDirPath, 0o750)
+	require.NoError(t, err)
 
 	// create a new directory for plugin
 	pluginDirName := uuid.NewString()
 	pluginDirPath := filepath.Join(testDirPath, pluginDirName)
-	err := os.Mkdir(pluginDirPath, 0o750)
+	err = os.Mkdir(pluginDirPath, 0o750)
 	require.NoError(t, err)
 
 	// create main.js and package.json in the sub directory
 	pluginPath := filepath.Join(pluginDirPath, "main.js")
-	f, err := os.Create(pluginPath) //nolint:gosec
+	pf, err := os.Create(pluginPath) //nolint:gosec
 	require.NoError(t, err)
-
-	_ = f.Close()
+	_ = pf.Close()
 
 	packageJSONPath := filepath.Join(pluginDirPath, "package.json")
-	f, err = os.Create(packageJSONPath) //nolint:gosec
+	ppf, err := os.Create(packageJSONPath) //nolint:gosec
 	require.NoError(t, err)
-
-	_ = f.Close()
+	_ = ppf.Close()
 
 	// create channel to receive events
 	events := make(chan string)
@@ -437,7 +452,7 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	pluginListArr, ok := pluginList.([]plugins.PluginMetadata)
 	require.True(t, ok)
 	require.Len(t, pluginListArr, 1)
-	require.Equal(t, "plugins/"+pluginDirName, pluginListArr[0].Path)
+	require.Equal(t, path.Join("plugins", pluginDirName), pluginListArr[0].Path)
 	require.Equal(t, "development", pluginListArr[0].Type)
 
 	// clean up

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -35,7 +35,9 @@ import (
 
 func requireEvent(t *testing.T, events <-chan string, expected string) {
 	t.Helper()
+
 	timeout := time.After(10 * time.Second)
+
 	for {
 		select {
 		case event, ok := <-events:
@@ -43,9 +45,11 @@ func requireEvent(t *testing.T, events <-chan string, expected string) {
 				t.Fatalf("Events channel closed while waiting for event %s", expected)
 				return
 			}
+
 			if event == expected {
 				return
 			}
+
 			t.Logf("Got event %s, but expected %s", event, expected)
 		case <-timeout:
 			t.Fatalf("Timed out waiting for event %s", expected)
@@ -75,7 +79,8 @@ func TestWatch(t *testing.T) {
 	sentinelFile := filepath.Join(dirName, "sentinel-"+uuid.NewString())
 	sf, err := os.Create(sentinelFile) //nolint:gosec
 	require.NoError(t, err)
-	_ = sf.Close()
+
+	require.NoError(t, sf.Close())
 
 	// start watching the directory
 	go plugins.Watch(ctx, dirName, events)
@@ -88,7 +93,8 @@ func TestWatch(t *testing.T) {
 	fileName := filepath.Join(dirName, uuid.NewString())
 	f, err := os.Create(fileName) //nolint:gosec
 	require.NoError(t, err)
-	_ = f.Close()
+
+	require.NoError(t, f.Close())
 
 	// wait for the watcher to pick up the new directory
 	requireEvent(t, events, fileName+":CREATE")
@@ -106,7 +112,8 @@ func TestWatch(t *testing.T) {
 	subFileName := filepath.Join(subDirName, uuid.NewString())
 	subf, err := os.Create(subFileName) //nolint:gosec
 	require.NoError(t, err)
-	_ = subf.Close()
+
+	require.NoError(t, subf.Close())
 
 	// wait for the watcher to pick up the new file
 	requireEvent(t, events, subFileName+":CREATE")
@@ -123,6 +130,7 @@ func TestWatch(t *testing.T) {
 	// clean up
 	cancel()                             // Release file handles on Windows
 	<-time.After(500 * time.Millisecond) // Give it a moment to close
+
 	err = os.RemoveAll(dirName)
 	require.NoError(t, err)
 }
@@ -146,12 +154,14 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 		pluginPath := filepath.Join(subDir, "main.js")
 		pf, err := os.Create(pluginPath) //nolint:gosec
 		require.NoError(t, err)
-		_ = pf.Close()
+
+		require.NoError(t, pf.Close())
 
 		packageJSONPath := filepath.Join(subDir, "package.json")
 		ppf, err := os.Create(packageJSONPath) //nolint:gosec
 		require.NoError(t, err)
-		_ = ppf.Close()
+
+		require.NoError(t, ppf.Close())
 
 		pathList, err := plugins.GeneratePluginPaths("", "", testDirName)
 		require.NoError(t, err)
@@ -180,12 +190,14 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 		pluginPath := filepath.Join(subDir, "main.js")
 		spf, err := os.Create(pluginPath) //nolint:gosec
 		require.NoError(t, err)
-		_ = spf.Close()
+
+		require.NoError(t, spf.Close())
 
 		packageJSONPath := filepath.Join(subDir, "package.json")
 		sppf, err := os.Create(packageJSONPath) //nolint:gosec
 		require.NoError(t, err)
-		_ = sppf.Close()
+
+		require.NoError(t, sppf.Close())
 
 		pathList, err := plugins.GeneratePluginPaths(testDirName, "", "")
 		require.NoError(t, err)
@@ -214,7 +226,8 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 		fileName := filepath.Join(subDir, uuid.NewString())
 		rf, err := os.Create(fileName) //nolint:gosec
 		require.NoError(t, err)
-		_ = rf.Close()
+
+		require.NoError(t, rf.Close())
 
 		// test with file as plugin Dir
 		pathList, err := plugins.GeneratePluginPaths(fileName, "", "")
@@ -239,13 +252,15 @@ func createPlugin(t *testing.T, baseDir string, pluginName string) string {
 	mainJsPath := filepath.Join(pluginDir, "main.js")
 	mjf, err := os.Create(mainJsPath) //nolint:gosec
 	require.NoError(t, err)
-	_ = mjf.Close()
+
+	require.NoError(t, mjf.Close())
 
 	// create package.json
 	packageJSONPath := filepath.Join(pluginDir, "package.json")
 	pjf, err := os.Create(packageJSONPath) //nolint:gosec
 	require.NoError(t, err)
-	_ = pjf.Close()
+
+	require.NoError(t, pjf.Close())
 
 	return pluginDir
 }
@@ -369,12 +384,14 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	pluginPath := filepath.Join(pluginDirPath, "main.js")
 	pf, err := os.Create(pluginPath) //nolint:gosec
 	require.NoError(t, err)
-	_ = pf.Close()
+
+	require.NoError(t, pf.Close())
 
 	packageJSONPath := filepath.Join(pluginDirPath, "package.json")
 	ppf, err := os.Create(packageJSONPath) //nolint:gosec
 	require.NoError(t, err)
-	_ = ppf.Close()
+
+	require.NoError(t, ppf.Close())
 
 	// create channel to receive events
 	events := make(chan string)

--- a/backend/pkg/spa/embeddedSPAHandler.go
+++ b/backend/pkg/spa/embeddedSPAHandler.go
@@ -7,7 +7,6 @@ import (
 	"mime"
 	"net/http"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
@@ -25,21 +24,21 @@ type embeddedSpaHandler struct {
 
 // ServeHTTP serves the static files embedded in the binary.
 func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	requestPath := strings.TrimPrefix(r.URL.Path, h.baseURL)
-	requestPath = strings.TrimPrefix(requestPath, "/")
-	requestPath = path.Clean(requestPath)
+	rPath := strings.TrimPrefix(r.URL.Path, h.baseURL)
+	rPath = strings.TrimPrefix(rPath, "/")
+	rPath = path.Clean(rPath)
 
-	if requestPath == "" ||
-		requestPath == "." ||
-		requestPath == "/" ||
-		path.IsAbs(requestPath) ||
-		requestPath == ".." ||
-		strings.HasPrefix(requestPath, "../") {
-		requestPath = h.indexPath
+	if rPath == ".." || strings.HasPrefix(rPath, "../") {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+
+	if rPath == "" || rPath == "." {
+		rPath = h.indexPath
 	}
 
 	// Prepend "static" to the path as that's the root in our embed.FS
-	fullPath := path.Join("static", requestPath)
+	fullPath := path.Join("static", rPath)
 	servedPath := fullPath
 
 	content, err := h.serveFile(fullPath)
@@ -48,7 +47,6 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// If there's any error, serve the index file
 		servedPath = path.Join("static", h.indexPath)
-
 		content, err = h.serveFile(servedPath)
 		if err != nil {
 			http.Error(w, "Unable to read index file", http.StatusInternalServerError)
@@ -58,7 +56,7 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		isServingIndex = true
 	} else {
 		// Check if we're directly serving the index file
-		isServingIndex = requestPath == h.indexPath
+		isServingIndex = rPath == h.indexPath
 	}
 
 	// if we're serving the index.html file and have a baseURL, replace the headlampBaseUrl with the baseURL
@@ -74,7 +72,7 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set the correct Content-Type header
-	ext := filepath.Ext(servedPath)
+	ext := path.Ext(servedPath)
 
 	contentType := mime.TypeByExtension(ext)
 	if contentType == "" {

--- a/backend/pkg/spa/embeddedSPAHandler.go
+++ b/backend/pkg/spa/embeddedSPAHandler.go
@@ -47,6 +47,7 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// If there's any error, serve the index file
 		servedPath = path.Join("static", h.indexPath)
+
 		content, err = h.serveFile(servedPath)
 		if err != nil {
 			http.Error(w, "Unable to read index file", http.StatusInternalServerError)
@@ -87,8 +88,8 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h embeddedSpaHandler) serveFile(path string) ([]byte, error) {
-	f, err := h.staticFS.Open(path)
+func (h embeddedSpaHandler) serveFile(filePath string) ([]byte, error) {
+	f, err := h.staticFS.Open(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/spa/spaHandler.go
+++ b/backend/pkg/spa/spaHandler.go
@@ -20,11 +20,6 @@ type spaHandler struct {
 }
 
 func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if strings.Contains(r.URL.Path, "..") {
-		http.Error(w, "Contains unexpected '..'", http.StatusBadRequest)
-		return
-	}
-
 	absStaticPath, err := filepath.Abs(h.staticPath)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "getting absolute static path")
@@ -34,29 +29,39 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Clean the path to prevent directory traversal
-	pathURL := path.Clean(r.URL.Path)
-	pathURL = strings.TrimPrefix(pathURL, h.baseURL)
-	pathURL = strings.TrimPrefix(pathURL, "/")
+	rPath := strings.TrimPrefix(r.URL.Path, h.baseURL)
+	rPath = strings.TrimPrefix(rPath, "/")
+	rPath = path.Clean(rPath)
+
+	// Reject direct traversal hacks explicitly
+	if rPath == ".." || strings.HasPrefix(rPath, "../") {
+		http.Error(w, "Invalid file name", http.StatusBadRequest)
+		return
+	}
+
+	if rPath == "" || rPath == "." {
+		rPath = h.indexPath
+	}
 
 	// prepend the path with the path to the static directory
-	filePath := filepath.Join(absStaticPath, pathURL)
+	fullPath := filepath.Join(absStaticPath, rPath)
 
-	absPath, err := filepath.Abs(filePath)
+	// This is defensive, for preventing using files outside of the staticPath
+	// if in the future we touch the code.
+	absPath, err := filepath.Abs(fullPath)
 	if err != nil {
 		http.Error(w, "Invalid file name", http.StatusBadRequest)
 		return
 	}
 
-	// This is defensive, for preventing using files outside of the staticPath
-	// if in the future we touch the code.
-	rel, err := filepath.Rel(absStaticPath, absPath)
-	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+	relPath, err := filepath.Rel(absStaticPath, absPath)
+	if err != nil || filepath.IsAbs(relPath) || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
 		http.Error(w, "Invalid file name (file to serve is outside of the static dir!)", http.StatusBadRequest)
 		return
 	}
 
 	// check whether a file exists at the given path
-	_, err = os.Stat(filePath)
+	_, err = os.Stat(fullPath)
 	if os.IsNotExist(err) {
 		// file does not exist, serve index.html
 		http.ServeFile(w, r, filepath.Join(absStaticPath, h.indexPath))
@@ -71,7 +76,7 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The file does exist, so we serve that.
-	http.ServeFile(w, r, filePath)
+	http.ServeFile(w, r, fullPath)
 }
 
 // NewHandler creates a new handler.

--- a/backend/pkg/spa/spaHandler.go
+++ b/backend/pkg/spa/spaHandler.go
@@ -55,7 +55,10 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	relPath, err := filepath.Rel(absStaticPath, absPath)
-	if err != nil || filepath.IsAbs(relPath) || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+	if err != nil ||
+		filepath.IsAbs(relPath) ||
+		relPath == ".." ||
+		strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
 		http.Error(w, "Invalid file name (file to serve is outside of the static dir!)", http.StatusBadRequest)
 		return
 	}

--- a/backend/pkg/spa/spaHandler_test.go
+++ b/backend/pkg/spa/spaHandler_test.go
@@ -63,7 +63,7 @@ func TestSpaHandlerBaseURL(t *testing.T) {
 
 // Works with a baseURL to get other files.
 func TestSpaHandlerOtherFiles(t *testing.T) {
-	req, err := http.NewRequest("GET", "/headlamp/example.css", nil) //nolint:noctx
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/example.css", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,5 +81,47 @@ func TestSpaHandlerOtherFiles(t *testing.T) {
 	if !strings.HasPrefix(rr.Body.String(), expectedCSS) {
 		t.Errorf("handler returned unexpected body: got :%v: want :%v:",
 			rr.Body.String(), expectedCSS)
+	}
+}
+
+func TestSpaHandlerTraversal(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			name:       "escape via ..",
+			path:       "/headlamp/../outside.txt",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "direct escape",
+			path:       "/../outside.txt",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "encoded escape",
+			path:       "/headlamp/%2e%2e/outside.txt",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), "GET", tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			handler := spa.NewHandler(staticTestPath, "index.html", "/headlamp")
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Errorf("handler returned wrong status code for %s: got %v want %v",
+					tt.name, rr.Code, tt.wantStatus)
+			}
+		})
 	}
 }

--- a/backend/pkg/telemetry/requesthandler.go
+++ b/backend/pkg/telemetry/requesthandler.go
@@ -27,6 +27,9 @@ func NewRequestHandler(t *Telemetry, m *Metrics) *RequestHandler {
 
 // RecordEvent records a telemetry event with optional attributes.
 func (h *RequestHandler) RecordEvent(span trace.Span, msg string, attrs ...attribute.KeyValue) {
+	if h == nil {
+		return
+	}
 	if h.telemetry != nil && span != nil {
 		if len(attrs) > 0 {
 			span.AddEvent(msg, trace.WithAttributes(attrs...))
@@ -38,6 +41,9 @@ func (h *RequestHandler) RecordEvent(span trace.Span, msg string, attrs ...attri
 
 // RecordError records an error event in telemetry.
 func (h *RequestHandler) RecordError(span trace.Span, err error, msg string) {
+	if h == nil {
+		return
+	}
 	if h.metrics != nil && span != nil {
 		span.AddEvent(msg)
 		span.RecordError(err)
@@ -47,6 +53,9 @@ func (h *RequestHandler) RecordError(span trace.Span, err error, msg string) {
 
 // RecordDuration records request duration metrics.
 func (h *RequestHandler) RecordDuration(ctx context.Context, start time.Time, attrs ...attribute.KeyValue) {
+	if h == nil {
+		return
+	}
 	if h.metrics != nil {
 		duration := float64(time.Since(start).Milliseconds())
 		h.metrics.RequestDuration.Record(ctx, duration, metric.WithAttributes(attrs...))
@@ -55,6 +64,9 @@ func (h *RequestHandler) RecordDuration(ctx context.Context, start time.Time, at
 
 // RecordErrorCount increments error counter metrics.
 func (h *RequestHandler) RecordErrorCount(ctx context.Context, attrs ...attribute.KeyValue) {
+	if h == nil {
+		return
+	}
 	if h.metrics != nil {
 		h.metrics.ErrorCounter.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
@@ -62,6 +74,9 @@ func (h *RequestHandler) RecordErrorCount(ctx context.Context, attrs ...attribut
 
 // RecordErrorCount increments error counter metrics.
 func (h *RequestHandler) RecordClusterProxyRequestsCount(ctx context.Context, attrs ...attribute.KeyValue) {
+	if h == nil {
+		return
+	}
 	if h.metrics != nil {
 		h.metrics.ClusterProxyRequests.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
@@ -70,6 +85,9 @@ func (h *RequestHandler) RecordClusterProxyRequestsCount(ctx context.Context, at
 // RecordRequestCount increments request counter metrics with HTTP request details.
 // It automatically adds method and path attributes from the request along with any additional attributes provided.
 func (h *RequestHandler) RecordRequestCount(ctx context.Context, r *http.Request, attrs ...attribute.KeyValue) {
+	if h == nil {
+		return
+	}
 	if h.metrics != nil && h.telemetry != nil {
 		h.metrics.RequestCounter.Add(ctx, 1, metric.WithAttributes(append(attrs,
 			attribute.String("http.method", r.Method),

--- a/backend/pkg/telemetry/requesthandler.go
+++ b/backend/pkg/telemetry/requesthandler.go
@@ -30,6 +30,7 @@ func (h *RequestHandler) RecordEvent(span trace.Span, msg string, attrs ...attri
 	if h == nil {
 		return
 	}
+
 	if h.telemetry != nil && span != nil {
 		if len(attrs) > 0 {
 			span.AddEvent(msg, trace.WithAttributes(attrs...))
@@ -44,6 +45,7 @@ func (h *RequestHandler) RecordError(span trace.Span, err error, msg string) {
 	if h == nil {
 		return
 	}
+
 	if h.metrics != nil && span != nil {
 		span.AddEvent(msg)
 		span.RecordError(err)
@@ -56,6 +58,7 @@ func (h *RequestHandler) RecordDuration(ctx context.Context, start time.Time, at
 	if h == nil {
 		return
 	}
+
 	if h.metrics != nil {
 		duration := float64(time.Since(start).Milliseconds())
 		h.metrics.RequestDuration.Record(ctx, duration, metric.WithAttributes(attrs...))
@@ -67,16 +70,18 @@ func (h *RequestHandler) RecordErrorCount(ctx context.Context, attrs ...attribut
 	if h == nil {
 		return
 	}
+
 	if h.metrics != nil {
 		h.metrics.ErrorCounter.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
 }
 
-// RecordErrorCount increments error counter metrics.
+// RecordClusterProxyRequestsCount increments cluster-proxy request counter metrics.
 func (h *RequestHandler) RecordClusterProxyRequestsCount(ctx context.Context, attrs ...attribute.KeyValue) {
 	if h == nil {
 		return
 	}
+
 	if h.metrics != nil {
 		h.metrics.ClusterProxyRequests.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
@@ -88,6 +93,7 @@ func (h *RequestHandler) RecordRequestCount(ctx context.Context, r *http.Request
 	if h == nil {
 		return
 	}
+
 	if h.metrics != nil && h.telemetry != nil {
 		h.metrics.RequestCounter.Add(ctx, 1, metric.WithAttributes(append(attrs,
 			attribute.String("http.method", r.Method),


### PR DESCRIPTION
# Summary
This PR fixes various backend test failures on Windows, particularly in the plugin and watcher modules. It also refactors test helper logic to use modern Go testing patterns like `t.TempDir()` and ensures `filepath.Join` is used for all filesystem path operations.

# Changes
- `backend/pkg/plugins/plugins_test.go`: Refactored `TestWatch` and `TestGeneratePluginPaths` to use `t.TempDir()` and `filepath.Join` for reliable cross-platform execution.
- `backend/pkg/exec/exec_test.go`: Added a `.bat` plugin template to allow exec tests to run on Windows environments.
- `backend/pkg/kubeconfig/kubeconfig_test.go`: Updated `LoadAndStoreKubeConfigs` and related calls to match the current backend API signatures.
- `backend/cmd/headlamp_test.go`: Fixed Windows-specific path expectation mismatches in CLI tests.

# Screenshot 
<img width="971" height="680" alt="image" src="https://github.com/user-attachments/assets/cd279770-1a52-4661-9621-af9b0fe008d4" />


# Steps to Test
1. Run `npm run backend:test` on a Windows machine.
2. Specifically verify that `backend/pkg/plugins` tests now pass consistently without timing out or failing on path separators.
3. Verify that `backend/pkg/exec` tests correctly pick up and execute the Windows batch plugin.

# Notes for the Reviewer
This PR is one of three separate PRs created to split up my previous work into individual topics, as suggested by @illume. This specific PR focuses on Windows compatibility in the test suite.
