### PR TITLE
frontend: AlertNotification: Fix interval leak on mount

### DIFF
--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -40,7 +40,7 @@ const ROUTES_WITHOUT_ALERT = ['login', 'token', 'settingsCluster'];
 export function PureAlertNotification({ checkerFunction }: PureAlertNotificationProps) {
   const [networkStatusCheckTimeFactor, setNetworkStatusCheckTimeFactor] = React.useState(0);
   const [error, setError] = React.useState<null | string | boolean>(null);
-  const [intervalID, setIntervalID] = React.useState<NodeJS.Timeout | null>(null);
+
   const { t } = useTranslation();
   const { pathname } = useLocation();
 
@@ -71,16 +71,6 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
     }, (networkStatusCheckTimeFactor + 1) * NETWORK_STATUS_CHECK_TIME);
   }
 
-  React.useEffect(
-    () => {
-      const id = registerSetInterval();
-      setIntervalID(id);
-      return () => clearInterval(id);
-    },
-    // eslint-disable-next-line
-    []
-  );
-
   // Make sure we do not show the alert notification if we are not on a cluster route.
   React.useEffect(() => {
     if (!getCluster()) {
@@ -90,11 +80,7 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
 
   React.useEffect(
     () => {
-      if (intervalID) {
-        clearInterval(intervalID);
-      }
       const id = registerSetInterval();
-      setIntervalID(id);
       return () => clearInterval(id);
     },
     // eslint-disable-next-line


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `AlertNotification` component by preventing an orphaned `setInterval` from leaking on component mount, which was causing unnecessary double-polling of the cluster health check in the background.

## Related Issue

Fixes #5375

## Changes

- Fixed a silent memory and network resource leak by removing a redundant `useEffect` hook in `frontend/src/components/common/AlertNotification.tsx` that created a race condition with the interval loop.
- Refactored `AlertNotification` logic to remove the manual `clearInterval` call, instead relying entirely on React's native `useEffect` cleanup function.
- Removed the now-unused `intervalID` state entirely to clean up the code, which successfully satisfies linting constraints.

## Steps to Test

1. Launch Headlamp and navigate to any cluster view (e.g., the Cluster Overview page).
2. Open your browser's Developer Tools and switch to the **Network** tab.
3. Observe the network requests hitting the cluster health check endpoint.
4. Verify that the endpoint is only being polled exactly once every 5 seconds (5000ms), rather than twice concurrently. 

## Notes for the Reviewer

By removing the `intervalID` state alongside the redundant `useEffect`, the component state is much leaner and more idiomatic to React's lifecycle.
