### PR TITLE
`frontend: resourceMap: Fix stale closure preventing node topology updates`

### DIFF
--- a/frontend/src/components/resourceMap/GraphView.tsx
+++ b/frontend/src/components/resourceMap/GraphView.tsx
@@ -196,18 +196,21 @@ function GraphViewContent({
   // Group the graph
   const [allNamespaces] = Namespace.useList();
   const [allNodes] = K8sNode.useList();
+
+  const activeNamespaces = groupBy === 'namespace' ? allNamespaces : undefined;
+  const activeNodes = groupBy === 'node' ? allNodes : undefined;
+
   const { visibleGraph, fullGraph } = useMemo(() => {
     const graph = groupGraph(filteredGraph.nodes, filteredGraph.edges, {
       groupBy,
-      namespaces: allNamespaces ?? [],
-      k8sNodes: allNodes ?? [],
+      namespaces: activeNamespaces ?? [],
+      k8sNodes: activeNodes ?? [],
     });
 
     const visibleGraph = collapseGraph(graph, { selectedNodeId, expandAll });
 
     return { visibleGraph, fullGraph: graph };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filteredGraph, groupBy, selectedNodeId, expandAll, allNamespaces]);
+  }, [filteredGraph, groupBy, selectedNodeId, expandAll, activeNamespaces, activeNodes]);
 
   const viewport = useGraphViewport();
 

--- a/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphGrouping.test.ts
@@ -122,6 +122,41 @@ describe('groupGraph', () => {
     expect(nodeNames).toEqual(['1', '3', '4', 'Node-node1']);
   });
 
+  it('associates k8sNode kubeObject with node groups when k8sNodes are provided', () => {
+    const k8sNodeObject = {
+      kind: 'Node',
+      metadata: { name: 'node1', uid: 'node1-uid' },
+    } as any;
+
+    const groupedGraph = groupGraph(nodes, edges, {
+      groupBy: 'node',
+      namespaces: [],
+      k8sNodes: [k8sNodeObject],
+    });
+
+    const nodeGroup = groupedGraph.nodes?.find(node => node.label === 'node1');
+
+    // The group should have the k8sNode kubeObject associated with it
+    expect(nodeGroup).toBeDefined();
+    expect(nodeGroup?.kubeObject).toBe(k8sNodeObject);
+    // The group ID should be updated to the node's UID
+    expect(nodeGroup?.id).toBe('node1-uid');
+  });
+
+  it('does not associate k8sNode when k8sNodes list is empty', () => {
+    const groupedGraph = groupGraph(nodes, edges, {
+      groupBy: 'node',
+      namespaces: [],
+      k8sNodes: [],
+    });
+
+    const nodeGroup = groupedGraph.nodes?.find(node => node.id === 'Node-node1');
+
+    // Without k8sNodes data, the group should not have a kubeObject
+    expect(nodeGroup).toBeDefined();
+    expect(nodeGroup?.kubeObject).toBeUndefined();
+  });
+
   it('groups nodes by instance', () => {
     const groupedGraph = groupGraph(nodes, edges, {
       groupBy: 'instance',


### PR DESCRIPTION
## Summary
Fixes a React stale closure bug in `GraphView.tsx` where the Resource Map failed to update its node groupings when cluster nodes were added or removed from the cluster.

## Related Issue
Fixes #5388 

## Root Cause
The `useMemo` hook calculating the graph topology omitted `allNodes` from its dependency array. This prevented the graph from recalculating when `K8sNode.useList()` yielded new cluster node data. The missing dependency warning was intentionally suppressed by an ESLint disable comment.

## Fix
1. Added `allNodes` to the `useMemo` dependency array to ensure reactive re-renders when cluster nodes mutate.
2. Removed the unsafe `// eslint-disable-next-line react-hooks/exhaustive-deps` suppression, as the hook now correctly adheres to exhaustive dependency rules. This re-enables the lint rule as a permanent regression guard for this component.

## Tests Added
Added 2 new test cases in `graphGrouping.test.ts`:
- **`associates k8sNode kubeObject with node groups when k8sNodes are provided`** — verifies that `groupGraph` with `groupBy: 'node'` correctly associates the `k8sNode` kubeObject and updates the group ID to the node's UID.
- **`does not associate k8sNode when k8sNodes list is empty`** — verifies groups remain unassociated when the `k8sNodes` list is empty, confirming the data dependency path.

## Verification
- Verified that adding `allNodes` does not trigger infinite render loops (Headlamp's `useList` hook safely maintains array references via the internal React-Query caching layer).
- Ran `npm run frontend:tsc` and `npm run frontend:lint` locally to confirm complete linter compliance.
- All 11 tests in `graphGrouping.test.ts` pass (9 existing + 2 new).

## Manual Testing Steps
1. `npm start` to run Headlamp connected to a cluster with multiple nodes
2. Navigate to **Resource Map** (sidebar → Resource Map)
3. Click **Group By: Node** chip
4. Add or remove a node from the cluster (e.g., `kubectl cordon/uncordon`)
5. **Before fix:** The graph would not update to reflect the node change
6. **After fix:** The graph recomputes and shows the updated node topology
