### PR TITLE
backend: k8cache: Fix global lock contention in GetClientSet

### DIFF
--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -820,7 +820,9 @@ func TestRefreshAndCacheNewToken_ProviderError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := auth.RefreshAndCacheNewToken(context.Background(), config, &fakeCache{}, "id_token", "OLD", srv.URL, "")
+	_, err := auth.RefreshAndCacheNewToken(
+		context.Background(), config, &fakeCache{}, "id_token", "OLD", srv.URL, "",
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting provider")
 }

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -50,10 +50,30 @@ type CachedClientSet struct {
 	lastUsed  time.Time
 }
 
+type inFlightEntry struct {
+	waitCh chan struct{}
+	cs     *kubernetes.Clientset
+	err    error
+}
+
 var (
 	clientsetCache = make(map[string]*CachedClientSet)
 	mu             sync.Mutex
 	janitorOnce    sync.Once
+
+	// inFlight keeps track of clientsets currently being created to avoid redundant work.
+	inFlight = make(map[string]*inFlightEntry)
+
+	// hookMu protects testingInFlightWait and clientsetCreator from concurrent access.
+	hookMu sync.RWMutex
+
+	// testingInFlightWait is a hook for testing synchronization.
+	testingInFlightWait = func() {}
+
+	// clientsetCreator is a hook for testing de-duplication.
+	clientsetCreator = func(k *kubeconfig.Context, token string) (*kubernetes.Clientset, error) {
+		return k.ClientSetWithToken(token)
+	}
 )
 
 // startJanitor launches a background goroutine (exactly once) that
@@ -99,6 +119,78 @@ func evictExpiredClientsets() {
 	}
 }
 
+// getCachedClientSet retrieves a clientset from the cache if it's valid and not expired.
+func getCachedClientSet(cacheKey string) (*kubernetes.Clientset, bool) {
+	mu.Lock()
+
+	cs, found := clientsetCache[cacheKey]
+	if !found {
+		mu.Unlock()
+		return nil, false
+	}
+
+	now := time.Now()
+
+	if now.Sub(cs.lastUsed) > clientsetTTL {
+		delete(clientsetCache, cacheKey)
+
+		// Extract cluster name from cacheKey (format: "clusterName\x00token")
+		clusterName := strings.Split(cacheKey, "\x00")[0]
+		mu.Unlock()
+
+		logger.Log(logger.LevelInfo, nil, nil,
+			fmt.Sprintf("expired clientset for cluster %s was deleted", clusterName))
+
+		return nil, false
+	}
+
+	cs.lastUsed = now
+	mu.Unlock()
+
+	return cs.clientset, true
+}
+
+// createAndCacheClientSet creates a new clientset and stores it in the cache.
+func createAndCacheClientSet(
+	k *kubeconfig.Context,
+	token, cacheKey string,
+	contextKey []string,
+) (*kubernetes.Clientset, error) {
+	hookMu.RLock()
+
+	creator := clientsetCreator
+
+	hookMu.RUnlock()
+
+	cs, err := creator(k, token)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating clientset for cluster %s: %w", contextKey[1], err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Double-check: another goroutine might have created a clientset for the same key
+	// while we were unlocked (though inFlight should prevent this for the same key,
+	// it's good practice for general double-checked locking).
+	if existing, found := clientsetCache[cacheKey]; found {
+		now := time.Now()
+		if now.Sub(existing.lastUsed) <= clientsetTTL {
+			// Reuse the existing one and discard ours.
+			existing.lastUsed = now
+
+			return existing.clientset, nil
+		}
+	}
+
+	clientsetCache[cacheKey] = &CachedClientSet{
+		clientset: cs,
+		lastUsed:  time.Now(),
+	}
+
+	return cs, nil
+}
+
 // GetClientSet returns *kubernetes.ClientSet and error which is further used for creating
 // SSAR requests to k8s server to authorize user. GetClientSet uses kubeconfig.Context and
 // authentication bearer token which will help to create clientSet based on the user's
@@ -111,36 +203,64 @@ func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, e
 
 	startJanitor()
 
