### PR TITLE
backend: portforward: add unit tests

### DIFF
--- a/backend/pkg/portforward/handler_unit_test.go
+++ b/backend/pkg/portforward/handler_unit_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/portforward"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRequestWithVars creates an http.Request with gorilla/mux route variables set.
+// This is needed because the handlers extract clusterName from mux.Vars(r).
+func newRequestWithVars(method, target string, body io.Reader, vars map[string]string) *http.Request {
+	req := httptest.NewRequestWithContext(context.Background(), method, target, body)
+	req = mux.SetURLVars(req, vars)
+
+	return req
+}
+
+// --- GetPortForwards handler tests ---
+
+func TestGetPortForwards_MissingCluster(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+	// No clusterName in mux vars — simulates a request without the route parameter.
+	r := newRequestWithVars(http.MethodGet, "/portforward/list", nil, map[string]string{})
+
+	portforward.GetPortForwards(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "cluster is required")
+}
+
+func TestGetPortForwards_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+	r := newRequestWithVars(http.MethodGet, "/portforward/list", nil, map[string]string{
+		"clusterName": "test-cluster",
+	})
+
+	portforward.GetPortForwards(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	// Empty list should return a valid JSON array.
+	assert.Equal(t, "[]\n", string(body))
+}
+
+func TestGetPortForwards_ContentTypeHeader(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+	r := newRequestWithVars(http.MethodGet, "/portforward/list", nil, map[string]string{
+		"clusterName": "any-cluster",
+	})
+
+	portforward.GetPortForwards(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	// Content-Type must be set to application/json for valid responses.
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+}
+
+// --- GetPortForwardByID handler tests ---
+
+func TestGetPortForwardByID_MissingCluster(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+	r := newRequestWithVars(http.MethodGet, "/portforward?id=abc", nil, map[string]string{})
+	r.URL = &url.URL{RawQuery: "id=abc"}
+
+	portforward.GetPortForwardByID(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "cluster is required")
+}
+
+func TestGetPortForwardByID_MissingID(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+	r := newRequestWithVars(http.MethodGet, "/portforward", nil, map[string]string{
+		"clusterName": "test-cluster",
+	})
+	r.URL = &url.URL{}
+
+	portforward.GetPortForwardByID(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "id is required")
+}
+
+func TestGetPortForwardByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+	r := newRequestWithVars(http.MethodGet, "/portforward?id=nonexistent", nil, map[string]string{
+		"clusterName": "test-cluster",
+	})
+	r.URL = &url.URL{RawQuery: "id=nonexistent"}
+
+	portforward.GetPortForwardByID(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "no portforward running with id")
+}
+
+// --- StopOrDeletePortForward handler tests ---
+
+func TestStopOrDeletePortForward_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+
+	body := bytes.NewBufferString("{invalid json")
+	r := newRequestWithVars(http.MethodDelete, "/portforward", body, map[string]string{
+		"clusterName": "test-cluster",
+	})
+
+	portforward.StopOrDeletePortForward(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+}
+
+func TestStopOrDeletePortForward_MissingID(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+
+	payload := map[string]interface{}{
+		"id":           "",
+		"stopOrDelete": true,
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	body := bytes.NewReader(jsonPayload)
+	r := newRequestWithVars(http.MethodDelete, "/portforward", body, map[string]string{
+		"clusterName": "test-cluster",
+	})
+
+	portforward.StopOrDeletePortForward(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	respBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(respBody), "id is required")
+}
+
+func TestStopOrDeletePortForward_NotFoundInCache(t *testing.T) {
+	t.Parallel()
+
+	ch := cache.New[interface{}]()
+	w := httptest.NewRecorder()
+
+	payload := map[string]interface{}{
+		"id":           "does-not-exist",
+		"stopOrDelete": true,
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	body := bytes.NewReader(jsonPayload)
+	r := newRequestWithVars(http.MethodDelete, "/portforward", body, map[string]string{
+		"clusterName": "test-cluster",
+	})
+
+	portforward.StopOrDeletePortForward(ch, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+
+	respBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(respBody), "failed to delete port forward")
+}

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -19,9 +19,15 @@ package portforward
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -239,4 +245,268 @@ func TestStopOrDeletePortForwardRequestValidate(t *testing.T) {
 
 	err = req.Validate()
 	assert.NoError(t, err)
+}
+
+// TestSafeCloseChan tests safeCloseChan for normal, nil, and double-close scenarios.
+func TestSafeCloseChan(t *testing.T) {
+	t.Run("normal_close", func(t *testing.T) {
+		ch := make(chan struct{})
+
+		// Should close without panic.
+		assert.NotPanics(t, func() { safeCloseChan(ch) })
+
+		// Use a non-blocking select to verify the channel is closed immediately,
+		// failing fast if safeCloseChan regresses.
+		select {
+		case _, ok := <-ch:
+			assert.False(t, ok, "channel should be closed")
+		default:
+			t.Fatal("channel should be closed")
+		}
+	})
+
+	t.Run("nil_channel", func(t *testing.T) {
+		// Closing a nil channel should not panic.
+		assert.NotPanics(t, func() { safeCloseChan(nil) })
+	})
+
+	t.Run("double_close_recovery", func(t *testing.T) {
+		ch := make(chan struct{})
+		close(ch)
+
+		// Closing an already-closed channel should recover from the panic.
+		assert.NotPanics(t, func() { safeCloseChan(ch) })
+	})
+}
+
+// TestHandlePortForwardError tests that handlePortForwardError correctly sets
+// status, error message, persists the state to cache, and closes the channel.
+func TestHandlePortForwardError(t *testing.T) {
+	c := cache.New[interface{}]()
+	ch := make(chan struct{}, 1)
+
+	pfDetails := &portForward{
+		ID:        "err-test",
+		Cluster:   "cluster",
+		Status:    RUNNING,
+		closeChan: ch,
+	}
+
+	logParams := map[string]string{"id": "err-test"}
+	errMsg := "something went wrong"
+
+	err := handlePortForwardError(c, pfDetails, logParams, errMsg)
+
+	assert.Error(t, err)
+	assert.Equal(t, errMsg, err.Error())
+	assert.Equal(t, STOPPED, pfDetails.Status)
+	assert.Equal(t, errMsg, pfDetails.Error)
+
+	// Verify the channel was closed by handlePortForwardError.
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok, "closeChan should be closed after handlePortForwardError")
+	default:
+		t.Fatal("closeChan should be closed after handlePortForwardError")
+	}
+
+	// Verify the updated state was persisted to the cache.
+	key := portforwardKeyGenerator(*pfDetails)
+	cached, cacheErr := c.Get(context.Background(), key)
+	require.NoError(t, cacheErr)
+
+	cachedPF, ok := cached.(portForward)
+	require.True(t, ok)
+	assert.Equal(t, STOPPED, cachedPF.Status)
+	assert.Equal(t, errMsg, cachedPF.Error)
+}
+
+// TestHandlePortForwardSuccess tests that handlePortForwardSuccess correctly
+// sets the status to RUNNING, clears the error, and persists to cache.
+func TestHandlePortForwardSuccess(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	pfDetails := &portForward{
+		ID:      "success-test",
+		Cluster: "cluster",
+		Status:  STOPPED,
+		Error:   "previous error",
+	}
+
+	logParams := map[string]string{"id": "success-test"}
+
+	handlePortForwardSuccess(c, pfDetails, logParams)
+
+	assert.Equal(t, RUNNING, pfDetails.Status)
+	assert.Empty(t, pfDetails.Error)
+
+	// Verify the updated state was persisted to the cache.
+	key := portforwardKeyGenerator(*pfDetails)
+	cached, cacheErr := c.Get(context.Background(), key)
+	require.NoError(t, cacheErr)
+
+	cachedPF, ok := cached.(portForward)
+	require.True(t, ok)
+	assert.Equal(t, RUNNING, cachedPF.Status)
+	assert.Empty(t, cachedPF.Error)
+}
+
+// TestGetFreePort tests that getFreePort returns a valid, non-zero port number.
+func TestGetFreePort(t *testing.T) {
+	port, err := getFreePort()
+	require.NoError(t, err)
+	assert.Greater(t, port, 0, "port must be positive")
+	assert.LessOrEqual(t, port, 65535, "port must be within valid range")
+}
+
+// TestGetPortForwardList_UserIDKeyIsolation verifies that the user ID
+// changes the cache key prefix, isolating entries between users.
+func TestGetPortForwardList_UserIDKeyIsolation(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	// Seed a portforward under the base cluster key (no user ID).
+	pf := portForward{ID: "pf-1", Cluster: "cluster", Pod: "web", Namespace: "default", Status: RUNNING}
+	portforwardstore(c, pf)
+
+	// Query with the base cluster key — should find the entry.
+	result := getPortForwardList(c, "cluster")
+	assert.Len(t, result, 1)
+	assert.Equal(t, "pf-1", result[0].ID)
+
+	// Query with a user-specific key — should NOT find the entry.
+	resultWithUser := getPortForwardList(c, "clusteruser123")
+	assert.Empty(t, resultWithUser, "user-specific key must not return entries stored under base cluster key")
+}
+
+// TestGetPortForwardByID_UserIDKeyIsolation verifies that getPortForwardByID
+// uses the correct key when a user ID is part of the cluster name.
+func TestGetPortForwardByID_UserIDKeyIsolation(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	// Seed a portforward under the base cluster key.
+	pf := portForward{ID: "pf-2", Cluster: "cluster", Pod: "api", Namespace: "prod", Status: RUNNING}
+	portforwardstore(c, pf)
+
+	// Lookup with the base cluster key — should succeed.
+	found, err := getPortForwardByID(c, "cluster", "pf-2")
+	require.NoError(t, err)
+	assert.Equal(t, "pf-2", found.ID)
+
+	// Lookup with a user-specific key — should fail.
+	_, err = getPortForwardByID(c, "clusteruser456", "pf-2")
+	assert.Error(t, err, "user-specific key must not find entries stored under base cluster key")
+}
+
+// TestGetPortForwardsHandler_UserIDKeyIsolation uses the exported HTTP handler
+// to verify that the X-HEADLAMP-USER-ID header causes a different cache lookup.
+func TestGetPortForwardsHandler_UserIDKeyIsolation(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	// Seed a portforward under the base cluster key.
+	pf := portForward{ID: "pf-3", Cluster: "cluster", Pod: "nginx", Namespace: "default", Status: RUNNING}
+	portforwardstore(c, pf)
+
+	// Request WITHOUT user ID header — should return the seeded entry.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward/list", nil)
+	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
+
+	GetPortForwards(c, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "pf-3")
+
+	// Request WITH user ID header — should return empty list.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward/list", nil)
+	r2 = mux.SetURLVars(r2, map[string]string{"clusterName": "cluster"})
+	r2.Header.Set("X-HEADLAMP-USER-ID", "user999")
+
+	GetPortForwards(c, w2, r2)
+
+	res2 := w2.Result()
+
+	defer func() { _ = res2.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, res2.StatusCode)
+
+	body2, err := io.ReadAll(res2.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "[]\n", string(body2), "user-specific query must not return entries stored under base cluster key")
+}
+
+// TestGetPortForwardByIDHandler_UserIDKeyIsolation uses the exported HTTP handler
+// to verify that the X-HEADLAMP-USER-ID header causes a different cache lookup.
+func TestGetPortForwardByIDHandler_UserIDKeyIsolation(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	// Seed a portforward under the base cluster key.
+	pf := portForward{ID: "pf-4", Cluster: "cluster", Pod: "redis", Namespace: "cache", Status: RUNNING}
+	portforwardstore(c, pf)
+
+	// Request WITHOUT user ID header — should find the entry.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward?id=pf-4", nil)
+	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
+	r.URL = &url.URL{RawQuery: "id=pf-4"}
+
+	GetPortForwardByID(c, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	// Request WITH user ID header — should NOT find it.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward?id=pf-4", nil)
+	r2 = mux.SetURLVars(r2, map[string]string{"clusterName": "cluster"})
+	r2.URL = &url.URL{RawQuery: "id=pf-4"}
+	r2.Header.Set("X-HEADLAMP-USER-ID", "user999")
+
+	GetPortForwardByID(c, w2, r2)
+
+	res2 := w2.Result()
+
+	defer func() { _ = res2.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotFound, res2.StatusCode,
+		"user-specific lookup must not find entries under base cluster key")
+}
+
+// TestStopOrDeletePortForwardHandler_UserIDKeyIsolation verifies that
+// StopOrDeletePortForward uses cluster+userID as the cache key.
+func TestStopOrDeletePortForwardHandler_UserIDKeyIsolation(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	// Seed a portforward under the base cluster key with a closeChan.
+	ch := make(chan struct{}, 1)
+	pf := portForward{ID: "pf-5", Cluster: "cluster", Pod: "app", Namespace: "ns", Status: RUNNING, closeChan: ch}
+	portforwardstore(c, pf)
+
+	// Try to stop with a user ID header — should fail because the key is different.
+	payload, err := json.Marshal(map[string]interface{}{"id": "pf-5", "stopOrDelete": true})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/portforward", bytes.NewReader(payload))
+	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
+	r.Header.Set("X-HEADLAMP-USER-ID", "user999")
+
+	StopOrDeletePortForward(c, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusInternalServerError, res.StatusCode,
+		"stop request with user ID must not find entries stored under base cluster key")
 }


### PR DESCRIPTION
## What this PR does

Adds comprehensive unit tests for the `pkg/portforward` package covering both exported HTTP handlers and internal helper functions that previously had zero unit test coverage.

The existing `handler_test.go` contains a single integration test gated behind `HEADLAMP_RUN_INTEGRATION_TESTS`, meaning all error paths and validation logic were untested in CI.

## Changes

### New file: `handler_unit_test.go` (external tests)

Unit tests for the three exported HTTP handler functions:

- **GetPortForwards**: missing cluster (400), empty list (200), user ID key composition, Content-Type header
- **GetPortForwardByID**: missing cluster (400), missing ID (400), cache miss (404), user ID key composition
- **StopOrDeletePortForward**: malformed JSON (400), missing ID validation (400), cache miss (500), user ID key composition

### Updated: `internal_test.go`

- **safeCloseChan**: normal close, nil channel, double-close panic recovery
- **handlePortForwardError**: status/error update and cache persistence
- **handlePortForwardSuccess**: status reset and cache persistence
- **getFreePort**: valid port range verification

## Testing

```bash
go vet ./pkg/portforward/...
go test ./pkg/portforward/... -v -count=1
```

All 28 tests pass. No Kubernetes cluster required.
