### PR TITLE
frontend: configSlice: handle invalid localStorage settings JSON on startup

### DIFF
--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -44,6 +44,7 @@ const makeStore = () => {
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',
+          sidebarSortAlphabetically: false,
           useEvict: true,
         },
         isDynamicClusterEnabled: false,

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -45,6 +45,7 @@ const makeStore = () => {
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',
+          sidebarSortAlphabetically: false,
           useEvict: true,
         },
       },

--- a/frontend/src/redux/configSlice.storage.test.ts
+++ b/frontend/src/redux/configSlice.storage.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('configSlice storage initialization', () => {
+  async function expectDefaultSettings() {
+    const { initialState, defaultTableRowsPerPageOptions } = await import('./configSlice');
+
+    expect(initialState.settings.tableRowsPerPageOptions).toEqual(defaultTableRowsPerPageOptions);
+    expect(initialState.settings.timezone).toBe('UTC');
+    expect(initialState.settings.sidebarSortAlphabetically).toBe(false);
+    expect(initialState.settings.useEvict).toBe(true);
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it('falls back to defaults when localStorage settings is invalid JSON', async () => {
+    localStorage.setItem('settings', '{ invalid json [');
+
+    await expectDefaultSettings();
+  });
+
+  it.each([
+    ['null', 'null'],
+    ['string', '"hello"'],
+    ['number', '123'],
+    ['array', '[1,2,3]'],
+  ])(
+    'falls back to defaults when localStorage settings parses as %s',
+    async (_type, settingsValue) => {
+      localStorage.setItem('settings', settingsValue);
+
+      await expectDefaultSettings();
+    }
+  );
+
+  it('sanitizes object settings and keeps only known, valid keys', async () => {
+    localStorage.setItem(
+      'settings',
+      JSON.stringify({
+        tableRowsPerPageOptions: 'abc',
+        timezone: 123,
+        sidebarSortAlphabetically: 'nope',
+        useEvict: 'yes',
+        unknownKey: 'unknown',
+      })
+    );
+
+    await expectDefaultSettings();
+    const { initialState } = await import('./configSlice');
+    expect(initialState.settings.unknownKey).toBeUndefined();
+  });
+
+  it('uses valid typed settings from storage', async () => {
+    localStorage.setItem(
+      'settings',
+      JSON.stringify({
+        tableRowsPerPageOptions: [10, 20, 30],
+        timezone: 'Asia/Kolkata',
+        sidebarSortAlphabetically: true,
+        useEvict: false,
+      })
+    );
+
+    const { initialState } = await import('./configSlice');
+
+    expect(initialState.settings.tableRowsPerPageOptions).toEqual([10, 20, 30]);
+    expect(initialState.settings.timezone).toBe('Asia/Kolkata');
+    expect(initialState.settings.sidebarSortAlphabetically).toBe(true);
+    expect(initialState.settings.useEvict).toBe(false);
+  });
+
+  it('falls back to default timezone when stored timezone is an invalid IANA string', async () => {
+    localStorage.setItem(
+      'settings',
+      JSON.stringify({
+        timezone: 'Not/A_Real_Time_Zone',
+      })
+    );
+
+    const { initialState } = await import('./configSlice');
+
+    expect(initialState.settings.timezone).toBe('UTC');
+  });
+});

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -65,6 +65,7 @@ export interface ConfigState {
      * timezone is the timezone to use for displaying dates and times.
      */
     timezone: string;
+    sidebarSortAlphabetically: boolean;
     useEvict: boolean;
     [key: string]: any;
   };
@@ -76,7 +77,67 @@ function defaultTimezone() {
   return import.meta.env.UNDER_TEST ? 'UTC' : Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
-const storedSettings = JSON.parse(localStorage.getItem('settings') || '{}');
+function isNumberArray(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(item => Number.isInteger(item) && item > 0)
+  );
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return typeof value === 'boolean';
+}
+
+function isValidTimeZone(value: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: value });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function loadStoredSettings(): Partial<ConfigState['settings']> {
+  try {
+    const rawSettings = localStorage.getItem('settings');
+    if (!rawSettings) {
+      return {};
+    }
+
+    const parsed: unknown = JSON.parse(rawSettings);
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const parsedSettings = parsed as Record<string, unknown>;
+    const sanitizedSettings: Partial<ConfigState['settings']> = {};
+
+    if (isNumberArray(parsedSettings.tableRowsPerPageOptions)) {
+      sanitizedSettings.tableRowsPerPageOptions = parsedSettings.tableRowsPerPageOptions;
+    }
+    if (isString(parsedSettings.timezone) && isValidTimeZone(parsedSettings.timezone)) {
+      sanitizedSettings.timezone = parsedSettings.timezone;
+    }
+    if (isBoolean(parsedSettings.sidebarSortAlphabetically)) {
+      sanitizedSettings.sidebarSortAlphabetically = parsedSettings.sidebarSortAlphabetically;
+    }
+    if (isBoolean(parsedSettings.useEvict)) {
+      sanitizedSettings.useEvict = parsedSettings.useEvict;
+    }
+
+    return sanitizedSettings;
+  } catch {
+    return {};
+  }
+}
+
+const storedSettings = loadStoredSettings();
 
 export const initialState: ConfigState = {
   clusters: null,
@@ -86,9 +147,9 @@ export const initialState: ConfigState = {
   allowKubeconfigChanges: false,
   settings: {
     tableRowsPerPageOptions:
-      storedSettings.tableRowsPerPageOptions || defaultTableRowsPerPageOptions,
+      storedSettings.tableRowsPerPageOptions ?? defaultTableRowsPerPageOptions,
     timezone: storedSettings.timezone || defaultTimezone(),
-    sidebarSortAlphabetically: storedSettings.sidebarSortAlphabetically || false,
+    sidebarSortAlphabetically: storedSettings.sidebarSortAlphabetically ?? false,
     useEvict: storedSettings.useEvict ?? true,
   },
 };

--- a/frontend/src/redux/configState.ts
+++ b/frontend/src/redux/configState.ts
@@ -52,6 +52,7 @@ export interface ConfigState {
      * timezone is the timezone to use for displaying dates and times.
      */
     timezone: string;
+    sidebarSortAlphabetically: boolean;
     useEvict: boolean;
     [key: string]: any;
   };


### PR DESCRIPTION
## Summary
This PR fixes a frontend startup bug where malformed JSON in `localStorage` key `settings` could crash initialization and keep Headlamp stuck on loading. The settings load now safely falls back to defaults.

## Related Issue
Fixes #5399

## Changes
- Updated `frontend/src/redux/configSlice.ts`
- Replaced direct `JSON.parse(localStorage.getItem('settings') || '{}')` with a safe loader function.
- Added fallback behavior for invalid/malformed JSON and non-object parsed values.
- Updated `frontend/src/redux/configSlice.storage.test.ts`
- Changed regression test to verify startup does not throw with malformed `settings`.
- Added assertions that default settings are applied.

## Steps to Test
1. Start frontend in dev mode.
2. In browser DevTools console, run:
```js
localStorage.setItem('settings', '{ invalid json [');
location.reload();
```
3. Verify the app loads normally (no startup crash / stuck loading screen).
4. Run test:
```bash
cd frontend && npm test -- src/redux/configSlice.storage.test.ts
```
5. Verify test passes.

## Screenshots (if applicable)
N/A (no UI change)

## Notes for the Reviewer
- Change is intentionally minimal and scoped only to `settings` parsing during config slice initialization.
- No behavior changes for valid stored settings.
