### PR TITLE
frontend: project: Fix swapped health icons in resources tab

### DIFF
--- a/frontend/src/components/project/ProjectResourcesTab.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.tsx
@@ -203,9 +203,9 @@ export function ProjectResourcesTab({
               <Icon
                 icon={
                   status === 'error'
-                    ? 'mdi:alert'
-                    : status === 'warning'
                     ? 'mdi:alert-circle'
+                    : status === 'warning'
+                    ? 'mdi:alert'
                     : 'mdi:check-circle'
                 }
                 style={{


### PR DESCRIPTION
DESCRIPTION :

The health status icons in the `ProjectResourcesTab` were swapped - error status displayed the warning triangle (`mdi:alert`) and warning status displayed the error circle (`mdi:alert-circle`).

This was inconsistent with `getHealthIcon` in `projectUtils.ts`, which correctly maps:
- `error` → `mdi:alert-circle` (filled circle)
- `warning` → `mdi:alert` (triangle)

### Before (main branch)
Warning status incorrectly shows circle icon (`mdi:alert-circle`) for degraded resources:

<img width="1917" height="1011" alt="image" src="https://github.com/user-attachments/assets/ca04b38b-a60c-442b-a6fa-5e4cd04a97ab" />

### After (fix branch)
Warning status now correctly shows triangle icon (`mdi:alert`), matching `getHealthIcon()` in `projectUtils.ts`:

<img width="1917" height="1017" alt="image" src="https://github.com/user-attachments/assets/54f7aca5-e901-4200-b355-34c782ace6d5" />### Testing

- ESLint on `ProjectResourcesTab.tsx` - clean, no errors
- `vitest run src/components/project/projectUtils.test.ts` - 21/21 tests passed
- Verified visual consistency between Projects list and Resources tab icons
