### PR TITLE
backend: auth: Clone DefaultTransport instead of bare http.Transport

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -679,9 +679,25 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		cluster := r.URL.Query().Get("cluster")
 
 		if config.Insecure {
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			baseTransport, ok := http.DefaultTransport.(*http.Transport)
+			if !ok {
+				err := errors.New("http.DefaultTransport is not an *http.Transport")
+				logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+					err, "failed to configure insecure oidc client transport")
+				http.Error(w, "Failed to configure oidc transport", http.StatusInternalServerError)
+
+				return
 			}
+
+			tr := baseTransport.Clone()
+
+			tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+			if baseTransport.TLSClientConfig != nil {
+				tlsCfg = baseTransport.TLSClientConfig.Clone()
+				tlsCfg.InsecureSkipVerify = true
+			}
+
+			tr.TLSClientConfig = tlsCfg
 			InsecureClient := &http.Client{Transport: tr}
 			ctx = oidc.ClientContext(ctx, InsecureClient)
 		}

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -213,31 +213,56 @@ func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 // re-enabling verification while trusting the supplied certificate bundle.
 func ConfigureTLSContext(ctx context.Context, skipTLSVerify *bool, caCert *string) context.Context {
 	if skipTLSVerify != nil && *skipTLSVerify {
-		tlsSkipTransport := &http.Transport{
-			// the gosec linter is disabled here because we are explicitly requesting to skip TLS verification.
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		base, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			logger.Log(logger.LevelError, nil,
+				errors.New("http.DefaultTransport is not *http.Transport"),
+				"failed to configure TLS transport")
+
+			return ctx
 		}
+
+		tlsSkipTransport := base.Clone()
+
+		tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+		if base.TLSClientConfig != nil {
+			tlsCfg = base.TLSClientConfig.Clone()
+			tlsCfg.InsecureSkipVerify = true
+		}
+
+		tlsSkipTransport.TLSClientConfig = tlsCfg
 		ctx = oidc.ClientContext(ctx, &http.Client{Transport: tlsSkipTransport})
 	}
 
 	if caCert != nil {
 		caCertPool := x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM([]byte(*caCert)) {
-			// Log error but continue with original context
 			logger.Log(logger.LevelError, nil,
 				errors.New("failed to append ca cert to pool"), "couldn't add custom cert to context")
 
 			return ctx
 		}
 
-		// the gosec linter is disabled because gosec promotes using a minVersion of TLS 1.2 or higher.
-		// since we are using a custom CA cert configured by the user, we are not forcing a minVersion.
-		customTransport := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: caCertPool,
-			},
+		base, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			logger.Log(logger.LevelError, nil,
+				errors.New("http.DefaultTransport is not *http.Transport"),
+				"failed to configure TLS transport")
+
+			return ctx
 		}
 
+		customTransport := base.Clone()
+
+		tlsCfg := &tls.Config{RootCAs: caCertPool}
+		if base.TLSClientConfig != nil {
+			tlsCfg = base.TLSClientConfig.Clone()
+			tlsCfg.RootCAs = caCertPool
+		}
+
+		tlsCfg.InsecureSkipVerify = false
+
+		customTransport.TLSClientConfig = tlsCfg
 		ctx = oidc.ClientContext(ctx, &http.Client{Transport: customTransport})
 	}
 

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -857,6 +857,51 @@ func TestConfigureTLSContext_CACert(t *testing.T) {
 	assert.True(t, caCertParsed.IsCA, "Generated certificate should be a CA certificate")
 }
 
