### PR TITLE
frontend: CustomResourceInstancesList: fix useNamespaces called inside .map()

### DIFF
--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -26,10 +26,10 @@ import { EmptyContent as Empty, Link, Loader, ResourceListView, ShowHideLabel } 
 function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
   const { t } = useTranslation(['glossary', 'translation']);
 
+  const namespaces = useNamespaces();
   const dataClassCrds = crds.map(crd => {
     const crdClass = crd.makeCRClass();
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const data = crdClass.useList({ cluster: crd.cluster, namespace: useNamespaces() });
+    const data = crdClass.useList({ cluster: crd.cluster, namespace: namespaces });
     return { data, crdClass, crd };
   });
 


### PR DESCRIPTION
## Summary
Fix react-hooks/rules-of-hooks violation in CrInstancesView where
useNamespaces was called inside a .map() callback, causing the number
of hook calls to vary between renders.

## Related Issue
Closes #5193

## Changes
- Moved useNamespaces() to the top level of CrInstancesView
- Removed eslint-disable-next-line comment
- Pass namespaces result into the .map() callback

## Steps to Test
1. Navigate to CRDs → select a CRD → open Instances view
2. Verify instances load correctly
3. Check no console errors about rules-of-hooks

## Notes for the Reviewer
- Only 1 file changed
- Simple fix — no new components needed