### PR TITLE
resourceMap: replace clearInterval with clearTimeout in KubeObjectNode

### DIFF
--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -181,7 +181,7 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
     }
 
     const id = setTimeout(() => setIsExpanded(true), EXPAND_DELAY);
-    return () => clearInterval(id);
+    return () => clearTimeout(id);
   }, [isHovered]);
 
   const icon = kubeObject ? (


### PR DESCRIPTION
## Summary
This PR fixes a incorrect timer cleanup in KubeObjectNode by replacing
`clearInterval` with `clearTimeout` in the hover-expand useEffect.
`clearInterval` does not cancel `setTimeout` timers — they are separate
browser APIs — so the cleanup was silently doing nothing.

## Related Issue
Fixes #5380 

## Changes
- Fixed wrong cleanup API in `frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx` line 184

## Steps to Test
1. Open Headlamp → select a cluster → click **Map** in the left sidebar
2. Hover over any node briefly (less than 450ms) then move cursor away
3. Before fix: node still expands because `clearInterval` never cancelled the `setTimeout`
4. After fix: node does not expand when hover ends before the 450ms delay completes

## Notes for the Reviewer
- 1 line changed, 1 file changed
- `clearInterval` does not cancel `setTimeout` timers per the browser/Node.js spec
- The incorrect cleanup was silently doing nothing, allowing state updates on unmounted components


