### PR TITLE
backend: auth: Fix OIDC refresh issuer override

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1080,19 +1080,20 @@ func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Hand
 
 		// refresh and cache new token
 		auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
-			Ctx:                ctx,
-			OIDCAuthConfig:     oidcAuthConfig,
-			Cache:              c.Cache,
-			Token:              token,
-			Cluster:            cluster,
-			Span:               span,
-			Writer:             w,
-			Request:            r,
-			TelemetryHandler:   c.TelemetryHandler,
-			OIDCUseAccessToken: c.OidcUseAccessToken,
-			OIDCIdpIssuerURL:   c.OidcIdpIssuerURL,
-			BaseURL:            c.BaseURL,
-			SessionTTL:         c.SessionTTL,
+			Ctx:                       ctx,
+			OIDCAuthConfig:            oidcAuthConfig,
+			Cache:                     c.Cache,
+			Token:                     token,
+			Cluster:                   cluster,
+			Span:                      span,
+			Writer:                    w,
+			Request:                   r,
+			TelemetryHandler:          c.TelemetryHandler,
+			OIDCUseAccessToken:        c.OidcUseAccessToken,
+			OIDCIdpIssuerURL:          c.OidcIdpIssuerURL,
+			OIDCValidatorIdpIssuerURL: c.OidcValidatorIdpIssuerURL,
+			BaseURL:                   c.BaseURL,
+			SessionTTL:                c.SessionTTL,
 		})
 
 		next.ServeHTTP(w, r)

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -250,6 +250,8 @@ func ConfigureTLSContext(ctx context.Context, skipTLSVerify *bool, caCert *strin
 // RefreshAndCacheNewToken obtains a fresh OIDC token using the cached refresh token
 // and re-populates the cache so subsequent requests can reuse it. The provided ctx
 // controls cancellation and deadlines for all outbound requests during the refresh.
+// validatorIssuerURL overrides the issuer expected by provider discovery when the
+// discovery URL and returned issuer differ.
 func RefreshAndCacheNewToken(ctx context.Context, oidcAuthConfig *kubeconfig.OidcConfig,
 	cache cache.Cache[interface{}],
 	tokenType, token, issuerURL, validatorIssuerURL string,

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -252,9 +252,13 @@ func ConfigureTLSContext(ctx context.Context, skipTLSVerify *bool, caCert *strin
 // controls cancellation and deadlines for all outbound requests during the refresh.
 func RefreshAndCacheNewToken(ctx context.Context, oidcAuthConfig *kubeconfig.OidcConfig,
 	cache cache.Cache[interface{}],
-	tokenType, token, issuerURL string,
+	tokenType, token, issuerURL, validatorIssuerURL string,
 ) (*oauth2.Token, error) {
 	ctx = ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
+
+	if validatorIssuerURL != "" {
+		ctx = oidc.InsecureIssuerURLContext(ctx, validatorIssuerURL)
+	}
 
 	// get provider
 	provider, err := oidc.NewProvider(ctx, issuerURL)
@@ -495,19 +499,20 @@ func marshalToString(val interface{}) (string, bool) {
 // RefreshAndSetTokenParams groups the inputs required to refresh a token and
 // update the Headlamp auth cookie.
 type RefreshAndSetTokenParams struct {
-	Ctx                context.Context
-	OIDCAuthConfig     *kubeconfig.OidcConfig
-	Cache              cache.Cache[interface{}]
-	Token              string
-	Cluster            string
-	Span               trace.Span
-	Writer             http.ResponseWriter
-	Request            *http.Request
-	TelemetryHandler   *telemetry.RequestHandler
-	OIDCUseAccessToken bool
-	OIDCIdpIssuerURL   string
-	BaseURL            string
-	SessionTTL         int
+	Ctx                       context.Context
+	OIDCAuthConfig            *kubeconfig.OidcConfig
+	Cache                     cache.Cache[interface{}]
+	Token                     string
+	Cluster                   string
+	Span                      trace.Span
+	Writer                    http.ResponseWriter
+	Request                   *http.Request
+	TelemetryHandler          *telemetry.RequestHandler
+	OIDCUseAccessToken        bool
+	OIDCIdpIssuerURL          string
+	OIDCValidatorIdpIssuerURL string
+	BaseURL                   string
+	SessionTTL                int
 }
 
 // RefreshAndSetToken refreshes an expiring token, updates the auth cookie,
@@ -531,6 +536,7 @@ func RefreshAndSetToken(params RefreshAndSetTokenParams) {
 		tokenType,
 		params.Token,
 		idpIssuerURL,
+		params.OIDCValidatorIdpIssuerURL,
 	)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"cluster": params.Cluster},

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -567,7 +567,7 @@ func newTokenServerJSON(t *testing.T, status int, body any) *httptest.Server {
 	return srv
 }
 
-func newOIDCProviderServer(t *testing.T, tokenHandler http.HandlerFunc) *httptest.Server {
+func newOIDCProviderServer(t *testing.T, issuerURL string, tokenHandler http.HandlerFunc) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
@@ -577,8 +577,13 @@ func newOIDCProviderServer(t *testing.T, tokenHandler http.HandlerFunc) *httptes
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
+		issuer := issuerURL
+		if issuer == "" {
+			issuer = srv.URL
+		}
+
 		cfg := map[string]any{
-			"issuer":         srv.URL,
+			"issuer":         issuer,
 			"token_endpoint": srv.URL + "/token",
 			"jwks_uri":       srv.URL + "/jwks",
 		}
@@ -751,7 +756,7 @@ func TestRefreshAndCacheNewToken_Success(t *testing.T) {
 	)
 
 	fc := &fakeCache{store: map[string]interface{}{oldKey: "REFRESH_OLD"}}
-	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, r *http.Request) {
 		require.NoError(t, r.ParseForm()) //nolint:gosec
 		require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
 		require.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
@@ -764,7 +769,7 @@ func TestRefreshAndCacheNewToken_Success(t *testing.T) {
 	})
 
 	config := &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"}
-	tok, err := auth.RefreshAndCacheNewToken(context.Background(), config, fc, "id_token", oldToken, srv.URL)
+	tok, err := auth.RefreshAndCacheNewToken(context.Background(), config, fc, "id_token", oldToken, srv.URL, "")
 	require.NoError(t, err)
 	assert.NotNil(t, tok)
 	assert.Equal(t, refreshNew, tok.RefreshToken)
@@ -779,6 +784,35 @@ func TestRefreshAndCacheNewToken_Success(t *testing.T) {
 	assert.Equal(t, 10*time.Second, fc.setWithTTLCalls[0].ttl)
 }
 
+func TestRefreshAndCacheNewToken_ValidatorIssuerOverride(t *testing.T) {
+	const (
+		oldToken     = "OLD"
+		oldKey       = "oidc-token-" + oldToken
+		issuerURL    = "https://issuer.example.com"
+		refreshToken = "REFRESH_OLD"
+	)
+
+	fc := &fakeCache{store: map[string]interface{}{oldKey: refreshToken}}
+	srv := newOIDCProviderServer(t, issuerURL, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm()) //nolint:gosec
+		require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
+		require.Equal(t, refreshToken, r.PostForm.Get("refresh_token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(oauthSuccessBody))
+	})
+
+	config := &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"}
+	_, err := auth.RefreshAndCacheNewToken(context.Background(), config, fc, "id_token", oldToken, srv.URL, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer did not match")
+
+	tok, err := auth.RefreshAndCacheNewToken(context.Background(), config, fc, "id_token", oldToken, srv.URL, issuerURL)
+	require.NoError(t, err)
+	assert.NotNil(t, tok)
+	assert.Equal(t, refreshNew, tok.RefreshToken)
+}
+
 func TestRefreshAndCacheNewToken_ProviderError(t *testing.T) {
 	config := &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -786,7 +820,7 @@ func TestRefreshAndCacheNewToken_ProviderError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := auth.RefreshAndCacheNewToken(context.Background(), config, &fakeCache{}, "id_token", "OLD", srv.URL)
+	_, err := auth.RefreshAndCacheNewToken(context.Background(), config, &fakeCache{}, "id_token", "OLD", srv.URL, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting provider")
 }
@@ -795,14 +829,14 @@ func TestRefreshAndCacheNewToken_TokenError(t *testing.T) {
 	const oldToken = "OLD"
 
 	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + oldToken: "REFRESH_OLD"}}
-	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{"error": "server_error"})
 	})
 
 	config := &kubeconfig.OidcConfig{ClientID: "cid", ClientSecret: "secret"}
-	_, err := auth.RefreshAndCacheNewToken(context.Background(), config, fc, "id_token", oldToken, srv.URL)
+	_, err := auth.RefreshAndCacheNewToken(context.Background(), config, fc, "id_token", oldToken, srv.URL, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "refreshing token")
 	assert.Len(t, fc.setCalls, 0)
@@ -817,7 +851,7 @@ func TestRefreshAndSetToken_DefaultsToIDToken(t *testing.T) {
 
 	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + oldToken: "REFRESH_OLD"}}
 
-	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 		require.NoError(t, r.ParseForm())
 		require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
@@ -868,7 +902,7 @@ func TestRefreshAndSetToken_UsesAccessToken(t *testing.T) {
 		"id_token":      "IGNORED",
 	}
 
-	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 		require.NoError(t, r.ParseForm())
 		require.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
@@ -911,7 +945,7 @@ func TestRefreshAndSetToken_ErrorDoesNotSetCookie(t *testing.T) {
 
 	fc := &fakeCache{store: map[string]interface{}{"oidc-token-" + oldToken: "REFRESH_OLD"}}
 
-	srv := newOIDCProviderServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "token refresh failed", http.StatusInternalServerError)
 	})
 


