### PR TITLE
test: add stories for DeleteMultipleButton component

### DIFF
--- a/frontend/src/components/cluster/Chooser.stories.tsx
+++ b/frontend/src/components/cluster/Chooser.stories.tsx
@@ -120,6 +120,7 @@ SingleCluster.args = {
   ],
   open: true,
 };
+SingleCluster.storyName = 'Single Cluster';
 
 export const ManyClusters = Template.bind({});
 ManyClusters.args = {
@@ -131,7 +132,7 @@ ManyClusters.args = {
     })),
   open: true,
 };
-
+ManyClusters.storyName = 'Many Clusters';
 export const NoClusters = Template.bind({});
 NoClusters.args = {
   clusters: [],

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { TestContext } from '../../../test';
+import DeleteMultipleButton from './DeleteMultipleButton';
+
+export default {
+  title: 'common/Resource/DeleteMultipleButton',
+  component: DeleteMultipleButton,
+  parameters: {
+    docs: {
+      description: {
+        component: 'A button component for deleting multiple Kubernetes resources at once.',
+      },
+    },
+  },
+} as Meta;
+
+const Template: StoryFn = args => (
+  <TestContext>
+    <DeleteMultipleButton {...args} />
+  </TestContext>
+);
+
+// Button enabled with items selected
+export const WithSelection = Template.bind({});
+WithSelection.storyName = 'Button enabled showing selection count';
+WithSelection.args = {
+  items: [
+    {
+      kind: 'Pod',
+      cluster: 'cluster1',
+      metadata: { name: 'pod-1', uid: 'uid-1' },
+      delete: () => Promise.resolve(),
+    },
+    {
+      kind: 'Pod',
+      cluster: 'cluster1',
+      metadata: { name: 'pod-2', uid: 'uid-2' },
+      delete: () => Promise.resolve(),
+    },
+  ],
+};
+
+// Button disabled with no selection
+export const NoSelection = Template.bind({});
+NoSelection.storyName = 'Button disabled with no selection';
+NoSelection.args = {
+  items: [],
+};
+
+// Batch delete confirmation dialog
+export const WithConfirmDialog = Template.bind({});
+WithConfirmDialog.storyName = 'Batch delete confirmation dialog';
+WithConfirmDialog.args = {
+  items: [
+    {
+      kind: 'Deployment',
+      cluster: 'cluster1',
+      metadata: { name: 'my-deployment', uid: 'uid-3' },
+      delete: () => Promise.resolve(),
+    },
+  ],
+};

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
@@ -14,19 +14,6 @@
  * limitations under the License.
  */
 
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 import { TestContext } from '../../../test';

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 import { TestContext } from '../../../test';

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
@@ -20,7 +20,7 @@ import { TestContext } from '../../../test';
 import DeleteMultipleButton from './DeleteMultipleButton';
 
 export default {
-  title: 'common/Resource/DeleteMultipleButton',
+  title: 'Resource/DeleteMultipleButton',
   component: DeleteMultipleButton,
   parameters: {
     docs: {
@@ -37,7 +37,6 @@ const Template: StoryFn = args => (
   </TestContext>
 );
 
-// Button enabled with items selected
 export const WithSelection = Template.bind({});
 WithSelection.storyName = 'Button enabled showing selection count';
 WithSelection.args = {
@@ -57,14 +56,20 @@ WithSelection.args = {
   ],
 };
 
-// Button disabled with no selection
 export const NoSelection = Template.bind({});
-NoSelection.storyName = 'Button disabled with no selection';
+NoSelection.storyName = 'No selection (component returns null)';
 NoSelection.args = {
   items: [],
 };
+NoSelection.parameters = {
+  docs: {
+    description: {
+      story:
+        'When no items are selected, DeleteMultipleButton returns null and renders nothing. This is the expected behavior.',
+    },
+  },
+};
 
-// Batch delete confirmation dialog
 export const WithConfirmDialog = Template.bind({});
 WithConfirmDialog.storyName = 'Batch delete confirmation dialog';
 WithConfirmDialog.args = {
@@ -76,4 +81,12 @@ WithConfirmDialog.args = {
       delete: () => Promise.resolve(),
     },
   ],
+};
+WithConfirmDialog.parameters = {
+  docs: {
+    description: {
+      story:
+        'Shows the delete button with one item selected. Click the button to open the confirmation dialog.',
+    },
+  },
 };

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.NoSelection.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.NoSelection.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithConfirmDialog.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithConfirmDialog.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <button
+      aria-label="Delete items"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithSelection.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithSelection.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <button
+      aria-label="Delete items"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div />
+  </div>
+</body>


### PR DESCRIPTION
Fixes #4691

## Changes
- Created DeleteMultipleButton.stories.tsx
- Added story: Button enabled showing selection count
- Added story: Button disabled with no selection
- Added story: Batch delete confirmation dialog

## Testing
Stories cover the main states of the DeleteMultipleButton component.