### PR TITLE
docs: frontend: resourceMap: Deduplicate merged graph elements

### DIFF
--- a/docs/development/plugins/functionality/extending-the-map.md
+++ b/docs/development/plugins/functionality/extending-the-map.md
@@ -9,6 +9,8 @@ Map view displays cluster resource on a graph. Plugins can extend this graph by 
 
 **Node** represents a Kubernetes resource. **Edges** connect different **nodes**, for example ReplicaSet connects to Pods it owns.
 
+Node and edge IDs should be stable and unique. When multiple selected sources return the same node or edge ID, Headlamp renders the first graph element for that ID.
+
 <figure>
 
 ![Screenshot of a Map with one ReplicaSet node connected to three Pods it owns](./images/map-rs-and-pods.png)

--- a/frontend/src/components/resourceMap/graph/graphModel.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphModel.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getNodeWeight, GraphNode } from './graphModel';
+import { deduplicateGraphElements, getNodeWeight, GraphNode } from './graphModel';
 
 describe('getNodeWeight', () => {
   it('correctly assigns default weights to different Kubernetes resource types', () => {
@@ -56,5 +56,94 @@ describe('getNodeWeight', () => {
   it('uses default weight for nodes without kubeObject', () => {
     const node: GraphNode = { id: 'plain-node' };
     expect(getNodeWeight(node)).toBe(500);
+  });
+});
+
+describe('deduplicateGraphElements', () => {
+  it('keeps one node for each ID', () => {
+    const { nodes } = deduplicateGraphElements(
+      [
+        { id: 'pod-1', label: 'Pod 1' },
+        { id: 'pod-1', label: 'Duplicate Pod 1' },
+        { id: 'pod-2', label: 'Pod 2' },
+      ],
+      []
+    );
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes.map(node => node.id)).toEqual(['pod-1', 'pod-2']);
+  });
+
+  it('keeps the first node when duplicate node IDs exist', () => {
+    const Details = () => null;
+    const kubeObject = { kind: 'Pod' } as any;
+    const data = { queue: 'default' };
+
+    const { nodes } = deduplicateGraphElements(
+      [
+        {
+          id: 'pod-1',
+          label: 'Pod 1',
+          subtitle: 'Pod',
+          icon: 'first icon',
+          kubeObject,
+          detailsComponent: Details,
+          customResourceDefinition: 'pods.example.com',
+          data,
+          weight: 900,
+        },
+        {
+          id: 'pod-1',
+          label: 'Volcano Pod 1',
+          subtitle: 'Volcano Pod',
+          icon: 'second icon',
+          kubeObject: { kind: 'Pod', metadata: { name: 'second' } } as any,
+          data: { queue: 'other' },
+          weight: 1000,
+        },
+      ],
+      []
+    );
+
+    expect(nodes.length).toEqual(1);
+    expect(nodes[0]).toMatchObject({
+      id: 'pod-1',
+      label: 'Pod 1',
+      subtitle: 'Pod',
+      icon: 'first icon',
+      kubeObject,
+      detailsComponent: Details,
+      customResourceDefinition: 'pods.example.com',
+      data,
+      weight: 900,
+    });
+  });
+
+  it('keeps one edge for each ID', () => {
+    const { edges } = deduplicateGraphElements(
+      [],
+      [
+        { id: 'pod-1-owner-1', source: 'pod-1', target: 'owner-1', label: 'first' },
+        { id: 'pod-1-owner-1', source: 'pod-1', target: 'owner-1', label: 'second' },
+        { id: 'pod-2-owner-1', source: 'pod-2', target: 'owner-1' },
+      ]
+    );
+
+    expect(edges).toEqual([
+      { id: 'pod-1-owner-1', source: 'pod-1', target: 'owner-1', label: 'first' },
+      { id: 'pod-2-owner-1', source: 'pod-2', target: 'owner-1' },
+    ]);
+  });
+
+  it('keeps distinct edges with the same source and target', () => {
+    const { edges } = deduplicateGraphElements(
+      [],
+      [
+        { id: 'owner-1-pod-1-owns', source: 'owner-1', target: 'pod-1' },
+        { id: 'owner-1-pod-1-schedules', source: 'owner-1', target: 'pod-1' },
+      ]
+    );
+
+    expect(edges).toHaveLength(2);
   });
 });

--- a/frontend/src/components/resourceMap/graph/graphModel.tsx
+++ b/frontend/src/components/resourceMap/graph/graphModel.tsx
@@ -85,6 +85,58 @@ export interface GraphEdge {
 }
 
 /**
+ * Deduplicates graph nodes and edges by ID.
+ *
+ * When duplicate nodes or edges are found, the first graph element is preserved.
+ *
+ * @param nodes - list of graph Nodes
+ * @param edges - list of graph Edges
+ * @returns graph elements with unique node and edge IDs
+ */
+export function deduplicateGraphElements(nodes: GraphNode[], edges: GraphEdge[]) {
+  return {
+    nodes: deduplicateGraphNodes(nodes),
+    edges: deduplicateGraphEdges(edges),
+  };
+}
+
+/**
+ * Deduplicates graph nodes by ID, preserving the first node for each ID.
+ *
+ * @param nodes - list of graph Nodes
+ * @returns graph Nodes with unique IDs
+ */
+function deduplicateGraphNodes(nodes: GraphNode[]): GraphNode[] {
+  const nodesById = new Map<string, GraphNode>();
+
+  nodes.forEach(node => {
+    if (!nodesById.has(node.id)) {
+      nodesById.set(node.id, node);
+    }
+  });
+
+  return Array.from(nodesById.values());
+}
+
+/**
+ * Deduplicates graph edges by ID, preserving the first edge for each ID.
+ *
+ * @param edges - list of graph Edges
+ * @returns graph Edges with unique IDs
+ */
+export function deduplicateGraphEdges(edges: GraphEdge[]): GraphEdge[] {
+  const edgesById = new Map<string, GraphEdge>();
+
+  edges.forEach(edge => {
+    if (!edgesById.has(edge.id)) {
+      edgesById.set(edge.id, edge);
+    }
+  });
+
+  return Array.from(edgesById.values());
+}
+
+/**
  * Graph Source defines a group of Nodes and Edges
  * that can be loaded on the Map
  *

--- a/frontend/src/components/resourceMap/sources/GraphSources.tsx
+++ b/frontend/src/components/resourceMap/sources/GraphSources.tsx
@@ -26,7 +26,14 @@ import {
   useState,
 } from 'react';
 import { KubeObject } from '../../../lib/k8s/cluster';
-import { GraphEdge, GraphNode, GraphSource, Relation } from '../graph/graphModel';
+import {
+  deduplicateGraphEdges,
+  deduplicateGraphElements,
+  GraphEdge,
+  GraphNode,
+  GraphSource,
+  Relation,
+} from '../graph/graphModel';
 
 /**
  * Map of nodes and edges where the key is source id
@@ -273,17 +280,27 @@ export function GraphSourceManager({ sources, children, relations }: GraphSource
       });
 
       const nodesPerSource = new Map<string, GraphNode[]>();
+      const selectedSourceIds = getFlatSources(sources)
+        .filter(source => selectedSources.has(source.id))
+        .map(source => source.id);
 
-      selectedSources.forEach(id => {
+      selectedSourceIds.forEach(id => {
         const data = sourceData.get(id);
+
+        const sourceGraph = deduplicateGraphElements(data?.nodes ?? [], data?.edges ?? []);
+
         if (data?.nodes) {
-          nodes = nodes.concat(data.nodes);
-          nodesPerSource.set(id, data.nodes);
+          nodes = nodes.concat(sourceGraph.nodes);
+          nodesPerSource.set(id, sourceGraph.nodes);
         }
         if (data?.edges) {
-          edges = edges.concat(data.edges);
+          edges = edges.concat(sourceGraph.edges);
         }
       });
+
+      const sourceGraph = deduplicateGraphElements(nodes, edges);
+      nodes = sourceGraph.nodes;
+      edges = sourceGraph.edges;
 
       // Create edges based on Relations
       enabledRelations.forEach(relation => {
@@ -309,7 +326,7 @@ export function GraphSourceManager({ sources, children, relations }: GraphSource
 
       return {
         nodes,
-        edges,
+        edges: deduplicateGraphEdges(edges),
         toggleSelection,
         setSelectedSources,
         selectedSources,


### PR DESCRIPTION
## Summary
Deduplicate resource map graph nodes and edges after selected sources and relations are merged.
## Related Issue
Fixes #5364
## Changes
- Added graph element deduplication by `GraphNode.id` and `GraphEdge.id`.
- Preserves the first graph element when duplicate IDs are returned by selected sources.
- Applies deduplication before filtering, grouping, lookup, layout, and rendering.
- Added tests for duplicate nodes, duplicate edges, and distinct edges with the same source/target.
- Documented duplicate ID behavior.
## Steps to Test
1. Open the resource map with overlapping sources enabled.
2. Verify duplicate node or edge IDs render as a single graph element.
## Screenshots (if applicable)
Before (pods enabled from the plugin source + Workloads -> Pods):
<img width="1524" height="598" alt="image" src="https://github.com/user-attachments/assets/93af9326-ec37-4b17-8a80-57ff12c3aad2" />
After (pods enabled from the plugin source + Workloads -> Pods):
<img width="1414" height="837" alt="image" src="https://github.com/user-attachments/assets/9ec8fb54-7a9d-42ff-bba6-5a52d2bfd3da" />
