### PR TITLE
multiplexer: Improve WebSocket stability

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -626,7 +626,7 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 		}
 
 		token, err := auth.GetTokenFromCookie(r, msg.ClusterID)
-		if err != nil && token != "" {
+		if err != nil {
 			logger.Log(logger.LevelError, map[string]string{"clusterID": msg.ClusterID}, err, "getting token from cookie")
 			m.sendClientError(lockClientConn, msg.ClusterID, msg.Path, msg.Query, msg.UserID, err)
 
@@ -669,6 +669,15 @@ func (m *Multiplexer) closeClientConnections(clientConn *WSConnLock) {
 	m.mutex.Unlock()
 
 	for _, conn := range connsToClose {
+		conn.mu.Lock()
+		if conn.Client == clientConn {
+			conn.Client = nil
+			conn.Status.State = StateClosed
+			conn.Status.LastMsg = time.Now()
+			conn.Status.Error = ""
+		}
+		conn.mu.Unlock()
+
 		conn.safeClose()
 	}
 }

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -254,6 +254,14 @@ func (m *Multiplexer) readServiceAccountToken(path string) (string, error) {
 	return token, nil
 }
 
+// IsClosed returns whether the connection is closed.
+func (c *Connection) IsClosed() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.closed
+}
+
 // updateStatus updates the status of a connection and notifies the client.
 func (c *Connection) updateStatus(state ConnectionState, err error) {
 	c.mu.Lock()
@@ -336,11 +344,12 @@ func (c *Connection) safeClose() {
 	c.closeOnce.Do(func() {
 		c.mu.Lock()
 		if !c.closed {
+			shouldWriteStatus := c.Status.State != StateClosed
 			c.Status.State = StateClosed
 			c.Status.LastMsg = time.Now()
 			c.Status.Error = ""
 
-			if c.Client != nil {
+			if shouldWriteStatus && c.Client != nil {
 				_ = c.writeStatusLocked()
 			}
 
@@ -571,7 +580,7 @@ func (m *Multiplexer) monitorConnection(conn *Connection) {
 
 // reconnect attempts to reestablish a connection.
 func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
-	if conn.closed {
+	if conn.IsClosed() {
 		return nil, fmt.Errorf("cannot reconnect closed connection")
 	}
 
@@ -884,14 +893,16 @@ func (m *Multiplexer) processClusterMessage(
 // of a resource. When a new message is received, it extracts the resource version from
 // the message metadata. If the resource version has changed since the last known version,
 // it sends a complete message to the client to update them with the latest resource state.
+// Non-JSON payloads (e.g., terminal/exec raw bytes or binary payloads) are gracefully
+// ignored and do not trigger an error.
 // Parameters:
-//   - message: The JSON-encoded message containing resource information.
+//   - message: The message containing resource information (or non-JSON frames to be ignored).
 //   - conn: The connection object representing the current connection.
 //   - clientConn: The WebSocket connection to the client.
 //   - lastResourceVersion: A pointer to the last known resource version string.
 //
 // Returns:
-//   - An error if any issues occur while processing the message, or nil if successful.
+//   - An error if any issues occur while writing to the client, or nil if successful/ignored.
 func (m *Multiplexer) sendIfNewResourceVersion(
 	message []byte,
 	conn *Connection,

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -334,6 +334,20 @@ func (c *Connection) writeStatusLocked() error {
 // safeClose safely closes the connection and its resources.
 func (c *Connection) safeClose() {
 	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		if !c.closed {
+			c.Status.State = StateClosed
+			c.Status.LastMsg = time.Now()
+			c.Status.Error = ""
+
+			if c.Client != nil {
+				_ = c.writeStatusLocked()
+			}
+
+			c.closed = true
+		}
+		c.mu.Unlock()
+
 		if c.Done != nil {
 			select {
 			case <-c.Done:
@@ -342,10 +356,6 @@ func (c *Connection) safeClose() {
 				close(c.Done)
 			}
 		}
-
-		c.mu.Lock()
-		c.closed = true
-		c.mu.Unlock()
 
 		if c.WSConn != nil {
 			_ = c.WSConn.Close()

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -609,6 +609,8 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 		msg, isFatal, err := m.readClientMessage(clientConn)
 		if err != nil {
 			if isFatal {
+				logUnexpectedClientReadClose(err)
+
 				break
 			}
 			// For non-fatal errors (like parsing), log and continue because
@@ -679,6 +681,12 @@ func (m *Multiplexer) closeClientConnections(clientConn *WSConnLock) {
 		conn.mu.Unlock()
 
 		conn.safeClose()
+	}
+}
+
+func logUnexpectedClientReadClose(err error) {
+	if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+		logger.Log(logger.LevelError, nil, err, "reading client message")
 	}
 }
 

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -667,6 +667,19 @@ func (m *Multiplexer) processClientMessage(
 		return
 	}
 
+	if msg.Type != "REQUEST" {
+		m.sendClientError(
+			lockClientConn,
+			msg.ClusterID,
+			msg.Path,
+			msg.Query,
+			msg.UserID,
+			fmt.Errorf("unsupported message type: %s", msg.Type),
+		)
+
+		return
+	}
+
 	token, err := auth.GetTokenFromCookie(r, msg.ClusterID)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"clusterID": msg.ClusterID}, err, "getting token from cookie")

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -662,7 +662,11 @@ func (m *Multiplexer) closeClientConnections(clientConn *WSConnLock) {
 
 	m.mutex.Lock()
 	for key, conn := range m.connections {
-		if conn.Client == clientConn {
+		conn.mu.RLock()
+		isClient := conn.Client == clientConn
+		conn.mu.RUnlock()
+
+		if isClient {
 			connsToClose = append(connsToClose, conn)
 
 			delete(m.connections, key)
@@ -963,10 +967,6 @@ func (m *Multiplexer) sendDataMessage(
 ) error {
 	dataMsg := m.createWrapperMessage(conn, messageType, message)
 
-	conn.mu.Lock()
-	conn.Status.LastMsg = time.Now()
-	conn.mu.Unlock()
-
 	conn.writeMu.Lock()
 	err := clientConn.WriteJSON(dataMsg)
 	conn.writeMu.Unlock()
@@ -974,6 +974,10 @@ func (m *Multiplexer) sendDataMessage(
 	if err != nil {
 		return err
 	}
+
+	conn.mu.Lock()
+	conn.Status.LastMsg = time.Now()
+	conn.mu.Unlock()
 
 	return nil
 }

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -259,6 +259,7 @@ func (c *Connection) updateStatus(state ConnectionState, err error) {
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
+
 		return
 	}
 
@@ -272,33 +273,52 @@ func (c *Connection) updateStatus(state ConnectionState, err error) {
 
 	if c.Client == nil {
 		c.mu.Unlock()
+
 		if state == StateClosed {
 			c.safeClose()
 		}
+
 		return
 	}
 
+	writeErr := c.writeStatusLocked()
+	c.mu.Unlock()
+
+	if writeErr != nil {
+		if !websocket.IsCloseError(writeErr, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+			logger.Log(logger.LevelError,
+				map[string]string{"clusterID": c.ClusterID},
+				writeErr,
+				"writing status message to client")
+		}
+	}
+
+	if state == StateClosed {
+		c.safeClose()
+	}
+}
+
+func (c *Connection) writeStatusLocked() error {
 	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
 	if c.closed {
-		c.writeMu.Unlock()
-		c.mu.Unlock()
-		return
+		return nil
 	}
 
 	statusData := struct {
 		State string `json:"state"`
 		Error string `json:"error"`
 	}{
-		State: string(state),
+		State: string(c.Status.State),
 		Error: c.Status.Error,
 	}
 
 	jsonData, jsonErr := json.Marshal(statusData)
 	if jsonErr != nil {
 		logger.Log(logger.LevelError, map[string]string{"clusterID": c.ClusterID}, jsonErr, "marshaling status message")
-		c.writeMu.Unlock()
-		c.mu.Unlock()
-		return
+
+		return nil
 	}
 
 	statusMsg := Message{
@@ -308,19 +328,7 @@ func (c *Connection) updateStatus(state ConnectionState, err error) {
 		Type:      "STATUS",
 	}
 
-	writeErr := c.Client.WriteJSON(statusMsg)
-	c.writeMu.Unlock()
-	c.mu.Unlock()
-
-	if writeErr != nil {
-		if !websocket.IsCloseError(writeErr, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-			logger.Log(logger.LevelError, map[string]string{"clusterID": c.ClusterID}, writeErr, "writing status message to client")
-		}
-	}
-
-	if state == StateClosed {
-		c.safeClose()
-	}
+	return c.Client.WriteJSON(statusMsg)
 }
 
 // safeClose safely closes the connection and its resources.
@@ -606,6 +614,7 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 			// For non-fatal errors (like parsing), log and continue because
 			// there is no routable client message context available.
 			logger.Log(logger.LevelError, nil, err, "failed to read client message")
+
 			continue
 		}
 
@@ -617,13 +626,19 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 		}
 
 		token, err := auth.GetTokenFromCookie(r, msg.ClusterID)
-		if err != nil {
+		if err != nil && token != "" {
 			logger.Log(logger.LevelError, map[string]string{"clusterID": msg.ClusterID}, err, "getting token from cookie")
 			m.sendClientError(lockClientConn, msg.ClusterID, msg.Path, msg.Query, msg.UserID, err)
+
 			continue
 		}
 
-		conn, err := m.getOrCreateConnection(msg, lockClientConn, &token)
+		var tokenPtr *string
+		if token != "" {
+			tokenPtr = &token
+		}
+
+		conn, err := m.getOrCreateConnection(msg, lockClientConn, tokenPtr)
 		if err != nil {
 			m.handleConnectionError(lockClientConn, msg, err)
 
@@ -647,6 +662,7 @@ func (m *Multiplexer) closeClientConnections(clientConn *WSConnLock) {
 	for key, conn := range m.connections {
 		if conn.Client == clientConn {
 			connsToClose = append(connsToClose, conn)
+
 			delete(m.connections, key)
 		}
 	}
@@ -742,6 +758,8 @@ func (m *Multiplexer) sendClientError(clientConn *WSConnLock, clusterID, path, q
 
 	errorMsg := Message{
 		ClusterID: clusterID,
+		Path:      path,
+		Query:     query,
 		UserID:    userID,
 		Data:      string(jsonData),
 		Type:      "ERROR",

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -98,6 +98,8 @@ type Connection struct {
 	usesServiceAccountToken bool
 	// Authentication token.
 	Token *string
+	// closeOnce is used to ensure the connection is closed only once.
+	closeOnce sync.Once
 }
 
 // Message represents a WebSocket message structure.
@@ -255,9 +257,8 @@ func (m *Multiplexer) readServiceAccountToken(path string) (string, error) {
 // updateStatus updates the status of a connection and notifies the client.
 func (c *Connection) updateStatus(state ConnectionState, err error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.closed {
+		c.mu.Unlock()
 		return
 	}
 
@@ -270,14 +271,17 @@ func (c *Connection) updateStatus(state ConnectionState, err error) {
 	}
 
 	if c.Client == nil {
+		c.mu.Unlock()
+		if state == StateClosed {
+			c.safeClose()
+		}
 		return
 	}
 
 	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
-
-	// Check if connection is closed before writing
 	if c.closed {
+		c.writeMu.Unlock()
+		c.mu.Unlock()
 		return
 	}
 
@@ -292,7 +296,8 @@ func (c *Connection) updateStatus(state ConnectionState, err error) {
 	jsonData, jsonErr := json.Marshal(statusData)
 	if jsonErr != nil {
 		logger.Log(logger.LevelError, map[string]string{"clusterID": c.ClusterID}, jsonErr, "marshaling status message")
-
+		c.writeMu.Unlock()
+		c.mu.Unlock()
 		return
 	}
 
@@ -303,13 +308,41 @@ func (c *Connection) updateStatus(state ConnectionState, err error) {
 		Type:      "STATUS",
 	}
 
-	if err := c.Client.WriteJSON(statusMsg); err != nil {
-		if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-			logger.Log(logger.LevelError, map[string]string{"clusterID": c.ClusterID}, err, "writing status message to client")
+	writeErr := c.Client.WriteJSON(statusMsg)
+	c.writeMu.Unlock()
+	c.mu.Unlock()
+
+	if writeErr != nil {
+		if !websocket.IsCloseError(writeErr, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+			logger.Log(logger.LevelError, map[string]string{"clusterID": c.ClusterID}, writeErr, "writing status message to client")
+		}
+	}
+
+	if state == StateClosed {
+		c.safeClose()
+	}
+}
+
+// safeClose safely closes the connection and its resources.
+func (c *Connection) safeClose() {
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		c.closed = true
+		c.mu.Unlock()
+
+		if c.Done != nil {
+			select {
+			case <-c.Done:
+				// Already closed
+			default:
+				close(c.Done)
+			}
 		}
 
-		c.closed = true
-	}
+		if c.WSConn != nil {
+			_ = c.WSConn.Close()
+		}
+	})
 }
 
 // establishClusterConnection creates a new WebSocket connection to a Kubernetes cluster.
@@ -557,14 +590,23 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	defer func() { _ = clientConn.Close() }()
-
 	lockClientConn := NewWSConnLock(clientConn)
 
+	defer func() {
+		_ = lockClientConn.Close()
+		m.closeClientConnections(lockClientConn)
+	}()
+
 	for {
-		msg, err := m.readClientMessage(clientConn)
+		msg, isFatal, err := m.readClientMessage(clientConn)
 		if err != nil {
-			break
+			if isFatal {
+				break
+			}
+			// For non-fatal errors (like parsing), we just log and continue
+			logger.Log(logger.LevelError, nil, err, "failed to read client message")
+			m.sendClientError(lockClientConn, "", "", "", "", err)
+			continue
 		}
 
 		// Check if it's a close message
@@ -576,7 +618,9 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 
 		token, err := auth.GetTokenFromCookie(r, msg.ClusterID)
 		if err != nil {
-			break
+			logger.Log(logger.LevelError, map[string]string{"clusterID": msg.ClusterID}, err, "getting token from cookie")
+			m.sendClientError(lockClientConn, msg.ClusterID, msg.Path, msg.Query, msg.UserID, err)
+			continue
 		}
 
 		conn, err := m.getOrCreateConnection(msg, lockClientConn, &token)
@@ -593,29 +637,42 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 			}
 		}
 	}
+}
 
-	m.cleanupConnections()
+// closeClientConnections closes all connections associated with a specific client.
+func (m *Multiplexer) closeClientConnections(clientConn *WSConnLock) {
+	var connsToClose []*Connection
+
+	m.mutex.Lock()
+	for key, conn := range m.connections {
+		if conn.Client == clientConn {
+			connsToClose = append(connsToClose, conn)
+			delete(m.connections, key)
+		}
+	}
+	m.mutex.Unlock()
+
+	for _, conn := range connsToClose {
+		conn.safeClose()
+	}
 }
 
 // readClientMessage reads a message from the client WebSocket connection.
-func (m *Multiplexer) readClientMessage(clientConn *websocket.Conn) (Message, error) {
+// It returns the message, a boolean indicating if the error is fatal for the connection, and the error.
+func (m *Multiplexer) readClientMessage(clientConn *websocket.Conn) (Message, bool, error) {
 	var msg Message
 
 	_, rawMessage, err := clientConn.ReadMessage()
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "reading message")
-
-		return Message{}, err
+		return Message{}, true, err
 	}
 
 	err = json.Unmarshal(rawMessage, &msg)
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "unmarshaling message")
-
-		return Message{}, err
+		return Message{}, false, err
 	}
 
-	return msg, nil
+	return msg, false, nil
 }
 
 // getOrCreateConnection gets an existing connection or creates a new one if it doesn't exist.
@@ -669,25 +726,42 @@ func (m *Multiplexer) refreshConnectionToken(conn *Connection, requestToken *str
 	return nil
 }
 
-// handleConnectionError handles errors that occur when establishing a connection.
-func (m *Multiplexer) handleConnectionError(clientConn *WSConnLock, msg Message, err error) {
-	errorMsg := struct {
-		ClusterID string `json:"clusterId"`
-		Error     string `json:"error"`
+// sendClientError sends an error message to the client WebSocket connection.
+func (m *Multiplexer) sendClientError(clientConn *WSConnLock, clusterID, path, query, userID string, err error) {
+	errorData := struct {
+		Error string `json:"error"`
 	}{
-		ClusterID: msg.ClusterID,
-		Error:     err.Error(),
+		Error: err.Error(),
 	}
 
-	if err = clientConn.WriteJSON(errorMsg); err != nil {
+	jsonData, jsonErr := json.Marshal(errorData)
+	if jsonErr != nil {
+		logger.Log(logger.LevelError, map[string]string{"clusterID": clusterID}, jsonErr, "marshaling error message")
+		return
+	}
+
+	errorMsg := Message{
+		ClusterID: clusterID,
+		Path:      path,
+		Query:     query,
+		UserID:    userID,
+		Data:      string(jsonData),
+		Type:      "ERROR",
+	}
+
+	if err := clientConn.WriteJSON(errorMsg); err != nil {
 		logger.Log(
 			logger.LevelError,
-			map[string]string{"clusterID": msg.ClusterID},
+			map[string]string{"clusterID": clusterID},
 			err,
 			"writing error message to client",
 		)
 	}
+}
 
+// handleConnectionError handles errors that occur when establishing a connection.
+func (m *Multiplexer) handleConnectionError(clientConn *WSConnLock, msg Message, err error) {
+	m.sendClientError(clientConn, msg.ClusterID, msg.Path, msg.Query, msg.UserID, err)
 	logger.Log(logger.LevelError, map[string]string{"clusterID": msg.ClusterID}, err, "establishing cluster connection")
 }
 
@@ -779,7 +853,10 @@ func (m *Multiplexer) sendIfNewResourceVersion(
 ) error {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(message, &obj); err != nil {
-		return fmt.Errorf("error unmarshaling message: %v", err)
+		// If we can't unmarshal as JSON, it might be binary data (e.g. from a terminal)
+		// We just return nil here to indicate no new resource version was found,
+		// but we don't want to stop processing messages.
+		return nil
 	}
 
 	// Try to find metadata directly
@@ -822,8 +899,6 @@ func (m *Multiplexer) sendCompleteMessage(conn *Connection, clientConn *WSConnLo
 		return nil // Connection is already closed, no need to send message
 	}
 
-	conn.mu.RUnlock()
-
 	completeMsg := Message{
 		ClusterID: conn.ClusterID,
 		Path:      conn.Path,
@@ -831,6 +906,7 @@ func (m *Multiplexer) sendCompleteMessage(conn *Connection, clientConn *WSConnLo
 		UserID:    conn.UserID,
 		Type:      "COMPLETE",
 	}
+	conn.mu.RUnlock()
 
 	conn.writeMu.Lock()
 	defer conn.writeMu.Unlock()
@@ -846,10 +922,6 @@ func (m *Multiplexer) sendCompleteMessage(conn *Connection, clientConn *WSConnLo
 }
 
 // sendDataMessage sends the actual data message to the client.
-//
-// Lock ordering note: writeMu is released before acquiring mu to
-// maintain a consistent lock order (mu → writeMu) with updateStatus
-// and prevent a lock-order inversion deadlock.
 func (m *Multiplexer) sendDataMessage(
 	conn *Connection,
 	clientConn *WSConnLock,
@@ -857,6 +929,10 @@ func (m *Multiplexer) sendDataMessage(
 	message []byte,
 ) error {
 	dataMsg := m.createWrapperMessage(conn, messageType, message)
+
+	conn.mu.Lock()
+	conn.Status.LastMsg = time.Now()
+	conn.mu.Unlock()
 
 	conn.writeMu.Lock()
 	err := clientConn.WriteJSON(dataMsg)
@@ -866,23 +942,12 @@ func (m *Multiplexer) sendDataMessage(
 		return err
 	}
 
-	conn.mu.Lock()
-	conn.Status.LastMsg = time.Now()
-	conn.mu.Unlock()
-
 	return nil
 }
 
 // cleanupConnection performs cleanup for a connection.
 func (m *Multiplexer) cleanupConnection(conn *Connection) {
-	conn.mu.Lock()
-	defer conn.mu.Unlock() // Ensure the mutex is unlocked even if an error occurs
-
-	conn.closed = true
-
-	if conn.WSConn != nil {
-		_ = conn.WSConn.Close()
-	}
+	conn.safeClose()
 
 	m.mutex.Lock()
 	connKey := m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)
@@ -917,12 +982,6 @@ func (m *Multiplexer) cleanupConnections() {
 
 	for key, conn := range m.connections {
 		conn.updateStatus(StateClosed, nil)
-		close(conn.Done)
-
-		if conn.WSConn != nil {
-			_ = conn.WSConn.Close()
-		}
-
 		delete(m.connections, key)
 	}
 }
@@ -946,36 +1005,14 @@ func (m *Multiplexer) CloseConnection(clusterID, path, userID string) {
 	conn, exists := m.connections[connKey]
 	if !exists {
 		m.mutex.Unlock()
-		// Don't log error for non-existent connections during cleanup
 		return
 	}
-
-	// Mark as closed before releasing the lock
-	conn.mu.Lock()
-	if conn.closed {
-		conn.mu.Unlock()
-		m.mutex.Unlock()
-		logger.Log(logger.LevelError, map[string]string{"clusterID": conn.ClusterID}, nil, "closing connection")
-
-		return
-	}
-
-	conn.closed = true
-	conn.mu.Unlock()
 
 	delete(m.connections, connKey)
 	m.mutex.Unlock()
 
-	// Lock the connection mutex before accessing shared resources
-	conn.mu.Lock()
-	defer conn.mu.Unlock() // Ensure the mutex is unlocked after the operations
-
-	// Close the Done channel and connections after removing from map
-	close(conn.Done)
-
-	if conn.WSConn != nil {
-		_ = conn.WSConn.Close()
-	}
+	conn.updateStatus(StateClosed, nil)
+	conn.safeClose()
 }
 
 // createConnectionKey creates a unique key for a connection based on cluster ID, path, and user ID.

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -326,7 +326,7 @@ func (c *Connection) writeStatusLocked() error {
 	if jsonErr != nil {
 		logger.Log(logger.LevelError, map[string]string{"clusterID": c.ClusterID}, jsonErr, "marshaling status message")
 
-		return nil
+		return jsonErr
 	}
 
 	statusMsg := Message{
@@ -639,39 +639,56 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 			continue
 		}
 
-		// Check if it's a close message
-		if msg.Type == "CLOSE" {
-			m.CloseConnection(msg.ClusterID, msg.Path, msg.UserID)
+		// Validate required routing fields upfront
+		if msg.ClusterID == "" || msg.Path == "" || msg.UserID == "" || msg.Type == "" {
+			errStr := fmt.Errorf(
+				"missing required routing fields: clusterId='%s', path='%s', userId='%s', type='%s'",
+				msg.ClusterID, msg.Path, msg.UserID, msg.Type,
+			)
+			logger.Log(logger.LevelError, nil, errStr, "invalid client message")
 
 			continue
 		}
 
-		token, err := auth.GetTokenFromCookie(r, msg.ClusterID)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"clusterID": msg.ClusterID}, err, "getting token from cookie")
-			m.sendClientError(lockClientConn, msg.ClusterID, msg.Path, msg.Query, msg.UserID, err)
+		m.processClientMessage(r, lockClientConn, msg)
+	}
+}
 
-			continue
-		}
+// processClientMessage processes a single client message that has been verified to be routable.
+func (m *Multiplexer) processClientMessage(
+	r *http.Request,
+	lockClientConn *WSConnLock,
+	msg Message,
+) {
+	// Check if it's a close message
+	if msg.Type == "CLOSE" {
+		m.CloseConnection(msg.ClusterID, msg.Path, msg.UserID)
 
-		var tokenPtr *string
-		if token != "" {
-			tokenPtr = &token
-		}
+		return
+	}
 
-		conn, err := m.getOrCreateConnection(msg, lockClientConn, tokenPtr)
-		if err != nil {
-			m.handleConnectionError(lockClientConn, msg, err)
+	token, err := auth.GetTokenFromCookie(r, msg.ClusterID)
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"clusterID": msg.ClusterID}, err, "getting token from cookie")
+		m.sendClientError(lockClientConn, msg.ClusterID, msg.Path, msg.Query, msg.UserID, err)
 
-			continue
-		}
+		return
+	}
 
-		if msg.Type == "REQUEST" && conn.Status.State == StateConnected {
-			err = m.writeMessageToCluster(conn, []byte(msg.Data))
-			if err != nil {
-				continue
-			}
-		}
+	var tokenPtr *string
+	if token != "" {
+		tokenPtr = &token
+	}
+
+	conn, err := m.getOrCreateConnection(msg, lockClientConn, tokenPtr)
+	if err != nil {
+		m.handleConnectionError(lockClientConn, msg, err)
+
+		return
+	}
+
+	if msg.Type == "REQUEST" && conn.Status.State == StateConnected {
+		_ = m.writeMessageToCluster(conn, []byte(msg.Data))
 	}
 }
 

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -326,10 +326,6 @@ func (c *Connection) updateStatus(state ConnectionState, err error) {
 // safeClose safely closes the connection and its resources.
 func (c *Connection) safeClose() {
 	c.closeOnce.Do(func() {
-		c.mu.Lock()
-		c.closed = true
-		c.mu.Unlock()
-
 		if c.Done != nil {
 			select {
 			case <-c.Done:
@@ -338,6 +334,10 @@ func (c *Connection) safeClose() {
 				close(c.Done)
 			}
 		}
+
+		c.mu.Lock()
+		c.closed = true
+		c.mu.Unlock()
 
 		if c.WSConn != nil {
 			_ = c.WSConn.Close()
@@ -603,9 +603,9 @@ func (m *Multiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Reque
 			if isFatal {
 				break
 			}
-			// For non-fatal errors (like parsing), we just log and continue
+			// For non-fatal errors (like parsing), log and continue because
+			// there is no routable client message context available.
 			logger.Log(logger.LevelError, nil, err, "failed to read client message")
-			m.sendClientError(lockClientConn, "", "", "", "", err)
 			continue
 		}
 
@@ -742,8 +742,6 @@ func (m *Multiplexer) sendClientError(clientConn *WSConnLock, clusterID, path, q
 
 	errorMsg := Message{
 		ClusterID: clusterID,
-		Path:      path,
-		Query:     query,
 		UserID:    userID,
 		Data:      string(jsonData),
 		Type:      "ERROR",

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -393,11 +393,13 @@ func TestMonitorConnection(t *testing.T) {
 	}()
 
 	time.Sleep(100 * time.Millisecond)
+
 	select {
 	case <-conn.Done:
 	default:
 		close(conn.Done)
 	}
+
 	<-done
 
 	assert.Equal(t, StateClosed, conn.Status.State)
@@ -1078,6 +1080,7 @@ func TestUpdateStatus_WithError(t *testing.T) {
 	default:
 		close(conn.Done)
 	}
+
 	conn.closed = true // Mark connection as closed
 
 	// Try to update state after close - should not change
@@ -1133,6 +1136,7 @@ func TestMonitorConnection_ReconnectFailure(t *testing.T) {
 	default:
 		close(conn.Done)
 	}
+
 	<-done
 }
 
@@ -1157,29 +1161,6 @@ func TestHandleClientWebSocket_InvalidMessages(t *testing.T) {
 	err = ws.WriteMessage(websocket.TextMessage, []byte("invalid json"))
 	require.NoError(t, err)
 
-	// Should receive an error message or close
-	_, message, err := ws.ReadMessage()
-	if err != nil {
-		// Connection may be closed due to error
-		if !websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
-			t.Errorf("expected abnormal closure, got %v", err)
-		}
-	} else {
-		assert.Contains(t, string(message), "error")
-	}
-
-	_ = ws.Close()
-
-	// Test invalid message type with new connection
-	ws, resp, err = websocket.DefaultDialer.Dial(wsURL, nil)
-	require.NoError(t, err)
-
-	if resp != nil && resp.Body != nil {
-		defer func() { _ = resp.Body.Close() }()
-	}
-
-	defer func() { _ = ws.Close() }()
-
 	err = ws.WriteJSON(Message{
 		Type:      "INVALID_TYPE",
 		ClusterID: "test-cluster",
@@ -1189,16 +1170,11 @@ func TestHandleClientWebSocket_InvalidMessages(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Should receive an error message or close
-	_, message, err = ws.ReadMessage()
-	if err != nil {
-		// Connection may be closed due to error
-		if !websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
-			t.Errorf("expected abnormal closure, got %v", err)
-		}
-	} else {
-		assert.Contains(t, string(message), "error")
-	}
+	_, message, err := ws.ReadMessage()
+	require.NoError(t, err)
+	assert.Contains(t, string(message), "ERROR")
+
+	_ = ws.Close()
 }
 
 func TestSendIfNewResourceVersion_VersionComparison(t *testing.T) {

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -487,6 +487,28 @@ func TestCloseConnection(t *testing.T) {
 	assert.True(t, conn.closed)
 }
 
+func TestCloseClientConnectionsClearsClientBeforeClosing(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore())
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	wsConn, wsServer := createTestWebSocketConnection()
+	defer wsServer.Close()
+
+	conn := createTestConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn)
+	conn.WSConn = wsConn.conn
+
+	connKey := m.createConnectionKey("test-cluster", "/api/v1/pods", "test-user")
+	m.connections[connKey] = conn
+
+	m.closeClientConnections(clientConn)
+
+	assert.Empty(t, m.connections)
+	assert.Nil(t, conn.Client)
+	assert.Equal(t, StateClosed, conn.Status.State)
+	assert.True(t, conn.closed)
+}
+
 func createTestConnection(
 	clusterID,
 	userID,

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -393,7 +393,11 @@ func TestMonitorConnection(t *testing.T) {
 	}()
 
 	time.Sleep(100 * time.Millisecond)
-	close(conn.Done)
+	select {
+	case <-conn.Done:
+	default:
+		close(conn.Done)
+	}
 	<-done
 
 	assert.Equal(t, StateClosed, conn.Status.State)
@@ -414,6 +418,9 @@ func TestUpdateStatus(t *testing.T) {
 	}
 
 	for _, state := range states {
+		conn.closed = false
+		conn.closeOnce = sync.Once{}
+		conn.Done = make(chan struct{})
 		conn.updateStatus(state, nil)
 		assert.Equal(t, state, conn.Status.State)
 	}
@@ -914,10 +921,7 @@ func TestHandleConnectionError(t *testing.T) {
 	testError := fmt.Errorf("test error")
 
 	// Capture the error message sent to the client
-	var receivedMsg struct {
-		ClusterID string `json:"clusterId"`
-		Error     string `json:"error"`
-	}
+	var receivedMsg Message
 
 	done := make(chan bool)
 
@@ -947,8 +951,8 @@ func TestHandleConnectionError(t *testing.T) {
 
 	select {
 	case <-done:
-		assert.Equal(t, "test-cluster", receivedMsg.ClusterID)
-		assert.Equal(t, "test error", receivedMsg.Error)
+		assert.Equal(t, "ERROR", receivedMsg.Type)
+		assert.Contains(t, receivedMsg.Data, `"error":"test error"`)
 	case <-time.After(time.Second):
 		t.Fatal("Test timed out")
 	}
@@ -999,8 +1003,9 @@ func TestReadClientMessage_InvalidMessage(t *testing.T) {
 	err = clientConn.WriteMessage(websocket.TextMessage, []byte("not json at all"))
 	require.NoError(t, err)
 
-	msg, err := m.readClientMessage(clientConn)
+	msg, isFatal, err := m.readClientMessage(clientConn)
 	require.Error(t, err)
+	assert.False(t, isFatal)
 	assert.Equal(t, Message{}, msg)
 
 	// Test JSON with invalid data type
@@ -1010,17 +1015,19 @@ func TestReadClientMessage_InvalidMessage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	msg, err = m.readClientMessage(clientConn)
+	msg, isFatal, err = m.readClientMessage(clientConn)
 	require.Error(t, err)
+	assert.False(t, isFatal)
 	assert.Equal(t, Message{}, msg)
 
 	// Test empty JSON object
 	err = clientConn.WriteMessage(websocket.TextMessage, []byte("{}"))
 	require.NoError(t, err)
 
-	msg, err = m.readClientMessage(clientConn)
+	msg, isFatal, err = m.readClientMessage(clientConn)
 	// Empty message is valid JSON but will be unmarshaled into an empty Message struct
 	require.NoError(t, err)
+	assert.False(t, isFatal)
 	assert.Equal(t, Message{}, msg)
 
 	// Test missing required fields
@@ -1030,9 +1037,10 @@ func TestReadClientMessage_InvalidMessage(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	msg, err = m.readClientMessage(clientConn)
+	msg, isFatal, err = m.readClientMessage(clientConn)
 	// Missing fields are allowed by json.Unmarshal
 	require.NoError(t, err)
+	assert.False(t, isFatal)
 	assert.Equal(t, Message{Data: "some data"}, msg)
 }
 
@@ -1053,6 +1061,9 @@ func TestUpdateStatus_WithError(t *testing.T) {
 	assert.Equal(t, testErr.Error(), conn.Status.Error)
 
 	// Test state change without error
+	conn.closed = false
+	conn.closeOnce = sync.Once{}
+	conn.Done = make(chan struct{})
 	conn.updateStatus(StateConnected, nil)
 	assert.Equal(t, StateConnected, conn.Status.State)
 	assert.Empty(t, conn.Status.Error)
@@ -1062,7 +1073,11 @@ func TestUpdateStatus_WithError(t *testing.T) {
 	assert.Equal(t, StateError, conn.Status.State)
 	assert.Equal(t, testErr.Error(), conn.Status.Error)
 
-	close(conn.Done)
+	select {
+	case <-conn.Done:
+	default:
+		close(conn.Done)
+	}
 	conn.closed = true // Mark connection as closed
 
 	// Try to update state after close - should not change
@@ -1113,7 +1128,11 @@ func TestMonitorConnection_ReconnectFailure(t *testing.T) {
 	assert.Equal(t, StateError, conn.Status.State)
 	assert.NotEmpty(t, conn.Status.Error)
 
-	close(conn.Done)
+	select {
+	case <-conn.Done:
+	default:
+		close(conn.Done)
+	}
 	<-done
 }
 
@@ -1218,7 +1237,7 @@ func TestSendIfNewResourceVersion_VersionComparison(t *testing.T) {
 	// Test invalid JSON
 	message = []byte(`invalid json`)
 	err = m.sendIfNewResourceVersion(message, conn, clientConn, &lastVersion)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "200", lastVersion) // Version should not change on error
 
 	// Test missing resourceVersion
@@ -1522,7 +1541,11 @@ func TestMonitorConnection_Reconnect(t *testing.T) {
 	assert.Contains(t, []ConnectionState{StateError, StateConnecting}, conn.Status.State)
 
 	// Clean up
-	close(conn.Done)
+	select {
+	case <-conn.Done:
+	default:
+		close(conn.Done)
+	}
 }
 
 func TestWriteMessageToCluster(t *testing.T) {

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -488,7 +488,7 @@ func TestCloseConnection(t *testing.T) {
 }
 
 func TestCloseClientConnectionsClearsClientBeforeClosing(t *testing.T) {
-	m := NewMultiplexer(kubeconfig.NewContextStore())
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
 	clientConn, clientServer := createTestWebSocketConnection()
 
 	defer clientServer.Close()

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -490,6 +490,7 @@ func TestCloseConnection(t *testing.T) {
 func TestCloseClientConnectionsClearsClientBeforeClosing(t *testing.T) {
 	m := NewMultiplexer(kubeconfig.NewContextStore())
 	clientConn, clientServer := createTestWebSocketConnection()
+
 	defer clientServer.Close()
 
 	wsConn, wsServer := createTestWebSocketConnection()

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -659,6 +659,14 @@ describe('WebSocket Multiplexer', () => {
             kind: 'Status',
             status: 'Failure',
             message: 'cluster connection failed',
+            metadata: {
+              resourceVersion: '0',
+              uid: `${WebSocketManager.createKey(
+                clusterName,
+                path,
+                query
+              )}:ERROR:cluster connection failed`,
+            },
           },
         });
       });
@@ -689,6 +697,14 @@ describe('WebSocket Multiplexer', () => {
             kind: 'Status',
             status: 'Failure',
             message: 'plain backend error',
+            metadata: {
+              resourceVersion: '0',
+              uid: `${WebSocketManager.createKey(
+                clusterName,
+                path,
+                query
+              )}:ERROR:plain backend error`,
+            },
           },
         });
       });

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -435,6 +435,7 @@ describe('WebSocket Multiplexer', () => {
           clusterName,
           '/api/v1/pods',
           '',
+          expect.any(Function),
           expect.any(Function)
         );
       });
@@ -707,6 +708,32 @@ describe('WebSocket Multiplexer', () => {
             },
           },
         });
+      });
+    });
+
+    it('should route backend error to dedicated error callback when provided', async () => {
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
+
+      const errorCallback = vi.fn();
+      await WebSocketManager.subscribe(clusterName, path, query, onMessage, errorCallback);
+      await mockServer.connected;
+      await mockServer.nextMessage;
+
+      await mockServer.send(
+        JSON.stringify({
+          clusterId: clusterName,
+          path,
+          query,
+          data: JSON.stringify({ error: 'dedicated error message' }),
+          type: 'ERROR',
+        })
+      );
+
+      await vi.waitFor(() => {
+        expect(errorCallback).toHaveBeenCalledWith(expect.any(Error));
+        expect(errorCallback.mock.calls[0][0].message).toBe('dedicated error message');
+        expect(onMessage).not.toHaveBeenCalled();
       });
     });
 

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -666,6 +666,7 @@ describe('WebSocket Multiplexer', () => {
                 path,
                 query
               )}:ERROR:cluster connection failed`,
+              resourceVersion: '0',
             },
           },
         });
@@ -703,6 +704,7 @@ describe('WebSocket Multiplexer', () => {
                 path,
                 query
               )}:ERROR:plain backend error`,
+              resourceVersion: '0',
             },
           },
         });

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -634,6 +634,66 @@ describe('WebSocket Multiplexer', () => {
       expect(console.error).toHaveBeenCalledWith('Failed to parse update data:', expect.any(Error));
     });
 
+    it('should handle JSON error messages from backend', async () => {
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
+
+      await WebSocketManager.subscribe(clusterName, path, query, onMessage);
+      await mockServer.connected;
+      await mockServer.nextMessage;
+
+      await mockServer.send(
+        JSON.stringify({
+          clusterId: clusterName,
+          path,
+          query,
+          data: JSON.stringify({ error: 'cluster connection failed' }),
+          type: 'ERROR',
+        })
+      );
+
+      await vi.waitFor(() => {
+        expect(onMessage).toHaveBeenCalledWith({
+          type: 'ERROR',
+          object: {
+            kind: 'Status',
+            status: 'Failure',
+            message: 'cluster connection failed',
+          },
+        });
+      });
+    });
+
+    it('should handle non-JSON error messages from backend', async () => {
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
+
+      await WebSocketManager.subscribe(clusterName, path, query, onMessage);
+      await mockServer.connected;
+      await mockServer.nextMessage;
+
+      await mockServer.send(
+        JSON.stringify({
+          clusterId: clusterName,
+          path,
+          query,
+          data: 'plain backend error',
+          type: 'ERROR',
+        })
+      );
+
+      await vi.waitFor(() => {
+        expect(onMessage).toHaveBeenCalledWith({
+          type: 'ERROR',
+          object: {
+            kind: 'Status',
+            status: 'Failure',
+            message: 'plain backend error',
+          },
+        });
+      });
+    });
+
     it('should handle message callback errors in useWebSocket', async () => {
       const errorMessage = 'Message processing failed';
       const errorFn = vi.fn().mockImplementation(() => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -661,7 +661,6 @@ describe('WebSocket Multiplexer', () => {
             status: 'Failure',
             message: 'cluster connection failed',
             metadata: {
-              resourceVersion: '0',
               uid: `${WebSocketManager.createKey(
                 clusterName,
                 path,
@@ -699,7 +698,6 @@ describe('WebSocket Multiplexer', () => {
             status: 'Failure',
             message: 'plain backend error',
             metadata: {
-              resourceVersion: '0',
               uid: `${WebSocketManager.createKey(
                 clusterName,
                 path,

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -463,19 +463,21 @@ export function useWebSocket<T>({
     let subscriptionQuery = '';
 
     const connectWebSocket = async () => {
+      let stableOnError: ((err: Error) => void) | undefined;
       try {
         const parsedUrl = new URL(url, getBaseWsUrl());
         subscriptionPath = parsedUrl.pathname;
         subscriptionQuery = parsedUrl.search.slice(1);
+        stableOnError = (err: Error) => {
+          console.error('WebSocket error for', subscriptionPath, err);
+          onError?.(err);
+        };
         const unsubscribe = await WebSocketManager.subscribe(
           cluster,
           subscriptionPath,
           subscriptionQuery,
           stableOnMessage,
-          (err: Error) => {
-            console.error('WebSocket error for', subscriptionPath, err);
-            onError?.(err);
-          }
+          stableOnError
         );
         if (isCancelled) {
           unsubscribe();
@@ -491,7 +493,7 @@ export function useWebSocket<T>({
             subscriptionPath,
             subscriptionQuery,
             stableOnMessage,
-            onError
+            stableOnError
           );
         }
         if (isCancelled) {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -353,7 +353,6 @@ export const WebSocketManager = {
               status: 'Failure',
               message: errorMessage,
               metadata: {
-                resourceVersion: '0',
                 uid: `${key}:ERROR:${errorMessage}`,
               },
             },

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -315,6 +315,10 @@ export const WebSocketManager = {
             kind: 'Status',
             status: 'Failure',
             message: errorMessage,
+            metadata: {
+              resourceVersion: '0',
+              uid: `${key}:ERROR:${errorMessage}`,
+            },
           },
         };
 

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -37,6 +37,9 @@ export const WebSocketManager = {
   /** Map of message handlers for each subscription path */
   listeners: new Map<string, Set<(data: any) => void>>(),
 
+  /** Map of error handlers for each subscription path */
+  errorListeners: new Map<string, Set<(err: Error) => void>>(),
+
   /** Set of paths that have received a COMPLETE message */
   completedPaths: new Set<string>(),
 
@@ -161,13 +164,15 @@ export const WebSocketManager = {
    * @param path - API resource path
    * @param query - Query parameters
    * @param onMessage - Callback for handling incoming messages
+   * @param onError - Callback for handling errors
    * @returns Promise resolving to cleanup function
    */
   async subscribe(
     clusterId: string,
     path: string,
     query: string,
-    onMessage: (data: any) => void
+    onMessage: (data: any) => void,
+    onError?: (err: Error) => void
   ): Promise<() => void> {
     const key = this.createKey(clusterId, path, query);
 
@@ -178,6 +183,13 @@ export const WebSocketManager = {
     const listeners = this.listeners.get(key) || new Set();
     listeners.add(onMessage);
     this.listeners.set(key, listeners);
+
+    // Add error listener if provided
+    if (onError) {
+      const errListeners = this.errorListeners.get(key) || new Set();
+      errListeners.add(onError);
+      this.errorListeners.set(key, errListeners);
+    }
 
     // Establish connection and send REQUEST
     const socket = await this.connect();
@@ -192,7 +204,7 @@ export const WebSocketManager = {
     socket.send(JSON.stringify(requestMsg));
 
     // Return cleanup function
-    return () => this.unsubscribe(key, clusterId, path, query, onMessage);
+    return () => this.unsubscribe(key, clusterId, path, query, onMessage, onError);
   },
 
   /**
@@ -215,13 +227,15 @@ export const WebSocketManager = {
    * @param path - API resource path being watched
    * @param query - Query parameters for filtering
    * @param onMessage - Message handler to remove from subscription
+   * @param onError - Error handler to remove from subscription
    */
   unsubscribe(
     key: string,
     clusterId: string,
     path: string,
     query: string,
-    onMessage: (data: any) => void
+    onMessage: (data: any) => void,
+    onError?: (err: Error) => void
   ): void {
     // Clear any pending unsubscribe for this key
     const pendingTimeout = this.pendingUnsubscribes.get(key);
@@ -262,6 +276,17 @@ export const WebSocketManager = {
         }, 100); // 100ms debounce
 
         this.pendingUnsubscribes.set(key, timeout);
+      }
+    }
+
+    // Remove the error listener
+    if (onError) {
+      const errListeners = this.errorListeners.get(key);
+      if (errListeners) {
+        errListeners.delete(onError);
+        if (errListeners.size === 0) {
+          this.errorListeners.delete(key);
+        }
       }
     }
   },
@@ -309,26 +334,39 @@ export const WebSocketManager = {
           errorMessage = data.data || errorMessage;
         }
 
-        const update = {
-          type: 'ERROR',
-          object: {
-            kind: 'Status',
-            status: 'Failure',
-            message: errorMessage,
-            metadata: {
-              resourceVersion: '0',
-              uid: `${key}:ERROR:${errorMessage}`,
-            },
-          },
-        };
-
-        const listeners = this.listeners.get(key);
-        if (listeners) {
-          for (const listener of listeners) {
+        const errListeners = this.errorListeners.get(key);
+        if (errListeners && errListeners.size > 0) {
+          const errorObj = new Error(errorMessage);
+          for (const errListener of errListeners) {
             try {
-              listener(update);
+              errListener(errorObj);
             } catch (err) {
               console.error('Failed to process WebSocket error message:', err);
+            }
+          }
+        } else {
+          // Fallback to data listeners as a safety net for legacy/direct callers
+          const update = {
+            type: 'ERROR',
+            object: {
+              kind: 'Status',
+              status: 'Failure',
+              message: errorMessage,
+              metadata: {
+                resourceVersion: '0',
+                uid: `${key}:ERROR:${errorMessage}`,
+              },
+            },
+          };
+
+          const listeners = this.listeners.get(key);
+          if (listeners) {
+            for (const listener of listeners) {
+              try {
+                listener(update);
+              } catch (err) {
+                console.error('Failed to process WebSocket error message:', err);
+              }
             }
           }
         }
@@ -433,7 +471,8 @@ export function useWebSocket<T>({
           cluster,
           subscriptionPath,
           subscriptionQuery,
-          stableOnMessage
+          stableOnMessage,
+          onError
         );
         if (isCancelled) {
           unsubscribe();
@@ -448,7 +487,8 @@ export function useWebSocket<T>({
             cluster,
             subscriptionPath,
             subscriptionQuery,
-            stableOnMessage
+            stableOnMessage,
+            onError
           );
         }
         if (isCancelled) {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -299,6 +299,38 @@ export const WebSocketManager = {
         return;
       }
 
+      // Handle ERROR messages from backend
+      if (data.type === 'ERROR') {
+        let errorMessage = 'Unknown error';
+        try {
+          const parsedData = data.data ? JSON.parse(data.data) : {};
+          errorMessage = parsedData.error || errorMessage;
+        } catch (e) {
+          errorMessage = data.data || errorMessage;
+        }
+
+        const update = {
+          type: 'ERROR',
+          object: {
+            kind: 'Status',
+            status: 'Failure',
+            message: errorMessage,
+          },
+        };
+
+        const listeners = this.listeners.get(key);
+        if (listeners) {
+          for (const listener of listeners) {
+            try {
+              listener(update);
+            } catch (err) {
+              console.error('Failed to process WebSocket error message:', err);
+            }
+          }
+        }
+        return;
+      }
+
       // Parse and validate update data
       let update;
       try {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -354,6 +354,7 @@ export const WebSocketManager = {
               message: errorMessage,
               metadata: {
                 uid: `${key}:ERROR:${errorMessage}`,
+                resourceVersion: '0',
               },
             },
           };
@@ -471,7 +472,10 @@ export function useWebSocket<T>({
           subscriptionPath,
           subscriptionQuery,
           stableOnMessage,
-          onError
+          (err: Error) => {
+            console.error('WebSocket error for', subscriptionPath, err);
+            onError?.(err);
+          }
         );
         if (isCancelled) {
           unsubscribe();

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -412,6 +412,7 @@ describe('useWatchKubeObjectLists (Multiplexer)', () => {
       'cluster-a',
       expect.stringContaining('/api/v1/namespaces/namespace-a/pods'),
       'watch=1&resourceVersion=1',
+      expect.any(Function),
       expect.any(Function)
     );
   });
@@ -442,6 +443,7 @@ describe('useWatchKubeObjectLists (Multiplexer)', () => {
       'cluster-a',
       expect.stringContaining('/api/v1/namespaces/namespace-a/pods'),
       'watch=1&resourceVersion=1',
+      expect.any(Function),
       expect.any(Function)
     );
     expect(mockSubscribe).toHaveBeenNthCalledWith(
@@ -449,6 +451,7 @@ describe('useWatchKubeObjectLists (Multiplexer)', () => {
       'cluster-b',
       expect.stringContaining('/api/v1/namespaces/namespace-b/pods'),
       'watch=1&resourceVersion=2',
+      expect.any(Function),
       expect.any(Function)
     );
   });
@@ -474,6 +477,7 @@ describe('useWatchKubeObjectLists (Multiplexer)', () => {
       'cluster-a',
       expect.stringContaining('/api/v1/pods'),
       'watch=1&resourceVersion=1',
+      expect.any(Function),
       expect.any(Function)
     );
   });

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -278,8 +278,12 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
       const parsedUrl = new URL(url, BASE_WS_URL);
 
       // Subscribe to WebSocket updates
-      WebSocketManager.subscribe(cluster, parsedUrl.pathname, parsedUrl.search.slice(1), update =>
-        handleUpdate(update, cluster, namespace)
+      WebSocketManager.subscribe(
+        cluster,
+        parsedUrl.pathname,
+        parsedUrl.search.slice(1),
+        update => handleUpdate(update, cluster, namespace),
+        error => console.error(`WebSocket subscription error for cluster ${cluster}:`, error)
       ).then(
         cleanup => cleanups.push(cleanup),
         error => {


### PR DESCRIPTION
## Summary
Fixes #5224 by making the WebSocket multiplexer tolerate per-request failures without dropping the whole client session. Malformed client messages, token lookup failures, and cluster dial errors are isolated to the affected request/cluster while the multiplexer keeps serving other active watches.

## Changes
- Refactor the client read loop to distinguish fatal socket read errors from non-fatal message parsing errors.
- Send routable backend `ERROR` frames for token and cluster connection failures.
- Route frontend multiplexer `ERROR` frames through `useWebSocket`'s `onError` callback instead of fabricating Kubernetes watch update events.
- Avoid resourceVersion parsing failures for non-watch/non-JSON cluster messages from tearing down the session.
- Synchronize connection close-state reads so reconnect checks do not race with `safeClose`.
- Add backend and frontend regression coverage for multiplexer error handling.

## Steps to Test
1. Open Headlamp with multiple resource watches active.
2. Trigger a malformed multiplexer request or a token/cluster connection error for one subscription.
3. Verify the affected subscription receives an error while the multiplexer connection and other watches remain active.

## Local Validation
- `go test ./cmd` - passed
- `npm test -- src/lib/k8s/api/v2/multiplexer.test.ts --run` - passed
- `npm run frontend:tsc` - passed
- `npm run frontend:lint` - passed
- `npm run backend:test` - passed

## Screenshots
N/A - backend/frontend protocol stability fix.

## Notes for the Reviewer
Rebased onto latest `main` and squashed the PR to one guideline-compliant commit: `multiplexer: Improve WebSocket stability`.