### PR TITLE
frontend: pod: Support container query param for log and exec deep-links

### DIFF
--- a/frontend/src/components/common/Terminal.test.tsx
+++ b/frontend/src/components/common/Terminal.test.tsx
@@ -86,4 +86,77 @@ describe('Terminal', () => {
 
     expect(true).toBe(true);
   });
+
+  describe('initialContainer', () => {
+    it('uses initialContainer when it matches a known container', async () => {
+      let capturedContainer: string | undefined;
+      const pod = {
+        ...createMockPod(async (container: string) => {
+          capturedContainer = container;
+          return { cancel: () => {}, getSocket: () => null };
+        }),
+        spec: {
+          nodeSelector: { 'kubernetes.io/os': 'linux' },
+          containers: [{ name: 'main' }, { name: 'sidecar' }],
+          initContainers: [],
+          ephemeralContainers: [],
+        },
+      };
+
+      render(
+        <TestContext>
+          <Terminal item={pod as any} open onClose={() => {}} initialContainer="sidecar" />
+        </TestContext>
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+      await act(() => new Promise(res => process.nextTick(res)));
+
+      expect(capturedContainer).toBe('sidecar');
+    });
+
+    it('falls back to default container when initialContainer is invalid', async () => {
+      let capturedContainer: string | undefined;
+      const pod = createMockPod(async (container: string) => {
+        capturedContainer = container;
+        return { cancel: () => {}, getSocket: () => null };
+      });
+
+      render(
+        <TestContext>
+          <Terminal item={pod as any} open onClose={() => {}} initialContainer="nonexistent" />
+        </TestContext>
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+      await act(() => new Promise(res => process.nextTick(res)));
+
+      expect(capturedContainer).toBe('main');
+    });
+
+    it('uses default container when initialContainer is not specified', async () => {
+      let capturedContainer: string | undefined;
+      const pod = createMockPod(async (container: string) => {
+        capturedContainer = container;
+        return { cancel: () => {}, getSocket: () => null };
+      });
+
+      render(
+        <TestContext>
+          <Terminal item={pod as any} open onClose={() => {}} />
+        </TestContext>
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+      await act(() => new Promise(res => process.nextTick(res)));
+
+      expect(capturedContainer).toBe('main');
+    });
+  });
 });

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -27,7 +27,7 @@ import { Terminal as XTerminal } from '@xterm/xterm';
 import _ from 'lodash';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getDefaultContainer } from '../../helpers/podContainer';
+import { getDefaultContainer, resolveContainerName } from '../../helpers/podContainer';
 import Pod from '../../lib/k8s/pod';
 import { Dialog } from './Dialog';
 
