### PR TITLE
fix: add storyName for SingleCluster and ManyClusters stories

### DIFF
--- a/frontend/src/components/cluster/Chooser.stories.tsx
+++ b/frontend/src/components/cluster/Chooser.stories.tsx
@@ -120,6 +120,7 @@ SingleCluster.args = {
   ],
   open: true,
 };
+SingleCluster.storyName = 'Single Cluster';
 
 export const ManyClusters = Template.bind({});
 ManyClusters.args = {
@@ -131,7 +132,7 @@ ManyClusters.args = {
     })),
   open: true,
 };
-
+ManyClusters.storyName = 'Many Clusters';
 export const NoClusters = Template.bind({});
 NoClusters.args = {
   clusters: [],


### PR DESCRIPTION
Fixes #4602
Fixes #4603

## Changes
- Added storyName 'Single Cluster' for SingleCluster story
- Added storyName 'Many Clusters' for ManyClusters story

## Why
These story names were missing which caused empty DialogTitle 
h1 accessibility issue in Storybook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved Storybook presentation by adding clear display names for single-cluster and many-cluster Chooser examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->