### PR TITLE
test: add stories for PortForward component

### DIFF
--- a/frontend/src/components/cluster/Chooser.stories.tsx
+++ b/frontend/src/components/cluster/Chooser.stories.tsx
@@ -120,6 +120,7 @@ SingleCluster.args = {
   ],
   open: true,
 };
+SingleCluster.storyName = 'Single Cluster';
 
 export const ManyClusters = Template.bind({});
 ManyClusters.args = {
@@ -131,7 +132,7 @@ ManyClusters.args = {
     })),
   open: true,
 };
-
+ManyClusters.storyName = 'Many Clusters';
 export const NoClusters = Template.bind({});
 NoClusters.args = {
   clusters: [],

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { TestContext } from '../../../test';
+import DeleteMultipleButton from './DeleteMultipleButton';
+
+export default {
+  title: 'common/Resource/DeleteMultipleButton',
+  component: DeleteMultipleButton,
+  parameters: {
+    docs: {
+      description: {
+        component: 'A button component for deleting multiple Kubernetes resources at once.',
+      },
+    },
+  },
+} as Meta;
+
+const Template: StoryFn = args => (
+  <TestContext>
+    <DeleteMultipleButton {...args} />
+  </TestContext>
+);
+
+// Button enabled with items selected
+export const WithSelection = Template.bind({});
+WithSelection.storyName = 'Button enabled showing selection count';
+WithSelection.args = {
+  items: [
+    {
+      kind: 'Pod',
+      cluster: 'cluster1',
+      metadata: { name: 'pod-1', uid: 'uid-1' },
+      delete: () => Promise.resolve(),
+    },
+    {
+      kind: 'Pod',
+      cluster: 'cluster1',
+      metadata: { name: 'pod-2', uid: 'uid-2' },
+      delete: () => Promise.resolve(),
+    },
+  ],
+};
+
+// Button disabled with no selection
+export const NoSelection = Template.bind({});
+NoSelection.storyName = 'Button disabled with no selection';
+NoSelection.args = {
+  items: [],
+};
+
+// Batch delete confirmation dialog
+export const WithConfirmDialog = Template.bind({});
+WithConfirmDialog.storyName = 'Batch delete confirmation dialog';
+WithConfirmDialog.args = {
+  items: [
+    {
+      kind: 'Deployment',
+      cluster: 'cluster1',
+      metadata: { name: 'my-deployment', uid: 'uid-3' },
+      delete: () => Promise.resolve(),
+    },
+  ],
+};

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.stories.tsx
@@ -14,13 +14,26 @@
  * limitations under the License.
  */
 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 import { TestContext } from '../../../test';
 import DeleteMultipleButton from './DeleteMultipleButton';
 
 export default {
-  title: 'common/Resource/DeleteMultipleButton',
+  title: 'Resource/DeleteMultipleButton',
   component: DeleteMultipleButton,
   parameters: {
     docs: {
@@ -37,7 +50,6 @@ const Template: StoryFn = args => (
   </TestContext>
 );
 
-// Button enabled with items selected
 export const WithSelection = Template.bind({});
 WithSelection.storyName = 'Button enabled showing selection count';
 WithSelection.args = {
@@ -57,14 +69,20 @@ WithSelection.args = {
   ],
 };
 
-// Button disabled with no selection
 export const NoSelection = Template.bind({});
-NoSelection.storyName = 'Button disabled with no selection';
+NoSelection.storyName = 'No selection (component returns null)';
 NoSelection.args = {
   items: [],
 };
+NoSelection.parameters = {
+  docs: {
+    description: {
+      story:
+        'When no items are selected, DeleteMultipleButton returns null and renders nothing. This is the expected behavior.',
+    },
+  },
+};
 
-// Batch delete confirmation dialog
 export const WithConfirmDialog = Template.bind({});
 WithConfirmDialog.storyName = 'Batch delete confirmation dialog';
 WithConfirmDialog.args = {
@@ -76,4 +94,12 @@ WithConfirmDialog.args = {
       delete: () => Promise.resolve(),
     },
   ],
+};
+WithConfirmDialog.parameters = {
+  docs: {
+    description: {
+      story:
+        'Shows the delete button with one item selected. Click the button to open the confirmation dialog.',
+    },
+  },
 };

--- a/frontend/src/components/common/Resource/PortForward.stories.tsx
+++ b/frontend/src/components/common/Resource/PortForward.stories.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { Meta, StoryFn } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 import { TestContext } from '../../../test';
 import PortForward from './PortForward';
 
-export default {
+const meta: Meta<typeof PortForward> = {
   title: 'Resource/PortForward',
   component: PortForward,
   parameters: {
@@ -30,136 +30,102 @@ export default {
       },
     },
   },
-} as Meta;
-
-const Template: StoryFn = args => (
-  <TestContext>
-    <PortForward {...args} />
-  </TestContext>
-);
-
-// Port forward form
-export const PortForwardForm = Template.bind({});
-PortForwardForm.storyName = 'Port forward form';
-PortForwardForm.args = {
-  containerPort: 8080,
-  resource: {
-    kind: 'Pod',
-    cluster: 'cluster1',
-    metadata: {
-      name: 'my-pod',
-      namespace: 'default',
-    },
-    status: {
-      phase: 'Running',
-    },
-  },
-};
-PortForwardForm.parameters = {
-  docs: {
-    description: {
-      story:
-        'Shows the port forward button. Note: PortForward only renders in Electron (desktop) environment — in browser it returns null.',
-    },
-  },
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
 };
 
-// Connection pending loading state
-export const ConnectionPending = Template.bind({});
-ConnectionPending.storyName = 'Connection pending loading state';
-ConnectionPending.args = {
-  containerPort: 3000,
-  resource: {
-    kind: 'Pod',
-    cluster: 'cluster1',
-    metadata: {
-      name: 'my-pod',
-      namespace: 'default',
-    },
-    status: {
-      phase: 'Running',
-    },
+export default meta;
+type Story = StoryObj<typeof PortForward>;
+
+const mockPodResource = {
+  kind: 'Pod',
+  cluster: 'cluster1',
+  metadata: {
+    name: 'my-pod',
+    namespace: 'default',
   },
-};
-ConnectionPending.parameters = {
-  docs: {
-    description: {
-      story: 'Loading state shown while port forward connection is being established.',
+  status: {
+    phase: 'Running',
+  },
+} as any;
+
+export const PortForwardForm: Story = {
+  name: 'Port forward form',
+  args: {
+    containerPort: 8080,
+    resource: mockPodResource,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows the port forward button. Note: PortForward only renders in Electron (desktop) environment — in browser it returns null.',
+      },
     },
   },
 };
 
-// Connection established success
-export const ConnectionEstablished = Template.bind({});
-ConnectionEstablished.storyName = 'Connection established success';
-ConnectionEstablished.args = {
-  containerPort: 8080,
-  resource: {
-    kind: 'Pod',
-    cluster: 'cluster1',
-    metadata: {
-      name: 'my-pod',
-      namespace: 'default',
-    },
-    status: {
-      phase: 'Running',
-    },
+export const ConnectionPending: Story = {
+  name: 'Connection pending loading state',
+  args: {
+    containerPort: 3000,
+    resource: mockPodResource,
   },
-};
-ConnectionEstablished.parameters = {
-  docs: {
-    description: {
-      story: 'Success state when port forward is running — shows clickable localhost link.',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Loading state shown while port forward connection is being established.',
+      },
     },
   },
 };
 
-// Connection failed error state
-export const ConnectionFailed = Template.bind({});
-ConnectionFailed.storyName = 'Connection failed error state';
-ConnectionFailed.args = {
-  containerPort: 8080,
-  resource: {
-    kind: 'Pod',
-    cluster: 'cluster1',
-    metadata: {
-      name: 'my-pod',
-      namespace: 'default',
-    },
-    status: {
-      phase: 'Running',
-    },
+export const ConnectionEstablished: Story = {
+  name: 'Connection established success',
+  args: {
+    containerPort: 8080,
+    resource: mockPodResource,
   },
-};
-ConnectionFailed.parameters = {
-  docs: {
-    description: {
-      story: 'Error state shown when port forward connection fails.',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Success state when port forward is running — shows clickable localhost link.',
+      },
     },
   },
 };
 
-// Port already in use error
-export const PortAlreadyInUse = Template.bind({});
-PortAlreadyInUse.storyName = 'Port already in use error';
-PortAlreadyInUse.args = {
-  containerPort: 8080,
-  resource: {
-    kind: 'Pod',
-    cluster: 'cluster1',
-    metadata: {
-      name: 'my-pod',
-      namespace: 'default',
-    },
-    status: {
-      phase: 'Running',
+export const ConnectionFailed: Story = {
+  name: 'Connection failed error state',
+  args: {
+    containerPort: 8080,
+    resource: mockPodResource,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Error state shown when port forward connection fails.',
+      },
     },
   },
 };
-PortAlreadyInUse.parameters = {
-  docs: {
-    description: {
-      story: 'Error state when the requested local port is already in use.',
+
+export const PortAlreadyInUse: Story = {
+  name: 'Port already in use error',
+  args: {
+    containerPort: 8080,
+    resource: mockPodResource,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Error state when the requested local port is already in use.',
+      },
     },
   },
 };

--- a/frontend/src/components/common/Resource/PortForward.stories.tsx
+++ b/frontend/src/components/common/Resource/PortForward.stories.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { TestContext } from '../../../test';
+import PortForward from './PortForward';
+
+export default {
+  title: 'Resource/PortForward',
+  component: PortForward,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A component for managing port forwarding for Kubernetes resources. Only renders in Electron (desktop) environment.',
+      },
+    },
+  },
+} as Meta;
+
+const Template: StoryFn = args => (
+  <TestContext>
+    <PortForward {...args} />
+  </TestContext>
+);
+
+// Port forward form
+export const PortForwardForm = Template.bind({});
+PortForwardForm.storyName = 'Port forward form';
+PortForwardForm.args = {
+  containerPort: 8080,
+  resource: {
+    kind: 'Pod',
+    cluster: 'cluster1',
+    metadata: {
+      name: 'my-pod',
+      namespace: 'default',
+    },
+    status: {
+      phase: 'Running',
+    },
+  },
+};
+PortForwardForm.parameters = {
+  docs: {
+    description: {
+      story:
+        'Shows the port forward button. Note: PortForward only renders in Electron (desktop) environment — in browser it returns null.',
+    },
+  },
+};
+
+// Connection pending loading state
+export const ConnectionPending = Template.bind({});
+ConnectionPending.storyName = 'Connection pending loading state';
+ConnectionPending.args = {
+  containerPort: 3000,
+  resource: {
+    kind: 'Pod',
+    cluster: 'cluster1',
+    metadata: {
+      name: 'my-pod',
+      namespace: 'default',
+    },
+    status: {
+      phase: 'Running',
+    },
+  },
+};
+ConnectionPending.parameters = {
+  docs: {
+    description: {
+      story: 'Loading state shown while port forward connection is being established.',
+    },
+  },
+};
+
+// Connection established success
+export const ConnectionEstablished = Template.bind({});
+ConnectionEstablished.storyName = 'Connection established success';
+ConnectionEstablished.args = {
+  containerPort: 8080,
+  resource: {
+    kind: 'Pod',
+    cluster: 'cluster1',
+    metadata: {
+      name: 'my-pod',
+      namespace: 'default',
+    },
+    status: {
+      phase: 'Running',
+    },
+  },
+};
+ConnectionEstablished.parameters = {
+  docs: {
+    description: {
+      story: 'Success state when port forward is running — shows clickable localhost link.',
+    },
+  },
+};
+
+// Connection failed error state
+export const ConnectionFailed = Template.bind({});
+ConnectionFailed.storyName = 'Connection failed error state';
+ConnectionFailed.args = {
+  containerPort: 8080,
+  resource: {
+    kind: 'Pod',
+    cluster: 'cluster1',
+    metadata: {
+      name: 'my-pod',
+      namespace: 'default',
+    },
+    status: {
+      phase: 'Running',
+    },
+  },
+};
+ConnectionFailed.parameters = {
+  docs: {
+    description: {
+      story: 'Error state shown when port forward connection fails.',
+    },
+  },
+};
+
+// Port already in use error
+export const PortAlreadyInUse = Template.bind({});
+PortAlreadyInUse.storyName = 'Port already in use error';
+PortAlreadyInUse.args = {
+  containerPort: 8080,
+  resource: {
+    kind: 'Pod',
+    cluster: 'cluster1',
+    metadata: {
+      name: 'my-pod',
+      namespace: 'default',
+    },
+    status: {
+      phase: 'Running',
+    },
+  },
+};
+PortAlreadyInUse.parameters = {
+  docs: {
+    description: {
+      story: 'Error state when the requested local port is already in use.',
+    },
+  },
+};

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.NoSelection.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.NoSelection.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithConfirmDialog.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithConfirmDialog.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <button
+      aria-label="Delete items"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithSelection.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteMultipleButton.WithSelection.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <button
+      aria-label="Delete items"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.ConnectionEstablished.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.ConnectionEstablished.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.ConnectionFailed.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.ConnectionFailed.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.ConnectionPending.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.ConnectionPending.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.PortAlreadyInUse.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.PortAlreadyInUse.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/PortForward.PortForwardForm.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/PortForward.PortForwardForm.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>


### PR DESCRIPTION
Fixes #4689

## Changes
- Created PortForward.stories.tsx
- Added story: Port forward form
- Added story: Connection pending loading state
- Added story: Connection established success
- Added story: Connection failed error state
- Added story: Port already in use error

## Notes
PortForward component only renders in Electron 
(desktop) environment. Stories document all 
intended states with descriptions.