@@ -48,6 +48,7 @@ interface TerminalProps extends DialogProps {
   /** Don't render the terminal in the dialog */
   noDialog?: boolean;
   onClose?: () => void;
+  initialContainer?: string;
 }
 
 interface XTerminalConnected {
@@ -59,9 +60,11 @@ interface XTerminalConnected {
 type execReturn = ReturnType<Pod['exec']>;
 
 export default function Terminal(props: TerminalProps) {
-  const { item, onClose, isAttach, noDialog, ...other } = props;
+  const { item, onClose, isAttach, noDialog, initialContainer, ...other } = props;
   const [terminalContainerRef, setTerminalContainerRef] = React.useState<HTMLElement | null>(null);
-  const [container, setContainer] = useState<string | null>(() => getDefaultContainer(item));
+  const [container, setContainer] = useState<string | null>(() =>
+    resolveContainerName(item, initialContainer)
+  );
   const execOrAttachRef = React.useRef<execReturn | null>(null);
   const fitAddonRef = React.useRef<FitAddon | null>(null);
   const xtermRef = React.useRef<XTerminalConnected | null>(null);

--- a/frontend/src/components/pod/Details.test.tsx
+++ b/frontend/src/components/pod/Details.test.tsx
@@ -15,7 +15,11 @@
  */
 
 import { act, render } from '@testing-library/react';
-import React from 'react';
+import { createMemoryHistory } from 'history';
+import { SnackbarProvider } from 'notistack';
+import { Provider } from 'react-redux';
+import { Route, Router } from 'react-router-dom';
+import defaultStore from '../../redux/stores/store';
 import { TestContext } from '../../test';
 
 const { mockActivityLaunch, mockDispatchHeadlampEvent } = vi.hoisted(() => ({
@@ -150,6 +154,22 @@ function simulatePodLoad() {
   }
 }
 
+function renderPodDetailsWithHistory(initialUrl: string) {
+  const history = createMemoryHistory({ initialEntries: [initialUrl] });
+  render(
+    <Provider store={defaultStore}>
+      <SnackbarProvider>
+        <Router history={history}>
+          <Route path="/c/main/pods/:namespace/:name">
+            <PodDetails name="test-pod" namespace="default" />
+          </Route>
+        </Router>
+      </SnackbarProvider>
+    </Provider>
+  );
+  return history;
+}
+
 describe('PodDetails auto-launch views', () => {
   beforeEach(() => {
     mockActivityLaunch.mockReset();
@@ -157,82 +177,6 @@ describe('PodDetails auto-launch views', () => {
     capturedOnResourceUpdate = undefined;
   });
 
-  it('auto-launches terminal when ?view=exec is present', () => {
-    render(
-      <TestContext
-        routerMap={{ namespace: 'default', name: 'test-pod' }}
-        urlPrefix="/c/main/pods"
-        urlSearchParams={{ view: 'exec' }}
-      >
-        <PodDetails name="test-pod" namespace="default" />
-      </TestContext>
-    );
-
-    act(() => {
-      simulatePodLoad();
-    });
-
-    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
-    expect(mockActivityLaunch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'terminal-pod-uid-123',
-        title: 'test-pod',
-      })
-    );
-  });
-
-  it('auto-launches logs when ?view=logs is present', () => {
-    render(
-      <TestContext
-        routerMap={{ namespace: 'default', name: 'test-pod' }}
-        urlPrefix="/c/main/pods"
-        urlSearchParams={{ view: 'logs' }}
-      >
-        <PodDetails name="test-pod" namespace="default" />
-      </TestContext>
-    );
-
-    act(() => {
-      simulatePodLoad();
-    });
-
-    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
-    expect(mockActivityLaunch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'logs-pod-uid-123',
-      })
-    );
-  });
-
-  it('does not re-launch logs on subsequent renders for the same pod', () => {
-    const { rerender } = render(
-      <TestContext
-        routerMap={{ namespace: 'default', name: 'test-pod' }}
-        urlPrefix="/c/main/pods"
-        urlSearchParams={{ view: 'logs' }}
-      >
-        <PodDetails name="test-pod" namespace="default" />
-      </TestContext>
-    );
-
-    act(() => {
-      simulatePodLoad();
-    });
-    act(() => {
-      rerender(
-        <TestContext
-          routerMap={{ namespace: 'default', name: 'test-pod' }}
-          urlPrefix="/c/main/pods"
-          urlSearchParams={{ view: 'logs' }}
-        >
-          <PodDetails name="test-pod" namespace="default" />
-        </TestContext>
-      );
-      simulatePodLoad();
-    });
-
-    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
-  });
   it('does not auto-launch anything when no view param is present', () => {
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }} urlPrefix="/c/main/pods">
@@ -247,7 +191,7 @@ describe('PodDetails auto-launch views', () => {
     expect(mockActivityLaunch).not.toHaveBeenCalled();
   });
 
-  it('does not auto-launch terminal when view param is something else', () => {
+  it('does not auto-launch when view param is something else', () => {
     render(
       <TestContext
         routerMap={{ namespace: 'default', name: 'test-pod' }}
@@ -265,49 +209,252 @@ describe('PodDetails auto-launch views', () => {
     expect(mockActivityLaunch).not.toHaveBeenCalled();
   });
 
-  it('does not re-launch terminal on subsequent renders for the same pod', () => {
-    render(
-      <TestContext
-        routerMap={{ namespace: 'default', name: 'test-pod' }}
-        urlPrefix="/c/main/pods"
-        urlSearchParams={{ view: 'exec' }}
-      >
-        <PodDetails name="test-pod" namespace="default" />
-      </TestContext>
-    );
+  describe('?view=logs', () => {
+    it('auto-launches logs', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'logs' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
 
-    act(() => {
-      simulatePodLoad();
-    });
-    act(() => {
-      simulatePodLoad();
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      expect(mockActivityLaunch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'logs-pod-uid-123',
+        })
+      );
     });
 
-    expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+    it('does not re-launch on subsequent renders for the same pod', () => {
+      const { rerender } = render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'logs' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+      act(() => {
+        rerender(
+          <TestContext
+            routerMap={{ namespace: 'default', name: 'test-pod' }}
+            urlPrefix="/c/main/pods"
+            urlSearchParams={{ view: 'logs' }}
+          >
+            <PodDetails name="test-pod" namespace="default" />
+          </TestContext>
+        );
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-launches when ?container changes for the same pod', () => {
+      const history = renderPodDetailsWithHistory(
+        '/c/main/pods/default/test-pod?view=logs&container=nginx'
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      expect(mockActivityLaunch.mock.calls[0][0].content.props.initialContainer).toBe('nginx');
+
+      act(() => {
+        history.push('/c/main/pods/default/test-pod?view=logs&container=sidecar');
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(2);
+      expect(mockActivityLaunch.mock.calls[1][0].content.props.initialContainer).toBe('sidecar');
+    });
+
+    it('passes ?container as initialContainer', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'logs', container: 'nginx' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      const launchArg = mockActivityLaunch.mock.calls[0][0];
+      expect(launchArg.content.props.initialContainer).toBe('nginx');
+    });
+
+    it('passes undefined initialContainer when ?container is absent', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'logs' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      const launchArg = mockActivityLaunch.mock.calls[0][0];
+      expect(launchArg.content.props.initialContainer).toBeUndefined();
+    });
   });
 
-  it('dispatches TERMINAL event with OPENED status for exec deep-link', () => {
-    render(
-      <TestContext
-        routerMap={{ namespace: 'default', name: 'test-pod' }}
-        urlPrefix="/c/main/pods"
-        urlSearchParams={{ view: 'exec' }}
-      >
-        <PodDetails name="test-pod" namespace="default" />
-      </TestContext>
-    );
+  describe('?view=exec', () => {
+    it('auto-launches terminal', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'exec' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
 
-    act(() => {
-      simulatePodLoad();
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      expect(mockActivityLaunch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'terminal-pod-uid-123',
+          title: 'test-pod',
+        })
+      );
     });
 
-    expect(mockDispatchHeadlampEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'headlamp.terminal',
-        data: expect.objectContaining({
-          status: 'open',
-        }),
-      })
-    );
+    it('does not re-launch on subsequent renders for the same pod', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'exec' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-launches when ?container changes for the same pod', () => {
+      const history = renderPodDetailsWithHistory(
+        '/c/main/pods/default/test-pod?view=exec&container=nginx'
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      expect(mockActivityLaunch.mock.calls[0][0].content.props.initialContainer).toBe('nginx');
+
+      act(() => {
+        history.push('/c/main/pods/default/test-pod?view=exec&container=sidecar');
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(2);
+      expect(mockActivityLaunch.mock.calls[1][0].content.props.initialContainer).toBe('sidecar');
+    });
+
+    it('passes ?container as initialContainer', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'exec', container: 'nginx' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      const launchArg = mockActivityLaunch.mock.calls[0][0];
+      expect(launchArg.content.props.initialContainer).toBe('nginx');
+    });
+
+    it('passes undefined initialContainer when ?container is absent', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'exec' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockActivityLaunch).toHaveBeenCalledTimes(1);
+      const launchArg = mockActivityLaunch.mock.calls[0][0];
+      expect(launchArg.content.props.initialContainer).toBeUndefined();
+    });
+
+    it('dispatches TERMINAL event with OPENED status', () => {
+      render(
+        <TestContext
+          routerMap={{ namespace: 'default', name: 'test-pod' }}
+          urlPrefix="/c/main/pods"
+          urlSearchParams={{ view: 'exec' }}
+        >
+          <PodDetails name="test-pod" namespace="default" />
+        </TestContext>
+      );
+
+      act(() => {
+        simulatePodLoad();
+      });
+
+      expect(mockDispatchHeadlampEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'headlamp.terminal',
+          data: expect.objectContaining({
+            status: 'open',
+          }),
+        })
+      );
+    });
   });
 });

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -29,7 +29,7 @@ import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
-import { getDefaultContainer } from '../../helpers/podContainer';
+import { getDefaultContainer, resolveContainerName } from '../../helpers/podContainer';
 import { KubeContainerStatus } from '../../lib/k8s/cluster';
 import Pod from '../../lib/k8s/pod';
 import { DefaultHeaderAction } from '../../redux/actionButtonsSlice';
@@ -67,11 +67,14 @@ const PaddedFormControlLabel = styled(FormControlLabel)(({ theme }) => ({
 
 interface PodLogViewerProps extends Omit<LogViewerProps, 'logs'> {
   item: Pod;
+  initialContainer?: string;
 }
 
 export function PodLogViewer(props: PodLogViewerProps) {
-  const { item, onClose, open, ...other } = props;
-  const [container, setContainer] = React.useState(() => getDefaultContainer(item));
+  const { item, onClose, open, initialContainer, ...other } = props;
+  const [container, setContainer] = React.useState(() =>
+    resolveContainerName(item, initialContainer)
+  );
   const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
   const [showTimestamps, setShowTimestamps] = useLocalStorageState<boolean>(
     'headlamp.logs.showTimestamps',
@@ -574,6 +577,7 @@ export default function PodDetails(props: PodDetailsProps) {
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const autoLaunchView = queryParams.get('view');
+  const autoLaunchContainer = queryParams.get('container') ?? undefined;
   const [podItem, setPodItem] = React.useState<Pod | null>(null);
 
   const launchLogs = React.useCallback(
@@ -584,7 +588,15 @@ export default function PodDetails(props: PodDetailsProps) {
         cluster: item.cluster,
         icon: <Icon icon="mdi:file-document-box-outline" width="100%" height="100%" />,
         location: 'full',
-        content: <PodLogViewer noDialog open item={item} onClose={() => {}} />,
+        content: (
+          <PodLogViewer
+            noDialog
+            open
+            item={item}
+            onClose={() => {}}
+            initialContainer={autoLaunchContainer}
+          />
+        ),
       });
       dispatchHeadlampEvent({
         type: HeadlampEventType.LOGS,
@@ -593,7 +605,7 @@ export default function PodDetails(props: PodDetailsProps) {
         },
       });
     },
-    [t, dispatchHeadlampEvent]
+    [t, dispatchHeadlampEvent, autoLaunchContainer]
   );
 
   const launchTerminal = React.useCallback(
@@ -612,6 +624,7 @@ export default function PodDetails(props: PodDetailsProps) {
             item={item}
             onClose={() => Activity.close(activityId)}
             isAttach={false}
+            initialContainer={autoLaunchContainer}
           />
         ),
       });
@@ -623,7 +636,7 @@ export default function PodDetails(props: PodDetailsProps) {
         },
       });
     },
-    [dispatchHeadlampEvent]
+    [dispatchHeadlampEvent, autoLaunchContainer]
   );
 
   React.useEffect(() => {
@@ -635,12 +648,12 @@ export default function PodDetails(props: PodDetailsProps) {
     if (
       podItem &&
       autoLaunchView === 'logs' &&
-      lastAutoLaunchedPodLogs.current !== podItem.metadata.uid
+      lastAutoLaunchedPodLogs.current !== `${podItem.metadata.uid}:${autoLaunchContainer ?? ''}`
     ) {
-      lastAutoLaunchedPodLogs.current = podItem.metadata.uid;
+      lastAutoLaunchedPodLogs.current = `${podItem.metadata.uid}:${autoLaunchContainer ?? ''}`;
       launchLogs(podItem);
     }
-  }, [podItem, launchLogs, autoLaunchView]);
+  }, [podItem, launchLogs, autoLaunchView, autoLaunchContainer]);
 
   React.useEffect(() => {
     if (autoLaunchView !== 'exec') {
@@ -651,12 +664,12 @@ export default function PodDetails(props: PodDetailsProps) {
     if (
       podItem &&
       autoLaunchView === 'exec' &&
-      lastAutoLaunchedPodExec.current !== podItem.metadata.uid
+      lastAutoLaunchedPodExec.current !== `${podItem.metadata.uid}:${autoLaunchContainer ?? ''}`
     ) {
-      lastAutoLaunchedPodExec.current = podItem.metadata.uid;
+      lastAutoLaunchedPodExec.current = `${podItem.metadata.uid}:${autoLaunchContainer ?? ''}`;
       launchTerminal(podItem);
     }
-  }, [podItem, launchTerminal, autoLaunchView]);
+  }, [podItem, launchTerminal, autoLaunchView, autoLaunchContainer]);
 
   function prepareExtraInfo(item: Pod | null) {
     let extraInfo: {

--- a/frontend/src/components/pod/PodLogViewer.test.tsx
+++ b/frontend/src/components/pod/PodLogViewer.test.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { TestContext } from '../../test';
+import { PodLogViewer } from './Details';
+
+vi.mock('../../lib/k8s', () => ({}));
+vi.mock('../../lib/k8s/pod', () => ({ default: vi.fn(), __esModule: true }));
+vi.mock('../../lib/k8s/cluster', () => ({}));
+
+vi.mock('../globalSearch/useLocalStorageState', () => ({
+  useLocalStorageState: (_key: string, defaultValue: any) => [defaultValue, vi.fn()],
+}));
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    open: vi.fn(),
+    clear: vi.fn(),
+    write: vi.fn(),
+    focus: vi.fn(),
+    onData: vi.fn(),
+    onResize: vi.fn(),
+    attachCustomKeyEventHandler: vi.fn(),
+    dispose: vi.fn(),
+    loadAddon: vi.fn(),
+  })),
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: vi.fn(),
+    activate: vi.fn(),
+  })),
+}));
+
+function makeMockPod(getLogs: (...args: any[]) => any) {
+  return {
+    metadata: { name: 'test-pod', namespace: 'default', uid: 'pod-uid-123' },
+    spec: {
+      containers: [{ name: 'nginx' }, { name: 'sidecar' }],
+      initContainers: [],
+      ephemeralContainers: [],
+    },
+    status: {
+      containerStatuses: [{ name: 'nginx', state: { running: {} }, restartCount: 0 }],
+    },
+    getName: () => 'test-pod',
+    getLogs,
+  } as any;
+}
+
+describe('PodLogViewer', () => {
+  describe('initialContainer', () => {
+    it('uses initialContainer when it matches a known container', () => {
+      const getLogs = vi.fn(() => () => {});
+      render(
+        <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }}>
+          <PodLogViewer
+            open
+            item={makeMockPod(getLogs)}
+            onClose={() => {}}
+            initialContainer="sidecar"
+          />
+        </TestContext>
+      );
+
+      expect(getLogs).toHaveBeenCalledWith('sidecar', expect.any(Function), expect.any(Object));
+    });
+
+    it('falls back to default container when initialContainer is invalid', () => {
+      const getLogs = vi.fn(() => () => {});
+      render(
+        <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }}>
+          <PodLogViewer
+            open
+            item={makeMockPod(getLogs)}
+            onClose={() => {}}
+            initialContainer="nonexistent"
+          />
+        </TestContext>
+      );
+
+      expect(getLogs).toHaveBeenCalledWith('nginx', expect.any(Function), expect.any(Object));
+    });
+
+    it('uses default container when initialContainer is not specified', () => {
+      const getLogs = vi.fn(() => () => {});
+      render(
+        <TestContext routerMap={{ namespace: 'default', name: 'test-pod' }}>
+          <PodLogViewer open item={makeMockPod(getLogs)} onClose={() => {}} />
+        </TestContext>
+      );
+
+      expect(getLogs).toHaveBeenCalledWith('nginx', expect.any(Function), expect.any(Object));
+    });
+  });
+});

