### PR TITLE
build: bump local golangci-lint installer to v2.11.3 to match CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "backend:build": "cd backend && go build -o ./headlamp-server ./cmd",
     "backend:lint": "npm run backend:install:linter && cd backend && ./tools/golangci-lint run",
     "backend:lint:fix": "npm run backend:install:linter && cd backend && ./tools/golangci-lint run --fix",
-    "backend:install:linter": "GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64",
+    "backend:install:linter": "GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3",
     "backend:test": "cd backend && go test -v -p 1 ./...",
     "backend:fuzz": "cd backend && go test -fuzz=. -fuzztime=30s ./pkg/auth/",
     "backend:coverage": "cd backend && go test -v -p 1 -coverprofile=coverage.out ./... && go tool cover -func=coverage.out",


### PR DESCRIPTION
## Summary

`npm run backend:lint` is currently broken on local machines that respect `backend/go.mod`'s toolchain pin. This one-line change in `package.json` aligns the local installer with what CI uses.

## The bug

`package.json:30` installs golangci-lint **v1.64** via:

```
GOBIN=\`pwd\`/backend/tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64
```

But:

- **CI uses v2.11.3** (`.github/workflows/backend-test.yml`'s `golangci-lint-action` step pins `version: v2.11.3`).
- `backend/.golangci.yml` is in **v2 schema** — line 1 is `version: "2"`. v1.64 cannot parse it.
- v1.64 was built against **Go 1.24** and refuses to lint modules declaring `go 1.25.x` in `go.mod`. `backend/go.mod` declares `go 1.25.9`.

So locally:

```
$ npm run backend:lint
Error: can't load config: the Go language version (go1.24) used to build golangci-lint
is lower than the targeted Go version (1.25.9)
```

CI works because the workflow ignores the npm script and pins its own version.

## The fix

Update `package.json` to install v2.11.3 (matching CI) with the v2 module path:

```diff
-"backend:install:linter": "GOBIN=\`pwd\`/backend/tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64",
+"backend:install:linter": "GOBIN=\`pwd\`/backend/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3",
```

v2.11.3 requires Go ≥ 1.25, which matches `backend/go.mod`'s declaration. Go's toolchain auto-switch handles older host installations transparently — verified locally on a host running 1.24.11 where `go install` auto-fetched 1.25.9 to satisfy the requirement.

## Verification

```
$ rm backend/tools/golangci-lint
$ npm run backend:lint
> GOBIN=\`pwd\`/backend/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
go: github.com/golangci/golangci-lint/v2@v2.11.3 requires go >= 1.25.0; switching to go1.25.9
0 issues.
```

## Why this is its own PR

Found while preparing #5420 (OIDC characterization tests). That PR depends on local lint working, but the lint fix is genuinely orthogonal to the test additions, so it's its own one-line change here. Reviewers can ack independently.