### PR TITLE
backend: externalproxy: Forward status code and content type

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -647,10 +647,15 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
+		if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+
+		w.WriteHeader(resp.StatusCode)
+
 		_, err = w.Write(respBody)
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "writing response")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 
 			return
 		}

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -462,6 +462,50 @@ func TestExternalProxy(t *testing.T) {
 	}
 }
 
+func TestExternalProxyForwarding(t *testing.T) {
+	// Create a new server for testing that returns a specific status and content type
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		_, _ = w.Write([]byte(`{"error": "not found"}`))
+	}))
+	defer proxyServer.Close()
+
+	proxyURL, err := url.Parse(proxyServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{proxyURL.String()},
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("proxy-to", proxyURL.String())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.Equal(t, `{"error": "not found"}`, rr.Body.String())
+}
+
 func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 	type test struct {
 		handler http.Handler


### PR DESCRIPTION
### Description
I noticed that the `/externalproxy` handler was not sending back the correct status codes and `Content-Type` from the external server. Because of this, the frontend was always getting a `200 OK` response, even if the external request had actually failed (like a 404 or 500 error). This was making it a bit confusing for the UI to show the right error message to the user.

### Changes made
- I have updated the code in `headlamp.go` so that it now forwards the actual status code using `w.WriteHeader`. 
- I also added a small logic to copy the `Content-Type` header from the external response so the browser knows exactly what kind of data it is receiving.

### Tests verified
- I have built the backend properly using `npm run backend:build` and it is working fine.
- I also ran the full tests with `npm run backend:test`. All the relevant tests have passed, so we are good to go.