--- a/frontend/src/helpers/podContainer.ts
+++ b/frontend/src/helpers/podContainer.ts
@@ -17,6 +17,36 @@
 import Pod from '../lib/k8s/pod';
 
 /**
+ * Returns all containers in a pod across spec.containers, spec.initContainers,
+ * and spec.ephemeralContainers.
+ *
+ * @param item - The pod object to check.
+ * @returns Array of all container specs (main, init, and ephemeral).
+ */
+export function getAllContainers(item: Pod): Array<{ name: string }> {
+  return [
+    ...(item.spec?.containers ?? []),
+    ...(item.spec?.initContainers ?? []),
+    ...(item.spec?.ephemeralContainers ?? []),
+  ];
+}
+
+/**
+ * Returns `preferredName` if it matches a known container in the pod, otherwise
+ * falls back to {@link getDefaultContainer}.
+ *
+ * @param item - The pod object to check.
+ * @param preferredName - The container name requested (e.g. from a query param).
+ * @returns A valid container name for the pod.
+ */
+export function resolveContainerName(item: Pod, preferredName: string | undefined): string {
+  if (preferredName && getAllContainers(item).some(c => c.name === preferredName)) {
+    return preferredName;
+  }
+  return getDefaultContainer(item);
+}
+
+/**
  * Gets the default container name for a pod based on its current execution state.
  *
  * It prioritizes running main containers, then running init containers,
@@ -25,7 +55,6 @@ import Pod from '../lib/k8s/pod';
  * @param item - The pod object to check.
  * @returns The name of the default container or an empty string if none exist.
  */
-
 export function getDefaultContainer(item: Pod): string {
   if (!item) {
     return '';


### PR DESCRIPTION
## Summary

This PR adds the ability for users to deep-link log and exec pages with a specific container to open.

We have some use-cases where we would like to link to logs for a specific, common container for users. This change enables that.

## Related Issue

No issue created.

## Changes

- Updated PodLogViewer / Terminal to accept an `initialContainer` prop, which will open the correct container in the UI.
- Refactored tests into describe blocks for the views functionality.

## Steps to Test

- Link to the logs of a Pod with multiple containers, and using the `&container=` query parameter, select a specific container that is not the default.
- Link to the logs of a Pod with multiple containers, without the `&container=` query parameter, and see that the default container is selected.
- Link to the logs of a Pod with multiple containers, and using the `&container=` query parameter with an invalid container, and see that the default container is selected.

## Screenshots (if applicable)

Screenshot not helpful here.

## Notes for the Reviewer

The query param does not update when the user changes containers. This is in line with the `?view=logs` query param not updating when the user exits the view.