### PR TITLE
downgrade electron

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -59,6 +59,14 @@ if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
 }
 
+// On Linux, force the GTK 3 backend. Electron 36+ defaults to GTK 4, which
+// conflicts with GTK 2/3 symbols pulled into the process by IM modules and
+// other shims on common desktops (e.g. GNOME on Fedora), aborting before
+// the window is shown.
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('gtk-version', '3');
+}
+
 let isRunningScript = false;
 if (process.env.HEADLAMP_RUN_SCRIPT) {
   isRunningScript = true;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^22.14.0",
         "@types/semver": "^7.7.0",
         "@types/yargs": "^17.0.35",
-        "electron": "^41.2.0",
+        "electron": "^38.8.6",
         "electron-builder": "^26.6.0",
         "esbuild": "^0.25.0",
         "i18next-parser": "^9.0.0",
@@ -4737,15 +4737,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.2.0.tgz",
-      "integrity": "sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==",
+      "version": "38.8.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.8.6.tgz",
+      "integrity": "sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -4990,23 +4990,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/electron/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -15721,31 +15704,14 @@
       }
     },
     "electron": {
-      "version": "41.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.2.0.tgz",
-      "integrity": "sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==",
+      "version": "38.8.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.8.6.tgz",
+      "integrity": "sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "24.12.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-          "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~7.16.0"
-          }
-        },
-        "undici-types": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-          "dev": true
-        }
       }
     },
     "electron-builder": {

--- a/app/package.json
+++ b/app/package.json
@@ -179,7 +179,7 @@
     "@types/node": "^22.14.0",
     "@types/semver": "^7.7.0",
     "@types/yargs": "^17.0.35",
-    "electron": "^41.2.0",
+    "electron": "^38.8.6",
     "electron-builder": "^26.6.0",
     "esbuild": "^0.25.0",
     "i18next-parser": "^9.0.0",


### PR DESCRIPTION
## Summary

There's some font processing related issue with Electron 41 which means electron doesn't load and the app window is left blank.
I have tried several electron versions and settled on the one in this PR (as the highest one that works) + the needed change for gtk.

## Steps to Test

1. `npm run app:start` and verify Headlamp actually loads