### PR DESCRIPTION
Apply the configured OIDC validator issuer override when refreshing tokens, matching the login flow behavior for providers whose discovery URL and issuer differ. Add regression coverage for refresh with mismatched discovery and issuer URLs.

## Summary

Fix OIDC token refresh when the configured discovery issuer URL differs from the issuer returned by the provider metadata.

Headlamp already supports this setup during login by applying `oidc.InsecureIssuerURLContext` when `--oidc-validator-idp-issuer-url` is configured. Token refresh did not apply the same override, so refresh could fail with an issuer mismatch even though login succeeded.

We have a Keycloak instance that is reachable via two URLs with dynamicBackchannel, which does mean the issuer in 'iss' diverges from the issuer URL set to reach the instance.

While login works when using "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)", refreshing the token is broken with the following error message:

{"level":"error","cluster":"main","source":"/headlamp/backend/cmd/headlamp.go","line":960,"error":"getting provider: oidc: issuer did not match the issuer returned by provider, expected \"https://keycloak.xxx.com/realms/xxx\" got \"https://keycloak.xxx.intern/realms/xxx\"","time":"2026-05-04T09:00:03Z","message":"failed to refresh token"}

## Changes

- Pass the configured validator issuer override into the OIDC token refresh path.
- Apply the override before `oidc.NewProvider` during refresh, matching the login flow behavior.
- Add regression coverage for refresh against a provider whose discovery URL and returned issuer differ.