-	cacheKey := fmt.Sprintf("%s-%s", contextKey[1], token)
+	cacheKey := contextKey[1] + "\x00" + token
+
+	// Check cache first
+	if cs, found := getCachedClientSet(cacheKey); found {
+		return cs, nil
+	}
 
 	mu.Lock()
-	defer mu.Unlock()
 
+	// Re-check cache under lock before deciding to create
 	if cs, found := clientsetCache[cacheKey]; found {
 		now := time.Now()
-
-		// If the clientset was expired then delete the existing clientset resulting only fresh clientset.
-		if now.Sub(cs.lastUsed) > clientsetTTL {
-			delete(clientsetCache, cacheKey)
-			logger.Log(logger.LevelInfo, nil, nil, fmt.Sprintf("expired clientset for cluster %s was deleted", contextKey[1]))
-		} else {
-			// If the clientset is not expired then refresh its last-used time and return it.
+		if now.Sub(cs.lastUsed) <= clientsetTTL {
 			cs.lastUsed = now
+			mu.Unlock()
+
 			return cs.clientset, nil
 		}
 	}
 
-	cs, err := k.ClientSetWithToken(token)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating clientset for cluster %s: %w", contextKey[1], err)
+	// If another goroutine is already creating this clientset, wait for it.
+	if entry, ok := inFlight[cacheKey]; ok {
+		mu.Unlock()
+
+		hookMu.RLock()
+
+		waitHook := testingInFlightWait
+
+		hookMu.RUnlock()
+
+		waitHook()
+		<-entry.waitCh
+
+		// Return the shared result.
+		return entry.cs, entry.err
 	}
 
-	clientsetCache[cacheKey] = &CachedClientSet{
-		clientset: cs,
-		lastUsed:  time.Now(),
+	// We are the one to create it.
+	entry := &inFlightEntry{
+		waitCh: make(chan struct{}),
 	}
+	inFlight[cacheKey] = entry
 
-	return cs, nil
+	mu.Unlock()
+
+	cs, err := createAndCacheClientSet(k, token, cacheKey, contextKey)
+
+	mu.Lock()
+
+	entry.cs = cs
+	entry.err = err
+
+	delete(inFlight, cacheKey)
+	close(entry.waitCh)
+
+	mu.Unlock()
+
+	return cs, err
 }
 
 // GetKindAndVerb extracts the Kubernetes resource kind and intended verb (e.g., get, watch)

--- a/backend/pkg/k8cache/concurrency_test.go
+++ b/backend/pkg/k8cache/concurrency_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// TestGetClientSet_InFlightDedup verifies that concurrent GetClientSet calls
+// for the same cache key result in only a single clientset creation.
+func TestGetClientSet_InFlightDedup(t *testing.T) {
+	k8cache.ResetClientsetCache()
+	k8cache.ResetInFlight()
+
+	const goroutines = 10
+
+	var (
+		createCount   atomic.Int32
+		wg            sync.WaitGroup
+		waiters       atomic.Int32
+		readyToCreate = make(chan struct{})
+		errs          = make([]error, goroutines)
+	)
+
+	restoreWaitHook := k8cache.SetTestingInFlightWait(func() {
+		if waiters.Add(1) == int32(goroutines-1) {
+			close(readyToCreate)
+		}
+	})
+	defer restoreWaitHook()
+
+	restoreCreator := k8cache.SetClientsetCreator(
+		func(_ *kubeconfig.Context, _ string) (*kubernetes.Clientset, error) {
+			if goroutines > 1 {
+				<-readyToCreate
+			}
+
+			createCount.Add(1)
+
+			return &kubernetes.Clientset{}, nil
+		},
+	)
+	defer restoreCreator()
+
+	ctx := &kubeconfig.Context{
+		ClusterID:   "/path+test-cluster",
+		Cluster:     &api.Cluster{Server: "https://example.com"},
+		AuthInfo:    &api.AuthInfo{Token: "test"},
+		KubeContext: &api.Context{Cluster: "test-cluster"},
+	}
+
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+
+			_, errs[idx] = k8cache.GetClientSet(ctx, "same-token")
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d returned error", i)
+	}
+
+	assert.Equal(t, int32(1), createCount.Load(),
+		"expected exactly 1 clientset creation, got %d", createCount.Load())
+}
+
+// TestGetClientSet_InFlightDedupDifferentKeys verifies that concurrent calls
+// with different cache keys create separate clientsets.
+func TestGetClientSet_InFlightDedupDifferentKeys(t *testing.T) {
+	k8cache.ResetClientsetCache()
+	k8cache.ResetInFlight()
+
+	var createCount atomic.Int32
+
+	restoreCreator := k8cache.SetClientsetCreator(
+		func(_ *kubeconfig.Context, _ string) (*kubernetes.Clientset, error) {
+			createCount.Add(1)
+
+			return &kubernetes.Clientset{}, nil
+		},
+	)
+	defer restoreCreator()
+
+	tokens := []string{"token-a", "token-b", "token-c"}
+
+	var wg sync.WaitGroup
+
+	errs := make([]error, len(tokens))
+	wg.Add(len(tokens))
+
+	for i, tok := range tokens {
+		go func(idx int, token string) {
+			defer wg.Done()
+
+			ctx := &kubeconfig.Context{
+				ClusterID:   "/path+test-cluster",
+				Cluster:     &api.Cluster{Server: "https://example.com"},
+				AuthInfo:    &api.AuthInfo{Token: "test"},
+				KubeContext: &api.Context{Cluster: "test-cluster"},
+			}
+
+			_, errs[idx] = k8cache.GetClientSet(ctx, token)
+		}(i, tok)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d (token %s) returned error", i, tokens[i])
+	}
+
+	assert.Equal(t, len(tokens), int(createCount.Load()),
+		"each unique token should create its own clientset")
+}

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -87,3 +87,41 @@ func ClientsetCacheLen() int {
 
 	return len(clientsetCache)
 }
