### PR TITLE
frontend: GatewayAPI: update resources to support v1.5

### DIFF
--- a/frontend/src/components/gateway/BackendTLSPolicyDetails.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyDetails.stories.tsx
@@ -36,11 +36,11 @@ export default {
         story: [],
         storyBase: [
           http.get(
-            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies`,
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1/namespaces/default/backendtlspolicies`,
             () => HttpResponse.error()
           ),
           http.get(
-            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies/example-policy`,
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1/namespaces/default/backendtlspolicies/example-policy`,
             () => HttpResponse.json(DEFAULT_BACKEND_TLS_POLICY)
           ),
           http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>

--- a/frontend/src/components/gateway/BackendTLSPolicyDetails.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyDetails.stories.tsx
@@ -40,8 +40,16 @@ export default {
             () => HttpResponse.error()
           ),
           http.get(
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies`,
+            () => HttpResponse.error()
+          ),
+          http.get(
             `${API_BASE}/apis/gateway.networking.k8s.io/v1/namespaces/default/backendtlspolicies/example-policy`,
             () => HttpResponse.json(DEFAULT_BACKEND_TLS_POLICY)
+          ),
+          http.get(
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies/example-policy`,
+            () => HttpResponse.error()
           ),
           http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({

--- a/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
@@ -35,10 +35,10 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies`, () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/backendtlspolicies`, () =>
             HttpResponse.json({
               kind: 'BackendTLSPolicyList',
-              apiVersion: 'gateway.networking.k8s.io/v1alpha3',
+              apiVersion: 'gateway.networking.k8s.io/v1',
               metadata: {},
               items: [DEFAULT_BACKEND_TLS_POLICY],
             })

--- a/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
@@ -43,9 +43,8 @@ export default {
               items: [DEFAULT_BACKEND_TLS_POLICY],
             })
           ),
-          http.get(
-            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies`,
-            () => HttpResponse.error()
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies`, () =>
+            HttpResponse.error()
           ),
         ],
       },

--- a/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
@@ -45,13 +45,7 @@ export default {
           ),
           http.get(
             `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies`,
-            () =>
-              HttpResponse.json({
-                kind: 'BackendTLSPolicyList',
-                apiVersion: 'gateway.networking.k8s.io/v1alpha3',
-                metadata: {},
-                items: [],
-              })
+            () => HttpResponse.error()
           ),
         ],
       },

--- a/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
@@ -43,6 +43,16 @@ export default {
               items: [DEFAULT_BACKEND_TLS_POLICY],
             })
           ),
+          http.get(
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies`,
+            () =>
+              HttpResponse.json({
+                kind: 'BackendTLSPolicyList',
+                apiVersion: 'gateway.networking.k8s.io/v1alpha3',
+                metadata: {},
+                items: [],
+              })
+          ),
         ],
       },
     },

--- a/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
@@ -45,10 +45,6 @@ export default {
             HttpResponse.error()
           ),
           http.get(
-            `${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes/default-grpcroute`,
-            () => HttpResponse.error()
-          ),
-          http.get(
             `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes/default-grpcroute`,
             () => HttpResponse.error()
           ),

--- a/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
@@ -41,11 +41,15 @@ export default {
           http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes`, () =>
             HttpResponse.json({})
           ),
-          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes`, () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes`, () =>
             HttpResponse.error()
           ),
           http.get(
-            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes/default-grpcroute`,
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes/default-grpcroute`,
+            () => HttpResponse.error()
+          ),
+          http.get(
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes/default-grpcroute`,
             () => HttpResponse.error()
           ),
           http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>

--- a/frontend/src/components/gateway/GRPCRouteList.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteList.stories.tsx
@@ -45,7 +45,7 @@ export default {
               items: [DEFAULT_GRPC_ROUTE],
             })
           ),
-          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes`, () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes`, () =>
             HttpResponse.error()
           ),
         ],

--- a/frontend/src/components/gateway/ReferenceGrantDetails.stories.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantDetails.stories.tsx
@@ -39,7 +39,7 @@ export default {
         story: [],
         storyBase: [
           http.get(
-            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants`,
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1/namespaces/default/referencegrants`,
             () => HttpResponse.json({})
           ),
           http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
@@ -71,7 +71,7 @@ Basic.parameters = {
     handlers: {
       story: [
         http.get(
-          `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants/example-refgrant`,
+          `${API_BASE}/apis/gateway.networking.k8s.io/v1/namespaces/default/referencegrants/example-refgrant`,
           () => HttpResponse.json(DEFAULT_REFERENCE_GRANT)
         ),
       ],

--- a/frontend/src/components/gateway/ReferenceGrantDetails.stories.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantDetails.stories.tsx
@@ -42,6 +42,10 @@ export default {
             `${API_BASE}/apis/gateway.networking.k8s.io/v1/namespaces/default/referencegrants`,
             () => HttpResponse.json({})
           ),
+          http.get(
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants`,
+            () => HttpResponse.error()
+          ),
           http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
