### PR TITLE
frontend: EditorDialog: Add aria-controls to action buttons

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -383,7 +383,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   function makeEditor() {
     const language = originalCodeRef.current.format || 'yaml';
     return (
-      <Box height="100%">
+      <Box height="100%" id={editorId}>
         {useSimpleEditor ? (
           <SimpleEditor language={language} value={code.code} onChange={onChange} />
         ) : (
@@ -431,6 +431,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   const dialogTitleId = useId('editor-dialog-title-');
+  const editorId = useId('editor-textarea-');
 
   const content = !item ? (
     <Loader title={t('Loading editor')} />
@@ -547,7 +548,7 @@ export default function EditorDialog(props: EditorDialogProps) {
             confirmDescription={t(
               'This will discard your changes in the editor. Do you want to proceed?'
             )}
-            // @todo: aria-controls should point to the textarea id
+            aria-controls={editorId}
           >
             {t('translation|Undo Changes')}
           </ConfirmButton>
@@ -564,7 +565,7 @@ export default function EditorDialog(props: EditorDialogProps) {
             color="primary"
             variant="contained"
             disabled={originalCodeRef.current.code === code.code || !!error}
-            // @todo: aria-controls should point to the textarea id
+            aria-controls={editorId}
           >
             {saveLabel || t('translation|Save & Apply')}
           </Button>

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -214,6 +214,7 @@
           >
             <div
               class="MuiBox-root css-10klw3m"
+              id="editor-textarea-id"
             >
               <div
                 class="mock-monaco-editor"
@@ -253,6 +254,7 @@
           class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
         >
           <button
+            aria-controls="editor-textarea-id"
             aria-label="Undo"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
             disabled=""
@@ -279,6 +281,7 @@
             />
           </button>
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -250,6 +250,7 @@
           >
             <div
               class="MuiBox-root css-10klw3m"
+              id="editor-textarea-id"
             >
               <div
                 class="mock-monaco-editor"
@@ -289,6 +290,7 @@
           class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
         >
           <button
+            aria-controls="editor-textarea-id"
             aria-label="Undo"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
             disabled=""
@@ -315,6 +317,7 @@
             />
           </button>
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"


### PR DESCRIPTION
## Summary

This PR fixes an accessibility (a11y) bug by adding the missing `aria-controls` attribute to the action buttons in the `EditorDialog` component.

## Related Issue

Fixes #5354  

## Changes

- Added a unique `editorId` using the `useId` hook in `frontend/src/components/common/Resource/EditorDialog.tsx`.
- Assigned the `editorId` to the `<Box>` wrapper that contains the code editor.
- Fixed the missing accessibility attributes by replacing the `// @todo: aria-controls should point to the textarea id` comments with the proper `aria-controls={editorId}` prop on the "Undo Changes" and "Save & Apply" buttons.

## Steps to Test

1. Run the Headlamp application and navigate to any resource in the cluster view (e.g., select a Pod).
2. Click on the 'Edit' button (pencil icon) in the top right corner of the resource details page.
3. Scroll down to the bottom of the dialog.
4. Open your browser's Developer Tools and inspect the "Undo Changes" or "Save & Apply" buttons.
5. Verify that the `<button>` tags now properly include the `aria-controls` attribute pointing to the ID of the editor wrapper.

## Notes for the Reviewer

- This is a straightforward accessibility enhancement aimed at screen reader support, effectively resolving the two `// @todo` comments previously left in the code for these buttons.
