### PR TITLE
backend, frontend: oidc: portable state, return-URL preservation, testAuth fix

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -866,6 +866,45 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	r.HandleFunc("/oidc", func(w http.ResponseWriter, r *http.Request) {
 		cluster := r.URL.Query().Get("cluster")
 
+		// mode controls how /oidc-callback redirects after a successful
+		// token exchange. "popup" preserves the legacy /auth?cluster=...
+		// contract; "fullPage" redirects directly to returnTo (or the
+		// cluster root if returnTo is absent). "desktop" is reserved for
+		// PR 2 of #5401 and is rejected here so its eventual semantics
+		// can't be silently established by abuse.
+		mode := r.URL.Query().Get("mode")
+		switch mode {
+		case "":
+			mode = "popup"
+		case "popup", "fullPage":
+			// ok
+		case "desktop":
+			http.Error(w,
+				"mode=desktop is reserved for the desktop OIDC code-handoff flow (PR 2 of #5401) "+
+					"and is not yet supported",
+				http.StatusBadRequest)
+
+			return
+		default:
+			http.Error(w, "invalid mode", http.StatusBadRequest)
+			return
+		}
+
+		var validatedReturnTo string
+
+		if rawReturnTo := r.URL.Query().Get("returnTo"); rawReturnTo != "" {
+			cleaned, vErr := auth.ValidateReturnTo(rawReturnTo, "")
+			if vErr != nil {
+				logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+					vErr, "rejected returnTo on /oidc")
+				http.Error(w, "invalid returnTo", http.StatusBadRequest)
+
+				return
+			}
+
+			validatedReturnTo = cleaned
+		}
+
 		flow, err := buildOIDCFlow(r.Context(), config, r, cluster)
 		if err != nil {
 			handleOIDCFlowError(w, r, cluster, err)
@@ -883,7 +922,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		payload := auth.StatePayload{
 			V:         auth.StateSchemaVersion,
 			Cluster:   cluster,
-			Mode:      "popup",
+			Mode:      mode,
+			ReturnTo:  validatedReturnTo,
 			ExpUnixMs: stateSigner.Now().Add(stateSigner.TTL()).UnixMilli(),
 			CSRF:      hex.EncodeToString(csrfBytes),
 		}
@@ -1029,7 +1069,45 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		// Set auth cookie
 		auth.SetTokenCookie(w, r, payload.Cluster, rawUserToken, config.BaseURL, config.SessionTTL)
 
-		redirectURL += fmt.Sprintf("auth?cluster=%1s", payload.Cluster)
+		// Re-validate returnTo at consumption time (defense in depth: even
+		// though the value was validated at /oidc and signed into the
+		// state, a future schema change or signing-key compromise should
+		// not be able to convert state into an arbitrary open redirect).
+		safeReturnTo := ""
+		if payload.ReturnTo != "" {
+			cleaned, vErr := auth.ValidateReturnTo(payload.ReturnTo, "")
+			if vErr == nil {
+				safeReturnTo = cleaned
+			} else {
+				logger.Log(logger.LevelError, map[string]string{"cluster": payload.Cluster},
+					vErr, "rejected returnTo on /oidc-callback (signed state had unsafe returnTo)")
+			}
+		}
+
+		switch payload.Mode {
+		case "fullPage":
+			// Skip /auth entirely. Redirect straight to returnTo, or to
+			// the cluster root if returnTo is absent or unsafe.
+			if safeReturnTo != "" {
+				redirectURL = safeReturnTo
+			} else {
+				redirectURL += fmt.Sprintf("c/%s/", payload.Cluster)
+			}
+		case "desktop":
+			// Belt-and-suspenders: /oidc rejects mode=desktop, but signed
+			// state could in principle carry it via a different code path.
+			http.Error(w, "mode=desktop is not yet supported", http.StatusBadRequest)
+			return
+		default:
+			// "popup" (and unset, treated as popup): preserve the existing
+			// /auth?cluster=... contract, optionally with returnTo so the
+			// /auth page can finish navigating after the popup-storage
+			// handshake.
+			redirectURL += fmt.Sprintf("auth?cluster=%s", payload.Cluster)
+			if safeReturnTo != "" {
+				redirectURL += "&returnTo=" + url.QueryEscape(safeReturnTo)
+			}
+		}
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	})

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,7 +38,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -101,14 +101,6 @@ type clientConfig struct {
 	Clusters                []Cluster `json:"clusters"`
 	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
 	AllowKubeconfigChanges  bool      `json:"allowKubeconfigChanges"`
-}
-
-type OauthConfig struct {
-	Config       *oauth2.Config
-	Verifier     *oidc.IDTokenVerifier
-	Ctx          context.Context
-	CodeVerifier string // PKCE code verifier
-	Cluster      string // cluster context name this is associated with
 }
 
 // returns True if a file exists.
@@ -391,7 +383,194 @@ func addPluginListRoute(config *HeadlampConfig, r *mux.Router) {
 	}).Methods("GET")
 }
 
+// oidcStateTTL is the lifetime of a signed state token. It bounds how long
+// a user has to complete the IdP round-trip before /oidc-callback rejects
+// the state as expired.
+//
 //nolint:gocognit,funlen,gocyclo
+const oidcStateTTL = 10 * time.Minute
+
+// oidcStateLRUSize bounds the number of consumed-state entries kept in
+// memory at once. Tokens older than this — by insertion order — can
+// reuse their CSRF; for typical login volume this is several orders of
+// magnitude above concurrent in-flight logins.
+const oidcStateLRUSize = 4096
+
+// minOIDCSigningKeyBytes is enforced both by NewStateSigner and at config
+// load time so that operators get a clear error before the server starts.
+const minOIDCSigningKeyBytes = 32
+
+// oidcFlow bundles the per-request OIDC plumbing needed by both /oidc and
+// /oidc-callback. Reconstructing it on the callback (rather than caching
+// it across requests) is what makes signed state portable across replicas.
+type oidcFlow struct {
+	OAuth2   *oauth2.Config
+	Verifier *oidc.IDTokenVerifier
+	Ctx      context.Context
+}
+
+// loadOIDCStateSigner constructs the StateSigner used by /oidc and
+// /oidc-callback.
+//
+// If config.OidcStateSigningKeyFile is set, the file is read, trailing
+// whitespace is trimmed, and the result is used as the HMAC key. The key
+// must be at least minOIDCSigningKeyBytes long; shorter keys produce a
+// startup error so misconfiguration is loud rather than silently degrading
+// to per-process random behavior.
+//
+// When the flag is unset, a 32-byte random key is generated. This works
+// for single-replica deployments but breaks multi-replica rollouts (the
+// kind of breakage characterized by #4019), so we emit one log line at
+// startup pointing operators at the flag.
+func loadOIDCStateSigner(config *HeadlampConfig) (*auth.StateSigner, error) {
+	if config.OidcStateSigningKeyFile != "" {
+		raw, err := os.ReadFile(config.OidcStateSigningKeyFile) //nolint:gosec
+		if err != nil {
+			return nil, fmt.Errorf("read oidc state signing key file: %w", err)
+		}
+
+		key := bytes.TrimRight(raw, " \t\r\n")
+		if len(key) < minOIDCSigningKeyBytes {
+			return nil, fmt.Errorf("oidc state signing key must be >= %d bytes (got %d)",
+				minOIDCSigningKeyBytes, len(key))
+		}
+
+		logger.Log(logger.LevelInfo, nil, nil,
+			"OIDC state signing key loaded from --oidc-state-signing-key-file")
+
+		return auth.NewStateSigner(key, oidcStateTTL, oidcStateLRUSize), nil
+	}
+
+	key := make([]byte, minOIDCSigningKeyBytes)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate oidc state signing key: %w", err)
+	}
+
+	logger.Log(logger.LevelInfo, nil, nil,
+		"OIDC state signing key generated per-process. For multi-replica "+
+			"deployments, set --oidc-state-signing-key-file=<path> with a shared key file.")
+
+	return auth.NewStateSigner(key, oidcStateTTL, oidcStateLRUSize), nil
+}
+
+// buildOIDCFlow constructs the per-request OIDC plumbing — the OAuth2
+// config, the ID-token verifier, and the request context with the right
+// TLS / issuer overrides applied.
+//
+// Both /oidc and /oidc-callback call this. Building it on the callback
+// (instead of caching the /oidc result in a per-process map) is what makes
+// signed state portable across replicas; the cluster name comes from the
+// signed state payload, so the callback can rebuild the same OAuth2 config
+// on any replica that has the same kubeconfig.
+func buildOIDCFlow(ctx context.Context, config *HeadlampConfig, r *http.Request,
+	cluster string,
+) (*oidcFlow, error) {
+	if config.Insecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+		insecureClient := &http.Client{Transport: tr}
+		ctx = oidc.ClientContext(ctx, insecureClient)
+	}
+
+	kContext, err := config.KubeConfigStore.GetContext(cluster)
+	if err != nil {
+		return nil, &oidcFlowError{kind: oidcFlowErrCluster, cluster: cluster, err: err}
+	}
+
+	oidcAuthConfig, err := kContext.OidcConfig()
+	if err != nil {
+		return nil, &oidcFlowError{kind: oidcFlowErrOIDCConfig, cluster: cluster, err: err}
+	}
+
+	ctx = auth.ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
+
+	if config.OidcValidatorIdpIssuerURL != "" {
+		ctx = oidc.InsecureIssuerURLContext(ctx, config.OidcValidatorIdpIssuerURL)
+	}
+
+	provider, err := oidc.NewProvider(ctx, oidcAuthConfig.IdpIssuerURL)
+	if err != nil {
+		return nil, &oidcFlowError{
+			kind: oidcFlowErrProvider, cluster: cluster, err: err,
+			extra: map[string]string{"idpIssuerURL": oidcAuthConfig.IdpIssuerURL},
+		}
+	}
+
+	validatorClientID := oidcAuthConfig.ClientID
+	if config.OidcValidatorClientID != "" {
+		validatorClientID = config.OidcValidatorClientID
+	}
+
+	verifier := provider.Verifier(&oidc.Config{ClientID: validatorClientID})
+	oauthConfig := &oauth2.Config{
+		ClientID:     oidcAuthConfig.ClientID,
+		ClientSecret: oidcAuthConfig.ClientSecret,
+		Endpoint:     provider.Endpoint(),
+		RedirectURL:  getOidcCallbackURL(r, config),
+		Scopes:       append([]string{oidc.ScopeOpenID}, oidcAuthConfig.Scopes...),
+	}
+
+	return &oidcFlow{OAuth2: oauthConfig, Verifier: verifier, Ctx: ctx}, nil
+}
+
+// oidcFlowErrKind classifies failures from buildOIDCFlow so callers can
+// translate them into the right HTTP status without re-doing the typing.
+type oidcFlowErrKind int
+
+const (
+	oidcFlowErrCluster oidcFlowErrKind = iota
+	oidcFlowErrOIDCConfig
+	oidcFlowErrProvider
+)
+
+type oidcFlowError struct {
+	kind    oidcFlowErrKind
+	cluster string
+	err     error
+	extra   map[string]string
+}
+
+func (e *oidcFlowError) Error() string { return e.err.Error() }
+func (e *oidcFlowError) Unwrap() error { return e.err }
+
+// handleOIDCFlowError preserves the existing HTTP contract from
+// /oidc and /oidc-callback for buildOIDCFlow failures: 404 on missing
+// cluster, 500 on OIDC config / provider failure. The wording matches
+// the pre-refactor handler so the public-facing error surface is
+// unchanged.
+func handleOIDCFlowError(w http.ResponseWriter, r *http.Request, cluster string, err error) {
+	var fe *oidcFlowError
+	if !errors.As(err, &fe) {
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster}, err, "OIDC flow error")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	switch fe.kind {
+	case oidcFlowErrCluster:
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+			fe.err, "failed to get context")
+		http.NotFound(w, r)
+	case oidcFlowErrOIDCConfig:
+		// Pre-refactor behavior: log "failed to get oidc config" only when
+		// in-cluster OIDC is configured; otherwise the error is expected
+		// for Service-Token-only contexts and would just be log noise.
+		// We can't easily access HeadlampConfig here without threading it,
+		// so we always log at debug-equivalent severity. The HTTP response
+		// is unchanged.
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+			fe.err, "failed to get oidc config")
+		http.Error(w, fe.err.Error(), http.StatusInternalServerError)
+	case oidcFlowErrProvider:
+		logger.Log(logger.LevelError, fe.extra, fe.err, "failed to get provider")
+		http.Error(w, fe.err.Error(), http.StatusInternalServerError)
+	default:
+		http.Error(w, fe.err.Error(), http.StatusInternalServerError)
+	}
+}
+
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
 
@@ -669,110 +848,65 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	config.addClusterSetupRoute(r)
 
-	var (
-		oauthRequestMap = make(map[string]*OauthConfig)
-		oauthMu         sync.Mutex
-	)
+	// stateSigner signs and verifies the OAuth2 state parameter for the
+	// OIDC handlers. A single signer is shared by /oidc and /oidc-callback
+	// in the same process. Operators that run multiple replicas must point
+	// every replica at the same signing key via
+	// --oidc-state-signing-key-file; otherwise a callback that lands on a
+	// different replica than the one that issued the state will be
+	// rejected (see #4019).
+	stateSigner, err := loadOIDCStateSigner(config)
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "loading OIDC state signing key")
+		// We deliberately do not fall back silently; a misconfigured key
+		// file is an operator error that should be loud.
+		panic(fmt.Sprintf("failed to load OIDC state signing key: %v", err))
+	}
 
 	r.HandleFunc("/oidc", func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.Background()
 		cluster := r.URL.Query().Get("cluster")
 
-		if config.Insecure {
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			}
-			InsecureClient := &http.Client{Transport: tr}
-			ctx = oidc.ClientContext(ctx, InsecureClient)
+		flow, err := buildOIDCFlow(r.Context(), config, r, cluster)
+		if err != nil {
+			handleOIDCFlowError(w, r, cluster, err)
+			return
 		}
 
-		kContext, err := config.KubeConfigStore.GetContext(cluster)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
-				err, "failed to get context")
-
-			http.NotFound(w, r)
+		csrfBytes := make([]byte, 16)
+		if _, err := rand.Read(csrfBytes); err != nil {
+			logger.Log(logger.LevelError, nil, err, "generating CSRF for OIDC state")
+			http.Error(w, "internal error", http.StatusInternalServerError)
 
 			return
 		}
 
-		oidcAuthConfig, err := kContext.OidcConfig()
-		if err != nil {
-			// Avoid the noise in the pod log while accessing Headlamp using Service Token
-			if config.OidcIdpIssuerURL != "" {
-				logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
-					err, "failed to get oidc config")
-			}
-
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-
-			return
-		}
-
-		ctx = auth.ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
-
-		if config.OidcValidatorIdpIssuerURL != "" {
-			ctx = oidc.InsecureIssuerURLContext(ctx, config.OidcValidatorIdpIssuerURL)
-		}
-
-		provider, err := oidc.NewProvider(ctx, oidcAuthConfig.IdpIssuerURL)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"idpIssuerURL": oidcAuthConfig.IdpIssuerURL},
-				err, "failed to get provider")
-
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-
-			return
-		}
-
-		validatorClientID := oidcAuthConfig.ClientID
-		if config.OidcValidatorClientID != "" {
-			validatorClientID = config.OidcValidatorClientID
-		}
-
-		oidcConfig := &oidc.Config{
-			ClientID: validatorClientID,
-		}
-
-		verifier := provider.Verifier(oidcConfig)
-		oauthConfig := &oauth2.Config{
-			ClientID:     oidcAuthConfig.ClientID,
-			ClientSecret: oidcAuthConfig.ClientSecret,
-			Endpoint:     provider.Endpoint(),
-			RedirectURL:  getOidcCallbackURL(r, config),
-			Scopes:       append([]string{oidc.ScopeOpenID}, oidcAuthConfig.Scopes...),
-		}
-
-		// state should be unique per request, cryptographically secure random, url safe
-		state := func() string {
-			b := make([]byte, 32)
-			if _, err := rand.Read(b); err != nil {
-				panic(err)
-			}
-
-			return base64.RawURLEncoding.EncodeToString(b)
-		}()
-
-		entry := &OauthConfig{
-			Config:   oauthConfig,
-			Verifier: verifier,
-			Ctx:      ctx,
-			Cluster:  cluster,
+		payload := auth.StatePayload{
+			V:         auth.StateSchemaVersion,
+			Cluster:   cluster,
+			Mode:      "popup",
+			ExpUnixMs: stateSigner.Now().Add(stateSigner.TTL()).UnixMilli(),
+			CSRF:      hex.EncodeToString(csrfBytes),
 		}
 
 		var authURL string
 
 		if config.OidcUsePKCE {
-			entry.CodeVerifier = oauth2.GenerateVerifier()
-			authURL = oauthConfig.AuthCodeURL(state, oauth2.S256ChallengeOption(entry.CodeVerifier))
-		} else {
-			authURL = oauthConfig.AuthCodeURL(state)
+			payload.CodeVerifier = oauth2.GenerateVerifier()
 		}
 
-		// Store the request config keyed by state for callback handling
-		oauthMu.Lock()
-		oauthRequestMap[state] = entry
-		oauthMu.Unlock()
+		state, err := stateSigner.Encode(payload)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "encoding OIDC state")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		if config.OidcUsePKCE {
+			authURL = flow.OAuth2.AuthCodeURL(state, oauth2.S256ChallengeOption(payload.CodeVerifier))
+		} else {
+			authURL = flow.OAuth2.AuthCodeURL(state)
+		}
 
 		http.Redirect(w, r, authURL, http.StatusFound)
 	}).Queries("cluster", "{cluster}")
@@ -785,43 +919,49 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		state := r.URL.Query().Get("state")
 
 		if state == "" {
-			logger.Log(logger.LevelError, nil, err, "invalid request state is empty")
+			logger.Log(logger.LevelError, nil, nil, "invalid request state is empty")
 			http.Error(w, "invalid request state is empty", http.StatusBadRequest)
 
 			return
 		}
 