@@ -73,6 +77,10 @@ Basic.parameters = {
         http.get(
           `${API_BASE}/apis/gateway.networking.k8s.io/v1/namespaces/default/referencegrants/example-refgrant`,
           () => HttpResponse.json(DEFAULT_REFERENCE_GRANT)
+        ),
+        http.get(
+          `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants/example-refgrant`,
+          () => HttpResponse.error()
         ),
       ],
     },

--- a/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
@@ -46,6 +46,10 @@ export default {
               items: [DEFAULT_REFERENCE_GRANT],
             })
           ),
+          http.get(
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/referencegrants`,
+            () => HttpResponse.error()
+          ),
         ],
       },
     },

--- a/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
@@ -46,9 +46,8 @@ export default {
               items: [DEFAULT_REFERENCE_GRANT],
             })
           ),
-          http.get(
-            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/referencegrants`,
-            () => HttpResponse.error()
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/referencegrants`, () =>
+            HttpResponse.error()
           ),
         ],
       },

--- a/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
@@ -38,10 +38,10 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/referencegrants`, () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/referencegrants`, () =>
             HttpResponse.json({
               kind: 'ReferenceGrantList',
-              apiVersion: 'gateway.networking.k8s.io/v1beta1',
+              apiVersion: 'gateway.networking.k8s.io/v1',
               metadata: {},
               items: [DEFAULT_REFERENCE_GRANT],
             })

--- a/frontend/src/components/gateway/manifests/backendtls.yaml
+++ b/frontend/src/components/gateway/manifests/backendtls.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: secure-backend-policy

--- a/frontend/src/components/gateway/manifests/grpcroute.yaml
+++ b/frontend/src/components/gateway/manifests/grpcroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: grpc-route

--- a/frontend/src/components/gateway/manifests/referencegrant.yaml
+++ b/frontend/src/components/gateway/manifests/referencegrant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: cross-namespace-backend-access

--- a/frontend/src/components/gateway/storyHelper.ts
+++ b/frontend/src/components/gateway/storyHelper.ts
@@ -23,7 +23,7 @@ import { KubeHTTPRoute } from '../../lib/k8s/httpRoute';
 import { KubeReferenceGrant } from '../../lib/k8s/referenceGrant';
 
 export const DEFAULT_GATEWAY: KubeGateway = {
-  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'Gateway',
   metadata: {
     creationTimestamp: '2023-07-19T09:48:42Z',
@@ -70,7 +70,7 @@ export const BROKEN_GATEWAY: KubeGateway = {
 };
 
 export const DEFAULT_GATEWAY_CLASS: KubeGatewayClass = {
-  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'GatewayClass',
   metadata: {
     creationTimestamp: '2023-07-19T09:48:42Z',
@@ -87,7 +87,7 @@ export const DEFAULT_GATEWAY_CLASS: KubeGatewayClass = {
 };
 
 export const DEFAULT_HTTP_ROUTE: KubeHTTPRoute = {
-  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'HTTPRoute',
   metadata: {
     creationTimestamp: '2023-07-19T09:48:42Z',
@@ -147,7 +147,7 @@ export const DEFAULT_HTTP_ROUTE: KubeHTTPRoute = {
 };
 
 export const EMPTY_HTTP_ROUTE: KubeHTTPRoute = {
-  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'HTTPRoute',
   metadata: {
     creationTimestamp: '2023-07-19T09:48:42Z',
@@ -165,7 +165,7 @@ export const EMPTY_HTTP_ROUTE: KubeHTTPRoute = {
 };
 
 export const DEFAULT_GRPC_ROUTE: KubeGRPCRoute = {
-  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'GRPCRoute',
   metadata: {
     creationTimestamp: '2023-07-19T09:48:42Z',
@@ -243,7 +243,7 @@ export const DEFAULT_GRPC_ROUTE: KubeGRPCRoute = {
 };
 
 export const DEFAULT_REFERENCE_GRANT: KubeReferenceGrant = {
-  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'ReferenceGrant',
   metadata: {
     uid: 'abc1234',
@@ -270,7 +270,7 @@ export const DEFAULT_REFERENCE_GRANT: KubeReferenceGrant = {
 };
 
 export const DEFAULT_BACKEND_TLS_POLICY: KubeBackendTLSPolicy = {
-  apiVersion: 'gateway.networking.k8s.io/v1alpha3',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'BackendTLSPolicy',
   metadata: {
     uid: 'abc1234',

--- a/frontend/src/lib/k8s/backendTLSPolicy.ts
+++ b/frontend/src/lib/k8s/backendTLSPolicy.ts
@@ -19,7 +19,7 @@ import { KubeObject, type KubeObjectInterface } from './KubeObject';
 /**
  * BackendTLSPolicyTargetRef defines the target resource (e.g., Service) for the TLS policy.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/#structure}
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#localpolicytargetreferencewithsectionname}
  */
 export interface BackendTLSPolicyTargetRef {
   group: string;
@@ -31,7 +31,7 @@ export interface BackendTLSPolicyTargetRef {
 /**
  * BackendTLSPolicyValidation defines TLS validation settings such as trusted CA and SAN.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/#structure}
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#backendtlspolicyvalidation}
  */
 export interface BackendTLSPolicyValidation {
   caCertificateRefs: {
@@ -44,6 +44,8 @@ export interface BackendTLSPolicyValidation {
 
 /**
  * BackendTLSPolicySpec defines the policy spec.
+ *
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#backendtlspolicyspec}
  */
 export interface BackendTLSPolicySpec {
   targetRefs: BackendTLSPolicyTargetRef[];
@@ -54,7 +56,7 @@ export interface BackendTLSPolicySpec {
 /**
  * BackendTLSPolicy is a Gateway API type that enforces TLS connections from the gateway to the backend.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/}
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#backendtlspolicy}
  */
 export interface KubeBackendTLSPolicy extends KubeObjectInterface {
   spec: BackendTLSPolicySpec;

--- a/frontend/src/lib/k8s/backendTLSPolicy.ts
+++ b/frontend/src/lib/k8s/backendTLSPolicy.ts
@@ -63,7 +63,7 @@ export interface KubeBackendTLSPolicy extends KubeObjectInterface {
 class BackendTLSPolicy extends KubeObject<KubeBackendTLSPolicy> {
   static kind = 'BackendTLSPolicy';
   static apiName = 'backendtlspolicies';
-  static apiVersion = ['gateway.networking.k8s.io/v1alpha3'];
+  static apiVersion = ['gateway.networking.k8s.io/v1', 'gateway.networking.k8s.io/v1alpha3'];
   static isNamespaced = true;
 
   get spec(): BackendTLSPolicySpec {

--- a/frontend/src/lib/k8s/backendTrafficPolicy.ts
+++ b/frontend/src/lib/k8s/backendTrafficPolicy.ts
@@ -20,7 +20,7 @@ import { KubeObject, type KubeObjectInterface } from './KubeObject';
  * BackendTrafficPolicyTargetRef defines a backend object that the policy applies to
  * (Service, ServiceImport, or implementation‑specific backendRef).
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/backendtrafficpolicy}
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#localpolicytargetreference}
  */
 export interface BackendTrafficPolicyTargetRef {
   group: string;
@@ -71,7 +71,7 @@ export interface SessionPersistence {
 /**
  * BackendTrafficPolicySpec defines the desired policy.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/backendtrafficpolicy/#spec}
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/specx/#backendtrafficpolicyspec}
  */
 export interface BackendTrafficPolicySpec {
   targetRefs: BackendTrafficPolicyTargetRef[];
@@ -92,6 +92,8 @@ export interface KubeBackendTrafficPolicy extends KubeObjectInterface {
  * XBackendTrafficPolicy – Gateway API experimental resource that controls
  * client behaviour (retries, session stickiness, etc.) when talking to a
  * backend.
+ *
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/specx/#xbackendtrafficpolicy}
  */
 class BackendTrafficPolicy extends KubeObject<KubeBackendTrafficPolicy> {
   static kind = 'XBackendTrafficPolicy';

--- a/frontend/src/lib/k8s/gateway.ts
+++ b/frontend/src/lib/k8s/gateway.ts
@@ -20,7 +20,7 @@ import { KubeObject, type KubeObjectInterface } from './KubeObject';
 /**
  * ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route).
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ParentReference} Gateway API reference for ParentReference
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#parentreference} Gateway API reference for ParentReference
  */
 export interface GatewayParentReference {
   group?: string;
@@ -34,7 +34,7 @@ export interface GatewayParentReference {
 /**
  * Listener embodies the concept of a logical endpoint where a Gateway accepts network connections.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Listener} Gateway API reference for Listener
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#listener} Gateway API reference for Listener
  */
 export interface GatewayListener {
   hostname: string;
@@ -47,7 +47,7 @@ export interface GatewayListener {
 /**
  * ListenerStatus is the status associated with a Listener.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.ListenerStatus} Gateway API reference for ListenerStatus
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#listenerstatus} Gateway API reference for ListenerStatus
  */
 export interface GatewayListenerStatus {
   name: string;
@@ -59,7 +59,7 @@ export interface GatewayListenerStatus {
 /**
  * GatewayStatusAddress describes a network address that is bound to a Gateway.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayStatusAddress} Gateway API reference for GatewayStatusAddress
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gatewaystatusaddress} Gateway API reference for GatewayStatusAddress
  */
 export interface GatewayStatusAddress {
   type?: string;
@@ -69,9 +69,9 @@ export interface GatewayStatusAddress {
 /**
  * Gateway represents an instance of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Gateway} Gateway API reference for Gateway
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gateway} Gateway API reference for Gateway
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/gateway/} Gateway API definition for Gateway
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/gateway/} Gateway API definition for Gateway
  */
 export interface KubeGateway extends KubeObjectInterface {
   spec?: {

--- a/frontend/src/lib/k8s/gatewayClass.ts
+++ b/frontend/src/lib/k8s/gatewayClass.ts
@@ -21,9 +21,9 @@ import { KubeObject } from './KubeObject';
 /**
  * GatewayClass is cluster-scoped resource defined by the infrastructure provider. This resource represents a class of Gateways that can be instantiated.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayClass} Gateway API reference for GatewayClass
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gatewayclass} Gateway API reference for GatewayClass
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/gatewayclass/} Gateway API definition for GatewayClass
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/} Gateway API definition for GatewayClass
  */
 export interface KubeGatewayClass extends KubeObjectInterface {
   spec: {

--- a/frontend/src/lib/k8s/grpcRoute.ts
+++ b/frontend/src/lib/k8s/grpcRoute.ts
@@ -78,7 +78,7 @@ export interface KubeGRPCRoute extends KubeObjectInterface {
 class GRPCRoute extends KubeObject<KubeGRPCRoute> {
   static kind = 'GRPCRoute';
   static apiName = 'grpcroutes';
-  static apiVersion = ['gateway.networking.k8s.io/v1', 'gateway.networking.k8s.io/v1beta1'];
+  static apiVersion = ['gateway.networking.k8s.io/v1', 'gateway.networking.k8s.io/v1alpha2'];
   static isNamespaced = true;
 
   get spec(): KubeGRPCRoute['spec'] {

--- a/frontend/src/lib/k8s/grpcRoute.ts
+++ b/frontend/src/lib/k8s/grpcRoute.ts
@@ -21,7 +21,7 @@ import { KubeObject } from './KubeObject';
 /**
  * GRPCRouteMatch defines the predicate used to match requests to a given action.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch} Gateway API reference for GRPCRouteMatch
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroutematch} Gateway API reference for GRPCRouteMatch
  */
 export interface GRPCRouteMatch {
   method?: {
@@ -40,7 +40,7 @@ export interface GRPCRouteMatch {
  * GRPCRouteRule defines semantics for matching a gRPC request based on conditions (matches),
  * processing it (filters), and forwarding the request to an API object (backendRefs).
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteRule} Gateway API reference for GRPCRouteRule
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcrouterule} Gateway API reference for GRPCRouteRule
  */
 export interface GRPCRouteRule {
   name?: string;
@@ -62,9 +62,9 @@ export interface GRPCRouteRule {
 /**
  * GRPCRoute is a Gateway API type for specifying routing behavior of gRPC requests from a Gateway listener to an API object, i.e. Service.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRoute} Gateway API reference for GRPCRoute
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroute} Gateway API reference for GRPCRoute
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/grpcroute/} Gateway API definition for GRPCRoute
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/} Gateway API definition for GRPCRoute
  */
 export interface KubeGRPCRoute extends KubeObjectInterface {
   spec: {

--- a/frontend/src/lib/k8s/httpRoute.ts
+++ b/frontend/src/lib/k8s/httpRoute.ts
@@ -21,9 +21,9 @@ import { KubeObject } from './KubeObject';
 /**
  * HTTPRouteRule defines semantics for matching an HTTP request based on conditions (matches), processing it (filters), and forwarding the request to an API object (backendRefs).
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule} Gateway API reference for HTTPRouteRule
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule} Gateway API reference for HTTPRouteRule
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/httproute/#rules} Gateway API definition for HTTPRouteRule
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#rules} Gateway API definition for HTTPRouteRule
  */
 export interface HTTPRouteRule {
   name?: string;
@@ -35,9 +35,9 @@ export interface HTTPRouteRule {
 /**
  * HTTPRoute is a Gateway API type for specifying routing behavior of HTTP requests from a Gateway listener to an API object, i.e. Service.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute} Gateway API reference for HTTPRoute
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproute} Gateway API reference for HTTPRoute
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/httproute/} Gateway API definition for HTTPRoute
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/httproute/} Gateway API definition for HTTPRoute
  */
 export interface KubeHTTPRoute extends KubeObjectInterface {
   spec: {

--- a/frontend/src/lib/k8s/referenceGrant.ts
+++ b/frontend/src/lib/k8s/referenceGrant.ts
@@ -46,7 +46,7 @@ export interface ReferenceGrantTo {
 /**
  * ReferenceGrant is a Gateway API type that enables cross-namespace references for resources like HTTPRoute or Gateway.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1beta1.ReferenceGrant} Gateway API reference for ReferenceGrant
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#referencegrant} Gateway API reference for ReferenceGrant
  *
  * @see {@link https://gateway-api.sigs.k8s.io/api-types/referencegrant/} Gateway API definition for ReferenceGrant
  */
@@ -61,7 +61,7 @@ export interface KubeReferenceGrant extends KubeObjectInterface {
 class ReferenceGrant extends KubeObject<KubeReferenceGrant> {
   static kind = 'ReferenceGrant';
   static apiName = 'referencegrants';
-  static apiVersion = ['gateway.networking.k8s.io/v1beta1'];
+  static apiVersion = ['gateway.networking.k8s.io/v1', 'gateway.networking.k8s.io/v1beta1'];
   static isNamespaced = true;
 
   get spec(): KubeReferenceGrant['spec'] {

--- a/frontend/src/lib/k8s/referenceGrant.ts
+++ b/frontend/src/lib/k8s/referenceGrant.ts
@@ -20,9 +20,9 @@ import { KubeObject } from './KubeObject';
 /**
  * ReferenceGrantFrom defines the source resource (e.g., HTTPRoute) that is allowed to reference a target resource.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1beta1.ReferenceGrant} Gateway API reference for ReferenceGrant
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#referencegrant} Gateway API reference for ReferenceGrant
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/referencegrant/#structure} Gateway API definition for ReferenceGrantFrom
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/#structure} Gateway API definition for ReferenceGrantFrom
  */
 export interface ReferenceGrantFrom {
   group: string;
@@ -33,9 +33,9 @@ export interface ReferenceGrantFrom {
 /**
  * ReferenceGrantTo defines the target resource (e.g., Service or Secret) that can be referenced.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1beta1.ReferenceGrant} Gateway API reference for ReferenceGrant
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#referencegrant} Gateway API reference for ReferenceGrant
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/referencegrant/#structure} Gateway API definition for ReferenceGrantTo
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/#structure} Gateway API definition for ReferenceGrantTo
  */
 export interface ReferenceGrantTo {
   group: string;
@@ -46,9 +46,9 @@ export interface ReferenceGrantTo {
 /**
  * ReferenceGrant is a Gateway API type that enables cross-namespace references for resources like HTTPRoute or Gateway.
  *
- * @see {@link https://gateway-api.sigs.k8s.io/reference/spec/#referencegrant} Gateway API reference for ReferenceGrant
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#referencegrant} Gateway API reference for ReferenceGrant
  *
- * @see {@link https://gateway-api.sigs.k8s.io/api-types/referencegrant/} Gateway API definition for ReferenceGrant
+ * @see {@link https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/} Gateway API definition for ReferenceGrant
  */
 export interface KubeReferenceGrant extends KubeObjectInterface {
   spec: {


### PR DESCRIPTION
This update introduces full support for Kubernetes Gateway API v1.5.1, including three key resource graduations to the Standard channel:
* BackendTLSPolicy
* GRPCRoute
* ReferenceGrant

## Major Changes

### BackendTLSPolicy: Graduated to v1 (Standard Channel)
- Accept both v1 (new) and v1alpha3 (backwards compatibility)
- Updated example manifests and test fixtures to v1
- Updated Storybook mocks to test against v1 API endpoints

### GRPCRoute: Corrected API Versions
- Changed from [v1, v1beta1] to [v1, v1alpha2]
- Note: v1beta1 was never served in Gateway API v1.5
- Updated manifests to use stable v1

### ReferenceGrant: Enhanced Support
- Added v1 to accepted versions (now [v1, v1beta1])
- Updated story mocks and manifests to demonstrate v1 usage

## Backwards Compatibility

All changes maintain full backwards compatibility:
- v1beta1 Gateway/GatewayClass/HTTPRoute/ReferenceGrant still accepted
- v1alpha3 BackendTLSPolicy still accepted
- v1alpha2 GRPCRoute newly supported
- Existing clusters on Gateway API <1.5 continue to work unchanged

## Implementation Details

- Updated 13 files total (type definitions, manifests, stories, mocks)
- Added comprehensive documentation with v1.5.1 release references
- All code changes validated with TypeScript compiler
- No breaking changes to public API

Fixes: Support for latest Kubernetes Gateway API v1.5.1
References: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.1