### PR TITLE
docs: frontend: resourceMap: Add status support for map nodes

### DIFF
--- a/docs/development/plugins/functionality/extending-the-map.md
+++ b/docs/development/plugins/functionality/extending-the-map.md
@@ -67,6 +67,7 @@ const mySource = {
         {
           id: myResource.metadata.uid, // ID should be unique
           kubeObject: new KubeObject(myResource),
+          status: "warning", // Optional: "success", "warning", or "error"
           // Optionally provide a custom details component to be shown when node is selected
           detailsComponent: ({ node }) => {
             return (
@@ -87,6 +88,10 @@ const mySource = {
   },
 };
 ```
+
+When `status` is provided, the node participates in the map's warning/error badge and the
+"Status: Error or Warning" filter. If `status` is omitted, Headlamp falls back to its default
+status detection for Kubernetes objects.
 
 Then to register it call `registerMapSource`
 

--- a/frontend/src/components/resourceMap/graph/graphFiltering.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphFiltering.test.ts
@@ -72,4 +72,58 @@ describe('filterGraph', () => {
     // Finds node 2 that has an error, and node 1 that is related to it
     expect(filteredNodes.map(it => it.id)).toEqual(['2', '1']);
   });
+
+  it('filters nodes by explicit status', () => {
+    const customNodes: GraphNode[] = [
+      { id: 'warning-node', status: 'warning' },
+      { id: 'error-node', status: 'error' },
+      { id: 'success-node', status: 'success' },
+    ];
+
+    const { nodes: filteredNodes } = filterGraph(customNodes, [], [{ type: 'hasErrors' }]);
+
+    expect(filteredNodes.map(it => it.id)).toEqual(['warning-node', 'error-node']);
+  });
+
+  it('includes nodes related to explicit status matches', () => {
+    const customNodes: GraphNode[] = [
+      { id: 'warning-node', status: 'warning' },
+      { id: 'related-node' },
+      { id: 'success-node', status: 'success' },
+    ];
+    const customEdges: GraphEdge[] = [
+      { id: 'warning-node-related-node', source: 'warning-node', target: 'related-node' },
+    ];
+
+    const { nodes: filteredNodes } = filterGraph(customNodes, customEdges, [{ type: 'hasErrors' }]);
+
+    expect(filteredNodes.map(it => it.id)).toEqual(['warning-node', 'related-node']);
+  });
+
+  it('uses explicit status before kube object status', () => {
+    const pods: GraphNode[] = [
+      {
+        id: 'pod-with-explicit-success',
+        status: 'success',
+        kubeObject: new Pod({
+          kind: 'Pod',
+          metadata: { namespace: 'ns1', name: 'pod-with-explicit-success' },
+          status: { phase: 'Failed' },
+        } as any),
+      },
+      {
+        id: 'pod-with-explicit-error',
+        status: 'error',
+        kubeObject: new Pod({
+          kind: 'Pod',
+          metadata: { namespace: 'ns1', name: 'pod-with-explicit-error' },
+          status: { phase: 'Running', conditions: [{ type: 'Ready', status: 'True' }] },
+        } as any),
+      },
+    ];
+
+    const { nodes: filteredNodes } = filterGraph(pods, [], [{ type: 'hasErrors' }]);
+
+    expect(filteredNodes.map(it => it.id)).toEqual(['pod-with-explicit-error']);
+  });
 });

--- a/frontend/src/components/resourceMap/graph/graphFiltering.ts
+++ b/frontend/src/components/resourceMap/graph/graphFiltering.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getStatus } from '../nodes/KubeObjectStatus';
+import { getGraphNodeStatus } from '../nodes/KubeObjectStatus';
 import { makeGraphLookup } from './graphLookup';
 import { GraphEdge, GraphNode } from './graphModel';
 
@@ -29,13 +29,13 @@ export type GraphFilter =
 
 /**
  * Filters the graph nodes and edges based on the provided filters
- * The filters are applied using an OR logic, meaning node will be included if it matches any of the filters
+ * The filters are applied using AND logic, meaning node must match all active filters
  *
  * Along with the matched node result also includes all the nodes that are related to it,
  * even if they don't match the filter
  *
  * The filters can be of the following types:
- * - `hasErrors`: Filters nodes that have errors based on their resource status. See {@link getStatus}
+ * - `hasErrors`: Filters nodes that have a warning or error status based on their graph node status.
  * - `namespace`: Filters nodes by their namespace
  *
  * @param nodes - List of all the nodes in the graph
@@ -93,10 +93,7 @@ export function filterGraph(nodes: GraphNode[], edges: GraphEdge[], filters: Gra
 
     filters.forEach(filter => {
       if (filter.type === 'hasErrors') {
-        keep &&=
-          'kubeObject' in node &&
-          node.kubeObject !== undefined &&
-          getStatus(node.kubeObject) !== 'success';
+        keep &&= getGraphNodeStatus(node) !== 'success';
       }
       if (filter.type === 'namespace' && filter.namespaces.size > 0) {
         keep &&=

--- a/frontend/src/components/resourceMap/graph/graphModel.tsx
+++ b/frontend/src/components/resourceMap/graph/graphModel.tsx
@@ -16,6 +16,9 @@
 
 import { ComponentType, ReactNode } from 'react';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
+
+export type GraphNodeStatus = 'error' | 'success' | 'warning';
+
 export type GraphNode = {
   /**
    * Unique ID for this node.
@@ -27,6 +30,8 @@ export type GraphNode = {
   label?: string;
   /** Subtitle for this node */
   subtitle?: string;
+  /** Optional health status used for map badges and status filtering */
+  status?: GraphNodeStatus;
   /** Custom icon for this node */
   icon?: ReactNode;
   /**

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -27,7 +27,7 @@ import { useGraphView, useNode } from '../GraphView';
 import { KubeIcon } from '../kubeIcon/KubeIcon';
 import { NodeGlance } from '../KubeObjectGlance/NodeGlance';
 import { GroupNodeComponent } from './GroupNode';
-import { getStatus } from './KubeObjectStatus';
+import { getGraphNodeStatus } from './KubeObjectStatus';
 
 const Container = styled('div')<{
   isExpanded: boolean;
@@ -159,18 +159,11 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
   const isSelected = id === graph.nodeSelection;
   const isCollapsed = node?.nodes?.length ? node?.collapsed : true;
 
-  let status = 'success';
-
-  if (kubeObject) {
-    status = getStatus(kubeObject) ?? 'success';
-  }
+  let status = node ? getGraphNodeStatus(node) : 'success';
 
   if (node?.nodes) {
-    const errors =
-      node?.nodes?.filter(it => it.kubeObject && getStatus(it.kubeObject) === 'error')?.length ?? 0;
-    const warnings =
-      node?.nodes?.filter(it => it.kubeObject && getStatus(it.kubeObject) === 'warning')?.length ??
-      0;
+    const errors = node.nodes.filter(it => getGraphNodeStatus(it) === 'error').length;
+    const warnings = node.nodes.filter(it => getGraphNodeStatus(it) === 'warning').length;
 
     if (warnings) {
       status = 'warning';

--- a/frontend/src/components/resourceMap/nodes/KubeObjectStatus.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectStatus.tsx
@@ -17,6 +17,7 @@
 import { KubeObject, Workload } from '../../../lib/k8s/cluster';
 import Pod from '../../../lib/k8s/pod';
 import { getReadyReplicas, getTotalReplicas } from '../../../lib/util';
+import type { GraphNode } from '../graph/graphModel';
 
 export type KubeObjectStatus = 'error' | 'success' | 'warning';
 
@@ -56,4 +57,14 @@ export function getStatus(w: KubeObject): KubeObjectStatus {
   }
 
   return 'success';
+}
+
+/**
+ * Returns status for a graph node.
+ * Explicit node status takes precedence over kube object status.
+ */
+export function getGraphNodeStatus(
+  node: Pick<GraphNode, 'kubeObject' | 'status'>
+): KubeObjectStatus {
+  return node.status ?? (node.kubeObject ? getStatus(node.kubeObject) : 'success');
 }


### PR DESCRIPTION
## Summary

Adds optional status support to resource map graph nodes so custom/plugin-provided nodes can participate in existing warning/error map behavior.

## Changes

- Added optional `status` metadata to `GraphNode`.
- Added graph-node status resolution that prefers explicit node status and falls back to existing kubeObject status detection.
- Updated map node badges and collapsed group aggregation to use graph-node status.
- Updated the “Status: Error or Warning” filter to include custom nodes with explicit warning/error status.
- Documented `status` in the map extension guide.
- Added tests for explicit warning/error node status and kubeObject status override behavior.
## Steps to Test

Register a plugin map node with `status: 'warning'` or `status: 'error'` and verify it shows the existing warning/error badge and appears in the “Status: Error or Warning” filter.

## Screenshots (if applicable)
Before: (from the Volcano plugin WIP map)
<img width="1800" height="844" alt="image" src="https://github.com/user-attachments/assets/1465f71a-e020-49f4-96d0-ac57427f398a" />

After:
<img width="1797" height="841" alt="image" src="https://github.com/user-attachments/assets/e73899e4-8eee-471e-bcea-ae2c267f09b3" />