### PR TITLE
backend: portforward: fix nil pointer panic on closed channel

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -336,7 +336,6 @@ func handlePortForwardError(
 	pfDetails *portForward,
 	logParams map[string]string,
 	errMsg string,
-	isReady bool,
 ) error {
 	logger.Log(logger.LevelError, logParams, errors.New(errMsg), "portforward error")
 
@@ -345,10 +344,6 @@ func handlePortForwardError(
 
 	portforwardstore(cache, *pfDetails)
 	safeCloseChan(pfDetails.closeChan)
-
-	if isReady {
-		return nil
-	}
 
 	return errors.New(errMsg)
 }
@@ -380,14 +375,22 @@ func handlePortForwardReadiness(
 	case <-readyChan:
 		if errOut.String() != "" {
 			return handlePortForwardError(cache, pfDetails, logParams,
-				fmt.Sprintf("portforward failed to start, stderr: %s", errOut.String()), false)
+				fmt.Sprintf("portforward failed, stderr: %s", errOut.String()))
 		}
 
 		handlePortForwardSuccess(cache, pfDetails, logParams)
-	case err := <-forwardErrChan:
-		return handlePortForwardError(cache, pfDetails, logParams, err.Error(), false)
+	case err, ok := <-forwardErrChan:
+		if !ok {
+			return handlePortForwardError(cache, pfDetails, logParams, "portforward stopped before ready")
+		}
+
+		if err == nil {
+			return handlePortForwardError(cache, pfDetails, logParams, "portforward failed: nil error received")
+		}
+
+		return handlePortForwardError(cache, pfDetails, logParams, err.Error())
 	case <-time.After(PortForwardReadinessTimeout):
-		return handlePortForwardError(cache, pfDetails, logParams, "timeout waiting for portforward to become ready", false)
+		return handlePortForwardError(cache, pfDetails, logParams, "timeout waiting for portforward to be ready")
 	case <-pfDetails.closeChan:
 		msg := "portforward stopped before becoming ready"
 

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -17,13 +17,76 @@ limitations under the License.
 package portforward
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestHandlePortForwardReadiness tests handlePortForwardReadiness function.
+func TestHandlePortForwardReadiness(t *testing.T) {
+	c := cache.New[interface{}]()
+	logParams := map[string]string{"id": "id"}
+	errOut := &bytes.Buffer{}
+
+	t.Run("closed_channel", func(t *testing.T) {
+		pfDetails := &portForward{
+			ID:        "id",
+			Cluster:   "cluster",
+			closeChan: make(chan struct{}, 1),
+			Status:    RUNNING,
+		}
+		readyChan := make(chan struct{}, 1)
+
+		forwardErrChan := make(chan error, 1)
+		close(forwardErrChan)
+
+		err := handlePortForwardReadiness(c, pfDetails, readyChan, errOut, logParams, forwardErrChan)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "stopped before ready")
+		assert.Equal(t, STOPPED, pfDetails.Status)
+	})
+
+	t.Run("nil_error", func(t *testing.T) {
+		pfDetails := &portForward{
+			ID:        "id",
+			Cluster:   "cluster",
+			closeChan: make(chan struct{}, 1),
+			Status:    RUNNING,
+		}
+		readyChan := make(chan struct{}, 1)
+
+		forwardErrChan := make(chan error, 1)
+		forwardErrChan <- nil
+
+		err := handlePortForwardReadiness(c, pfDetails, readyChan, errOut, logParams, forwardErrChan)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nil error received")
+		assert.Equal(t, STOPPED, pfDetails.Status)
+	})
+
+	t.Run("actual_error", func(t *testing.T) {
+		pfDetails := &portForward{
+			ID:        "id",
+			Cluster:   "cluster",
+			closeChan: make(chan struct{}, 1),
+			Status:    RUNNING,
+		}
+		readyChan := make(chan struct{}, 1)
+
+		forwardErrChan := make(chan error, 1)
+		forwardErrChan <- fmt.Errorf("some error")
+
+		err := handlePortForwardReadiness(c, pfDetails, readyChan, errOut, logParams, forwardErrChan)
+		assert.Error(t, err)
+		assert.Equal(t, "some error", err.Error())
+		assert.Equal(t, STOPPED, pfDetails.Status)
+	})
+}
 
 // TestPortforwardKeyGenerator tests portforwardKeyGenerator function.
 func TestPortforwardKeyGenerator(t *testing.T) {


### PR DESCRIPTION
### **Summary**
This is a follow-up to PR #5316. It fixes a critical nil-pointer dereference (panic) in the port-forwarding backend identified by Copilot post-merge. The panic occurred when the port-forward process exited gracefully, causing the error channel to be closed and the receiver to attempt calling .Error() on a nil error object.

### **Related Issue**
Follow-up to #5316 (Fixes a regression introduced during the final cleanup of #5316).

### **Changes**
backend/pkg/portforward/handler.go: Updated the forwardErrChan receiver in handlePortForwardReadiness to use the comma-ok idiom. It now correctly identifies when a channel is closed and returns gracefully instead of attempting to process a nil error.

