### PR TITLE
frontend: common/ReleaseNotes/ReleaseNotes: Fix h3 appearing without …

### DIFF
--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotes.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotes.stories.tsx
@@ -44,7 +44,7 @@ export default {
         ),
         http.get('https://api.github.com/repos/kinvolk/headlamp/releases/tags/v1.9.9', () =>
           HttpResponse.json({
-            body: '### Hello\n\nworld',
+            body: '## Hello\n\n### Sub-heading\n\nworld',
           })
         ),
       ],

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotes.Default.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotes.Default.stories.storyshot
@@ -142,8 +142,13 @@
           <div
             class="MuiBox-root css-fm9d3m"
           >
-            <h3>
+            <h2>
               Hello
+            </h2>
+            
+
+            <h3>
+              Sub-heading
             </h3>
             
 


### PR DESCRIPTION

## Summary

This PR fixes the heading hierarchy in the `ReleaseNotes` Default story by replacing a standalone `h3` mock body with a proper `h1 → h2 → h3` structure.

## Related Issue

Fixes #4589

## Changes

- Updated mock API response body in `ReleaseNotes.stories.tsx` from `'### Hello\n\nworld'` to `'## Hello\n\n### Sub-heading\n\nworld'`
- Updated `ReleaseNotes.Default.stories.storyshot` snapshot to reflect the corrected heading hierarchy

## Steps to Test

1. Run Storybook: `npm run storybook` inside `frontend/`
2. Navigate to **common/ReleaseNotes/ReleaseNotes → Default**
3. Observe the modal renders headings in correct order: `h1 (Release Notes) → h2 (Hello) → h3 (Sub-heading)`


## Screenshots (if applicable)
<img width="1919" height="864" alt="image" src="https://github.com/user-attachments/assets/86b84e92-9df9-4e55-a223-47f622afa2a3" />


## Notes for the Reviewer

- This is a test/story-only fix — no production component code was changed.
- The same fix was already applied to `ReleaseNotesModal.stories.tsx` (Show story) in the previous commit `09a5651`; this brings the `ReleaseNotes` Default story into consistency with it.