+
+// ResetInFlight clears the inFlight map for test isolation.
+func ResetInFlight() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	inFlight = make(map[string]*inFlightEntry)
+}
+
+// SetClientsetCreator sets a custom clientset creator function for testing.
+// It returns a function to restore the original creator.
+func SetClientsetCreator(fn func(*kubeconfig.Context, string) (*kubernetes.Clientset, error)) func() {
+	hookMu.Lock()
+	original := clientsetCreator
+	clientsetCreator = fn
+	hookMu.Unlock()
+
+	return func() {
+		hookMu.Lock()
+		clientsetCreator = original
+		hookMu.Unlock()
+	}
+}
+
+// SetTestingInFlightWait sets a custom wait hook for testing.
+// It returns a function to restore the original hook.
+func SetTestingInFlightWait(fn func()) func() {
+	hookMu.Lock()
+	original := testingInFlightWait
+	testingInFlightWait = fn
+	hookMu.Unlock()
+
+	return func() {
+		hookMu.Lock()
+		testingInFlightWait = original
+		hookMu.Unlock()
+	}
+}


### PR DESCRIPTION
### **Summary:**

This PR addresses a performance bottleneck in the k8cache package where a global mutex was held during the expensive initialization of Kubernetes clientsets. By implementing a double-checked locking strategy, we ensure that the global lock is released before performing slow operations (like executing authentication plugins), allowing concurrent authorization requests to proceed for already-cached clients.

### **Fixes:** #5350

### **Changes:**

` backend/pkg/k8cache/authorization.go:`
- Refactored GetClientSet to release the mutex (mu) before calling k.ClientSetWithToken(token).
- Added a second cache check after re-acquiring the lock to prevent redundant clientset creation in high-concurrency scenarios.
- Updated return paths to ensure the lock is always released correctly.

### **Steps to Test:**

1. Navigate to the backend directory.
2. Run the specialized tests for the cache package: go test -v ./pkg/k8cache/...
3. Verify that the server still builds correctly: go build ./...
4. (Optional) Simulate concurrent requests to ensure no race conditions occur during clientset creation.

### **Validation Results:**

1. Unit Tests: ok github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache 2.092s (All tests passed).
2. Build: Success.
3. Lint: golangci-lint passed for the modified file.