### PR TITLE
frontend: multiplexer: Fix pending subscription cleanup

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -409,6 +409,78 @@ describe('WebSocket Multiplexer', () => {
         { timeout: 10000 }
       );
     });
+
+    it('should cleanup when unmounted before subscription resolves', async () => {
+      const fullUrl = `${BASE_WS_URL}api/v1/pods`;
+      const cleanup = vi.fn();
+      let resolveSubscribe: (cleanup: () => void) => void = () => {};
+      const subscribeSpy = vi.spyOn(WebSocketManager, 'subscribe').mockReturnValue(
+        new Promise<() => void>(resolve => {
+          resolveSubscribe = resolve;
+        })
+      );
+
+      const { unmount } = renderHook(() =>
+        useWebSocket({
+          url: () => fullUrl,
+          enabled: true,
+          cluster: clusterName,
+          onMessage,
+          onError,
+        })
+      );
+
+      await vi.waitFor(() => {
+        expect(subscribeSpy).toHaveBeenCalledWith(
+          clusterName,
+          '/api/v1/pods',
+          '',
+          expect.any(Function)
+        );
+      });
+
+      unmount();
+      resolveSubscribe(cleanup);
+
+      await vi.waitFor(() => {
+        expect(cleanup).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should remove subscription state when unmounted before subscription rejects', async () => {
+      const fullUrl = `${BASE_WS_URL}api/v1/pods`;
+      const key = WebSocketManager.createKey(clusterName, '/api/v1/pods', '');
+      let rejectConnect: (error: Error) => void = () => {};
+      vi.spyOn(WebSocketManager, 'connect').mockReturnValue(
+        new Promise<WebSocket>((_, reject) => {
+          rejectConnect = reject;
+        })
+      );
+
+      const { unmount } = renderHook(() =>
+        useWebSocket({
+          url: () => fullUrl,
+          enabled: true,
+          cluster: clusterName,
+          onMessage,
+          onError,
+        })
+      );
+
+      await vi.waitFor(() => {
+        expect(WebSocketManager.activeSubscriptions.has(key)).toBe(true);
+        expect(WebSocketManager.listeners.get(key)?.size).toBe(1);
+      });
+
+      unmount();
+      rejectConnect(new Error('WebSocket connection failed'));
+
+      await vi.waitFor(() => {
+        expect(WebSocketManager.listeners.has(key)).toBe(false);
+        expect(WebSocketManager.activeSubscriptions.has(key)).toBe(false);
+        expect(onError).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('WebSocket error handling', () => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -372,17 +372,40 @@ export function useWebSocket<T>({
     }
 
     let cleanup: (() => void) | undefined;
+    let isCancelled = false;
+    let subscriptionPath: string | undefined;
+    let subscriptionQuery = '';
 
     const connectWebSocket = async () => {
       try {
         const parsedUrl = new URL(url, getBaseWsUrl());
-        cleanup = await WebSocketManager.subscribe(
+        subscriptionPath = parsedUrl.pathname;
+        subscriptionQuery = parsedUrl.search.slice(1);
+        const unsubscribe = await WebSocketManager.subscribe(
           cluster,
-          parsedUrl.pathname,
-          parsedUrl.search.slice(1),
+          subscriptionPath,
+          subscriptionQuery,
           stableOnMessage
         );
+        if (isCancelled) {
+          unsubscribe();
+        } else {
+          cleanup = unsubscribe;
+        }
       } catch (err) {
+        if (subscriptionPath) {
+          const key = WebSocketManager.createKey(cluster, subscriptionPath, subscriptionQuery);
+          WebSocketManager.unsubscribe(
+            key,
+            cluster,
+            subscriptionPath,
+            subscriptionQuery,
+            stableOnMessage
+          );
+        }
+        if (isCancelled) {
+          return;
+        }
         console.error('WebSocket connection failed:', err);
         onError?.(err as Error);
       }
@@ -391,6 +414,7 @@ export function useWebSocket<T>({
     connectWebSocket();
 
     return () => {
+      isCancelled = true;
       if (cleanup) {
         cleanup();
       }


### PR DESCRIPTION
## Summary

This PR fixes a WebSocket subscription cleanup race by ensuring `useWebSocket` unsubscribes even when the hook unmounts before `WebSocketManager.subscribe()` resolves.

## Related Issue

Fixes #5404

## Changes

- Updated `useWebSocket` cleanup logic in `frontend/src/lib/k8s/api/v2/multiplexer.ts`.
- Fixed leaked multiplexer subscriptions when a pending subscription resolves after unmount.
- Added a regression test for cleanup when unmounted before subscription resolution.

## Steps to Test

1. Run `npm run frontend:lint`.
2. Run `npm run frontend:test -- src/lib/k8s/api/v2/multiplexer.test.ts --run`.
3. Verify the multiplexer test suite passes.

## Notes for the Reviewer

- The change is scoped to the hook cleanup path and does not alter `WebSocketManager.subscribe()` behavior.
