### PR TITLE
backend: Bump go version to 1.25.9

### DIFF
--- a/.github/workflows/build-other-arch.yml
+++ b/.github/workflows/build-other-arch.yml
@@ -59,7 +59,7 @@ jobs:
             -e GOPROXY=off \
             -e GONOSUMDB='*' \
             -w /backend \
-            golang:1.25.8@sha256:bd1e2df4e6259b2bd5b1de0e6b22ca414502cd6e7276a5dd5dd414b65063be58 \
+            golang:1.25.9@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 \
             sh -c "go build ./... && go test ./..."
       - name: Build ${{ matrix.arch }} container image
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ default_agent: "@dev-agent"
 >
 > **Build/Config files:**
 > - `/package.json` - Root package with all npm scripts and Node.js version (>=20.11.1)
-> - `/backend/go.mod` - Go version (1.25.8)
+> - `/backend/go.mod` - Go version (1.25.9)
 > - `/CONTRIBUTING.md` - Contributing guidelines
 > - `/OWNERS` - Code reviewers and approvers
 
@@ -74,7 +74,7 @@ should NOT unless explicitly requested or strictly necessary for the change
 - **Runtimes/tools:**
   - Node.js >=20.11.1 (specified in `/package.json` engines field)
   - npm >=10.0.0 (specified in `/package.json` engines field)
-  - Go 1.25.8 (specified in `/backend/go.mod`)
+  - Go 1.25.9 (specified in `/backend/go.mod`)
 - **Reproduce locally:** Use commands from `/package.json` scripts section and documentation files listed above.
 
 ---
@@ -377,7 +377,7 @@ Reference sources:
 **Version Information:**
 - Node.js: >=20.11.1 (from `/package.json`)
 - npm: >=10.0.0 (from `/package.json`)
-- Go: 1.25.8 (from `/backend/go.mod`)
+- Go: 1.25.9 (from `/backend/go.mod`)
 
 **Key Command Sources:**
 - Build/test commands: `/package.json`

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG IMAGE_BASE=alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 FROM ${IMAGE_BASE} AS image-base
 
-FROM --platform=${BUILDPLATFORM} golang:1.25.8@sha256:f55a6ec7f24aedc1ed66e2641fdc52de01f2d24d6e49d1fa38582c07dd5f601d AS backend-build
+FROM --platform=${BUILDPLATFORM} golang:1.25.9@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 AS backend-build
 
 WORKDIR /headlamp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     cd ./backend && go build -o ./headlamp-server ./cmd/
 
-FROM --platform=${BUILDPLATFORM} node:22@sha256:f90672bf4c76dfc077d17be4c115b1ae7731d2e8558b457d86bca42aeb193866 AS frontend-build
+FROM --platform=${BUILDPLATFORM} node:22@sha256:9059d9d7db987b86299e052ff6630cd95e5a770336967c21110e53289a877433 AS frontend-build
 
 # We need .git and app/ in order to get the version and git version for the frontend/.env file
 # that's generated when building the frontend.

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,5 +1,5 @@
 # Build the plugin
-FROM node:22@sha256:f90672bf4c76dfc077d17be4c115b1ae7731d2e8558b457d86bca42aeb193866 as builder
+FROM node:22@sha256:9059d9d7db987b86299e052ff6630cd95e5a770336967c21110e53289a877433 as builder
 
 # Set the working directory
 WORKDIR /headlamp-plugins

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/headlamp/backend
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
The stdlib contains a couple of CVEs and those are fixed in go version 1.25.9 so updated the go version. Other dep update suggestions from Artifacthub is already fixed in main

<img width="1610" height="97" alt="image" src="https://github.com/user-attachments/assets/bfce0a42-c3c1-4891-bd6a-f23cd413c102" />