-		oauthMu.Lock()
+		payload, err := stateSigner.Decode(state)
+		if err != nil {
+			// Any decode failure (bad signature, malformed, expired, bad
+			// version, oversize) collapses to "invalid request" so we
+			// don't leak details to anonymous callers.
+			logger.Log(logger.LevelError, nil, err, "decoding OIDC state")
+			http.Error(w, "invalid request", http.StatusBadRequest)
 
-		oauthConfig, ok := oauthRequestMap[state]
-		if ok {
-			// We have a copy of the oauthConfig, we can delete the map entry now
-			delete(oauthRequestMap, state)
+			return
 		}
 
-		oauthMu.Unlock()
-
-		if !ok {
+		if !stateSigner.MarkConsumed(payload.CSRF) {
+			// State has already been used. Same wording as the unknown-
+			// state path so callers can't infer whether a state was
+			// previously valid.
 			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		flow, err := buildOIDCFlow(r.Context(), config, r, payload.Cluster)
+		if err != nil {
+			handleOIDCFlowError(w, r, payload.Cluster, err)
 			return
 		}
 
 		var oauth2Token *oauth2.Token
 
-		var err error
-
 		// Exchange authorization code for token, with or without PKCE
-		if config.OidcUsePKCE && oauthConfig.CodeVerifier != "" {
-			// Use PKCE code verifier for token exchange
-			oauth2Token, err = oauthConfig.Config.Exchange(
-				oauthConfig.Ctx,
+		if config.OidcUsePKCE && payload.CodeVerifier != "" {
+			oauth2Token, err = flow.OAuth2.Exchange(
+				flow.Ctx,
 				r.URL.Query().Get("code"),
-				oauth2.SetAuthURLParam("code_verifier", oauthConfig.CodeVerifier),
+				oauth2.SetAuthURLParam("code_verifier", payload.CodeVerifier),
 			)
 		} else {
-			// Standard token exchange without PKCE
-			oauth2Token, err = oauthConfig.Config.Exchange(
-				oauthConfig.Ctx,
+			oauth2Token, err = flow.OAuth2.Exchange(
+				flow.Ctx,
 				r.URL.Query().Get("code"),
 			)
 		}
@@ -840,7 +980,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		rawUserToken, ok := oauth2Token.Extra(tokenType).(string)
 		if !ok {
-			logger.Log(logger.LevelError, nil, err, fmt.Sprintf("no %s field in oauth2 token", tokenType))
+			logger.Log(logger.LevelError, nil, nil, fmt.Sprintf("no %s field in oauth2 token", tokenType))
 			http.Error(w, fmt.Sprintf("No %s field in oauth2 token.", tokenType), http.StatusInternalServerError)
 
 			return
@@ -854,7 +994,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		idToken, err := oauthConfig.Verifier.Verify(oauthConfig.Ctx, rawUserToken)
+		idToken, err := flow.Verifier.Verify(flow.Ctx, rawUserToken)
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "failed to verify ID Token")
 			http.Error(w, "Failed to verify ID Token: "+err.Error(), http.StatusInternalServerError)
@@ -887,9 +1027,9 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		// Set auth cookie
-		auth.SetTokenCookie(w, r, oauthConfig.Cluster, rawUserToken, config.BaseURL, config.SessionTTL)
+		auth.SetTokenCookie(w, r, payload.Cluster, rawUserToken, config.BaseURL, config.SessionTTL)
 
-		redirectURL += fmt.Sprintf("auth?cluster=%1s", oauthConfig.Cluster)
+		redirectURL += fmt.Sprintf("auth?cluster=%1s", payload.Cluster)
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	})

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -404,10 +404,14 @@ const minOIDCSigningKeyBytes = 32
 // oidcFlow bundles the per-request OIDC plumbing needed by both /oidc and
 // /oidc-callback. Reconstructing it on the callback (rather than caching
 // it across requests) is what makes signed state portable across replicas.
+//
+// The request-scoped context with TLS / issuer overrides is returned
+// alongside the flow rather than stored on it, so callers stay honest
+// about cancellation. Idiomatic Go (and contextcheck) avoids storing
+// context in struct fields.
 type oidcFlow struct {
 	OAuth2   *oauth2.Config
 	Verifier *oidc.IDTokenVerifier
-	Ctx      context.Context
 }
 
 // loadOIDCStateSigner constructs the StateSigner used by /oidc and
@@ -439,7 +443,7 @@ func loadOIDCStateSigner(config *HeadlampConfig) (*auth.StateSigner, error) {
 		logger.Log(logger.LevelInfo, nil, nil,
 			"OIDC state signing key loaded from --oidc-state-signing-key-file")
 
-		return auth.NewStateSigner(key, oidcStateTTL, oidcStateLRUSize), nil
+		return auth.NewStateSigner(key, oidcStateTTL, auth.WithLRUSize(oidcStateLRUSize)), nil
 	}
 
 	key := make([]byte, minOIDCSigningKeyBytes)
@@ -451,12 +455,12 @@ func loadOIDCStateSigner(config *HeadlampConfig) (*auth.StateSigner, error) {
 		"OIDC state signing key generated per-process. For multi-replica "+
 			"deployments, set --oidc-state-signing-key-file=<path> with a shared key file.")
 
-	return auth.NewStateSigner(key, oidcStateTTL, oidcStateLRUSize), nil
+	return auth.NewStateSigner(key, oidcStateTTL, auth.WithLRUSize(oidcStateLRUSize)), nil
 }
 
 // buildOIDCFlow constructs the per-request OIDC plumbing — the OAuth2
-// config, the ID-token verifier, and the request context with the right
-// TLS / issuer overrides applied.
+// config and the ID-token verifier — and returns the request context
+// with the right TLS / issuer overrides applied.
 //
 // Both /oidc and /oidc-callback call this. Building it on the callback
 // (instead of caching the /oidc result in a per-process map) is what makes
@@ -465,7 +469,7 @@ func loadOIDCStateSigner(config *HeadlampConfig) (*auth.StateSigner, error) {
 // on any replica that has the same kubeconfig.
 func buildOIDCFlow(ctx context.Context, config *HeadlampConfig, r *http.Request,
 	cluster string,
-) (*oidcFlow, error) {
+) (*oidcFlow, context.Context, error) {
 	if config.Insecure {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
@@ -476,12 +480,12 @@ func buildOIDCFlow(ctx context.Context, config *HeadlampConfig, r *http.Request,
 
 	kContext, err := config.KubeConfigStore.GetContext(cluster)
 	if err != nil {
-		return nil, &oidcFlowError{kind: oidcFlowErrCluster, cluster: cluster, err: err}
+		return nil, ctx, &errFlowCluster{cluster: cluster, err: err}
 	}
 
 	oidcAuthConfig, err := kContext.OidcConfig()
 	if err != nil {
-		return nil, &oidcFlowError{kind: oidcFlowErrOIDCConfig, cluster: cluster, err: err}
+		return nil, ctx, &errFlowOIDCConfig{cluster: cluster, err: err}
 	}
 
 	ctx = auth.ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
@@ -492,10 +496,7 @@ func buildOIDCFlow(ctx context.Context, config *HeadlampConfig, r *http.Request,
 
 	provider, err := oidc.NewProvider(ctx, oidcAuthConfig.IdpIssuerURL)
 	if err != nil {
-		return nil, &oidcFlowError{
-			kind: oidcFlowErrProvider, cluster: cluster, err: err,
-			extra: map[string]string{"idpIssuerURL": oidcAuthConfig.IdpIssuerURL},
-		}
+		return nil, ctx, &errFlowProvider{issuerURL: oidcAuthConfig.IdpIssuerURL, err: err}
 	}
 
 	validatorClientID := oidcAuthConfig.ClientID
@@ -512,63 +513,63 @@ func buildOIDCFlow(ctx context.Context, config *HeadlampConfig, r *http.Request,
 		Scopes:       append([]string{oidc.ScopeOpenID}, oidcAuthConfig.Scopes...),
 	}
 
-	return &oidcFlow{OAuth2: oauthConfig, Verifier: verifier, Ctx: ctx}, nil
+	return &oidcFlow{OAuth2: oauthConfig, Verifier: verifier}, ctx, nil
 }
 
-// oidcFlowErrKind classifies failures from buildOIDCFlow so callers can
-// translate them into the right HTTP status without re-doing the typing.
-type oidcFlowErrKind int
-
-const (
-	oidcFlowErrCluster oidcFlowErrKind = iota
-	oidcFlowErrOIDCConfig
-	oidcFlowErrProvider
-)
-
-type oidcFlowError struct {
-	kind    oidcFlowErrKind
+// Concrete buildOIDCFlow error types. handleOIDCFlowError dispatches via
+// errors.As so each carries exactly the fields its caller needs and there
+// is no untyped `extra` map to drift.
+type errFlowCluster struct {
 	cluster string
 	err     error
-	extra   map[string]string
 }
 
-func (e *oidcFlowError) Error() string { return e.err.Error() }
-func (e *oidcFlowError) Unwrap() error { return e.err }
+func (e *errFlowCluster) Error() string { return e.err.Error() }
+func (e *errFlowCluster) Unwrap() error { return e.err }
 
-// handleOIDCFlowError preserves the existing HTTP contract from
-// /oidc and /oidc-callback for buildOIDCFlow failures: 404 on missing
-// cluster, 500 on OIDC config / provider failure. The wording matches
-// the pre-refactor handler so the public-facing error surface is
-// unchanged.
-func handleOIDCFlowError(w http.ResponseWriter, r *http.Request, cluster string, err error) {
-	var fe *oidcFlowError
-	if !errors.As(err, &fe) {
-		logger.Log(logger.LevelError, map[string]string{"cluster": cluster}, err, "OIDC flow error")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+type errFlowOIDCConfig struct {
+	cluster string
+	err     error
+}
 
-		return
-	}
+func (e *errFlowOIDCConfig) Error() string { return e.err.Error() }
+func (e *errFlowOIDCConfig) Unwrap() error { return e.err }
 
-	switch fe.kind {
-	case oidcFlowErrCluster:
-		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
-			fe.err, "failed to get context")
+type errFlowProvider struct {
+	issuerURL string
+	err       error
+}
+
+func (e *errFlowProvider) Error() string { return e.err.Error() }
+func (e *errFlowProvider) Unwrap() error { return e.err }
+
+// handleOIDCFlowError translates buildOIDCFlow failures into HTTP
+// responses: 404 for missing cluster, 500 for OIDC config / provider
+// failure. Logs the full error server-side; the HTTP body is generic
+// to avoid leaking IdP-supplied error strings to anonymous callers.
+func handleOIDCFlowError(w http.ResponseWriter, r *http.Request, err error) {
+	var (
+		clusterErr  *errFlowCluster
+		configErr   *errFlowOIDCConfig
+		providerErr *errFlowProvider
+	)
+
+	switch {
+	case errors.As(err, &clusterErr):
+		logger.Log(logger.LevelError, map[string]string{"cluster": clusterErr.cluster},
+			clusterErr.err, "failed to get context")
 		http.NotFound(w, r)
-	case oidcFlowErrOIDCConfig:
-		// Pre-refactor behavior: log "failed to get oidc config" only when
-		// in-cluster OIDC is configured; otherwise the error is expected
-		// for Service-Token-only contexts and would just be log noise.
-		// We can't easily access HeadlampConfig here without threading it,
-		// so we always log at debug-equivalent severity. The HTTP response
-		// is unchanged.
-		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
-			fe.err, "failed to get oidc config")
-		http.Error(w, fe.err.Error(), http.StatusInternalServerError)
-	case oidcFlowErrProvider:
-		logger.Log(logger.LevelError, fe.extra, fe.err, "failed to get provider")
-		http.Error(w, fe.err.Error(), http.StatusInternalServerError)
+	case errors.As(err, &configErr):
+		logger.Log(logger.LevelError, map[string]string{"cluster": configErr.cluster},
+			configErr.err, "failed to get oidc config")
+		http.Error(w, "oidc not configured for cluster", http.StatusInternalServerError)
+	case errors.As(err, &providerErr):
+		logger.Log(logger.LevelError, map[string]string{"idpIssuerURL": providerErr.issuerURL},
+			providerErr.err, "failed to get provider")
+		http.Error(w, "oidc provider unavailable", http.StatusInternalServerError)
 	default:
-		http.Error(w, fe.err.Error(), http.StatusInternalServerError)
+		logger.Log(logger.LevelError, nil, err, "OIDC flow error")
+		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 }
 
@@ -952,9 +953,15 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	// rejected (see #4019).
 	stateSigner, err := loadOIDCStateSigner(config)
 	if err != nil {
+		// A bad --oidc-state-signing-key-file (unreadable, too short) is
+		// an operator startup error and not survivable. We panic instead
+		// of returning the error to keep createHeadlampHandler's
+		// signature unchanged across many call sites; the recovery path
+		// in production is "fix the file and restart the binary".
+		// loadOIDCStateSigner only errors on file IO + length validation,
+		// not on the per-process default-key path, so tests that don't
+		// exercise the bad-key code path are unaffected.
 		logger.Log(logger.LevelError, nil, err, "loading OIDC state signing key")
-		// We deliberately do not fall back silently; a misconfigured key
-		// file is an operator error that should be loud.
 		panic(fmt.Sprintf("failed to load OIDC state signing key: %v", err))
 	}
 
@@ -962,21 +969,21 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		cluster := r.URL.Query().Get("cluster")
 
 		// mode controls how /oidc-callback redirects after a successful
-		// token exchange. "popup" preserves the legacy /auth?cluster=...
-		// contract; "fullPage" redirects directly to returnTo (or the
-		// cluster root if returnTo is absent). "desktop" is reserved for
-		// PR 2 of #5401 and is rejected here so its eventual semantics
-		// can't be silently established by abuse.
-		mode := r.URL.Query().Get("mode")
+		// token exchange. ModePopup preserves the legacy /auth?cluster=...
+		// contract; ModeFullPage redirects directly to returnTo (or the
+		// cluster root if returnTo is absent). ModeDesktop is reserved
+		// for PR 2 of #5401 and is rejected here so its eventual
+		// semantics can't be silently established by abuse.
+		mode := auth.StateMode(r.URL.Query().Get("mode"))
 		switch mode {
 		case "":
-			mode = "popup"
-		case "popup", "fullPage":
+			mode = auth.ModePopup
+		case auth.ModePopup, auth.ModeFullPage:
 			// ok
-		case "desktop":
+		case auth.ModeDesktop:
 			http.Error(w,
-				"mode=desktop is reserved for the desktop OIDC code-handoff flow (PR 2 of #5401) "+
-					"and is not yet supported",
+				"mode=desktop is reserved for the desktop OIDC code-handoff flow "+
+					"(see kubernetes-sigs/headlamp#5401, PR 2) and is not yet supported",
 				http.StatusBadRequest)
 
 			return
@@ -988,7 +995,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		var validatedReturnTo string
 
 		if rawReturnTo := r.URL.Query().Get("returnTo"); rawReturnTo != "" {
-			cleaned, vErr := auth.ValidateReturnTo(rawReturnTo, "")
+			cleaned, vErr := auth.ValidateReturnTo(rawReturnTo, config.BaseURL)
 			if vErr != nil {
 				logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
 					vErr, "rejected returnTo on /oidc")
@@ -1000,9 +1007,9 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			validatedReturnTo = cleaned
 		}
 
-		flow, err := buildOIDCFlow(r.Context(), config, r, cluster)
+		flow, _, err := buildOIDCFlow(r.Context(), config, r, cluster)
 		if err != nil {
-			handleOIDCFlowError(w, r, cluster, err)
+			handleOIDCFlowError(w, r, err)
 			return
 		}
 
@@ -1015,12 +1022,10 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		payload := auth.StatePayload{
-			V:         auth.StateSchemaVersion,
-			Cluster:   cluster,
-			Mode:      mode,
-			ReturnTo:  validatedReturnTo,
-			ExpUnixMs: stateSigner.Now().Add(stateSigner.TTL()).UnixMilli(),
-			CSRF:      hex.EncodeToString(csrfBytes),
+			Cluster:  cluster,
+			Mode:     mode,
+			ReturnTo: validatedReturnTo,
+			CSRF:     hex.EncodeToString(csrfBytes),
 		}
 
 		var authURL string
@@ -1088,9 +1093,9 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		flow, err := buildOIDCFlow(r.Context(), config, r, payload.Cluster)
+		flow, flowCtx, err := buildOIDCFlow(r.Context(), config, r, payload.Cluster)
 		if err != nil {
-			handleOIDCFlowError(w, r, payload.Cluster, err)
+			handleOIDCFlowError(w, r, err)
 			return
 		}
 
@@ -1099,20 +1104,30 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		// Exchange authorization code for token, with or without PKCE
 		if config.OidcUsePKCE && payload.CodeVerifier != "" {
 			oauth2Token, err = flow.OAuth2.Exchange(
-				flow.Ctx,
+				flowCtx,
 				r.URL.Query().Get("code"),
 				oauth2.SetAuthURLParam("code_verifier", payload.CodeVerifier),
 			)
 		} else {
 			oauth2Token, err = flow.OAuth2.Exchange(
-				flow.Ctx,
+				flowCtx,
 				r.URL.Query().Get("code"),
 			)
 		}
 
 		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "failed to exchange token")
-			http.Error(w, "Failed to exchange token: "+err.Error(), http.StatusInternalServerError)
+			// Don't echo the upstream OAuth2 error body to the browser;
+			// it can carry full IdP HTTP response bodies including
+			// internal addresses or stack traces. Log the full detail
+			// server-side and surface a generic message via
+			// oidcCallbackError so the response shape matches the rest
+			// of the 4xx/5xx paths.
+			logger.Log(logger.LevelError, map[string]string{"cluster": payload.Cluster},
+				err, "failed to exchange token")
+			oidcCallbackError(w, r, http.StatusInternalServerError,
+				"Failed to exchange token",
+				"The identity provider rejected the sign-in. Please try again.",
+				payload.Cluster, config.BaseURL)
 
 			return
 		}
@@ -1138,7 +1153,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		idToken, err := flow.Verifier.Verify(flow.Ctx, rawUserToken)
+		idToken, err := flow.Verifier.Verify(flowCtx, rawUserToken)
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "failed to verify ID Token")
 			http.Error(w, "Failed to verify ID Token: "+err.Error(), http.StatusInternalServerError)
@@ -1177,9 +1192,11 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		// though the value was validated at /oidc and signed into the
 		// state, a future schema change or signing-key compromise should
 		// not be able to convert state into an arbitrary open redirect).
+		// We pass config.BaseURL so the validator also enforces the
+		// sub-path prefix when one is configured.
 		safeReturnTo := ""
 		if payload.ReturnTo != "" {
-			cleaned, vErr := auth.ValidateReturnTo(payload.ReturnTo, "")
+			cleaned, vErr := auth.ValidateReturnTo(payload.ReturnTo, config.BaseURL)
 			if vErr == nil {
 				safeReturnTo = cleaned
 			} else {
@@ -1188,26 +1205,28 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			}
 		}
 
+		escapedCluster := url.PathEscape(payload.Cluster)
+
 		switch payload.Mode {
-		case "fullPage":
+		case auth.ModeFullPage:
 			// Skip /auth entirely. Redirect straight to returnTo, or to
 			// the cluster root if returnTo is absent or unsafe.
 			if safeReturnTo != "" {
 				redirectURL = safeReturnTo
 			} else {
-				redirectURL += fmt.Sprintf("c/%s/", payload.Cluster)
+				redirectURL += "c/" + escapedCluster + "/"
 			}
-		case "desktop":
+		case auth.ModeDesktop:
 			// Belt-and-suspenders: /oidc rejects mode=desktop, but signed
 			// state could in principle carry it via a different code path.
 			http.Error(w, "mode=desktop is not yet supported", http.StatusBadRequest)
 			return
 		default:
-			// "popup" (and unset, treated as popup): preserve the existing
-			// /auth?cluster=... contract, optionally with returnTo so the
-			// /auth page can finish navigating after the popup-storage
-			// handshake.
-			redirectURL += fmt.Sprintf("auth?cluster=%s", payload.Cluster)
+			// ModePopup (and unset, treated as popup): preserve the
+			// existing /auth?cluster=... contract, optionally with
+			// returnTo so the /auth page can finish navigating after the
+			// popup-storage handshake.
+			redirectURL += "auth?cluster=" + url.QueryEscape(payload.Cluster)
 			if safeReturnTo != "" {
 				redirectURL += "&returnTo=" + url.QueryEscape(safeReturnTo)
 			}

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"io/fs"
 	"net/http"
@@ -571,6 +572,100 @@ func handleOIDCFlowError(w http.ResponseWriter, r *http.Request, cluster string,
 	}
 }
 
+// oidcCallbackError writes a 4xx/5xx response on /oidc-callback failure.
+// Browser callers (Accept: text/html) get a small HTML page with a link
+// back to the cluster (or root) so they're not stranded on a JSON error;
+// non-browser callers get the existing plain-text contract preserved
+// from the pre-stage-5 handler. plainBody is what non-HTML callers see
+// (preserve historical wording for downstream contract); htmlReason is
+// the friendlier text shown inside the HTML page.
+func oidcCallbackError(
+	w http.ResponseWriter, r *http.Request, status int,
+	plainBody, htmlReason string,
+	cluster, baseURL string,
+) {
+	if !wantsHTML(r) {
+		http.Error(w, plainBody, status)
+		return
+	}
+
+	clusterRoot := "/"
+	if trimmed := strings.Trim(baseURL, "/"); trimmed != "" {
+		clusterRoot = "/" + trimmed + "/"
+	}
+
+	if cluster != "" {
+		clusterRoot += "c/" + url.PathEscape(cluster) + "/"
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+
+	page := buildOIDCErrorPage(htmlReason, clusterRoot)
+	if _, err := io.WriteString(w, page); err != nil {
+		logger.Log(logger.LevelError, nil, err, "writing OIDC error page")
+	}
+}
+
+// wantsHTML returns true when the caller's Accept header prefers HTML
+// over JSON / plain text. We treat any "text/html" or "*/*" without a
+// more specific JSON preference as HTML — browsers are the dominant
+// caller of /oidc-callback so this skews toward HTML when the header
+// is ambiguous.
+func wantsHTML(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	if accept == "" {
+		return false
+	}
+
+	lower := strings.ToLower(accept)
+	if strings.Contains(lower, "application/json") &&
+		!strings.Contains(lower, "text/html") {
+		return false
+	}
+
+	return strings.Contains(lower, "text/html") || strings.Contains(lower, "*/*")
+}
+
+// buildOIDCErrorPage renders the small HTML page shown on
+// /oidc-callback failures. The reason is HTML-escaped via
+// html/template; the link target is constructed from trusted server
+// state (cluster root) and is not user-controlled, so it's spliced in
+// directly via the template.
+func buildOIDCErrorPage(reason, clusterRoot string) string {
+	tmpl := template.Must(template.New("oidc-error").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sign-in error — Headlamp</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body { font-family: system-ui, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1rem; color: #222; }
+h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+p { line-height: 1.4; }
+a { color: #1565c0; }
+</style>
+</head>
+<body>
+<h1>Sign-in didn't complete</h1>
+<p>{{.Reason}}</p>
+<p><a href="{{.Home}}">Return to Headlamp</a> and try again.</p>
+</body>
+</html>`))
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, struct {
+		Reason string
+		Home   string
+	}{Reason: reason, Home: clusterRoot}); err != nil {
+		// Fall back to a static body if templating somehow fails. Defensive
+		// only — the template above is constant.
+		return "Sign-in didn't complete. <a href=\"" + clusterRoot + "\">Return to Headlamp</a>."
+	}
+
+	return buf.String()
+}
+
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
 
@@ -960,7 +1055,10 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		if state == "" {
 			logger.Log(logger.LevelError, nil, nil, "invalid request state is empty")
-			http.Error(w, "invalid request state is empty", http.StatusBadRequest)
+			oidcCallbackError(w, r, http.StatusBadRequest,
+				"invalid request state is empty",
+				"The sign-in link is missing required information.",
+				"", config.BaseURL)
 
 			return
 		}
@@ -971,16 +1069,22 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			// version, oversize) collapses to "invalid request" so we
 			// don't leak details to anonymous callers.
 			logger.Log(logger.LevelError, nil, err, "decoding OIDC state")
-			http.Error(w, "invalid request", http.StatusBadRequest)
+			oidcCallbackError(w, r, http.StatusBadRequest,
+				"invalid request",
+				"The sign-in link is invalid or has expired. Please start the sign-in again.",
+				"", config.BaseURL)
 
 			return
 		}
 
 		if !stateSigner.MarkConsumed(payload.CSRF) {
-			// State has already been used. Same wording as the unknown-
-			// state path so callers can't infer whether a state was
-			// previously valid.
-			http.Error(w, "invalid request", http.StatusBadRequest)
+			// State has already been used. Same response shape as the
+			// unknown-state path so callers can't infer whether a state
+			// was previously valid.
+			oidcCallbackError(w, r, http.StatusBadRequest,
+				"invalid request",
+				"This sign-in link has already been used. Please start the sign-in again.",
+				payload.Cluster, config.BaseURL)
 			return
 		}
 

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -1,0 +1,421 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Characterization tests for the /oidc and /oidc-callback handlers.
+//
+// These tests document the CURRENT behavior of the OIDC login handlers as
+// they exist in headlamp.go on main. They make no production-code changes
+// and are intended as the regression net for the PR-1 work tracked in
+// https://github.com/kubernetes-sigs/headlamp/issues/5401.
+//
+// They were added in response to maintainer feedback on #5401 asking for
+// more tests before any refactor of this code (#3482 is the active auth
+// extraction track; PR #4230 extracts RefreshAndSetToken).
+//
+// Coverage targets (each is a subtest below):
+//
+//   1. /oidc issues a 32-byte base64 random `state` parameter and includes
+//      it in the IdP redirect URL; multiple calls produce different states.
+//   2. /oidc populates the per-process oauthRequestMap such that a
+//      subsequent /oidc-callback with the same state can find its entry.
+//      (Verified via end-to-end behavior, not direct map inspection.)
+//   3. /oidc-callback with a missing `state` query param returns 400 with
+//      body "invalid request state is empty".
+//   4. /oidc-callback with an unknown state returns 400 with body
+//      "invalid request".
+//   5. /oidc-callback with valid state but a token-exchange failure
+//      returns 500 with body "Failed to exchange token: ...".
+//   6. After the state is consumed, replaying the same state returns 400
+//      "invalid request" (single-use semantics).
+//   7. Multi-replica regression test for #4019: state issued by handler A,
+//      callback delivered to handler B, returns 400 "invalid request".
+//      This test currently asserts the BUG. When stage 3 of the PR-1 plan
+//      lands (signed stateless state payload), this test must be updated
+//      to assert the FIXED behavior, not deleted.
+//
+// Mocking strategy: each subtest spins up a small httptest.Server that
+// implements the OIDC discovery + JWKS + token endpoints. The /token
+// endpoint responses are configurable per test. We then wire a kubeconfig
+// context whose OidcConf points at that server, build a HeadlampConfig +
+// handler the same way other tests in this file do, and drive the two
+// HTTP handlers through the standard handler.ServeHTTP path.
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// oidcTestServer is a minimal mock OIDC provider exposing the discovery,
+// JWKS, and token endpoints required to drive /oidc and /oidc-callback.
+type oidcTestServer struct {
+	server       *httptest.Server
+	tokenHandler http.HandlerFunc
+}
+
+// newOIDCTestServer starts an in-process OIDC mock and returns a handle.
+// If tokenHandler is nil, /token returns 500 (used for tests that only need
+// to drive /oidc, not /oidc-callback).
+func newOIDCTestServer(t *testing.T, tokenHandler http.HandlerFunc) *oidcTestServer {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		cfg := map[string]any{
+			"issuer":                                srv.URL,
+			"authorization_endpoint":                srv.URL + "/auth",
+			"token_endpoint":                        srv.URL + "/token",
+			"jwks_uri":                              srv.URL + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		}
+		if err := json.NewEncoder(w).Encode(cfg); err != nil {
+			t.Fatalf("encode discovery: %v", err)
+		}
+	})
+
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if _, err := w.Write([]byte(`{"keys":[]}`)); err != nil {
+			t.Fatalf("write jwks: %v", err)
+		}
+	})
+
+	if tokenHandler != nil {
+		mux.HandleFunc("/token", tokenHandler)
+	} else {
+		mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+	}
+
+	return &oidcTestServer{server: srv, tokenHandler: tokenHandler}
+}
+
+// URL returns the issuer URL of the mock OIDC server.
+func (o *oidcTestServer) URL() string {
+	return o.server.URL
+}
+
+// newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
+// kubeconfig context whose IdP issuer points at the supplied mock server.
+// Returns the handler and the cluster name registered.
+func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer) (http.Handler, string) {
+	t.Helper()
+
+	const clusterName = "oidc-char-test"
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	err := kubeConfigStore.AddContext(&kubeconfig.Context{
+		Name: clusterName,
+		Cluster: &api.Cluster{
+			Server: "https://test-cluster.example.com",
+		},
+		AuthInfo: &api.AuthInfo{},
+		OidcConf: &kubeconfig.OidcConfig{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			IdpIssuerURL: oidcSrv.URL(),
+			Scopes:       []string{"profile", "email"},
+		},
+		Source: kubeconfig.KubeConfig,
+	})
+	require.NoError(t, err)
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	return createHeadlampHandler(context.Background(), c), clusterName
+}
+
+// driveOIDCStart calls /oidc?cluster=<cluster> against the supplied handler
+// and returns the redirect Location URL or fails the test.
+func driveOIDCStart(t *testing.T, handler http.Handler, cluster string) *url.URL {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oidc?cluster="+cluster, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code,
+		"GET /oidc should 302 to the IdP; got %d body=%q", rr.Code, rr.Body.String())
+
+	loc := rr.Header().Get("Location")
+	require.NotEmpty(t, loc, "Location header missing on /oidc redirect")
+
+	u, err := url.Parse(loc)
+	require.NoError(t, err)
+
+	return u
+}
+
+// extractState returns the `state` query parameter from a parsed URL,
+// asserting non-empty.
+func extractState(t *testing.T, u *url.URL) string {
+	t.Helper()
+
+	state := u.Query().Get("state")
+	require.NotEmpty(t, state, "state parameter missing from %s", u.String())
+
+	return state
+}
+
+// callOIDCCallback invokes /oidc-callback with the supplied query string
+// against the given handler and returns the response.
+func callOIDCCallback(t *testing.T, handler http.Handler, rawQuery string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oidc-callback?"+rawQuery, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	return rr
+}
+
+// TestOIDCStart_StateIsRandom32Bytes covers target #1: each /oidc call
+// issues a fresh, base64-url-encoded 32-byte random state.
+func TestOIDCStart_StateIsRandom32Bytes(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+	seen := make(map[string]struct{})
+
+	const calls = 5
+
+	for i := 0; i < calls; i++ {
+		loc := driveOIDCStart(t, handler, cluster)
+		state := extractState(t, loc)
+
+		// state is base64.RawURLEncoding-encoded; decode and assert 32 bytes.
+		raw, err := base64.RawURLEncoding.DecodeString(state)
+		require.NoError(t, err, "state %q should be base64.RawURLEncoding", state)
+		require.Equal(t, 32, len(raw),
+			"state should decode to 32 random bytes; got %d bytes", len(raw))
+
+		_, dup := seen[state]
+		require.False(t, dup, "state %q reused across /oidc calls (collision or bug)", state)
+		seen[state] = struct{}{}
+	}
+
+	require.Len(t, seen, calls, "expected %d distinct states across %d calls", calls, calls)
+}
+
+// TestOIDCStart_RedirectsToIdP covers target #1 (continued): the redirect
+// target is the configured IdP authorization endpoint and carries the
+// expected client_id, response_type, scope, redirect_uri.
+func TestOIDCStart_RedirectsToIdP(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+	loc := driveOIDCStart(t, handler, cluster)
+
+	require.Equal(t, oidcSrv.URL()+"/auth", loc.Scheme+"://"+loc.Host+loc.Path,
+		"redirect should point at the IdP authorization endpoint")
+
+	q := loc.Query()
+	assert.Equal(t, "test-client-id", q.Get("client_id"))
+	assert.Equal(t, "code", q.Get("response_type"))
+	assert.Contains(t, q.Get("scope"), "openid")
+	assert.NotEmpty(t, q.Get("redirect_uri"), "redirect_uri must be set")
+}
+
+// TestOIDCCallback_MissingState covers target #3: calling /oidc-callback
+// with no `state` query param returns 400 with the documented error body.
+func TestOIDCCallback_MissingState(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+	handler, _ := newOIDCTestHandler(t, oidcSrv)
+
+	rr := callOIDCCallback(t, handler, "code=anything")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid request state is empty",
+		"body wording is part of the public contract; downstream tooling matches on it")
+}
+
+// TestOIDCCallback_UnknownState covers target #4: calling /oidc-callback
+// with a state value that was never issued returns 400 "invalid request".
+func TestOIDCCallback_UnknownState(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+	handler, _ := newOIDCTestHandler(t, oidcSrv)
+
+	rr := callOIDCCallback(t, handler, "state=never-issued&code=fake")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	body := strings.TrimSpace(rr.Body.String())
+	assert.Equal(t, "invalid request", body,
+		"body wording is part of the contract reproduced by the multi-replica failure mode")
+}
+
+// TestOIDCCallback_TokenExchangeFailure covers target #5: with a valid
+// state but a token endpoint that fails, /oidc-callback returns 500 and
+// the state is consumed (single-use, target #6 boundary case).
+func TestOIDCCallback_TokenExchangeFailure(t *testing.T) {
+	// /token endpoint deliberately rejects the exchange.
+	tokenHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+
+		_, _ = io.WriteString(w, `{"error":"invalid_grant"}`)
+	})
+	oidcSrv := newOIDCTestServer(t, tokenHandler)
+	handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+	loc := driveOIDCStart(t, handler, cluster)
+	state := extractState(t, loc)
+
+	rr := callOIDCCallback(t, handler, fmt.Sprintf("state=%s&code=fake", state))
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code,
+		"token exchange failure should surface as 500")
+	assert.Contains(t, rr.Body.String(), "Failed to exchange token",
+		"error body should identify the failure stage; current handler echoes the IdP error")
+}
+
+// TestOIDCCallback_StateIsSingleUse covers target #6: a state is consumed
+// once. The first callback (with our failing /token mock) returns 500;
+// the second replay of the same state returns 400 "invalid request"
+// because the entry was deleted on first use, regardless of the exchange
+// outcome.
+//
+// The current handler at headlamp.go:799 calls delete(oauthRequestMap,
+// state) BEFORE the token exchange runs, so any subsequent replay misses
+// the map.
+func TestOIDCCallback_StateIsSingleUse(t *testing.T) {
+	tokenHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+
+		_, _ = io.WriteString(w, `{"error":"invalid_grant"}`)
+	})
+	oidcSrv := newOIDCTestServer(t, tokenHandler)
+	handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+	loc := driveOIDCStart(t, handler, cluster)
+	state := extractState(t, loc)
+
+	// First call: state lookup succeeds, token exchange fails → 500.
+	rr1 := callOIDCCallback(t, handler, fmt.Sprintf("state=%s&code=fake", state))
+	require.Equal(t, http.StatusInternalServerError, rr1.Code,
+		"sanity: first callback exercised the consumed code path")
+
+	// Second call with the same state: lookup fails → 400 invalid request.
+	rr2 := callOIDCCallback(t, handler, fmt.Sprintf("state=%s&code=fake", state))
+	assert.Equal(t, http.StatusBadRequest, rr2.Code,
+		"replaying a consumed state should fail")
+	assert.Contains(t, rr2.Body.String(), "invalid request",
+		"replay rejection uses the same body wording as unknown-state")
+}
+
+// TestOIDCCallback_MultiReplicaStateLoss is the explicit regression test
+// for #4019 (multi-replica state loss).
+//
+// Two independent handler instances are constructed; each has its own
+// in-process oauthRequestMap because oauthRequestMap is allocated inside
+// createHeadlampHandler at headlamp.go:673. We start the OIDC flow on
+// instance A (which writes the state into A's map) and deliver the
+// callback to instance B (whose map has no such entry). The current
+// behavior is `400 invalid request`.
+//
+// This test currently asserts THE BUG. When stage 3 of the PR-1 plan in
+// #5401 lands (signed stateless state payload that does not require a
+// shared map), this test must be UPDATED — not deleted — to assert the
+// new behavior:
+//
+//   - if both handlers share a signing key (the new --oidc-state-signing-
+//     key-file flag), the callback to B should succeed (or get to the
+//     token-exchange step, which our mock can be wired to either succeed
+//     or fail at).
+//   - if the handlers do NOT share a signing key, B should reject the
+//     state with a signature-verification error, not a "lookup miss"
+//     (different error path, similar 400).
+//
+// Until that update lands, this test serves as the canonical reproduction
+// of the bug.
+func TestOIDCCallback_MultiReplicaStateLoss(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+
+	handlerA, clusterA := newOIDCTestHandler(t, oidcSrv)
+	handlerB, clusterB := newOIDCTestHandler(t, oidcSrv)
+
+	// Both replicas register the same cluster name (matches the
+	// real-world deployment where two pods see the same kubeconfig).
+	require.Equal(t, clusterA, clusterB,
+		"sanity: replicas reference the same cluster name")
+
+	// 1. /oidc on replica A. State is written into A's per-process map.
+	loc := driveOIDCStart(t, handlerA, clusterA)
+	state := extractState(t, loc)
+
+	// 2. /oidc-callback on replica B with the state issued by A.
+	rr := callOIDCCallback(t, handlerB, fmt.Sprintf("state=%s&code=fake", state))
+
+	// Current behavior: B has no entry, rejects with 400.
+	require.Equal(t, http.StatusBadRequest, rr.Code,
+		"#4019 regression: callback to a different replica returns 400")
+
+	body := strings.TrimSpace(rr.Body.String())
+	require.Equal(t, "invalid request", body,
+		"#4019 regression: failure mode is the unknown-state path, not a "+
+			"different error type")
+
+	// Sanity: the state IS recognized on the issuing replica, proving the
+	// failure on B is specifically a per-process map lookup miss and not
+	// some unrelated rejection (e.g. malformed state).
+	rrA := callOIDCCallback(t, handlerA, fmt.Sprintf("state=%s&code=fake", state))
+	require.NotEqual(t, http.StatusBadRequest, rrA.Code,
+		"sanity: replica A should accept the state it issued (token exchange "+
+			"is expected to fail downstream because the test mock is unwired, "+
+			"but state lookup must succeed)")
+}

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -442,10 +442,11 @@ func TestOIDCCallback_MultiReplica(t *testing.T) {
 
 		rr := callOIDCCallback(t, handlerB, fmt.Sprintf("state=%s&code=fake", state))
 
-		require.NotEqual(t, http.StatusBadRequest, rr.Code,
-			"#4019 fix: with shared signing key, B should accept A's state and "+
-				"proceed to the token-exchange step (which our test mock fails, "+
-				"yielding 500 — but state validation has succeeded). got %d body=%q",
+		require.Equal(t, http.StatusInternalServerError, rr.Code,
+			"#4019 fix: with shared signing key, B accepts A's state and "+
+				"proceeds to the token-exchange step (which our test mock fails, "+
+				"yielding 500 — what matters is that state validation succeeded). "+
+				"got %d body=%q",
 			rr.Code, rr.Body.String())
 	})
 }
@@ -529,7 +530,7 @@ func TestOIDCStart_RejectsDesktopMode(t *testing.T) {
 	_, rr := driveOIDCStartWithQuery(t, handler, query)
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
-	require.Contains(t, rr.Body.String(), "PR 2",
+	require.Contains(t, rr.Body.String(), "not yet supported",
 		"error body should explain that desktop mode is reserved")
 }
 

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -533,3 +533,68 @@ func TestOIDCStart_RejectsDesktopMode(t *testing.T) {
 		"error body should explain that desktop mode is reserved")
 }
 
+// callOIDCCallbackWithAccept invokes /oidc-callback with the given Accept
+// header, used by the stage 5 HTML content-negotiation tests.
+func callOIDCCallbackWithAccept(t *testing.T, handler http.Handler, rawQuery, accept string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oidc-callback?"+rawQuery, nil)
+	require.NoError(t, err)
+
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	return rr
+}
+
+// TestOIDCCallback_HTMLErrorPages covers stage 5: when Accept: text/html
+// is present, the 4xx error responses render an HTML page with a link
+// back to Headlamp; non-HTML callers continue to get the plain-text
+// contract checked by the earlier characterization tests.
+func TestOIDCCallback_HTMLErrorPages(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+	handler, _ := newOIDCTestHandler(t, oidcSrv)
+
+	t.Run("missing_state_html", func(t *testing.T) {
+		rr := callOIDCCallbackWithAccept(t, handler, "code=anything", "text/html")
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Header().Get("Content-Type"), "text/html")
+		body := rr.Body.String()
+		require.Contains(t, body, "<html", "expected HTML page on text/html callers")
+		require.Contains(t, body, "Return to Headlamp",
+			"expected the page to offer a way back into the app")
+	})
+
+	t.Run("unknown_state_html", func(t *testing.T) {
+		rr := callOIDCCallbackWithAccept(t, handler, "state=never-issued&code=fake", "text/html")
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Contains(t, rr.Header().Get("Content-Type"), "text/html")
+		require.Contains(t, rr.Body.String(), "Return to Headlamp")
+	})
+
+	t.Run("missing_state_json_unchanged", func(t *testing.T) {
+		// Existing characterization-test contract: non-HTML callers still
+		// get the plain-text body. Asserting alongside HTML test so a
+		// regression in either direction is caught here.
+		rr := callOIDCCallbackWithAccept(t, handler, "code=anything", "application/json")
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.NotContains(t, rr.Header().Get("Content-Type"), "text/html")
+		require.Contains(t, rr.Body.String(), "invalid request state is empty")
+	})
+
+	t.Run("unknown_state_text_unchanged", func(t *testing.T) {
+		rr := callOIDCCallbackWithAccept(t, handler, "state=bogus.bogus&code=fake", "")
+
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.NotContains(t, rr.Header().Get("Content-Type"), "text/html")
+		require.Contains(t, rr.Body.String(), "invalid request")
+	})
+}

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -64,6 +64,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -135,7 +136,17 @@ func (o *oidcTestServer) URL() string {
 // newOIDCTestHandler builds a Headlamp handler with one OIDC-configured
 // kubeconfig context whose IdP issuer points at the supplied mock server.
 // Returns the handler and the cluster name registered.
+//
+// If signingKeyFile is non-empty, the handler is built with
+// OidcStateSigningKeyFile pointing at it. This lets the multi-replica
+// subtests assert behavior both with and without a shared signing key.
 func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer) (http.Handler, string) {
+	return newOIDCTestHandlerWithKey(t, oidcSrv, "")
+}
+
+func newOIDCTestHandlerWithKey(
+	t *testing.T, oidcSrv *oidcTestServer, signingKeyFile string,
+) (http.Handler, string) {
 	t.Helper()
 
 	const clusterName = "oidc-char-test"
@@ -164,9 +175,10 @@ func newOIDCTestHandler(t *testing.T, oidcSrv *oidcTestServer) (http.Handler, st
 				UseInCluster:    false,
 				KubeConfigStore: kubeConfigStore,
 			},
-			Cache:            cache.New[interface{}](),
-			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
-			TelemetryHandler: &telemetry.RequestHandler{},
+			Cache:                   cache.New[interface{}](),
+			TelemetryConfig:         GetDefaultTestTelemetryConfig(),
+			TelemetryHandler:        &telemetry.RequestHandler{},
+			OidcStateSigningKeyFile: signingKeyFile,
 		},
 	}
 
@@ -223,9 +235,13 @@ func callOIDCCallback(t *testing.T, handler http.Handler, rawQuery string) *http
 	return rr
 }
 
-// TestOIDCStart_StateIsRandom32Bytes covers target #1: each /oidc call
-// issues a fresh, base64-url-encoded 32-byte random state.
-func TestOIDCStart_StateIsRandom32Bytes(t *testing.T) {
+// TestOIDCStart_StateIsSignedToken covers target #1: each /oidc call
+// issues a fresh signed state token. Stage 3 of the PR-1 refactor
+// replaced the original 32-byte random state with an HMAC-signed JSON
+// payload (auth.StateSigner). The state now has the form
+// "<base64url(payload)>.<base64url(HMAC-SHA256))>" — distinct per call
+// because the embedded CSRF is a fresh 16 random bytes per call.
+func TestOIDCStart_StateIsSignedToken(t *testing.T) {
 	oidcSrv := newOIDCTestServer(t, nil)
 	handler, cluster := newOIDCTestHandler(t, oidcSrv)
 
@@ -237,14 +253,20 @@ func TestOIDCStart_StateIsRandom32Bytes(t *testing.T) {
 		loc := driveOIDCStart(t, handler, cluster)
 		state := extractState(t, loc)
 
-		// state is base64.RawURLEncoding-encoded; decode and assert 32 bytes.
-		raw, err := base64.RawURLEncoding.DecodeString(state)
-		require.NoError(t, err, "state %q should be base64.RawURLEncoding", state)
-		require.Equal(t, 32, len(raw),
-			"state should decode to 32 random bytes; got %d bytes", len(raw))
+		// Format: "<bodyB64>.<sigB64>" where sigB64 decodes to 32 bytes.
+		dot := strings.IndexByte(state, '.')
+		require.Greater(t, dot, 0, "state %q missing payload/sig separator", state)
+
+		bodyB64, sigB64 := state[:dot], state[dot+1:]
+		require.NotEmpty(t, bodyB64, "state %q has empty payload segment", state)
+		require.NotEmpty(t, sigB64, "state %q has empty signature segment", state)
+
+		sig, err := base64.RawURLEncoding.DecodeString(sigB64)
+		require.NoError(t, err, "signature %q should be base64.RawURLEncoding", sigB64)
+		require.Equal(t, 32, len(sig), "signature should be 32 bytes (HMAC-SHA256)")
 
 		_, dup := seen[state]
-		require.False(t, dup, "state %q reused across /oidc calls (collision or bug)", state)
+		require.False(t, dup, "state %q reused across /oidc calls (CSRF nonce should make every state distinct)", state)
 		seen[state] = struct{}{}
 	}
 
@@ -358,64 +380,88 @@ func TestOIDCCallback_StateIsSingleUse(t *testing.T) {
 		"replay rejection uses the same body wording as unknown-state")
 }
 
-// TestOIDCCallback_MultiReplicaStateLoss is the explicit regression test
-// for #4019 (multi-replica state loss).
+// TestOIDCCallback_MultiReplica covers the #4019 regression two ways:
 //
-// Two independent handler instances are constructed; each has its own
-// in-process oauthRequestMap because oauthRequestMap is allocated inside
-// createHeadlampHandler at headlamp.go:673. We start the OIDC flow on
-// instance A (which writes the state into A's map) and deliver the
-// callback to instance B (whose map has no such entry). The current
-// behavior is `400 invalid request`.
+//   - without_shared_signing_key: each handler instance generates its own
+//     per-process HMAC key at startup, so a state token issued by A is
+//     rejected as bad-signature when delivered to B. This characterizes
+//     the multi-replica failure mode operators get when they don't set
+//     --oidc-state-signing-key-file.
+//   - with_shared_signing_key: both handlers load the same key from the
+//     same file. A state token issued by A is accepted by B (it
+//     proceeds to token exchange, which fails on our stub /token; the
+//     exact downstream status doesn't matter — what matters is that
+//     state validation succeeded, i.e. the response is not 400 "invalid
+//     request").
 //
-// This test currently asserts THE BUG. When stage 3 of the PR-1 plan in
-// #5401 lands (signed stateless state payload that does not require a
-// shared map), this test must be UPDATED — not deleted — to assert the
-// new behavior:
-//
-//   - if both handlers share a signing key (the new --oidc-state-signing-
-//     key-file flag), the callback to B should succeed (or get to the
-//     token-exchange step, which our mock can be wired to either succeed
-//     or fail at).
-//   - if the handlers do NOT share a signing key, B should reject the
-//     state with a signature-verification error, not a "lookup miss"
-//     (different error path, similar 400).
-//
-// Until that update lands, this test serves as the canonical reproduction
-// of the bug.
-func TestOIDCCallback_MultiReplicaStateLoss(t *testing.T) {
-	oidcSrv := newOIDCTestServer(t, nil)
+// Renamed from TestOIDCCallback_MultiReplicaStateLoss because the test
+// now describes the fix, not the bug.
+func TestOIDCCallback_MultiReplica(t *testing.T) {
+	t.Run("without_shared_signing_key", func(t *testing.T) {
+		oidcSrv := newOIDCTestServer(t, nil)
 
-	handlerA, clusterA := newOIDCTestHandler(t, oidcSrv)
-	handlerB, clusterB := newOIDCTestHandler(t, oidcSrv)
+		handlerA, clusterA := newOIDCTestHandler(t, oidcSrv)
+		handlerB, clusterB := newOIDCTestHandler(t, oidcSrv)
 
-	// Both replicas register the same cluster name (matches the
-	// real-world deployment where two pods see the same kubeconfig).
-	require.Equal(t, clusterA, clusterB,
-		"sanity: replicas reference the same cluster name")
+		require.Equal(t, clusterA, clusterB,
+			"sanity: replicas reference the same cluster name")
 
-	// 1. /oidc on replica A. State is written into A's per-process map.
-	loc := driveOIDCStart(t, handlerA, clusterA)
-	state := extractState(t, loc)
+		loc := driveOIDCStart(t, handlerA, clusterA)
+		state := extractState(t, loc)
 
-	// 2. /oidc-callback on replica B with the state issued by A.
-	rr := callOIDCCallback(t, handlerB, fmt.Sprintf("state=%s&code=fake", state))
+		rr := callOIDCCallback(t, handlerB, fmt.Sprintf("state=%s&code=fake", state))
 
-	// Current behavior: B has no entry, rejects with 400.
-	require.Equal(t, http.StatusBadRequest, rr.Code,
-		"#4019 regression: callback to a different replica returns 400")
+		require.Equal(t, http.StatusBadRequest, rr.Code,
+			"#4019 without shared signing key: B rejects A's signed state with 400")
 
-	body := strings.TrimSpace(rr.Body.String())
-	require.Equal(t, "invalid request", body,
-		"#4019 regression: failure mode is the unknown-state path, not a "+
-			"different error type")
+		body := strings.TrimSpace(rr.Body.String())
+		require.Contains(t, body, "invalid request",
+			"failure mode is the generic invalid-state path; we deliberately "+
+				"don't leak signature-vs-other distinctions to anonymous callers")
+	})
 
-	// Sanity: the state IS recognized on the issuing replica, proving the
-	// failure on B is specifically a per-process map lookup miss and not
-	// some unrelated rejection (e.g. malformed state).
-	rrA := callOIDCCallback(t, handlerA, fmt.Sprintf("state=%s&code=fake", state))
-	require.NotEqual(t, http.StatusBadRequest, rrA.Code,
-		"sanity: replica A should accept the state it issued (token exchange "+
-			"is expected to fail downstream because the test mock is unwired, "+
-			"but state lookup must succeed)")
+	t.Run("with_shared_signing_key", func(t *testing.T) {
+		oidcSrv := newOIDCTestServer(t, nil)
+
+		// Write a shared signing key to a temp file used by both handlers.
+		key := make([]byte, 32)
+		for i := range key {
+			key[i] = byte(0xA0 ^ i) // arbitrary deterministic 32 bytes
+		}
+
+		keyFile := writeTempKeyFile(t, key)
+
+		handlerA, clusterA := newOIDCTestHandlerWithKey(t, oidcSrv, keyFile)
+		handlerB, clusterB := newOIDCTestHandlerWithKey(t, oidcSrv, keyFile)
+
+		require.Equal(t, clusterA, clusterB,
+			"sanity: replicas reference the same cluster name")
+
+		loc := driveOIDCStart(t, handlerA, clusterA)
+		state := extractState(t, loc)
+
+		rr := callOIDCCallback(t, handlerB, fmt.Sprintf("state=%s&code=fake", state))
+
+		require.NotEqual(t, http.StatusBadRequest, rr.Code,
+			"#4019 fix: with shared signing key, B should accept A's state and "+
+				"proceed to the token-exchange step (which our test mock fails, "+
+				"yielding 500 — but state validation has succeeded). got %d body=%q",
+			rr.Code, rr.Body.String())
+	})
+}
+
+// writeTempKeyFile writes the given key bytes to a temp file and returns
+// the path. Used by the multi-replica subtests to give two handler
+// instances the same signing key.
+func writeTempKeyFile(t *testing.T, key []byte) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := dir + "/oidc-state-signing.key"
+
+	if err := os.WriteFile(path, key, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	return path
 }

--- a/backend/cmd/oidc_handlers_test.go
+++ b/backend/cmd/oidc_handlers_test.go
@@ -465,3 +465,71 @@ func writeTempKeyFile(t *testing.T, key []byte) string {
 
 	return path
 }
+
+// driveOIDCStartWithQuery is like driveOIDCStart but lets the caller
+// supply a full query string. Used by stage 4 tests that want to add
+// returnTo / mode parameters.
+func driveOIDCStartWithQuery(t *testing.T, handler http.Handler, query string) (*url.URL, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/oidc?"+query, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		return nil, rr
+	}
+
+	loc := rr.Header().Get("Location")
+	require.NotEmpty(t, loc, "Location header missing on /oidc redirect")
+
+	u, err := url.Parse(loc)
+	require.NoError(t, err)
+
+	return u, rr
+}
+
+// TestOIDCStart_RejectsBadReturnTo covers the /oidc returnTo validation
+// added in stage 4. Open redirect attempts must be rejected with 400 at
+// issue time, before the IdP redirect.
+func TestOIDCStart_RejectsBadReturnTo(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+	cases := []string{
+		"https://evil/",
+		"//evil",
+		"/foo/../etc",
+		"javascript:alert(1)",
+	}
+
+	for _, bad := range cases {
+		bad := bad
+		t.Run(bad, func(t *testing.T) {
+			query := fmt.Sprintf("cluster=%s&returnTo=%s", cluster, url.QueryEscape(bad))
+			_, rr := driveOIDCStartWithQuery(t, handler, query)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code,
+				"expected 400 rejecting unsafe returnTo %q, got %d body=%q",
+				bad, rr.Code, rr.Body.String())
+		})
+	}
+}
+
+// TestOIDCStart_RejectsDesktopMode covers the explicit reservation of
+// mode=desktop for PR 2 of #5401.
+func TestOIDCStart_RejectsDesktopMode(t *testing.T) {
+	oidcSrv := newOIDCTestServer(t, nil)
+	handler, cluster := newOIDCTestHandler(t, oidcSrv)
+
+	query := fmt.Sprintf("cluster=%s&mode=desktop", cluster)
+	_, rr := driveOIDCStartWithQuery(t, handler, query)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "PR 2",
+		"error body should explain that desktop mode is reserved")
+}
+

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -138,6 +138,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		OidcSkipTLSVerify:         conf.OidcSkipTLSVerify,
 		OidcUseAccessToken:        conf.OidcUseAccessToken,
 		OidcUsePKCE:               conf.OidcUsePKCE,
+		OidcStateSigningKeyFile:   conf.OidcStateSigningKeyFile,
 		MeUsernamePaths:           conf.MeUsernamePath,
 		MeEmailPaths:              conf.MeEmailPath,
 		MeGroupsPaths:             conf.MeGroupsPath,

--- a/backend/pkg/auth/return_to.go
+++ b/backend/pkg/auth/return_to.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// MaxReturnToLen is the maximum length, in bytes, of a returnTo value after
+// URL-decoding. The bound is intentionally generous to accommodate deep-links
+// with several query parameters while still rejecting payload-shaped inputs.
+const MaxReturnToLen = 2048
+
+// ErrReturnToInvalid is returned by ValidateReturnTo when the input does not
+// satisfy the safety rules. Callers should treat the input as untrusted and
+// not echo it back to users in error responses.
+var ErrReturnToInvalid = errors.New("invalid returnTo")
+
+// ValidateReturnTo validates a returnTo URL fragment intended for an in-app
+// redirect after OIDC login.
+//
+// The returned string is the cleaned value (path + raw query, no fragment).
+// If baseURL is non-empty, the validated path is required to live under
+// baseURL's path prefix. baseURL is interpreted as a URL for prefix matching;
+// only its path is consulted.
+//
+// Rules:
+//   - must start with "/"
+//   - reject scheme-relative ("//host") and absolute ("http://", "https://", etc.)
+//   - reject encoded traversal: literal "..", "%2e%2e" (case-insensitive)
+//   - reject control characters (\x00-\x1f, \x7f) anywhere in the input
+//   - max MaxReturnToLen bytes after URL-decoding
+//   - fragments are rejected (callers must strip them before calling)
+func ValidateReturnTo(s, baseURL string) (string, error) {
+	if s == "" {
+		return "", fmt.Errorf("%w: empty", ErrReturnToInvalid)
+	}
+
+	if len(s) > MaxReturnToLen {
+		return "", fmt.Errorf("%w: too long", ErrReturnToInvalid)
+	}
+
+	// Reject control characters in the raw form. Decoding can hide them.
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("%w: control character", ErrReturnToInvalid)
+		}
+	}
+
+	// Encoded traversal — case-insensitive. We check the raw form so that
+	// callers can't sneak ".." past us via percent-encoding even before
+	// url.Parse normalizes it.
+	lower := strings.ToLower(s)
+	if strings.Contains(lower, "%2e%2e") {
+		return "", fmt.Errorf("%w: encoded traversal", ErrReturnToInvalid)
+	}
+
+	// Must start with a single "/" — reject scheme-relative ("//host") up front.
+	if !strings.HasPrefix(s, "/") {
+		return "", fmt.Errorf("%w: must start with /", ErrReturnToInvalid)
+	}
+
+	if strings.HasPrefix(s, "//") {
+		return "", fmt.Errorf("%w: scheme-relative", ErrReturnToInvalid)
+	}
+
+	// Parse and inspect the URL. url.Parse does not by itself reject schemes,
+	// so we have to check explicitly. A leading "/" already rules out most
+	// absolute forms, but be defensive against URL-parser quirks.
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrReturnToInvalid, err)
+	}
+
+	if u.Scheme != "" || u.Host != "" || u.User != nil {
+		return "", fmt.Errorf("%w: must be path-only", ErrReturnToInvalid)
+	}
+
+	if u.Fragment != "" || strings.Contains(s, "#") {
+		return "", fmt.Errorf("%w: fragment not allowed", ErrReturnToInvalid)
+	}
+
+	// Decoded-length check. url.Parse percent-decodes the path; query stays raw.
+	decoded := u.Path
+	if u.RawQuery != "" {
+		decoded += "?" + u.RawQuery
+	}
+
+	if len(decoded) > MaxReturnToLen {
+		return "", fmt.Errorf("%w: too long after decoding", ErrReturnToInvalid)
+	}
+
+	// Literal traversal segments in the decoded path.
+	for _, seg := range strings.Split(u.Path, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("%w: traversal", ErrReturnToInvalid)
+		}
+	}
+
+	// baseURL prefix constraint. We compare normalized paths to avoid trivial
+	// suffix-of-name attacks ("/foobar" passing a "/foo" prefix).
+	if baseURL != "" {
+		bu, err := url.Parse(baseURL)
+		if err != nil {
+			return "", fmt.Errorf("%w: bad baseURL: %v", ErrReturnToInvalid, err)
+		}
+
+		basePath := bu.Path
+		if basePath == "" {
+			basePath = "/"
+		}
+
+		if !pathHasPrefix(u.Path, basePath) {
+			return "", fmt.Errorf("%w: outside baseURL", ErrReturnToInvalid)
+		}
+	}
+
+	out := u.Path
+	if u.RawQuery != "" {
+		out += "?" + u.RawQuery
+	}
+
+	return out, nil
+}
+
+// pathHasPrefix reports whether p is at or under prefix on path-segment
+// boundaries. "/foobar" does not have prefix "/foo"; "/foo/bar" does.
+func pathHasPrefix(p, prefix string) bool {
+	if prefix == "/" || prefix == "" {
+		return strings.HasPrefix(p, "/")
+	}
+
+	prefix = strings.TrimRight(prefix, "/")
+	if p == prefix {
+		return true
+	}
+
+	return strings.HasPrefix(p, prefix+"/")
+}

--- a/backend/pkg/auth/return_to_test.go
+++ b/backend/pkg/auth/return_to_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateReturnTo_Accept(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"root", "/", "/"},
+		{"deep cluster path", "/c/main/pods/default/foo", "/c/main/pods/default/foo"},
+		{"with query", "/c/main/pods/default/foo?view=logs", "/c/main/pods/default/foo?view=logs"},
+		{"trailing slash", "/c/main/", "/c/main/"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ValidateReturnTo(tc.in, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateReturnTo_Reject(t *testing.T) {
+	t.Parallel()
+
+	long := "/" + strings.Repeat("a", MaxReturnToLen+1)
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"https absolute", "https://evil/"},
+		{"http absolute", "http://evil/"},
+		{"scheme relative", "//evil"},
+		{"literal traversal", "/foo/../etc"},
+		{"encoded lower", "%2e%2e/etc"},
+		{"encoded upper", "%2E%2E/etc"},
+		{"encoded mixed", "/foo/%2e%2E/bar"},
+		{"javascript scheme", "javascript:alert(1)"},
+		{"data scheme", "data:text/html,<script>"},
+		{"NUL", "/foo\x00"},
+		{"control 0x1f", "/foo\x1f"},
+		{"DEL", "/foo\x7f"},
+		{"oversized", long},
+		{"fragment", "/foo#bar"},
+		{"missing leading slash", "foo/bar"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ValidateReturnTo(tc.in, "")
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.in)
+			}
+
+			if !errors.Is(err, ErrReturnToInvalid) {
+				t.Fatalf("expected ErrReturnToInvalid, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateReturnTo_BaseURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("under base", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := ValidateReturnTo("/headlamp/c/main/pods", "https://example.com/headlamp/")
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+
+		if got != "/headlamp/c/main/pods" {
+			t.Fatalf("unexpected output %q", got)
+		}
+	})
+
+	t.Run("equal to base", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := ValidateReturnTo("/headlamp", "https://example.com/headlamp")
+		if err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+
+		if got != "/headlamp" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("escapes base", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ValidateReturnTo("/other/page", "https://example.com/headlamp")
+		if err == nil {
+			t.Fatalf("expected escape rejection")
+		}
+	})
+
+	t.Run("suffix-of-name not under prefix", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ValidateReturnTo("/headlamper/x", "https://example.com/headlamp")
+		if err == nil {
+			t.Fatalf("expected suffix-of-name rejection")
+		}
+	})
+}

--- a/backend/pkg/auth/state.go
+++ b/backend/pkg/auth/state.go
@@ -29,18 +29,53 @@ import (
 	"time"
 )
 
+// StateMode is the redirect-flow shape carried in StatePayload.Mode.
+// Centralizing the valid set here lets callers (the /oidc and
+// /oidc-callback handlers) compare against typed constants instead of
+// stringly-typed values, and lets the desktop reservation be enforced
+// in one place.
+type StateMode string
+
+const (
+	// ModePopup is the default; AuthChooser opens /oidc in a popup window
+	// and the callback redirects through /auth so the popup can hand the
+	// auth-success signal to its opener.
+	ModePopup StateMode = "popup"
+	// ModeFullPage is for direct navigation entries; the callback
+	// redirects straight to ReturnTo, skipping /auth.
+	ModeFullPage StateMode = "fullPage"
+	// ModeDesktop is reserved for the PR-2 desktop OIDC code-handoff
+	// flow. /oidc rejects it with 400 today.
+	ModeDesktop StateMode = "desktop"
+)
+
+// Valid reports whether m is one of the recognized StateModes.
+func (m StateMode) Valid() bool {
+	switch m {
+	case ModePopup, ModeFullPage, ModeDesktop:
+		return true
+	default:
+		return false
+	}
+}
+
 // StatePayload is the JSON payload that round-trips between the /oidc and
 // /oidc-callback handlers via the OAuth2 `state` query parameter. It carries
 // everything the callback needs to reconstruct the OIDC config and verify
 // the request without per-process server state.
 type StatePayload struct {
-	V            int    `json:"v"`       // schema version, currently 1
-	Cluster      string `json:"cluster"` // cluster name from /oidc query
-	Mode         string `json:"mode"`    // "popup" | "fullPage" | "desktop"
-	ReturnTo     string `json:"returnTo,omitempty"`
-	CodeVerifier string `json:"codeVerifier"` // PKCE
-	ExpUnixMs    int64  `json:"exp"`          // unix milliseconds
-	CSRF         string `json:"csrf"`         // 16 random bytes hex
+	V            int       `json:"v"`       // schema version, currently 1
+	Cluster      string    `json:"cluster"` // cluster name from /oidc query
+	Mode         StateMode `json:"mode"`
+	ReturnTo     string    `json:"returnTo,omitempty"`
+	CodeVerifier string    `json:"codeVerifier,omitempty"` // PKCE; absent when PKCE is off
+	// ExpUnixMs is the absolute expiry time in unix milliseconds.
+	// The wire-format key is "expMs" (not the JWT-conventional "exp",
+	// which is unix seconds) so debuggers and log aggregators don't
+	// misread the unit by a factor of 1000. Encode populates this
+	// automatically from the signer's clock + TTL; Decode requires it.
+	ExpUnixMs int64  `json:"expMs"`
+	CSRF      string `json:"csrf"` // 16 random bytes hex
 }
 
 // StateSchemaVersion is the only schema version the StateSigner accepts.
@@ -53,6 +88,10 @@ const MaxStatePayloadBytes = 4 * 1024
 // MinStateKeyBytes is the smallest acceptable HMAC key length.
 const MinStateKeyBytes = 32
 
+// defaultLRUSize is the consumed-CSRF cache size used when the caller
+// doesn't supply WithLRUSize.
+const defaultLRUSize = 1024
+
 // Errors returned by StateSigner.Decode. Callers should not echo error
 // details to end users; treat any error as "invalid request".
 var (
@@ -61,20 +100,42 @@ var (
 	ErrStateBadVersion    = errors.New("state bad schema version")
 	ErrStateExpired       = errors.New("state expired")
 	ErrStatePayloadTooBig = errors.New("state payload too large")
+	ErrStateMissingCSRF   = errors.New("state missing CSRF")
+	ErrStateMissingExpiry = errors.New("state missing expiry")
 )
 
-// Clock is the time source used by StateSigner. Production uses time.Now;
-// tests inject a fake clock to drive expiry deterministically.
-type Clock func() time.Time
+// clockFn is the time source used by StateSigner. Production uses
+// time.Now; tests inject a fake clock to drive expiry deterministically.
+// Unexported so the type's API surface stays minimal.
+type clockFn func() time.Time
+
+// SignerOption configures a StateSigner at construction time.
+type SignerOption func(*StateSigner)
+
+// WithClock replaces the time source. Intended for tests so expiry can
+// be driven without sleeping. Has no effect on existing in-flight calls.
+func WithClock(c func() time.Time) SignerOption {
+	return func(s *StateSigner) { s.clock = c }
+}
+
+// WithLRUSize overrides the consumed-CSRF cache capacity.
+func WithLRUSize(n int) SignerOption {
+	return func(s *StateSigner) {
+		if n > 0 {
+			s.lruSize = n
+		}
+	}
+}
 
 // StateSigner encodes and decodes signed state tokens for the OIDC handlers,
 // and tracks consumed CSRF identifiers to enforce single-use semantics.
 //
-// A StateSigner is safe for concurrent use by multiple goroutines.
+// A StateSigner is safe for concurrent use by multiple goroutines; all
+// fields are either immutable after construction or guarded by mu.
 type StateSigner struct {
 	key   []byte
 	ttl   time.Duration
-	clock Clock
+	clock clockFn
 
 	mu       sync.Mutex
 	lru      *list.List
@@ -85,39 +146,43 @@ type StateSigner struct {
 // NewStateSigner constructs a StateSigner.
 //
 // key must be at least MinStateKeyBytes long; shorter keys panic so that
-// misconfiguration is loud rather than silent. ttl is the maximum age a
-// token may have before Decode rejects it. lruSize bounds the consumed-CSRF
-// cache; a typical value is 1024.
-func NewStateSigner(key []byte, ttl time.Duration, lruSize int) *StateSigner {
+// misconfiguration is loud rather than silent. ttl is the expiry stamped
+// on every Encode call (now + ttl).
+//
+// Optional behaviors are configured via SignerOptions: WithClock for tests,
+// WithLRUSize to override the consumed-CSRF cache capacity (default 1024).
+func NewStateSigner(key []byte, ttl time.Duration, opts ...SignerOption) *StateSigner {
 	if len(key) < MinStateKeyBytes {
 		panic(fmt.Sprintf("auth.NewStateSigner: key must be >= %d bytes, got %d", MinStateKeyBytes, len(key)))
 	}
 
-	if lruSize <= 0 {
-		lruSize = 1024
-	}
-
-	return &StateSigner{
+	s := &StateSigner{
 		key:      append([]byte(nil), key...),
 		ttl:      ttl,
 		clock:    time.Now,
 		lru:      list.New(),
-		consumed: make(map[string]*list.Element, lruSize),
-		lruSize:  lruSize,
+		consumed: make(map[string]*list.Element, defaultLRUSize),
+		lruSize:  defaultLRUSize,
 	}
-}
 
-// SetClock overrides the time source. Intended for tests.
-func (s *StateSigner) SetClock(c Clock) {
-	s.clock = c
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
 }
 
 // Encode serializes p as base64url(json) + "." + base64url(HMAC-SHA256).
 // The encoding is URL-safe and fits comfortably inside a query parameter.
+//
+// Encode stamps the schema version and expiry automatically; callers don't
+// need to set p.V or p.ExpUnixMs (and any value they pass is overwritten).
+// Encode does not validate Mode — the handler is responsible for refusing
+// callers that ask for unsupported modes (it knows which modes the deploy
+// supports; the package-level constants only describe what's representable).
 func (s *StateSigner) Encode(p StatePayload) (string, error) {
-	if p.V == 0 {
-		p.V = StateSchemaVersion
-	}
+	p.V = StateSchemaVersion
+	p.ExpUnixMs = s.clock().Add(s.ttl).UnixMilli()
 
 	body, err := json.Marshal(p)
 	if err != nil {
@@ -137,12 +202,18 @@ func (s *StateSigner) Encode(p StatePayload) (string, error) {
 	return bodyB64 + "." + sig, nil
 }
 
-// Decode verifies the signature, schema version, payload size, and expiry,
-// returning the parsed payload on success.
+// Decode verifies the signature, schema version, payload size, expiry,
+// and CSRF presence, returning the parsed payload on success.
 //
 // Decode does NOT mark the payload's CSRF as consumed; callers invoke
 // MarkConsumed separately so that the consume step happens after any other
 // validations that might reject the request.
+//
+// A token whose ExpUnixMs is zero is rejected with ErrStateMissingExpiry
+// — there is no "never expires" mode. A token whose CSRF is empty is
+// rejected with ErrStateMissingCSRF, since the single-use guarantee is
+// keyed on CSRF and an empty key would silently degrade to "every replay
+// passes".
 func (s *StateSigner) Decode(token string) (StatePayload, error) {
 	dot := strings.IndexByte(token, '.')
 	if dot < 0 {
@@ -185,11 +256,16 @@ func (s *StateSigner) Decode(token string) (StatePayload, error) {
 		return StatePayload{}, ErrStateBadVersion
 	}
 
-	if p.ExpUnixMs > 0 {
-		nowMs := s.clock().UnixMilli()
-		if nowMs > p.ExpUnixMs {
-			return StatePayload{}, ErrStateExpired
-		}
+	if p.ExpUnixMs <= 0 {
+		return StatePayload{}, ErrStateMissingExpiry
+	}
+
+	if s.clock().UnixMilli() > p.ExpUnixMs {
+		return StatePayload{}, ErrStateExpired
+	}
+
+	if p.CSRF == "" {
+		return StatePayload{}, ErrStateMissingCSRF
 	}
 
 	return p, nil
@@ -200,9 +276,14 @@ func (s *StateSigner) Decode(token string) (StatePayload, error) {
 // false. Eviction of the LRU's oldest entry can let a previously-consumed
 // csrf re-pass; with lruSize tuned to dwarf concurrent in-flight logins
 // this is acceptable.
+//
+// MarkConsumed panics if csrf is empty. Callers are expected to validate
+// the payload via Decode (which rejects empty CSRF) before reaching this
+// point; the panic exists so a programmer error stays loud rather than
+// silently degrading the single-use guarantee to "every replay passes".
 func (s *StateSigner) MarkConsumed(csrf string) (firstUse bool) {
 	if csrf == "" {
-		return false
+		panic("auth.StateSigner.MarkConsumed: empty CSRF (Decode should have rejected this)")
 	}
 
 	s.mu.Lock()
@@ -229,15 +310,4 @@ func (s *StateSigner) MarkConsumed(csrf string) (firstUse bool) {
 	}
 
 	return true
-}
-
-// TTL returns the configured token lifetime. Useful for callers that want
-// to set ExpUnixMs to clock+TTL when constructing a payload.
-func (s *StateSigner) TTL() time.Duration {
-	return s.ttl
-}
-
-// Now returns the signer's current clock time.
-func (s *StateSigner) Now() time.Time {
-	return s.clock()
 }

--- a/backend/pkg/auth/state.go
+++ b/backend/pkg/auth/state.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"container/list"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// StatePayload is the JSON payload that round-trips between the /oidc and
+// /oidc-callback handlers via the OAuth2 `state` query parameter. It carries
+// everything the callback needs to reconstruct the OIDC config and verify
+// the request without per-process server state.
+type StatePayload struct {
+	V            int    `json:"v"`       // schema version, currently 1
+	Cluster      string `json:"cluster"` // cluster name from /oidc query
+	Mode         string `json:"mode"`    // "popup" | "fullPage" | "desktop"
+	ReturnTo     string `json:"returnTo,omitempty"`
+	CodeVerifier string `json:"codeVerifier"` // PKCE
+	ExpUnixMs    int64  `json:"exp"`          // unix milliseconds
+	CSRF         string `json:"csrf"`         // 16 random bytes hex
+}
+
+// StateSchemaVersion is the only schema version the StateSigner accepts.
+const StateSchemaVersion = 1
+
+// MaxStatePayloadBytes bounds the decoded JSON payload size to keep
+// attacker-supplied tokens from forcing large allocations.
+const MaxStatePayloadBytes = 4 * 1024
+
+// MinStateKeyBytes is the smallest acceptable HMAC key length.
+const MinStateKeyBytes = 32
+
+// Errors returned by StateSigner.Decode. Callers should not echo error
+// details to end users; treat any error as "invalid request".
+var (
+	ErrStateMalformed     = errors.New("state malformed")
+	ErrStateBadSignature  = errors.New("state bad signature")
+	ErrStateBadVersion    = errors.New("state bad schema version")
+	ErrStateExpired       = errors.New("state expired")
+	ErrStatePayloadTooBig = errors.New("state payload too large")
+)
+
+// Clock is the time source used by StateSigner. Production uses time.Now;
+// tests inject a fake clock to drive expiry deterministically.
+type Clock func() time.Time
+
+// StateSigner encodes and decodes signed state tokens for the OIDC handlers,
+// and tracks consumed CSRF identifiers to enforce single-use semantics.
+//
+// A StateSigner is safe for concurrent use by multiple goroutines.
+type StateSigner struct {
+	key   []byte
+	ttl   time.Duration
+	clock Clock
+
+	mu       sync.Mutex
+	lru      *list.List
+	consumed map[string]*list.Element
+	lruSize  int
+}
+
+// NewStateSigner constructs a StateSigner.
+//
+// key must be at least MinStateKeyBytes long; shorter keys panic so that
+// misconfiguration is loud rather than silent. ttl is the maximum age a
+// token may have before Decode rejects it. lruSize bounds the consumed-CSRF
+// cache; a typical value is 1024.
+func NewStateSigner(key []byte, ttl time.Duration, lruSize int) *StateSigner {
+	if len(key) < MinStateKeyBytes {
+		panic(fmt.Sprintf("auth.NewStateSigner: key must be >= %d bytes, got %d", MinStateKeyBytes, len(key)))
+	}
+
+	if lruSize <= 0 {
+		lruSize = 1024
+	}
+
+	return &StateSigner{
+		key:      append([]byte(nil), key...),
+		ttl:      ttl,
+		clock:    time.Now,
+		lru:      list.New(),
+		consumed: make(map[string]*list.Element, lruSize),
+		lruSize:  lruSize,
+	}
+}
+
+// SetClock overrides the time source. Intended for tests.
+func (s *StateSigner) SetClock(c Clock) {
+	s.clock = c
+}
+
+// Encode serializes p as base64url(json) + "." + base64url(HMAC-SHA256).
+// The encoding is URL-safe and fits comfortably inside a query parameter.
+func (s *StateSigner) Encode(p StatePayload) (string, error) {
+	if p.V == 0 {
+		p.V = StateSchemaVersion
+	}
+
+	body, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("encode state: %w", err)
+	}
+
+	if len(body) > MaxStatePayloadBytes {
+		return "", fmt.Errorf("%w: %d bytes", ErrStatePayloadTooBig, len(body))
+	}
+
+	bodyB64 := base64.RawURLEncoding.EncodeToString(body)
+
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write([]byte(bodyB64))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return bodyB64 + "." + sig, nil
+}
+
+// Decode verifies the signature, schema version, payload size, and expiry,
+// returning the parsed payload on success.
+//
+// Decode does NOT mark the payload's CSRF as consumed; callers invoke
+// MarkConsumed separately so that the consume step happens after any other
+// validations that might reject the request.
+func (s *StateSigner) Decode(token string) (StatePayload, error) {
+	dot := strings.IndexByte(token, '.')
+	if dot < 0 {
+		return StatePayload{}, ErrStateMalformed
+	}
+
+	bodyB64, sigB64 := token[:dot], token[dot+1:]
+	if bodyB64 == "" || sigB64 == "" {
+		return StatePayload{}, ErrStateMalformed
+	}
+
+	gotSig, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return StatePayload{}, fmt.Errorf("%w: signature encoding", ErrStateMalformed)
+	}
+
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write([]byte(bodyB64))
+	wantSig := mac.Sum(nil)
+
+	if !hmac.Equal(gotSig, wantSig) {
+		return StatePayload{}, ErrStateBadSignature
+	}
+
+	body, err := base64.RawURLEncoding.DecodeString(bodyB64)
+	if err != nil {
+		return StatePayload{}, fmt.Errorf("%w: body encoding", ErrStateMalformed)
+	}
+
+	if len(body) > MaxStatePayloadBytes {
+		return StatePayload{}, ErrStatePayloadTooBig
+	}
+
+	var p StatePayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return StatePayload{}, fmt.Errorf("%w: %v", ErrStateMalformed, err)
+	}
+
+	if p.V != StateSchemaVersion {
+		return StatePayload{}, ErrStateBadVersion
+	}
+
+	if p.ExpUnixMs > 0 {
+		nowMs := s.clock().UnixMilli()
+		if nowMs > p.ExpUnixMs {
+			return StatePayload{}, ErrStateExpired
+		}
+	}
+
+	return p, nil
+}
+
+// MarkConsumed records csrf as consumed and reports whether this is the
+// first call for that csrf. Subsequent calls within the LRU window return
+// false. Eviction of the LRU's oldest entry can let a previously-consumed
+// csrf re-pass; with lruSize tuned to dwarf concurrent in-flight logins
+// this is acceptable.
+func (s *StateSigner) MarkConsumed(csrf string) (firstUse bool) {
+	if csrf == "" {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if elem, ok := s.consumed[csrf]; ok {
+		s.lru.MoveToFront(elem)
+		return false
+	}
+
+	elem := s.lru.PushFront(csrf)
+	s.consumed[csrf] = elem
+
+	for s.lru.Len() > s.lruSize {
+		oldest := s.lru.Back()
+		if oldest == nil {
+			break
+		}
+
+		s.lru.Remove(oldest)
+		if k, ok := oldest.Value.(string); ok {
+			delete(s.consumed, k)
+		}
+	}
+
+	return true
+}
+
+// TTL returns the configured token lifetime. Useful for callers that want
+// to set ExpUnixMs to clock+TTL when constructing a payload.
+func (s *StateSigner) TTL() time.Duration {
+	return s.ttl
+}
+
+// Now returns the signer's current clock time.
+func (s *StateSigner) Now() time.Time {
+	return s.clock()
+}

--- a/backend/pkg/auth/state_test.go
+++ b/backend/pkg/auth/state_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestKey(b byte) []byte {
+	k := make([]byte, MinStateKeyBytes)
+	for i := range k {
+		k[i] = b
+	}
+
+	return k
+}
+
+func samplePayload() StatePayload {
+	return StatePayload{
+		V:            StateSchemaVersion,
+		Cluster:      "main",
+		Mode:         "popup",
+		ReturnTo:     "/c/main/pods",
+		CodeVerifier: "abcDEF1234567890abcDEF1234567890abcdef0123",
+		ExpUnixMs:    time.Now().Add(5 * time.Minute).UnixMilli(),
+		CSRF:         "deadbeefcafef00d0011223344556677",
+	}
+}
+
+func TestStateSigner_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0xAB), 5*time.Minute, 16)
+
+	want := samplePayload()
+
+	tok, err := s.Encode(want)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	if !strings.Contains(tok, ".") {
+		t.Fatalf("token missing separator: %q", tok)
+	}
+
+	got, err := s.Decode(tok)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got != want {
+		t.Fatalf("round-trip mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+func TestStateSigner_TamperedSignature(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0xAB), 5*time.Minute, 16)
+
+	tok, err := s.Encode(samplePayload())
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// Flip the last byte of the signature segment.
+	tampered := tok[:len(tok)-1]
+	if tok[len(tok)-1] == 'A' {
+		tampered += "B"
+	} else {
+		tampered += "A"
+	}
+
+	_, err = s.Decode(tampered)
+	if !errors.Is(err, ErrStateBadSignature) {
+		t.Fatalf("expected ErrStateBadSignature, got %v", err)
+	}
+}
+
+func TestStateSigner_DifferentKey(t *testing.T) {
+	t.Parallel()
+
+	a := NewStateSigner(newTestKey(0x01), 5*time.Minute, 16)
+	b := NewStateSigner(newTestKey(0x02), 5*time.Minute, 16)
+
+	tok, err := a.Encode(samplePayload())
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	_, err = b.Decode(tok)
+	if !errors.Is(err, ErrStateBadSignature) {
+		t.Fatalf("expected ErrStateBadSignature across signers, got %v", err)
+	}
+}
+
+func TestStateSigner_Expired(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0xCC), 5*time.Minute, 16)
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s.SetClock(func() time.Time { return now })
+
+	p := samplePayload()
+	p.ExpUnixMs = now.Add(time.Minute).UnixMilli()
+
+	tok, err := s.Encode(p)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// Advance past expiry.
+	s.SetClock(func() time.Time { return now.Add(2 * time.Minute) })
+
+	_, err = s.Decode(tok)
+	if !errors.Is(err, ErrStateExpired) {
+		t.Fatalf("expected ErrStateExpired, got %v", err)
+	}
+}
+
+func TestStateSigner_BadVersion(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0xDD), 5*time.Minute, 16)
+
+	p := samplePayload()
+	p.V = 999
+
+	tok, err := s.Encode(p)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	_, err = s.Decode(tok)
+	if !errors.Is(err, ErrStateBadVersion) {
+		t.Fatalf("expected ErrStateBadVersion, got %v", err)
+	}
+}
+
+func TestStateSigner_PayloadTooBig(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0xEE), 5*time.Minute, 16)
+
+	p := samplePayload()
+	p.CodeVerifier = strings.Repeat("a", MaxStatePayloadBytes+1)
+
+	_, err := s.Encode(p)
+	if !errors.Is(err, ErrStatePayloadTooBig) {
+		t.Fatalf("expected ErrStatePayloadTooBig on encode, got %v", err)
+	}
+}
+
+func TestStateSigner_Malformed(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0xFF), 5*time.Minute, 16)
+
+	cases := []string{
+		"",
+		"no-dot-here",
+		".onlydot",
+		"onlydot.",
+		"$$$.$$$",
+	}
+
+	for _, tc := range cases {
+		_, err := s.Decode(tc)
+		if err == nil {
+			t.Fatalf("expected error decoding %q", tc)
+		}
+	}
+}
+
+func TestStateSigner_MarkConsumed(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0x11), 5*time.Minute, 4)
+
+	if !s.MarkConsumed("a") {
+		t.Fatalf("first MarkConsumed should return true")
+	}
+
+	if s.MarkConsumed("a") {
+		t.Fatalf("second MarkConsumed should return false")
+	}
+
+	// Fill the LRU past its capacity to evict "a".
+	for i := 0; i < 8; i++ {
+		s.MarkConsumed(fmt.Sprintf("k%d", i))
+	}
+
+	// "a" was evicted; it can re-pass once. This documents the LRU
+	// semantics: capacity should dwarf concurrent in-flight logins.
+	if !s.MarkConsumed("a") {
+		t.Fatalf("after eviction, MarkConsumed(\"a\") should return true again")
+	}
+}
+
+func TestStateSigner_NewStateSigner_RejectsShortKey(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on short key")
+		}
+	}()
+
+	_ = NewStateSigner(make([]byte, MinStateKeyBytes-1), time.Minute, 4)
+}

--- a/backend/pkg/auth/state_test.go
+++ b/backend/pkg/auth/state_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package auth
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -35,12 +38,10 @@ func newTestKey(b byte) []byte {
 
 func samplePayload() StatePayload {
 	return StatePayload{
-		V:            StateSchemaVersion,
 		Cluster:      "main",
-		Mode:         "popup",
+		Mode:         ModePopup,
 		ReturnTo:     "/c/main/pods",
 		CodeVerifier: "abcDEF1234567890abcDEF1234567890abcdef0123",
-		ExpUnixMs:    time.Now().Add(5 * time.Minute).UnixMilli(),
 		CSRF:         "deadbeefcafef00d0011223344556677",
 	}
 }
@@ -48,11 +49,11 @@ func samplePayload() StatePayload {
 func TestStateSigner_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	s := NewStateSigner(newTestKey(0xAB), 5*time.Minute, 16)
+	s := NewStateSigner(newTestKey(0xAB), 5*time.Minute, WithLRUSize(16))
 
-	want := samplePayload()
+	in := samplePayload()
 
-	tok, err := s.Encode(want)
+	tok, err := s.Encode(in)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -66,15 +67,26 @@ func TestStateSigner_RoundTrip(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
+	// Encode stamps V and ExpUnixMs; the input doesn't carry those so we
+	// build the expected payload here and require everything else to
+	// round-trip exactly.
+	want := in
+	want.V = StateSchemaVersion
+	want.ExpUnixMs = got.ExpUnixMs
+
 	if got != want {
 		t.Fatalf("round-trip mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+
+	if got.ExpUnixMs <= 0 {
+		t.Fatalf("Encode should stamp ExpUnixMs; got %d", got.ExpUnixMs)
 	}
 }
 
 func TestStateSigner_TamperedSignature(t *testing.T) {
 	t.Parallel()
 
-	s := NewStateSigner(newTestKey(0xAB), 5*time.Minute, 16)
+	s := NewStateSigner(newTestKey(0xAB), 5*time.Minute, WithLRUSize(16))
 
 	tok, err := s.Encode(samplePayload())
 	if err != nil {
@@ -98,8 +110,8 @@ func TestStateSigner_TamperedSignature(t *testing.T) {
 func TestStateSigner_DifferentKey(t *testing.T) {
 	t.Parallel()
 
-	a := NewStateSigner(newTestKey(0x01), 5*time.Minute, 16)
-	b := NewStateSigner(newTestKey(0x02), 5*time.Minute, 16)
+	a := NewStateSigner(newTestKey(0x01), 5*time.Minute, WithLRUSize(16))
+	b := NewStateSigner(newTestKey(0x02), 5*time.Minute, WithLRUSize(16))
 
 	tok, err := a.Encode(samplePayload())
 	if err != nil {
@@ -115,21 +127,23 @@ func TestStateSigner_DifferentKey(t *testing.T) {
 func TestStateSigner_Expired(t *testing.T) {
 	t.Parallel()
 
-	s := NewStateSigner(newTestKey(0xCC), 5*time.Minute, 16)
-
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	s.SetClock(func() time.Time { return now })
+	clockTime := now
 
-	p := samplePayload()
-	p.ExpUnixMs = now.Add(time.Minute).UnixMilli()
+	s := NewStateSigner(
+		newTestKey(0xCC),
+		time.Minute,
+		WithLRUSize(16),
+		WithClock(func() time.Time { return clockTime }),
+	)
 
-	tok, err := s.Encode(p)
+	tok, err := s.Encode(samplePayload())
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
 
 	// Advance past expiry.
-	s.SetClock(func() time.Time { return now.Add(2 * time.Minute) })
+	clockTime = now.Add(2 * time.Minute)
 
 	_, err = s.Decode(tok)
 	if !errors.Is(err, ErrStateExpired) {
@@ -140,17 +154,14 @@ func TestStateSigner_Expired(t *testing.T) {
 func TestStateSigner_BadVersion(t *testing.T) {
 	t.Parallel()
 
-	s := NewStateSigner(newTestKey(0xDD), 5*time.Minute, 16)
+	s := NewStateSigner(newTestKey(0xDD), 5*time.Minute, WithLRUSize(16))
 
-	p := samplePayload()
-	p.V = 999
+	// Encode stamps V automatically, so simulate a wrong-version token by
+	// hand-crafting the body and signing with the same key.
+	body := []byte(`{"v":999,"cluster":"main","mode":"popup","csrf":"abc","expMs":99999999999999}`)
+	tok := craftToken(s, body)
 
-	tok, err := s.Encode(p)
-	if err != nil {
-		t.Fatalf("encode: %v", err)
-	}
-
-	_, err = s.Decode(tok)
+	_, err := s.Decode(tok)
 	if !errors.Is(err, ErrStateBadVersion) {
 		t.Fatalf("expected ErrStateBadVersion, got %v", err)
 	}
@@ -159,7 +170,7 @@ func TestStateSigner_BadVersion(t *testing.T) {
 func TestStateSigner_PayloadTooBig(t *testing.T) {
 	t.Parallel()
 
-	s := NewStateSigner(newTestKey(0xEE), 5*time.Minute, 16)
+	s := NewStateSigner(newTestKey(0xEE), 5*time.Minute, WithLRUSize(16))
 
 	p := samplePayload()
 	p.CodeVerifier = strings.Repeat("a", MaxStatePayloadBytes+1)
@@ -173,7 +184,7 @@ func TestStateSigner_PayloadTooBig(t *testing.T) {
 func TestStateSigner_Malformed(t *testing.T) {
 	t.Parallel()
 
-	s := NewStateSigner(newTestKey(0xFF), 5*time.Minute, 16)
+	s := NewStateSigner(newTestKey(0xFF), 5*time.Minute, WithLRUSize(16))
 
 	cases := []string{
 		"",
@@ -194,7 +205,7 @@ func TestStateSigner_Malformed(t *testing.T) {
 func TestStateSigner_MarkConsumed(t *testing.T) {
 	t.Parallel()
 
-	s := NewStateSigner(newTestKey(0x11), 5*time.Minute, 4)
+	s := NewStateSigner(newTestKey(0x11), 5*time.Minute, WithLRUSize(4))
 
 	if !s.MarkConsumed("a") {
 		t.Fatalf("first MarkConsumed should return true")
@@ -225,5 +236,58 @@ func TestStateSigner_NewStateSigner_RejectsShortKey(t *testing.T) {
 		}
 	}()
 
-	_ = NewStateSigner(make([]byte, MinStateKeyBytes-1), time.Minute, 4)
+	_ = NewStateSigner(make([]byte, MinStateKeyBytes-1), time.Minute)
+}
+
+// craftToken signs the given body with s.key, bypassing Encode's
+// invariant stamping. Used by Decode-only negative tests.
+func craftToken(s *StateSigner, body []byte) string {
+	bodyB64 := base64.RawURLEncoding.EncodeToString(body)
+
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write([]byte(bodyB64))
+
+	return bodyB64 + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func TestStateSigner_RejectsMissingExpiry(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0x55), 5*time.Minute, WithLRUSize(16))
+
+	body := []byte(`{"v":1,"cluster":"main","mode":"popup","csrf":"abc","expMs":0}`)
+	tok := craftToken(s, body)
+
+	_, err := s.Decode(tok)
+	if !errors.Is(err, ErrStateMissingExpiry) {
+		t.Fatalf("expected ErrStateMissingExpiry, got %v", err)
+	}
+}
+
+func TestStateSigner_RejectsMissingCSRF(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0x66), 5*time.Minute, WithLRUSize(16))
+
+	body := []byte(`{"v":1,"cluster":"main","mode":"popup","csrf":"","expMs":99999999999999}`)
+	tok := craftToken(s, body)
+
+	_, err := s.Decode(tok)
+	if !errors.Is(err, ErrStateMissingCSRF) {
+		t.Fatalf("expected ErrStateMissingCSRF, got %v", err)
+	}
+}
+
+func TestStateSigner_MarkConsumed_PanicsOnEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := NewStateSigner(newTestKey(0x77), time.Minute, WithLRUSize(4))
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on empty CSRF")
+		}
+	}()
+
+	s.MarkConsumed("")
 }

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -74,6 +74,13 @@ type Config struct {
 	MeGroupsPath              string `koanf:"me-groups-path"`
 	MeUserInfoURL             string `koanf:"me-user-info-url"`
 	OidcUsePKCE               bool   `koanf:"oidc-use-pkce"`
+	// OidcStateSigningKeyFile, when set, points at a file containing the
+	// HMAC key used to sign the OAuth2 `state` parameter. Without it,
+	// Headlamp generates a per-process random key at startup, which works
+	// for single-replica deployments but breaks under multi-replica
+	// rollouts (#4019). The key file's contents (trailing whitespace
+	// trimmed) must be at least 32 bytes.
+	OidcStateSigningKeyFile string `koanf:"oidc-state-signing-key-file"`
 	// telemetry configs
 	ServiceName        string   `koanf:"service-name"`
 	ServiceVersion     *string  `koanf:"service-version"`
@@ -468,6 +475,12 @@ func addOIDCFlags(f *flag.FlagSet) {
 	f.Bool("oidc-use-access-token", false, "Setup oidc to pass through the access_token instead of the default id_token")
 	f.Bool("oidc-use-cookie", false, "Enable OIDC cookie usage even when not running in-cluster")
 	f.Bool("oidc-use-pkce", false, "Use PKCE (Proof Key for Code Exchange) for enhanced security in OIDC flow")
+	f.String("oidc-state-signing-key-file", "",
+		"Path to a file containing the HMAC key used to sign the OAuth2 state parameter. "+
+			"Required for multi-replica deployments so that all replicas can verify state "+
+			"tokens issued by any other replica. The file must contain at least 32 bytes "+
+			"(trailing whitespace is trimmed). When unset, a per-process random key is "+
+			"generated at startup.")
 	f.String("me-username-path", DefaultMeUsernamePath,
 		"Comma separated JMESPath expressions used to read username from the JWT payload")
 	f.String("me-email-path", DefaultMeEmailPath,

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -27,15 +27,19 @@ type HeadlampConfig struct {
 	OidcSkipTLSVerify         bool
 	OidcCACert                string
 	OidcUsePKCE               bool
-	OidcScopes                []string
-	Cache                     cache.Cache[interface{}]
-	Multiplexer               WebSocketMultiplexer
-	TelemetryConfig           config.Config
-	TelemetryHandler          *telemetry.RequestHandler
-	MeUsernamePaths           string
-	MeEmailPaths              string
-	MeGroupsPaths             string
-	MeUserInfoURL             string
+	// OidcStateSigningKeyFile, when set, is the path to a file holding the
+	// HMAC key used to sign the OAuth2 state parameter. See
+	// config.Config.OidcStateSigningKeyFile for the operator-facing docs.
+	OidcStateSigningKeyFile string
+	OidcScopes              []string
+	Cache                   cache.Cache[interface{}]
+	Multiplexer             WebSocketMultiplexer
+	TelemetryConfig         config.Config
+	TelemetryHandler        *telemetry.RequestHandler
+	MeUsernamePaths         string
+	MeEmailPaths            string
+	MeGroupsPaths           string
+	MeUserInfoURL           string
 }
 
 type HeadlampCFG struct {

--- a/e2e-tests/tests/oidc.spec.ts
+++ b/e2e-tests/tests/oidc.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * E2E coverage for the PR-1 OIDC consolidation work (#5401).
+ *
+ * These tests run against the OIDC reproduction harness in
+ * tools/oidc-repro/. Bring the stack up first:
+ *
+ *   tools/oidc-repro/scripts/up.sh
+ *
+ * Then point the test runner at the harness:
+ *
+ *   HEADLAMP_TEST_URL=http://<NODE_IP>:30080 \
+ *   HEADLAMP_OIDC_E2E=1 \
+ *   HEADLAMP_OIDC_USER=alice@example.com \
+ *   HEADLAMP_OIDC_PASSWORD=password \
+ *   HEADLAMP_OIDC_CLUSTER=main \
+ *   npx playwright test tests/oidc.spec.ts
+ *
+ * When HEADLAMP_OIDC_E2E is unset, the entire describe block is skipped,
+ * so this file is safe to ship without breaking unconfigured CI.
+ *
+ * Multi-replica scenario: the up.sh harness already runs two replicas
+ * behind an nginx round-robin, so the deep-link happy path implicitly
+ * exercises the #4019 fix (the IdP redirect lands on whichever replica
+ * the round-robin picks). For an explicit assertion, set
+ * HEADLAMP_OIDC_MULTI_REPLICA=1; otherwise that subtest is skipped.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const oidcEnabled = !!process.env.HEADLAMP_OIDC_E2E;
+
+const cluster = process.env.HEADLAMP_OIDC_CLUSTER || 'main';
+const username = process.env.HEADLAMP_OIDC_USER || 'alice@example.com';
+const password = process.env.HEADLAMP_OIDC_PASSWORD || 'password';
+
+test.describe('OIDC login (PR-1 stages 1-7)', () => {
+  test.skip(!oidcEnabled, 'set HEADLAMP_OIDC_E2E=1 with the tools/oidc-repro/ harness running');
+
+  // Drive the Dex login form. Adjust selectors here only if Dex's stock
+  // login page changes shape; everything else in this file is harness-
+  // independent.
+  async function loginViaDex(page: import('@playwright/test').Page) {
+    // Dex's local-credentials connector page.
+    await page.fill('input[name="login"]', username);
+    await page.fill('input[name="password"]', password);
+    await page.click('button[type="submit"]');
+
+    // Some Dex deployments have an explicit "Grant access" approval.
+    const approve = page.locator('button:has-text("Grant Access")');
+    if (await approve.count()) {
+      await approve.first().click();
+    }
+  }
+
+  test('deep-link → IdP → original URL (popup mode happy path)', async ({ page }) => {
+    const target = `/c/${cluster}/pods?ns=default`;
+
+    // Hitting the protected URL bounces the user through AuthChooser →
+    // /oidc → IdP → /oidc-callback → /auth?returnTo=… → target.
+    await page.goto(target);
+
+    // Wait for the AuthChooser dialog and click "Sign In" (popup mode).
+    await page.click('button:has-text("Sign In")');
+
+    // Playwright lets us drive a popup window when the click opens one.
+    // Some flows do a same-tab redirect instead of a popup; handle both.
+    const popupPromise = page.waitForEvent('popup').catch(() => null);
+    const popup = await popupPromise;
+
+    const oidcPage = popup ?? page;
+
+    // Drive Dex.
+    await loginViaDex(oidcPage);
+
+    // We end up back on the original deep-link.
+    await expect(page).toHaveURL(new RegExp(`${cluster}/pods`), { timeout: 30_000 });
+  });
+
+  test('deep-link with reload between AuthChooser and IdP return → original URL', async ({
+    page,
+  }) => {
+    const target = `/c/${cluster}/deployments`;
+
+    await page.goto(target);
+
+    // Reload before clicking Sign In. The returnTo encoded into the
+    // /oidc URL must come from window.location now, not from the
+    // (lost) location.state.from.
+    await page.reload();
+
+    await page.click('button:has-text("Sign In")');
+
+    const popup = await page.waitForEvent('popup').catch(() => null);
+    await loginViaDex(popup ?? page);
+
+    await expect(page).toHaveURL(new RegExp(`${cluster}/deployments`), { timeout: 30_000 });
+  });
+
+  test('direct /oidc?…&mode=fullPage entry → original URL', async ({ page }) => {
+    const returnTo = `/c/${cluster}/services`;
+    const oidcUrl = `/oidc?cluster=${cluster}&mode=fullPage&returnTo=${encodeURIComponent(
+      returnTo
+    )}`;
+
+    await page.goto(oidcUrl);
+
+    // mode=fullPage means the server redirects directly to the IdP
+    // without going through AuthChooser; we land on the Dex login page.
+    await loginViaDex(page);
+
+    // /oidc-callback in fullPage mode redirects directly to returnTo
+    // (no /auth bounce).
+    await expect(page).toHaveURL(new RegExp(`${cluster}/services`), { timeout: 30_000 });
+  });
+
+  test('stale state on /oidc-callback → HTML error page', async ({ page }) => {
+    // Hit /oidc-callback with garbage state. Browser Accept: text/html
+    // triggers the stage-5 HTML error page rather than the JSON 400.
+    const resp = await page.goto('/oidc-callback?state=bogus&code=fake');
+
+    expect(resp?.status()).toBe(400);
+
+    // The page should contain the friendly message and a link back to
+    // Headlamp, NOT a raw JSON or plain-text error.
+    await expect(page.locator('text=sign-in', { hasText: /sign-in/i })).toBeVisible();
+    await expect(page.locator('a:has-text("Return to Headlamp")')).toBeVisible();
+  });
+
+  test('multi-replica deep-link → original URL (round-robin proxy)', async ({ page }) => {
+    test.skip(
+      !process.env.HEADLAMP_OIDC_MULTI_REPLICA,
+      'set HEADLAMP_OIDC_MULTI_REPLICA=1 to exercise the #4019 fix end-to-end via the harness'
+    );
+
+    // The harness already runs two replicas behind an nginx round-robin;
+    // success here proves /oidc on replica A and /oidc-callback on
+    // replica B with a shared signing key works end-to-end. The
+    // expected outcome is identical to the popup happy path; the value
+    // of asserting it as its own test is documenting the #4019 fix.
+    const target = `/c/${cluster}/pods?ns=kube-system`;
+
+    await page.goto(target);
+    await page.click('button:has-text("Sign In")');
+
+    const popup = await page.waitForEvent('popup').catch(() => null);
+    await loginViaDex(popup ?? page);
+
+    await expect(page).toHaveURL(new RegExp(`${cluster}/pods`), { timeout: 30_000 });
+  });
+});

--- a/e2e-tests/tests/oidc.spec.ts
+++ b/e2e-tests/tests/oidc.spec.ts
@@ -61,10 +61,15 @@ test.describe('OIDC login (PR-1 stages 1-7)', () => {
     await page.fill('input[name="password"]', password);
     await page.click('button[type="submit"]');
 
-    // Some Dex deployments have an explicit "Grant access" approval.
-    const approve = page.locator('button:has-text("Grant Access")');
-    if (await approve.count()) {
-      await approve.first().click();
+    // Some Dex deployments add an explicit consent step. Wait briefly
+    // for the button to render and become interactive; if it never
+    // appears, assume this Dex deployment doesn't have it and continue.
+    const approve = page.getByRole('button', { name: /grant access/i });
+    try {
+      await approve.waitFor({ state: 'visible', timeout: 2000 });
+      await approve.click();
+    } catch {
+      // No consent step on this Dex install. Proceed.
     }
   }
 

--- a/frontend/src/components/authchooser/buildOauthUrl.test.ts
+++ b/frontend/src/components/authchooser/buildOauthUrl.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildOauthUrl } from './buildOauthUrl';
 
-const FIXED_NOW = 'Wed May 06 2026 00:00:00 GMT+0000';
+const FIXED_NOW = '1714953600000';
 
 function parseQuery(url: string): URLSearchParams {
   const q = url.split('?')[1] || '';

--- a/frontend/src/components/authchooser/buildOauthUrl.ts
+++ b/frontend/src/components/authchooser/buildOauthUrl.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * buildOauthUrl is the pure URL constructor used by AuthChooser to
+ * produce the /oidc kickoff URL. Lives in its own file so unit tests can
+ * import it without dragging in the full AuthChooser module graph (which
+ * pulls in Redux, MUI, the k8s client layer, etc.).
+ */
+export function buildOauthUrl(
+  appUrl: string,
+  cluster: string,
+  mode: 'popup' | 'fullPage',
+  fromPath: string,
+  fromSearch: string,
+  currentPath: string,
+  currentSearch: string,
+  now: string
+): string {
+  let returnTo = '';
+  if (fromPath) {
+    returnTo = fromPath + (fromSearch || '');
+  } else {
+    returnTo = (currentPath || '') + (currentSearch || '');
+  }
+
+  // Strip any fragment defensively. The backend rejects "#" in returnTo
+  // and fragments don't survive a server-side redirect anyway.
+  if (returnTo) {
+    const hash = returnTo.indexOf('#');
+    if (hash >= 0) {
+      returnTo = returnTo.slice(0, hash);
+    }
+  }
+
+  // /auth itself is not a meaningful returnTo — it would just bounce the
+  // user back into the chooser.
+  if (returnTo === '/auth' || returnTo.startsWith('/auth?')) {
+    returnTo = '';
+  }
+
+  const params = new URLSearchParams();
+  params.set('cluster', cluster);
+  params.set('mode', mode);
+  params.set('dt', now);
+  if (returnTo) {
+    params.set('returnTo', returnTo);
+  }
+
+  return `${appUrl}oidc?${params.toString()}`;
+}

--- a/frontend/src/components/authchooser/index.test.tsx
+++ b/frontend/src/components/authchooser/index.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildOauthUrl } from './buildOauthUrl';
+
+const FIXED_NOW = 'Wed May 06 2026 00:00:00 GMT+0000';
+
+function parseQuery(url: string): URLSearchParams {
+  const q = url.split('?')[1] || '';
+  return new URLSearchParams(q);
+}
+
+describe('buildOauthUrl', () => {
+  it('uses location.state.from.pathname+search when provided', () => {
+    const url = buildOauthUrl(
+      '/',
+      'main',
+      'popup',
+      '/c/main/pods',
+      '?view=logs',
+      '/auth',
+      '',
+      FIXED_NOW
+    );
+    const q = parseQuery(url);
+
+    expect(q.get('cluster')).toBe('main');
+    expect(q.get('mode')).toBe('popup');
+    expect(q.get('returnTo')).toBe('/c/main/pods?view=logs');
+  });
+
+  it('falls back to currentPath when from is empty', () => {
+    const url = buildOauthUrl(
+      '/',
+      'main',
+      'popup',
+      '',
+      '',
+      '/c/main/deployments',
+      '?ns=default',
+      FIXED_NOW
+    );
+    const q = parseQuery(url);
+
+    expect(q.get('returnTo')).toBe('/c/main/deployments?ns=default');
+  });
+
+  it('strips fragments from returnTo', () => {
+    const url = buildOauthUrl(
+      '/',
+      'main',
+      'popup',
+      '/c/main/pods',
+      '?view=logs#tab=2',
+      '',
+      '',
+      FIXED_NOW
+    );
+    const q = parseQuery(url);
+
+    expect(q.get('returnTo')).toBe('/c/main/pods?view=logs');
+    expect(q.get('returnTo')).not.toContain('#');
+  });
+
+  it('omits returnTo when the candidate is /auth itself', () => {
+    const url = buildOauthUrl('/', 'main', 'popup', '/auth', '?cluster=main', '', '', FIXED_NOW);
+    const q = parseQuery(url);
+
+    expect(q.has('returnTo')).toBe(false);
+  });
+
+  it('passes mode=fullPage through', () => {
+    const url = buildOauthUrl('/', 'main', 'fullPage', '/c/main', '', '', '', FIXED_NOW);
+    const q = parseQuery(url);
+
+    expect(q.get('mode')).toBe('fullPage');
+  });
+
+  it('always includes the dt cache buster', () => {
+    const url = buildOauthUrl('/', 'main', 'popup', '/c/main', '', '', '', FIXED_NOW);
+    const q = parseQuery(url);
+
+    expect(q.get('dt')).toBe(FIXED_NOW);
+  });
+});

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -39,13 +39,6 @@ import Loader from '../common/Loader';
 import OauthPopup from '../oidcauth/OauthPopup';
 import { buildOauthUrl } from './buildOauthUrl';
 
-/**
- * Re-export buildOauthUrl for backward compatibility. Implementation
- * lives in buildOauthUrl.ts so unit tests can import it without pulling
- * in Redux / MUI / k8s client layers.
- */
-export { buildOauthUrl };
-
 function ColorButton({ children, ...rest }: ComponentProps<typeof Button>) {
   return (
     <Button variant="contained" sx={{ width: '14rem', padding: '0.5rem 2rem' }} {...rest}>
@@ -105,7 +98,7 @@ function AuthChooser({ children }: AuthChooserProps) {
       fromTyped?.search || '',
       typeof window !== 'undefined' ? window.location.pathname || '' : '',
       typeof window !== 'undefined' ? window.location.search || '' : '',
-      Date()
+      Date.now().toString()
     );
   }, [from, clusterName]);
 

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -37,6 +37,14 @@ import Empty from '../common/EmptyContent';
 import Link from '../common/Link';
 import Loader from '../common/Loader';
 import OauthPopup from '../oidcauth/OauthPopup';
+import { buildOauthUrl } from './buildOauthUrl';
+
+/**
+ * Re-export buildOauthUrl for backward compatibility. Implementation
+ * lives in buildOauthUrl.ts so unit tests can import it without pulling
+ * in Redux / MUI / k8s client layers.
+ */
+export { buildOauthUrl };
 
 function ColorButton({ children, ...rest }: ComponentProps<typeof Button>) {
   return (
@@ -74,6 +82,32 @@ function AuthChooser({ children }: AuthChooserProps) {
   }
 
   const numClusters = Object.keys(clusters || {}).length;
+
+  // Build the OIDC kickoff URL.
+  //
+  // returnTo: prefer location.state.from (set by ProtectedRoute when the
+  // user was redirected here from a deep-link), falling back to the
+  // current pathname+search so a refresh on the AuthChooser still
+  // preserves where the user was trying to go. Fragments are stripped:
+  // the backend rejects "#" in returnTo and they don't survive a
+  // server-side redirect anyway.
+  //
+  // mode=popup matches the existing button-driven popup flow. fullPage
+  // is for direct navigation entries (e.g. a bookmark hitting /oidc) and
+  // future autologin work; the AuthChooser button always uses popup.
+  const oauthUrl = React.useMemo(() => {
+    const fromTyped = from as Location | undefined;
+    return buildOauthUrl(
+      getAppUrl(),
+      getCluster() || '',
+      'popup',
+      fromTyped?.pathname || '',
+      fromTyped?.search || '',
+      typeof window !== 'undefined' ? window.location.pathname || '' : '',
+      typeof window !== 'undefined' ? window.location.search || '' : '',
+      Date()
+    );
+  }, [from, clusterName]);
 
   function runTestAuthAgain() {
     setError(null);
@@ -204,7 +238,7 @@ function AuthChooser({ children }: AuthChooserProps) {
           : t('Authentication')
       }
       error={error}
-      oauthUrl={`${getAppUrl()}oidc?dt=${Date()}&cluster=${getCluster()}`}
+      oauthUrl={oauthUrl}
       clusterAuthType={clusterAuthType}
       handleTryAgain={runTestAuthAgain}
       handleOidcAuth={() => {

--- a/frontend/src/components/oidcauth/index.test.tsx
+++ b/frontend/src/components/oidcauth/index.test.tsx
@@ -46,11 +46,8 @@ describe('OIDCAuth', () => {
   });
 
   it('falls back to navigating to returnTo after the configured delay', () => {
-    const replaceMock = vi.fn();
-    // Patch history.replace via a wrapper component? Simpler: spy on
-    // window.location only verifies real navigation; here we just
-    // confirm the setTimeout is scheduled. We rely on the
-    // OIDCAuthFallbackDelayMs export and the side-effect having run.
+    // Verify the setTimeout is scheduled with the correct delay.
+    // Navigation verification is covered by e2e tests.
     const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
 
     render(
@@ -61,7 +58,6 @@ describe('OIDCAuth', () => {
 
     const calls = setTimeoutSpy.mock.calls.filter(c => c[1] === OIDCAuthFallbackDelayMs);
     expect(calls.length).toBeGreaterThanOrEqual(1);
-    expect(replaceMock).not.toHaveBeenCalled(); // setTimeout never fired
   });
 
   it('does not schedule a fallback when returnTo is absent', () => {
@@ -88,5 +84,26 @@ describe('OIDCAuth', () => {
     unmount();
 
     expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['absolute URL', 'https://evil.example/'],
+    ['scheme-relative', '//evil.example/'],
+    ['embedded scheme via path', '/foo://bar'],
+    ['traversal', '/c/main/../../etc/passwd'],
+    ['empty', ''],
+    ['relative', 'foo/bar'],
+  ])('does not schedule a fallback for unsafe returnTo (%s)', (_label, value) => {
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+
+    const search = new URLSearchParams({ cluster: 'main', returnTo: value }).toString();
+    render(
+      <MemoryRouter initialEntries={[`/auth?${search}`]}>
+        <OIDCAuth />
+      </MemoryRouter>
+    );
+
+    const calls = setTimeoutSpy.mock.calls.filter(c => c[1] === OIDCAuthFallbackDelayMs);
+    expect(calls).toHaveLength(0);
   });
 });

--- a/frontend/src/components/oidcauth/index.test.tsx
+++ b/frontend/src/components/oidcauth/index.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OIDCAuth, { OIDCAuthFallbackDelayMs } from './index';
+
+// Stub i18n hook to avoid loading the full i18n setup in this unit test.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+
+describe('OIDCAuth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('sets auth_status=success when cluster is present', () => {
+    render(
+      <MemoryRouter initialEntries={['/auth?cluster=main&returnTo=%2Fc%2Fmain%2Fpods']}>
+        <OIDCAuth />
+      </MemoryRouter>
+    );
+
+    expect(localStorage.getItem('auth_status')).toBe('success');
+  });
+
+  it('falls back to navigating to returnTo after the configured delay', () => {
+    const replaceMock = vi.fn();
+    // Patch history.replace via a wrapper component? Simpler: spy on
+    // window.location only verifies real navigation; here we just
+    // confirm the setTimeout is scheduled. We rely on the
+    // OIDCAuthFallbackDelayMs export and the side-effect having run.
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+
+    render(
+      <MemoryRouter initialEntries={['/auth?cluster=main&returnTo=%2Fc%2Fmain%2Fpods']}>
+        <OIDCAuth />
+      </MemoryRouter>
+    );
+
+    const calls = setTimeoutSpy.mock.calls.filter(c => c[1] === OIDCAuthFallbackDelayMs);
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(replaceMock).not.toHaveBeenCalled(); // setTimeout never fired
+  });
+
+  it('does not schedule a fallback when returnTo is absent', () => {
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+
+    render(
+      <MemoryRouter initialEntries={['/auth?cluster=main']}>
+        <OIDCAuth />
+      </MemoryRouter>
+    );
+
+    const calls = setTimeoutSpy.mock.calls.filter(c => c[1] === OIDCAuthFallbackDelayMs);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('cancels the fallback on unmount', () => {
+    const clearSpy = vi.spyOn(window, 'clearTimeout');
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/auth?cluster=main&returnTo=%2Fc%2Fmain%2Fpods']}>
+        <OIDCAuth />
+      </MemoryRouter>
+    );
+
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/oidcauth/index.tsx
+++ b/frontend/src/components/oidcauth/index.tsx
@@ -17,14 +17,27 @@
 import Typography from '@mui/material/Typography';
 import { FunctionComponent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 //@todo: needs cleanup.
 
+// OIDCAuthFallbackDelayMs is how long /auth waits before navigating to
+// returnTo on its own. The popup→opener storage handshake (when /auth is
+// running inside an OAuth popup with a live opener) usually completes
+// well before this, in which case AuthChooser's onCode handler navigates
+// the opener and unmounts /auth, which cancels this fallback.
+//
+// When the storage handshake doesn't fire (page reloaded, opener gone,
+// full-page redirect, etc.), the fallback unblocks the "Redirecting to
+// main page…" hang reported in #4877 / #2126.
+export const OIDCAuthFallbackDelayMs = 250;
+
 const OIDCAuth: FunctionComponent<{}> = () => {
   const location = useLocation();
+  const history = useHistory();
   const urlSearchParams = new URLSearchParams(location.search);
   const cluster = urlSearchParams.get('cluster');
+  const returnTo = urlSearchParams.get('returnTo') || '';
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -32,6 +45,22 @@ const OIDCAuth: FunctionComponent<{}> = () => {
       localStorage.setItem('auth_status', 'success');
     }
   }, [cluster]);
+
+  // Defense-in-depth fallback: if the popup storage handshake never
+  // completes, navigate the user out of the "Redirecting…" page on our
+  // own. Cancelled on unmount so the happy path (opener navigates,
+  // unmounting us) doesn't double-navigate.
+  useEffect(() => {
+    if (!returnTo) {
+      return;
+    }
+
+    const id = window.setTimeout(() => {
+      history.replace(returnTo);
+    }, OIDCAuthFallbackDelayMs);
+
+    return () => window.clearTimeout(id);
+  }, [returnTo, history]);
 
   return <Typography color="textPrimary">{t('Redirecting to main page…')}</Typography>;
 };

--- a/frontend/src/components/oidcauth/index.tsx
+++ b/frontend/src/components/oidcauth/index.tsx
@@ -32,12 +32,30 @@ import { useHistory, useLocation } from 'react-router-dom';
 // main page…" hang reported in #4877 / #2126.
 export const OIDCAuthFallbackDelayMs = 250;
 
+// isSafeReturnTo restricts returnTo to same-origin path-only values to
+// prevent open-redirect attacks via the ?returnTo= query parameter.
+// Accepts: paths starting with a single "/" that are not protocol-relative
+// ("//host"), do not embed a scheme ("://"), and contain no ".." segments.
+function isSafeReturnTo(value: string): boolean {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) {
+    return false;
+  }
+  if (value.includes('://')) {
+    return false;
+  }
+  if (/(^|\/)\.\.(\/|$)/.test(value)) {
+    return false;
+  }
+  return true;
+}
+
 const OIDCAuth: FunctionComponent<{}> = () => {
   const location = useLocation();
   const history = useHistory();
   const urlSearchParams = new URLSearchParams(location.search);
   const cluster = urlSearchParams.get('cluster');
-  const returnTo = urlSearchParams.get('returnTo') || '';
+  const rawReturnTo = urlSearchParams.get('returnTo') || '';
+  const returnTo = isSafeReturnTo(rawReturnTo) ? rawReturnTo : '';
   const { t } = useTranslation();
 
   useEffect(() => {

--- a/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clusterName = 'oidc-cluster';
+
+// Mock cluster getter so testAuth resolves without window state.
+vi.mock('../../../cluster', () => ({
+  getCluster: () => clusterName,
+  getSelectedClusters: () => [clusterName],
+}));
+
+// Mock the redux store. The shape mirrors what testAuth reads:
+// state.config.clusters[name].auth_type.
+const fakeState: { config: { clusters: Record<string, { auth_type?: string }> } } = {
+  config: { clusters: {} },
+};
+
+vi.mock('../../../../redux/stores/store', () => ({
+  default: {
+    getState: () => fakeState,
+  },
+}));
+
+// Spy hooks for clusterRequest / post used by testAuth.
+const clusterRequestMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock('./clusterRequests', () => ({
+  clusterRequest: (...args: any[]) => clusterRequestMock(...args),
+  post: (...args: any[]) => postMock(...args),
+  request: vi.fn(),
+}));
+
+// Other modules clusterApi.ts imports — keep them inert.
+vi.mock('../../../../helpers/addBackstageAuthHeaders', () => ({
+  addBackstageAuthHeaders: (h: Record<string, string>) => h,
+}));
+vi.mock('../../../../helpers/clusterSettings', () => ({
+  loadClusterSettings: () => ({}),
+}));
+vi.mock('../../../../helpers/debugVerbose', () => ({ isDebugVerbose: () => false }));
+vi.mock('../../../../helpers/getHeadlampAPIHeaders', () => ({
+  getHeadlampAPIHeaders: () => ({}),
+}));
+vi.mock('../../../../stateless', () => ({ storeStatelessClusterKubeconfig: vi.fn() }));
+vi.mock('../../../../stateless/deleteClusterKubeconfig', () => ({
+  deleteClusterKubeconfig: vi.fn(),
+}));
+vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
+  findKubeconfigByClusterName: vi.fn().mockResolvedValue(null),
+}));
+
+import { testAuth } from './clusterApi';
+
+describe('testAuth', () => {
+  beforeEach(() => {
+    clusterRequestMock.mockReset();
+    postMock.mockReset();
+    fakeState.config.clusters = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('OIDC cluster: /me returning a real identity is authenticated', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    clusterRequestMock.mockResolvedValueOnce({ username: 'alice@example.com' });
+
+    await expect(testAuth(clusterName)).resolves.toMatchObject({ username: 'alice@example.com' });
+
+    expect(clusterRequestMock).toHaveBeenCalledWith(
+      '/me',
+      expect.objectContaining({ cluster: clusterName })
+    );
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('OIDC cluster: system:anonymous identity is treated as not-authenticated', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    clusterRequestMock.mockResolvedValueOnce({ username: 'system:anonymous' });
+
+    await expect(testAuth(clusterName)).rejects.toMatchObject({ status: 401 });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('OIDC cluster: empty username is treated as not-authenticated', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: 'oidc' };
+
+    clusterRequestMock.mockResolvedValueOnce({});
+
+    await expect(testAuth(clusterName)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('non-OIDC cluster: testAuth still uses SSRR (unchanged)', async () => {
+    fakeState.config.clusters[clusterName] = { auth_type: '' };
+
+    postMock.mockResolvedValueOnce({ status: { resourceRules: [] } });
+
+    await expect(testAuth(clusterName)).resolves.toBeDefined();
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/apis/authorization.k8s.io/v1/selfsubjectrulesreviews',
+      expect.any(Object),
+      false,
+      expect.objectContaining({ cluster: clusterName })
+    );
+    expect(clusterRequestMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -34,9 +34,17 @@ import { JSON_HEADERS } from './constants';
  *
  * For OIDC clusters (auth_type === 'oidc'), this calls the headlamp-server
  * `/clusters/{cluster}/me` endpoint, which validates the per-cluster auth
- * cookie. If the cookie is missing or expired, the server returns 401 or
- * a `system:anonymous` identity, both of which we treat as
- * "not-authenticated" so the caller routes the user to AuthChooser.
+ * cookie. The handler is implemented at backend/pkg/auth/auth.go HandleMe;
+ * it returns 401 with `{"message": "unauthorized"}` (or "token expired")
+ * when the cookie is missing, malformed, or its embedded JWT cannot be
+ * verified, and otherwise returns `{"username": ..., "email": ..., ...}`
+ * with the JMESPath-extracted username from the JWT payload.
+ *
+ * The `clusterRequest` wrapper rejects the promise on any non-2xx, so
+ * 401 from /me surfaces as a thrown error and the caller routes the
+ * user to AuthChooser. The defense-in-depth `system:anonymous` check
+ * below covers the case where a future kubeconfig wires its OIDC
+ * username path to a claim that resolves to that string.
  *
  * This works around the SSRR false-positive reported in #4721: when
  * `system:basic-user` is granted to `system:unauthenticated`, SSRR
@@ -52,18 +60,19 @@ export async function testAuth(cluster = '', namespace = 'default') {
     const clusterAuthType = store.getState().config?.clusters?.[clusterName]?.auth_type;
 
     if (clusterAuthType === 'oidc') {
-      // /me returns 401 when the auth cookie is missing or invalid;
-      // returns identity JSON otherwise. We treat a successful response
-      // whose username starts with system:anonymous as not-authenticated
-      // (the apiserver's stand-in identity for unauthenticated requests
-      // when anonymous auth is enabled).
       const me = await clusterRequest('/me', {
         timeout: 5 * 1000,
         cluster: clusterName,
       });
 
-      const username: string = (me && (me.username || me.user?.username)) || '';
+      const username: string = (me && me.username) || '';
       if (!username || username.startsWith('system:anonymous')) {
+        // Defense in depth: a 200 with a system:anonymous-equivalent
+        // username should not count as authenticated. The backend is
+        // expected to surface unauthenticated cookies as 401 (which
+        // clusterRequest already throws on); this branch covers an
+        // operator who configures the JMESPath username extraction in a
+        // way that resolves to "system:anonymous" or empty.
         const err = new Error('not authenticated') as Error & { status?: number };
         err.status = 401;
         throw err;

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -31,10 +31,49 @@ import { JSON_HEADERS } from './constants';
 /**
  * Test authentication for the given cluster.
  * Will throw an error if the user is not authenticated.
+ *
+ * For OIDC clusters (auth_type === 'oidc'), this calls the headlamp-server
+ * `/clusters/{cluster}/me` endpoint, which validates the per-cluster auth
+ * cookie. If the cookie is missing or expired, the server returns 401 or
+ * a `system:anonymous` identity, both of which we treat as
+ * "not-authenticated" so the caller routes the user to AuthChooser.
+ *
+ * This works around the SSRR false-positive reported in #4721: when
+ * `system:basic-user` is granted to `system:unauthenticated`, SSRR
+ * returns HTTP 201 for both anonymous and authenticated callers, so it
+ * cannot be used as the auth signal on those clusters.
+ *
+ * For non-OIDC clusters, behavior is unchanged: SSRR is the auth signal.
  */
 export async function testAuth(cluster = '', namespace = 'default') {
-  const spec = { namespace };
   const clusterName = cluster || getCluster();
+
+  if (clusterName) {
+    const clusterAuthType = store.getState().config?.clusters?.[clusterName]?.auth_type;
+
+    if (clusterAuthType === 'oidc') {
+      // /me returns 401 when the auth cookie is missing or invalid;
+      // returns identity JSON otherwise. We treat a successful response
+      // whose username starts with system:anonymous as not-authenticated
+      // (the apiserver's stand-in identity for unauthenticated requests
+      // when anonymous auth is enabled).
+      const me = await clusterRequest('/me', {
+        timeout: 5 * 1000,
+        cluster: clusterName,
+      });
+
+      const username: string = (me && (me.username || me.user?.username)) || '';
+      if (!username || username.startsWith('system:anonymous')) {
+        const err = new Error('not authenticated') as Error & { status?: number };
+        err.status = 401;
+        throw err;
+      }
+
+      return me;
+    }
+  }
+
+  const spec = { namespace };
 
   return post('/apis/authorization.k8s.io/v1/selfsubjectrulesreviews', { spec }, false, {
     timeout: 5 * 1000,

--- a/tools/oidc-repro/README.md
+++ b/tools/oidc-repro/README.md
@@ -1,0 +1,190 @@
+# OIDC Reproduction Harness
+
+Local kind + Dex setup for reproducing the four #5401 in-scope failure modes
+before writing PR 1 code.
+
+The point of this harness is to **prove or disprove the hypotheses in the v2
+design sketch** before committing to the implementation:
+
+1. **#4019** — does the per-process `oauthRequestMap` actually break with two
+   `headlamp-server` replicas behind a round-robin proxy?
+2. **#4877 / #2134** — is `history.replace(from)` at
+   `frontend/src/components/authchooser/index.tsx:154,160,164` actually
+   sufficient on current `main`? If yes, what's the residual? Page reload?
+   Autologin? Something else?
+3. **#4721** — does `selfsubjectrulesreviews` really return 201 for
+   `system:unauthenticated` on the cluster shapes the reporter mentioned?
+4. **#2126** — does the desktop callback land in the system browser as
+   reported, and does the renderer state never update?
+
+If any of these reproductions fail, the design changes — don't write the PR
+until the repros are green-or-confirmed-already-fixed.
+
+## Prerequisites
+
+- `kind` (≥ 0.20)
+- `kubectl`
+- `docker`
+- `mkcert` (optional — only if you want browser-trusted TLS for Dex; the
+  default flow uses HTTP on the loopback)
+- `npm` and Headlamp's normal dev dependencies (already in this repo)
+
+## Layout
+
+```
+tools/oidc-repro/
+├── README.md                      # this file
+├── kind-config.yaml               # 1-node kind cluster with OIDC apiserver flags
+├── dex/
+│   ├── dex-config.yaml            # Dex IdP with two static users
+│   └── dex-deploy.yaml            # Dex Deployment + Service in the cluster
+├── headlamp/
+│   ├── headlamp-config.yaml       # OIDC config for backend (OIDC_CLIENT_ID etc.)
+│   ├── two-replicas.yaml          # two headlamp-server replicas behind a Service
+│   └── nginx-rr.conf              # nginx round-robin in front of two replicas (for #4019)
+├── scripts/
+│   ├── up.sh                      # boot kind + dex + headlamp; print URLs
+│   ├── down.sh                    # tear everything down
+│   ├── repro-4019.sh              # multi-replica state-loss repro
+│   ├── repro-4877.sh              # deep-link repro (and reload variant)
+│   ├── repro-4721.sh              # SSRR-anonymous repro
+│   └── repro-2126.sh              # desktop callback repro (Electron build required)
+└── notes/                         # write findings here as you go
+```
+
+## Quickstart
+
+```bash
+cd tools/oidc-repro
+./scripts/up.sh
+```
+
+`up.sh` boots:
+
+- a kind cluster with `--oidc-issuer-url`, `--oidc-client-id`, and
+  `--oidc-username-claim` set to point at the in-cluster Dex
+- Dex with two static users (`alice@example.com` / `password`,
+  `bob@example.com` / `password`) and a static client `headlamp-test`
+- two `headlamp-server` replicas (built from the current checkout) behind an
+  `nginx` reverse proxy that round-robins between them
+- prints:
+  - Dex issuer URL
+  - Headlamp URL (the nginx address)
+  - sample OIDC client config for `headlamp-server`
+
+Then run any `repro-*.sh`. Each prints what it's testing, runs it, and tells
+you what to look for.
+
+## Per-issue repro recipe
+
+### #4019 — multi-replica state loss
+
+```
+./scripts/repro-4019.sh
+```
+
+What it does:
+
+1. Forces `nginx-rr.conf` into a deterministic alternating pattern (replica A,
+   replica B, A, B…) so the `/oidc` and `/oidc-callback` requests are
+   guaranteed to land on different pods.
+2. Drives a headless browser through the OIDC flow.
+3. Expected on `main`: callback returns 400 "unknown state" because replica B
+   has no entry in its in-process `oauthRequestMap` for the state issued by
+   replica A.
+
+What you're verifying: the failure is real; the state map is process-local;
+fix space is "stateless signed state" or "shared cache backend." Decision is
+in the v2 sketch.
+
+Record in `notes/4019.md`:
+
+- exact request log showing replica routing
+- whether the failure mode matches `oauthRequestMap` lookup miss specifically
+  (vs. some other failure)
+
+### #4877 / #2134 — original URL preservation
+
+```
+./scripts/repro-4877.sh
+```
+
+What it does:
+
+1. Opens `/c/main/pods/default/<some-pod>?view=logs` while logged out.
+2. Lets the existing AuthChooser handle the OIDC redirect.
+3. Checks where the user lands after login.
+
+The hypothesis from the v2 review: `authchooser/index.tsx:154,160,164` already
+calls `history.replace(from)` so the popup flow may already preserve the URL.
+If so, the residual must be one of:
+
+- page **reload** of the deep-linked URL while authenticated state is missing
+  (`location.state.from` is lost on reload)
+- autologin / full-page redirect with no opener window
+- some other path that bypasses the popup
+
+The repro script tests both popup and reload variants. If reload preserves the
+URL, the issue is fully fixed on `main` and PR 1 becomes regression coverage
+only. If reload doesn't, that's the residual to design for.
+
+Record in `notes/4877.md` what variant fails and what the URL bar shows at
+each step.
+
+### #4721 — `testAuth` false positive
+
+```
+./scripts/repro-4721.sh
+```
+
+What it does:
+
+1. Without authenticating, hits the cluster's `selfsubjectrulesreviews`
+   endpoint as `system:anonymous`.
+2. Reports the HTTP status and body shape.
+
+What you're verifying: agapoff's report — that on at least some cluster
+shapes, SSRR returns 201 with empty rules for anonymous callers. If kind's
+default RBAC doesn't grant SSRR to anonymous, the script also patches in the
+old `system:basic-user` ClusterRoleBinding shape so the test is meaningful.
+
+Record in `notes/4721.md` the SSRR response body for both authenticated and
+anonymous callers — that's the input to the cookie-verification fix design.
+
+### #2126 — desktop callback handoff
+
+```
+./scripts/repro-2126.sh
+```
+
+This one needs an Electron build (`npm run app:build`). The script:
+
+1. Builds the Electron app in dev mode.
+2. Configures a kubeconfig-OIDC cluster pointing at the in-cluster Dex.
+3. Drives the Sign In flow.
+
+Expected: the system browser opens, completes Dex login, lands on
+`/oidc-callback` in the browser (not in Electron's renderer), and the
+Electron renderer never updates. That's the failure to fix.
+
+Record in `notes/2126.md` whether anything is in `localStorage` /
+cookies on the Electron side after the system-browser flow ends.
+
+## When to stop
+
+Each repro is "done" when you can either:
+
+- demonstrate the failure deterministically (and have written down the
+  exact symptoms, request log, and any cookie/localStorage state), **or**
+- prove the failure is no longer reproducible on current `main` (and have
+  written down what changed and what residual scope remains for PR 1)
+
+Once all four are answered, write the PR 1 design *brief* in `notes/pr1-brief.md`
+based on what you found, then start coding.
+
+## Out of scope for this harness
+
+- #5402 sub-path A (desktop exec credentials, EKS/GKE) — needs a real cloud
+  cluster; not reproducible in kind. Defer until PR 1 is in review.
+- #5402 sub-path B (in-cluster impersonation) — needs PR 1's signed state +
+  session-model decision first. Different harness.

--- a/tools/oidc-repro/dex/dex-config.yaml
+++ b/tools/oidc-repro/dex/dex-config.yaml
@@ -1,0 +1,53 @@
+# Dex IdP config for the OIDC reproduction harness.
+#
+# Two static users so the multi-replica repro can use distinct sessions.
+# A static client matching what headlamp-server is configured with.
+#
+# Issuer URL is the in-cluster Service. For Headlamp running OUT-of-cluster
+# (dev mode on the host), use a port-forward and override OIDC_ISSUER_URL.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dex
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dex-config
+  namespace: dex
+data:
+  config.yaml: |
+    issuer: http://dex.dex.svc.cluster.local:5556/dex
+
+    storage:
+      type: memory
+
+    web:
+      http: 0.0.0.0:5556
+
+    oauth2:
+      skipApprovalScreen: true
+      # PKCE supported; Headlamp's go-oidc client uses it when configured.
+
+    staticClients:
+      - id: headlamp-test
+        redirectURIs:
+          # Both forms because dev runs on the host and prod runs in-cluster.
+          - 'http://localhost:4466/oidc-callback'
+          - 'http://localhost:8080/oidc-callback'
+          - 'http://headlamp.headlamp.svc.cluster.local/oidc-callback'
+        name: 'Headlamp (repro)'
+        secret: headlamp-test-secret
+
+    enablePasswordDB: true
+    staticPasswords:
+      # Passwords are bcrypt of "password".
+      - email: "alice@example.com"
+        # bcrypt of 'password'
+        hash: "$2y$10$YLGTFTQQZcDOXGoWRMOz7O2VC/XAjLC/gC38fx2y7gjmP29s.1aEK"
+        username: "alice"
+        userID: "alice-id"
+      - email: "bob@example.com"
+        hash: "$2y$10$YLGTFTQQZcDOXGoWRMOz7O2VC/XAjLC/gC38fx2y7gjmP29s.1aEK"
+        username: "bob"
+        userID: "bob-id"

--- a/tools/oidc-repro/dex/dex-deploy.yaml
+++ b/tools/oidc-repro/dex/dex-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.39.1
+          args: ["dex", "serve", "/etc/dex/cfg/config.yaml"]
+          ports:
+            - containerPort: 5556
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex/cfg
+      volumes:
+        - name: config
+          configMap:
+            name: dex-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: dex
+spec:
+  type: ClusterIP
+  selector:
+    app: dex
+  ports:
+    - port: 5556
+      targetPort: http
+      name: http

--- a/tools/oidc-repro/headlamp/nginx-rr.conf
+++ b/tools/oidc-repro/headlamp/nginx-rr.conf
@@ -1,0 +1,46 @@
+# nginx round-robin in front of two headlamp-server replicas.
+#
+# The `least_conn` strategy is intentionally NOT used — we want strict
+# alternation so /oidc and /oidc-callback are guaranteed to land on
+# different pods. This is the worst-case scenario for the per-process
+# oauthRequestMap and the deterministic way to reproduce #4019.
+events {
+  worker_connections 1024;
+}
+
+http {
+  upstream headlamp_pool {
+    # Round-robin is the nginx default with no directive.
+    # Two replicas: hl-a and hl-b. Headers added below let the repro script
+    # see which replica handled each request.
+    server hl-a:4466;
+    server hl-b:4466;
+  }
+
+  log_format upstreamlog '$remote_addr - $upstream_addr [$time_local] '
+                         '"$request" $status $upstream_response_time';
+
+  access_log /var/log/nginx/access.log upstreamlog;
+
+  server {
+    listen 8080;
+    server_name _;
+
+    location / {
+      proxy_pass http://headlamp_pool;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      # Surface the chosen upstream so the repro script can assert
+      # alternation.
+      add_header X-Upstream-Addr $upstream_addr always;
+
+      # WebSocket upgrades for the multiplexer.
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+  }
+}

--- a/tools/oidc-repro/headlamp/two-replicas.yaml
+++ b/tools/oidc-repro/headlamp/two-replicas.yaml
@@ -1,0 +1,184 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: headlamp
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: headlamp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: headlamp
+    namespace: headlamp
+---
+# OIDC config consumed by both replicas. Override OIDC_ISSUER_URL in dev mode
+# if Dex is reached via port-forward.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-oidc
+  namespace: headlamp
+data:
+  OIDC_ISSUER_URL: "http://dex.dex.svc.cluster.local:5556/dex"
+  OIDC_CLIENT_ID: "headlamp-test"
+  OIDC_CLIENT_SECRET: "headlamp-test-secret"
+  OIDC_SCOPES: "openid,email,profile,groups,offline_access"
+---
+# TWO replicas, each as its own Deployment so we can address them
+# individually as hl-a and hl-b from nginx.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hl-a
+  namespace: headlamp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hl-a
+  template:
+    metadata:
+      labels:
+        app: hl-a
+    spec:
+      serviceAccountName: headlamp
+      containers:
+        - name: headlamp
+          # Built locally by up.sh and loaded into kind via `kind load docker-image`.
+          image: headlamp:repro
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-in-cluster"
+            - "-dev"
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            - "-oidc-scopes=$(OIDC_SCOPES)"
+          envFrom:
+            - configMapRef:
+                name: headlamp-oidc
+          ports:
+            - containerPort: 4466
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hl-a
+  namespace: headlamp
+spec:
+  selector:
+    app: hl-a
+  ports:
+    - port: 4466
+      targetPort: 4466
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hl-b
+  namespace: headlamp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hl-b
+  template:
+    metadata:
+      labels:
+        app: hl-b
+    spec:
+      serviceAccountName: headlamp
+      containers:
+        - name: headlamp
+          image: headlamp:repro
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-in-cluster"
+            - "-dev"
+            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
+            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
+            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            - "-oidc-scopes=$(OIDC_SCOPES)"
+          envFrom:
+            - configMapRef:
+                name: headlamp-oidc
+          ports:
+            - containerPort: 4466
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hl-b
+  namespace: headlamp
+spec:
+  selector:
+    app: hl-b
+  ports:
+    - port: 4466
+      targetPort: 4466
+---
+# nginx in front of hl-a and hl-b — strict round-robin to make the
+# multi-replica state-loss bug deterministic.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-rr
+  namespace: headlamp
+data:
+  nginx.conf: |
+    # Replaced at apply time by up.sh from headlamp/nginx-rr.conf.
+    # See the file in the repo for the actual config.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-rr
+  namespace: headlamp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-rr
+  template:
+    metadata:
+      labels:
+        app: nginx-rr
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: cfg
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: cfg
+          configMap:
+            name: nginx-rr
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  type: NodePort
+  selector:
+    app: nginx-rr
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30080

--- a/tools/oidc-repro/kind-config.yaml
+++ b/tools/oidc-repro/kind-config.yaml
@@ -1,0 +1,22 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: headlamp-oidc-repro
+nodes:
+  - role: control-plane
+    # OIDC apiserver flags are intentionally NOT set here. The #5401 reproductions
+    # (state loss, redirect, testAuth, desktop callback) only exercise Headlamp's
+    # OIDC client; the apiserver doesn't need to validate tokens. Setting the
+    # `--oidc-issuer-url` flag points kube-apiserver at Dex BEFORE Dex exists,
+    # which makes kubeadm's wait-control-plane time out (apiserver can't start
+    # without reachable JWKS).
+    #
+    # When you reach the #5402 sub-path B work (in-cluster impersonation), add
+    # the flags below and recreate the cluster AFTER Dex is already deployed.
+    #
+    # extraArgs:
+    #   oidc-issuer-url: "http://dex.dex.svc.cluster.local:5556/dex"
+    #   oidc-client-id: "headlamp-test"
+    #   oidc-username-claim: "email"
+    #   oidc-groups-claim: "groups"
+networking:
+  apiServerAddress: "127.0.0.1"

--- a/tools/oidc-repro/scripts/down.sh
+++ b/tools/oidc-repro/scripts/down.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CLUSTER_NAME=headlamp-oidc-repro
+
+if kind get clusters | grep -qx "$CLUSTER_NAME"; then
+  echo "==> Deleting kind cluster $CLUSTER_NAME"
+  kind delete cluster --name "$CLUSTER_NAME"
+else
+  echo "no cluster $CLUSTER_NAME; nothing to do"
+fi

--- a/tools/oidc-repro/scripts/repro-2126.sh
+++ b/tools/oidc-repro/scripts/repro-2126.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Reproduce #2126 — desktop callback handoff.
+#
+# This one is manual because it needs an Electron build and the system
+# browser. Script just lays out the recipe.
+set -euo pipefail
+
+mkdir -p tools/oidc-repro/notes
+NOTES=tools/oidc-repro/notes/2126.md
+
+cat <<EOF
+=== #2126 manual repro ===
+
+Prerequisites:
+  - Headlamp Electron dev build (npm run app-dev or npm run app:build)
+  - Dex port-forwarded so the system browser can reach it:
+      kubectl -n dex port-forward svc/dex 5556:5556
+  - A kubeconfig with an OIDC user pointing at the in-cluster cluster.
+
+Steps:
+1. Launch the Electron app (npm run app-dev from repo root).
+2. Add the kubeconfig-OIDC cluster.
+3. Click Sign In on that cluster.
+
+Observe:
+  - Does Headlamp open the SYSTEM browser, or an in-Electron BrowserWindow?
+    For kubeconfig OIDC clusters the failure path is system browser.
+  - After Dex login, does the browser land on /oidc-callback and then /auth?
+  - Does the Electron renderer ever update? (Expected: no — that's #2126.)
+  - Are there any cookies or localStorage entries on the Electron side after
+    the system-browser flow? (Expected: no.)
+
+Diagnostic taps:
+  - Watch the Electron main process console for 'open-url' events.
+  - Watch headlamp-server logs for /oidc-callback hits and where they redirect.
+
+Record findings in $NOTES.
+
+PR 2 design check: confirm the failure is exactly "callback in system browser,
+no path back to Electron renderer". If something else is also broken (e.g. the
+cookie IS being set but the renderer doesn't notice), the design changes.
+EOF
+
+cat <<EOF >> "$NOTES"
+# 2126 repro run on $(date -Iseconds)
+
+## Observations
+- Sign-in opens (system browser / Electron window):
+- After Dex login, browser URL ends at:
+- Electron renderer state after flow:
+- Cookies on Electron side (auth_status, headlamp_token, etc.):
+- localStorage entries:
+
+## PR 2 design implications
+EOF
+
+echo "Recipe printed. Notes template at $NOTES."

--- a/tools/oidc-repro/scripts/repro-4019.sh
+++ b/tools/oidc-repro/scripts/repro-4019.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Reproduce #4019 — multi-replica state loss.
+#
+# Hypothesis: /oidc lands on replica A, IdP redirects /oidc-callback to replica
+# B, replica B's in-process oauthRequestMap has no entry for that state, and
+# the callback returns 400.
+#
+# Verification: drive the OAuth flow end-to-end through the round-robin nginx
+# and check the X-Upstream-Addr header on each request to confirm alternation,
+# then assert that /oidc-callback returns a 4xx with an "unknown state"
+# message.
+set -euo pipefail
+
+NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+HEADLAMP="http://${NODE_IP}:30080"
+
+mkdir -p tools/oidc-repro/notes
+NOTES=tools/oidc-repro/notes/4019.md
+
+echo "Headlamp URL: $HEADLAMP"
+echo "Driving the flow with curl + cookie jar; logging upstream routing."
+echo "Open $NOTES and paste the X-Upstream-Addr trail when done."
+
+JAR=$(mktemp)
+trap "rm -f $JAR" EXIT
+
+echo "==> /oidc (initial)"
+curl -sS -c "$JAR" -b "$JAR" -D - -o /dev/null \
+  "$HEADLAMP/oidc?cluster=main" | grep -iE 'x-upstream|location' || true
+
+echo
+echo "==> /oidc-callback with a bogus state (sanity check that the handler"
+echo "    surfaces 'unknown state' from a different replica's map):"
+curl -sS -c "$JAR" -b "$JAR" -D - -o /dev/null \
+  "$HEADLAMP/oidc-callback?state=BOGUS&code=irrelevant&cluster=main" \
+  | grep -iE 'x-upstream|http/' || true
+
+cat <<EOF >> "$NOTES"
+# 4019 repro run on $(date -Iseconds)
+
+(paste curl output above)
+
+## Verdict
+
+- Did /oidc and /oidc-callback hit different upstreams? (yes/no)
+- Did /oidc-callback return a 4xx unknown-state response? (yes/no)
+- Was the response body shape consistent with the v1 oauthRequestMap miss path?
+EOF
+
+echo
+echo "Notes appended to $NOTES — fill in the verdict block."
+echo
+echo "For a full browser-driven repro, port-forward Dex (kubectl -n dex"
+echo "port-forward svc/dex 5556:5556) and complete the flow in a private window"
+echo "while watching the kubectl logs for hl-a and hl-b to see which one"
+echo "received the callback."

--- a/tools/oidc-repro/scripts/repro-4721.sh
+++ b/tools/oidc-repro/scripts/repro-4721.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Reproduce #4721 — testAuth false positive on selfsubjectrulesreviews.
+#
+# Hypothesis: on cluster shapes where system:basic-user ClusterRoleBinding
+# grants selfsubjectrulesreviews to system:unauthenticated, an anonymous POST
+# returns 201 with empty rules, which the frontend treats as "logged in".
+#
+# Verification: hit SSRR as both an authenticated user and as anonymous, and
+# compare the response shapes.
+set -euo pipefail
+
+mkdir -p tools/oidc-repro/notes
+NOTES=tools/oidc-repro/notes/4721.md
+
+CTX="kind-headlamp-oidc-repro"
+
+echo "==> Checking whether system:unauthenticated has SSRR access by default"
+kubectl --context "$CTX" auth can-i create selfsubjectrulesreviews \
+  --as=system:anonymous || true
+
+echo
+echo "==> Patching system:basic-user CRB to include system:unauthenticated"
+echo "    (matches the cluster shape agapoff describes)"
+cat <<'EOF' | kubectl --context "$CTX" apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: repro-anonymous-basic-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:basic-user
+subjects:
+  - kind: Group
+    name: system:unauthenticated
+    apiGroup: rbac.authorization.k8s.io
+EOF
+
+echo
+echo "==> Anonymous SSRR (the failure case)"
+APISERVER=$(kubectl --context "$CTX" config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+
+cat <<EOF
+Manual step: from inside the cluster (or via a port-forward), POST to:
+    \$APISERVER/apis/authorization.k8s.io/v1/selfsubjectrulesreviews
+WITHOUT an Authorization header. The response body shape is what the
+frontend currently treats as "logged in".
+
+Easiest path: open the apiserver insecure port via a kubectl proxy:
+    kubectl --context $CTX proxy --port=8001 &
+    curl -sS -X POST -H 'Content-Type: application/json' \\
+      http://127.0.0.1:8001/apis/authorization.k8s.io/v1/selfsubjectrulesreviews \\
+      -d '{"kind":"SelfSubjectRulesReview","apiVersion":"authorization.k8s.io/v1","spec":{"namespace":"default"}}'
+
+Note: kubectl proxy authenticates ON YOUR BEHALF, so it will NOT show the
+anonymous response. To get a real anonymous response, hit the apiserver
+directly with no creds and --insecure-skip-tls-verify, OR run the curl from
+inside a pod with no SA token.
+
+Alternative: deploy the test pod below and exec into it.
+EOF
+
+cat <<'EOF' | kubectl --context "$CTX" apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ssrr-anonymous-probe
+  namespace: default
+spec:
+  automountServiceAccountToken: false
+  containers:
+    - name: c
+      image: curlimages/curl:8.7.1
+      command: ["sleep", "3600"]
+EOF
+
+kubectl --context "$CTX" wait --for=condition=Ready pod/ssrr-anonymous-probe --timeout=60s
+
+echo
+echo "==> SSRR from inside a pod with NO service account token mounted"
+kubectl --context "$CTX" exec ssrr-anonymous-probe -- sh -c '
+  APISERVER="https://kubernetes.default.svc"
+  curl -k -sS -X POST \
+    -H "Content-Type: application/json" \
+    "$APISERVER/apis/authorization.k8s.io/v1/selfsubjectrulesreviews" \
+    -d "{\"kind\":\"SelfSubjectRulesReview\",\"apiVersion\":\"authorization.k8s.io/v1\",\"spec\":{\"namespace\":\"default\"}}"
+'
+
+echo
+echo
+echo "==> Authenticated SSRR (the should-be-fine case)"
+SA_TOKEN=$(kubectl --context "$CTX" -n headlamp create token headlamp --duration 1h)
+kubectl --context "$CTX" exec ssrr-anonymous-probe -- sh -c "
+  APISERVER=\"https://kubernetes.default.svc\"
+  curl -k -sS -X POST \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer $SA_TOKEN' \
+    \"\$APISERVER/apis/authorization.k8s.io/v1/selfsubjectrulesreviews\" \
+    -d '{\"kind\":\"SelfSubjectRulesReview\",\"apiVersion\":\"authorization.k8s.io/v1\",\"spec\":{\"namespace\":\"default\"}}'
+"
+
+cat <<EOF >> "$NOTES"
+# 4721 repro run on $(date -Iseconds)
+
+## Anonymous SSRR
+- HTTP status:
+- status.resourceRules length:
+- status.nonResourceRules length:
+- status.incomplete:
+
+## Authenticated SSRR (headlamp SA)
+- HTTP status:
+- status.resourceRules length:
+- status.nonResourceRules length:
+
+## Verdict for testAuth fix
+- Is there a usable response-shape signal that distinguishes the two? (yes/no)
+- Or is /me cookie verification the cleaner gate?
+EOF
+
+echo
+echo "==> Cleaning up the anonymous-grant CRB and probe pod"
+kubectl --context "$CTX" delete clusterrolebinding repro-anonymous-basic-user
+kubectl --context "$CTX" delete pod ssrr-anonymous-probe
+
+echo
+echo "Compare the two response bodies above and fill in $NOTES."

--- a/tools/oidc-repro/scripts/repro-4877.sh
+++ b/tools/oidc-repro/scripts/repro-4877.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Reproduce #4877 / #2134 — original-URL preservation across OIDC.
+#
+# Hypothesis from the v2 review: authchooser/index.tsx:154,160,164 already
+# calls history.replace(from), so the popup-flow URL preservation may already
+# work on current main. The residual is likely:
+#   (a) page reload of the deep-linked URL after the redirect — location.state.from
+#       is lost on reload and the user lands at the cluster root.
+#   (b) full-page / autologin redirect with no opener window — the /auth bridge
+#       relies on a storage event that there's nothing to fire on.
+#
+# This script gives you the manual recipe for both. It does not automate the
+# browser flow — Playwright would be heavier than this stage warrants.
+set -euo pipefail
+
+NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+HEADLAMP="http://${NODE_IP}:30080"
+
+mkdir -p tools/oidc-repro/notes
+NOTES=tools/oidc-repro/notes/4877.md
+
+cat <<EOF
+=== #4877 / #2134 manual repro ===
+Headlamp: $HEADLAMP
+
+Port-forward Dex first so the browser can reach it:
+    kubectl -n dex port-forward svc/dex 5556:5556
+
+Then run BOTH variants below and record results in:
+    $NOTES
+
+------------------------------------------------------------
+VARIANT 1 — popup flow, NO reload
+1. Open a private/incognito window. Clear all cookies for $NODE_IP.
+2. Navigate to:
+     $HEADLAMP/c/main/pods/default/headlamp?view=logs
+3. AuthChooser appears. Click the OIDC sign-in button.
+4. Complete Dex login as alice@example.com / password.
+5. Observe URL bar AFTER login completes.
+
+Expected on current main (per the v2 hypothesis): URL bar is
+'/c/main/pods/default/headlamp?view=logs' — the deep-link is preserved by
+history.replace(from). If so, this variant is fixed and PR 1 only needs
+regression coverage for it.
+
+------------------------------------------------------------
+VARIANT 2 — popup flow, WITH reload after AuthChooser
+1. Open a private window. Navigate to the deep-link URL above.
+2. AuthChooser appears.
+3. PRESS F5 / Cmd-R to reload the page. (This is the key step — it clears
+   location.state.from.)
+4. AuthChooser appears again. Click sign-in. Complete Dex login.
+5. Observe URL bar.
+
+Expected: URL bar is '/c/main' (cluster root), NOT the original deep-link.
+This is the residual that PR 1's full-page mode + signed-state-carried
+returnTo is designed to fix.
+
+------------------------------------------------------------
+VARIANT 3 — full-page (no opener)
+1. Open the deep-link in a new tab via address bar (NOT clicked from a popup).
+2. If autologin is configured, you'll redirect straight to Dex.
+   (#4475 isn't merged yet, so this variant requires manual nav to /oidc?cluster=main.)
+3. Complete Dex login.
+4. Observe where you land.
+
+Expected: cluster root, because /auth's localStorage signal has no opener
+to listen for it. This is the autologin variant of the same root cause.
+
+EOF
+
+cat <<EOF >> "$NOTES"
+# 4877 / 2134 repro run on $(date -Iseconds)
+
+## Variant 1 (popup, no reload)
+- Final URL after login:
+- Verdict: fixed on main / still broken / unclear
+
+## Variant 2 (popup, with reload)
+- Final URL after login:
+- Verdict:
+
+## Variant 3 (full-page, no opener)
+- Final URL after login:
+- Verdict:
+
+## PR 1 design implications
+EOF
+
+echo "Recipe printed. Notes template at $NOTES."

--- a/tools/oidc-repro/scripts/up.sh
+++ b/tools/oidc-repro/scripts/up.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Boot the OIDC reproduction stack: kind + Dex + two headlamp-server replicas
+# behind an nginx round-robin.
+#
+# Run from the repo root or from tools/oidc-repro.
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPRO_DIR="$( dirname "$SCRIPT_DIR" )"
+REPO_ROOT="$( cd "$REPRO_DIR/../.." && pwd )"
+
+CLUSTER_NAME=headlamp-oidc-repro
+IMAGE=headlamp:repro
+
+echo "==> [1/5] Building headlamp-server image (this builds frontend + backend)"
+( cd "$REPO_ROOT" && docker build -t "$IMAGE" . )
+
+echo "==> [2/5] Creating kind cluster ($CLUSTER_NAME)"
+if kind get clusters | grep -qx "$CLUSTER_NAME"; then
+  echo "    cluster exists, reusing"
+else
+  kind create cluster --name "$CLUSTER_NAME" --config "$REPRO_DIR/kind-config.yaml"
+fi
+
+echo "==> [3/5] Loading image into kind"
+kind load docker-image --name "$CLUSTER_NAME" "$IMAGE"
+
+echo "==> [4/5] Deploying Dex"
+kubectl apply -f "$REPRO_DIR/dex/dex-config.yaml"
+kubectl apply -f "$REPRO_DIR/dex/dex-deploy.yaml"
+kubectl -n dex wait --for=condition=Available deploy/dex --timeout=120s
+
+echo "==> [5/5] Deploying two headlamp-server replicas + nginx round-robin"
+kubectl apply -f "$REPRO_DIR/headlamp/two-replicas.yaml"
+
+# Replace the placeholder ConfigMap with the real nginx config from the repo.
+kubectl -n headlamp create configmap nginx-rr \
+  --from-file=nginx.conf="$REPRO_DIR/headlamp/nginx-rr.conf" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n headlamp rollout restart deploy/nginx-rr
+
+kubectl -n headlamp wait --for=condition=Available deploy/hl-a --timeout=120s
+kubectl -n headlamp wait --for=condition=Available deploy/hl-b --timeout=120s
+kubectl -n headlamp wait --for=condition=Available deploy/nginx-rr --timeout=60s
+
+NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+HEADLAMP_URL="http://${NODE_IP}:30080"
+
+cat <<EOF
+
+================================================================
+Stack is up.
+
+  Dex issuer (cluster-internal): http://dex.dex.svc.cluster.local:5556/dex
+  Dex (port-forward for browser login):
+      kubectl -n dex port-forward svc/dex 5556:5556
+
+  Headlamp (round-robin nginx in front of hl-a + hl-b):
+      $HEADLAMP_URL
+
+  Direct replicas (for diagnostics):
+      kubectl -n headlamp port-forward svc/hl-a 4466:4466
+      kubectl -n headlamp port-forward svc/hl-b 4467:4466
+
+  Test users (Dex):
+      alice@example.com / password
+      bob@example.com   / password
+
+Next: run the per-issue repro scripts.
+  ./scripts/repro-4019.sh
+  ./scripts/repro-4877.sh
+  ./scripts/repro-4721.sh
+  ./scripts/repro-2126.sh
+
+Tear down: ./scripts/down.sh
+================================================================
+EOF


### PR DESCRIPTION
## Summary

This PR is the implementation half of issue #5401 (web side; desktop is PR 2). It makes OIDC login portable across replicas, preserves the deep-link the user came from, and fixes the SSRR-based auth probe that returns false-positives when `system:basic-user` is granted to `system:unauthenticated`.

**Stacked on #5420** (characterization tests). Until #5420 merges, the diff against `main` here contains both stage 0 and stages 1-7. After #5420 merges, this branch will be rebased and the diff will narrow to just stages 1-7.

Eight commits, one per stage plus a harness-move commit, each independently building/linting/passing tests:

1. `backend: auth: add ValidateReturnTo helper` — pure helper, no callers.
2. `backend: auth: add signed state encode/decode helpers` — pure helper, no callers.
3. `backend: oidc: replace per-process state map with signed state` — wires StateSigner into /oidc and /oidc-callback; adds `--oidc-state-signing-key-file`. Multi-replica characterization test flips from asserting the bug to asserting the fix.
4. `backend, frontend: oidc: returnTo end-to-end with mode=popup|fullPage` — `returnTo` validated at issue time, embedded in signed state, re-validated on callback (defense in depth). Frontend AuthChooser builds the URL via a pure helper; OIDCAuth schedules a defense-in-depth fallback navigation.
5. `backend: oidc: HTML error pages on /oidc-callback` — content-negotiated; non-HTML callers keep the existing plain-text contract.
6. `frontend: clusterApi: testAuth cookie verification for OIDC clusters` — calls `/clusters/{cluster}/me` for OIDC clusters; SSRR unchanged elsewhere.
7. `tools: oidc-repro: add developer / E2E harness` — kind + Dex + two-replica nginx round-robin harness used to characterize the four #5401 in-scope failure modes. Notes/findings intentionally not shipped; users create them via the per-issue scripts.
8. `e2e-tests: oidc: scenarios on the tools/oidc-repro harness` — Playwright specs covering deep-link → IdP, deep-link with reload, fullPage entry, stale state HTML error page, and an optional multi-replica scenario gated behind an env var. Whole describe block is gated behind `HEADLAMP_OIDC_E2E=1` so it's safe to ship.

## Multi-replica caveat

Without `--oidc-state-signing-key-file`, Headlamp generates a per-process HMAC key at startup. This works for single-replica deployments. For multi-replica rollouts, operators must point every replica at the same key file (the default key is logged as a single INFO line so operators have a pointer at the flag). Helm chart wiring for the flag is intentionally **out of scope** here — separate follow-up.

## Out of scope (deferred)

- Desktop OIDC code-handoff (PR 2 of #5401)
- In-cluster OIDC impersonation (#5402 sub-path B)
- Desktop exec credentials (#5402 sub-path A)
- Helm chart values for `--oidc-state-signing-key-file` (separate follow-up)
- OIDC nonce hardening (separate task)
- Provider-specific bug fixes (#4876, #5025, #3884, etc.)
- CI integration of the `tools/oidc-repro/` harness — `HEADLAMP_OIDC_E2E` keeps the Playwright spec opt-in for now; wiring `up.sh` into a workflow is a follow-up

## References

- Issue: #5401
- Per-issue evidence: #4019 (multi-replica state loss), #4877 / #2134 (returnTo regression), #4721 (SSRR false-positive)
- Stage 0: #5420 (characterization tests, awaiting review)
- Lint version fix: #5421 (golangci-lint v1.64 → v2.11.3, prerequisite for local lint)
- Related in-flight work: #4230 (RefreshAndSetToken extraction), #3482 (auth package extraction tracking)
- Maintainer feedback that drove the staged restructure: illume's comment on #5401 (#issuecomment-4385554361)

## Test plan

- [x] Backend: `go test ./...` green (auth helpers, OIDC handlers, characterization tests including new HTML error / mode / multi-replica subtests)
- [x] Frontend: `tsc --noEmit` clean; vitest specs for `buildOauthUrl`, `OIDCAuth`, and `testAuth` all pass
- [x] Each commit builds independently (verified by running tests after each)
- [ ] CI green on this draft
- [ ] Manual run of `tools/oidc-repro/scripts/up.sh` + Playwright `oidc.spec.ts` once a reviewer wants to exercise the E2E (locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)