### PR TITLE
Fix/cluster redirect OIDC

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -37,6 +37,25 @@ import { useSidebarItem } from '../Sidebar';
 export default function RouteSwitcher(props: { requiresToken: () => boolean }) {
   // The NotFoundRoute always has to be evaluated in the last place.
   const routes = useTypedSelector(state => state.routes.routes);
+  const cluster = useCluster();
+  const history = useHistory();
+
+  React.useEffect(() => {
+    const pendingCluster = sessionStorage.getItem('pendingCluster');
+
+    if (!history?.location?.pathname) return;
+
+    if (!history.location.pathname.startsWith('/c/')) return;
+
+    if (pendingCluster && pendingCluster !== cluster) {
+      sessionStorage.removeItem('pendingCluster');
+
+      const newPath = history.location.pathname.replace(/^\/c\/[^/]+/, `/c/${pendingCluster}`);
+
+      history.replace(newPath);
+    }
+  }, [cluster, history]);
+
   const routeFilters = useTypedSelector(state => state.routes.routeFilters);
   const defaultRoutes = Object.values(getDefaultRoutes()).concat(NotFoundRoute);
   const clusters = useClustersConf();


### PR DESCRIPTION
## Summary

This PR fixes an issue where, after OIDC authentication, Headlamp redirects users back to the previously active cluster instead of the intended one.

The fix preserves the intended cluster using sessionStorage and restores it in RouteSwitcher after login.

## Related Issue

Fixes #5409

## Changes

- Added logic in RouteSwitcher to restore the intended cluster after authentication
- Used sessionStorage to temporarily store the selected cluster across redirects
- Ensured correct URL update after login to avoid fallback to previous cluster

## Steps to Test

1. Start Headlamp locally
2. Navigate to a cluster (e.g., cluster A)
3. Switch to another cluster (e.g., cluster B) that requires authentication
4. Complete the login process
5. Verify that the application redirects to cluster B instead of cluster A

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The fix is isolated to RouteSwitcher and does not affect other routing logic
- No changes were made to authentication flow itself, only post-login redirection handling
- Verified behavior manually using simulated pendingCluster in sessionStorage