+// TestConfigureTLSContext_SkipTLS_PreservesDefaults verifies that cloning
+// http.DefaultTransport preserves proxy and timeout settings.
+func TestConfigureTLSContext_SkipTLS_PreservesDefaults(t *testing.T) {
+	skipTLSVerify := true
+	resultCtx := auth.ConfigureTLSContext(context.Background(), &skipTLSVerify, nil)
+
+	client, ok := resultCtx.Value(oauth2.HTTPClient).(*http.Client)
+	require.True(t, ok, "context should contain an *http.Client")
+
+	tr, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "transport should be *http.Transport")
+
+	defaultTr, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok, "http.DefaultTransport should be *http.Transport")
+
+	assert.NotNil(t, tr.Proxy, "transport.Proxy should be preserved from DefaultTransport")
+	assert.Equal(t, defaultTr.TLSHandshakeTimeout, tr.TLSHandshakeTimeout, "TLSHandshakeTimeout should be preserved")
+	assert.Equal(t, defaultTr.IdleConnTimeout, tr.IdleConnTimeout, "IdleConnTimeout should be preserved")
+	assert.True(t, tr.TLSClientConfig.InsecureSkipVerify, "InsecureSkipVerify should be true")
+}
+
+// TestConfigureTLSContext_CACert_PreservesDefaults verifies the caCert branch
+// also preserves default transport settings.
+func TestConfigureTLSContext_CACert_PreservesDefaults(t *testing.T) {
+	caCertBytes, err := os.ReadFile("../../cmd/headlamp_testdata/ca.crt")
+	require.NoError(t, err)
+
+	caCert := string(caCertBytes)
+	resultCtx := auth.ConfigureTLSContext(context.Background(), nil, &caCert)
+
+	client, ok := resultCtx.Value(oauth2.HTTPClient).(*http.Client)
+	require.True(t, ok, "context should contain an *http.Client")
+
+	tr, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "transport should be *http.Transport")
+
+	defaultTr, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok, "http.DefaultTransport should be *http.Transport")
+
+	assert.NotNil(t, tr.Proxy, "transport.Proxy should be preserved from DefaultTransport")
+	assert.Equal(t, defaultTr.TLSHandshakeTimeout, tr.TLSHandshakeTimeout, "TLSHandshakeTimeout should be preserved")
+	assert.Equal(t, defaultTr.IdleConnTimeout, tr.IdleConnTimeout, "IdleConnTimeout should be preserved")
+	assert.NotNil(t, tr.TLSClientConfig.RootCAs, "RootCAs should be set")
+}
+
 func makeTestToken(t *testing.T, claims map[string]interface{}) string {
 	// helper to build unsigned JWT-like string for tests
 	header := map[string]string{"alg": "none", "typ": "JWT"}


### PR DESCRIPTION
Fixes #5405
Refs #5218

## Summary

Three backend locations create `&http.Transport{}` from scratch solely to customize TLS (skip verification or inject a custom CA). This silently discards important defaults set by `http.DefaultTransport` — proxy support, dial timeouts, TLS handshake timeouts.

Fix: use `http.DefaultTransport.(*http.Transport).Clone()` and override only `TLSClientConfig`.

## Changes

- `backend/pkg/auth/auth.go` — `ConfigureTLSContext`: both the `skipTLSVerify` and `caCert` branches now clone `DefaultTransport`
- `backend/cmd/headlamp.go` — `/oidc` handler `config.Insecure` branch now clones `DefaultTransport`
- `backend/pkg/auth/auth_test.go` — added `TestConfigureTLSContext_SkipTLS_PreservesDefaults` and `TestConfigureTLSContext_CACert_PreservesDefaults` to verify proxy, timeouts, and TLS config are all preserved after cloning

## Steps to Test

1. `cd backend && go test ./... -count=1` — all tests pass
2. The two new tests specifically verify:
   - `transport.Proxy` is non-nil (would be `nil` with bare `&http.Transport{}`)
   - `TLSHandshakeTimeout` and `IdleConnTimeout` are non-zero
   - TLS customization (`InsecureSkipVerify` / `RootCAs`) is still applied

## Notes for the Reviewer

- The removed gosec comment on the `caCert` branch (`gosec promotes using a minVersion of TLS 1.2...`) was explaining why no `MinVersion` was set on the bare struct. With `Clone()`, the default TLS behavior is inherited and `InsecureSkipVerify` isn't set in that branch, so the comment no longer applies.
- No functional changes to the `/oidc` handler logic or `ConfigureTLSContext` contract — only how the transport is constructed.