### PR TITLE
frontend: TimeAgo: Fix stale closure on date change

### DIFF
--- a/frontend/src/components/common/Label.test.tsx
+++ b/frontend/src/components/common/Label.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { timeAgo } from '../../lib/util';
+import { TestContext } from '../../test';
+import { DateLabel } from './Label';
+
+vi.mock('../../lib/util', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../lib/util')>();
+
+  return {
+    ...actual,
+    timeAgo: vi.fn((date: string) => `time ago for ${date}`),
+  };
+});
+
+describe('DateLabel', () => {
+  it('updates the relative time when the date prop changes without remounting', () => {
+    const firstDate = '2026-05-08T10:00:00.000Z';
+    const secondDate = '2026-05-08T10:01:00.000Z';
+
+    const { rerender } = render(
+      <TestContext>
+        <DateLabel date={firstDate} />
+      </TestContext>
+    );
+
+    expect(screen.getByText(`time ago for ${firstDate}`)).toBeInTheDocument();
+
+    rerender(
+      <TestContext>
+        <DateLabel date={secondDate} />
+      </TestContext>
+    );
+
+    expect(screen.getByText(`time ago for ${secondDate}`)).toBeInTheDocument();
+    expect(screen.queryByText(`time ago for ${firstDate}`)).not.toBeInTheDocument();
+    expect(timeAgo).toHaveBeenLastCalledWith(secondDate, { format: 'brief' });
+  });
+});

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -256,17 +256,15 @@ export function DateLabel(props: DateLabelProps) {
  * Automatically refreshes
  */
 function TimeAgo({ date, format }: { date: number | string | Date; format?: DateFormatOptions }) {
-  const [formattedDate, setFormattedDate] = useState<string>(() => timeAgo(date, { format }));
+  const [, setTick] = useState(0);
 
   useEffect(() => {
     const id = setInterval(() => {
-      const newFormattedDate = timeAgo(date, { format });
-      setFormattedDate(newFormattedDate);
+      setTick(t => t + 1);
     }, 1_000);
 
     return () => clearInterval(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return formattedDate;
+  return timeAgo(date, { format }) as unknown as JSX.Element;
 }

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -255,7 +255,7 @@ export function DateLabel(props: DateLabelProps) {
  * Shows time passed since given date
  * Automatically refreshes
  */
-function TimeAgo({ date, format }: { date: number | string | Date; format?: DateFormatOptions }) {
+function TimeAgo({ date, format }: Pick<DateLabelProps, 'date' | 'format'>): React.ReactNode {
   const [, setTick] = useState(0);
 
   useEffect(() => {
@@ -266,5 +266,5 @@ function TimeAgo({ date, format }: { date: number | string | Date; format?: Date
     return () => clearInterval(id);
   }, []);
 
-  return timeAgo(date, { format }) as unknown as JSX.Element;
+  return timeAgo(date, { format });
 }


### PR DESCRIPTION
## Summary

This PR fixes a stale closure bug in the `TimeAgo` component by removing the interval callback's dependency on captured `date` and `format` values. The interval now only triggers a re-render tick, while the displayed relative time is calculated during render from the latest props.

## Related Issue

Fixes #5376

## Changes

- Fixed a stale closure bug in `frontend/src/components/common/Label.tsx` within the `TimeAgo` component where the interval loop could ignore new `date` or `format` props.
- Changed the interval callback to update a tick counter instead of storing a formatted date derived from stale closure values.
- Kept the effect dependency array empty because the effect only manages the timer lifecycle and does not read `date` or `format`.
- Removed the unsafe `as unknown as JSX.Element` assertion and explicitly typed `TimeAgo` as returning `React.ReactNode`, allowing the `timeAgo(...)` string to be returned directly.

## Steps to Test

1. Navigate to a page in the Headlamp UI that utilizes the `DateLabel` or `TimeAgo` component (e.g., a table with creation timestamps).
2. Trigger an update that changes the date of an existing item in the table without completely remounting the row (or test via an explicit state update in a parent component).
3. Observe that the displayed relative time correctly jumps to the time relative to the *new* date immediately, and the 1-second interval ticking continues properly.

## Notes for the Reviewer

- The ESLint rule bypass (`// eslint-disable-next-line react-hooks/exhaustive-deps`) was removed as it is no longer necessary.
- `TimeAgo` intentionally keeps the timer effect independent from `date` and `format`; prop changes naturally re-render the component and the next displayed value is computed from the latest props.
