### PR TITLE
charts: deployment: Stop overriding OIDC env config

### DIFF
--- a/charts/headlamp/Chart.yaml
+++ b/charts/headlamp/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 maintainers:
   - name: kinvolk
     url: https://kinvolk.io/
-version: 0.42.0
+version: 0.43.0
 appVersion: 0.42.0
 annotations:
   artifacthub.io/signKey: |

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -128,6 +128,28 @@ config:
       name: your-oidc-secret
 ```
 
+### Upgrade Notes
+
+Chart `0.43.0` changes how OIDC values are passed to Headlamp. The chart now relies on
+Headlamp's `HEADLAMP_CONFIG_*` environment variables instead of translating legacy
+`OIDC_*` and `ME_USER_INFO_URL` values into container arguments.
+
+If you provide OIDC values through `env:` or an external secret, rename those entries to
+the `HEADLAMP_CONFIG_*` equivalents before upgrading. In particular:
+
+- `OIDC_CLIENT_ID` -> `HEADLAMP_CONFIG_OIDC_CLIENT_ID`
+- `OIDC_CLIENT_SECRET` -> `HEADLAMP_CONFIG_OIDC_CLIENT_SECRET`
+- `OIDC_ISSUER_URL` -> `HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL`
+- `OIDC_SCOPES` -> `HEADLAMP_CONFIG_OIDC_SCOPES`
+- `OIDC_CALLBACK_URL` -> `HEADLAMP_CONFIG_OIDC_CALLBACK_URL`
+- `OIDC_VALIDATOR_CLIENT_ID` -> `HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID`
+- `OIDC_VALIDATOR_ISSUER_URL` -> `HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL`
+- `OIDC_USE_ACCESS_TOKEN` -> `HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN`
+- `OIDC_USE_PKCE` -> `HEADLAMP_CONFIG_OIDC_USE_PKCE`
+- `ME_USER_INFO_URL` -> `HEADLAMP_CONFIG_ME_USER_INFO_URL`
+
+Values set through `config.oidc.*` continue to work without changes.
+
 ### Deployment Configuration
 
 | Key | Type | Default | Description |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -1,16 +1,4 @@
 {{- $oidc := .Values.config.oidc }}
-{{- $env := .Values.env }}
-
-{{- $clientID := "" }}
-{{- $clientSecret := "" }}
-{{- $issuerURL := "" }}
-{{- $scopes := "" }}
-{{- $callbackURL := "" }}
-{{- $validatorClientID := "" }}
-{{- $validatorIssuerURL := "" }}
-{{- $usePKCE := "" }}
-{{- $useAccessToken := "" }}
-{{- $meUserInfoURL := "" }}
 {{- $readOnlyRootFs := eq (include "headlamp.readOnlyRootFilesystem" .Values) "true" }}
 {{- $pluginManagerSecurityContext := dict }}
 {{- if .Values.pluginsManager.securityContext }}
@@ -21,41 +9,6 @@
 {{- $readOnlyRootFsPlugins := and .Values.pluginsManager.enabled (eq (include "headlamp.readOnlyRootFilesystem" (dict "securityContext" $pluginManagerSecurityContext)) "true") }}
 {{- $tmpCtx := include "headlamp.tmpVolumeContext" (dict "volumeMounts" .Values.volumeMounts "volumes" .Values.volumes "readOnly" $readOnlyRootFs "mountName" "headlamp-tmp") | fromYaml }}
 {{- $pluginsTmpCtx := include "headlamp.tmpVolumeContext" (dict "volumeMounts" .Values.pluginsManager.volumeMounts "volumes" .Values.volumes "readOnly" $readOnlyRootFsPlugins "mountName" "headlamp-plugins-tmp") | fromYaml }}
-
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-{{- range $env }}
-  {{- if eq .name "OIDC_CLIENT_ID" }}
-    {{- $clientID = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_CLIENT_SECRET" }}
-    {{- $clientSecret = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_ISSUER_URL" }}
-    {{- $issuerURL = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_SCOPES" }}
-    {{- $scopes = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_CALLBACK_URL" }}
-    {{- $callbackURL = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_VALIDATOR_CLIENT_ID" }}
-    {{- $validatorClientID = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_VALIDATOR_ISSUER_URL" }}
-    {{- $validatorIssuerURL = .value }}
-  {{- end }}
-  {{- if eq .name "OIDC_USE_ACCESS_TOKEN" }}
-    {{- $useAccessToken = .value | toString }}
-  {{- end }}
-  {{- if eq .name "OIDC_USE_PKCE" }}
-    {{- $usePKCE = .value | toString }}
-  {{- end }}
-  {{- if eq .name "ME_USER_INFO_URL" }}
-    {{- $meUserInfoURL = .value | toString }}
-  {{- end }}
-{{- end }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -123,70 +76,70 @@ spec:
           env:
             {{- if $oidc.secret.create }}
             {{- if $oidc.clientID }}
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: clientID
             {{- end }}
             {{- if $oidc.clientSecret }}
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: clientSecret
             {{- end }}
             {{- if $oidc.issuerURL }}
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: issuerURL
             {{- end }}
             {{- if $oidc.scopes }}
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: scopes
             {{- end }}
             {{- if $oidc.callbackURL }}
-            - name: OIDC_CALLBACK_URL
+            - name: HEADLAMP_CONFIG_OIDC_CALLBACK_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: callbackURL
             {{- end }}
             {{- if $oidc.validatorClientID }}
-            - name: OIDC_VALIDATOR_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: validatorClientID
             {{- end }}
             {{- if $oidc.validatorIssuerURL }}
-            - name: OIDC_VALIDATOR_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: validatorIssuerURL
             {{- end }}
             {{- if $oidc.useAccessToken }}
-            - name: OIDC_USE_ACCESS_TOKEN
+            - name: HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: useAccessToken
             {{- end }}
             {{- if $oidc.usePKCE }}
-            - name: OIDC_USE_PKCE
+            - name: HEADLAMP_CONFIG_OIDC_USE_PKCE
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
                   key: usePKCE
             {{- end }}
             {{- if $oidc.meUserInfoURL }}
-            - name: ME_USER_INFO_URL
+            - name: HEADLAMP_CONFIG_ME_USER_INFO_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ $oidc.secret.name }}
@@ -194,43 +147,43 @@ spec:
             {{- end }}
             {{- else }}
             {{- if $oidc.clientID }}
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: {{ $oidc.clientID }}
             {{- end }}
             {{- if $oidc.clientSecret }}
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: {{ $oidc.clientSecret }}
             {{- end }}
             {{- if $oidc.issuerURL }}
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: {{ $oidc.issuerURL }}
             {{- end }}
             {{- if $oidc.scopes }}
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: {{ $oidc.scopes }}
             {{- end }}
             {{- if $oidc.callbackURL }}
-            - name: OIDC_CALLBACK_URL
+            - name: HEADLAMP_CONFIG_OIDC_CALLBACK_URL
               value: {{ $oidc.callbackURL }}
             {{- end }}
             {{- if $oidc.validatorClientID }}
-            - name: OIDC_VALIDATOR_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID
               value: {{ $oidc.validatorClientID }}
             {{- end }}
             {{- if $oidc.validatorIssuerURL }}
-            - name: OIDC_VALIDATOR_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL
               value: {{ $oidc.validatorIssuerURL }}
             {{- end }}
             {{- if $oidc.useAccessToken }}
-            - name: OIDC_USE_ACCESS_TOKEN
+            - name: HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN
               value: {{ $oidc.useAccessToken | quote }}
             {{- end }}
             {{- if $oidc.usePKCE }}
-            - name: OIDC_USE_PKCE
+            - name: HEADLAMP_CONFIG_OIDC_USE_PKCE
               value: {{ $oidc.usePKCE | quote }}
             {{- end }}
             {{- if $oidc.meUserInfoURL }}
-            - name: ME_USER_INFO_URL
+            - name: HEADLAMP_CONFIG_ME_USER_INFO_URL
               value: {{ $oidc.meUserInfoURL }}
             {{- end }}
             {{- end }}
@@ -263,76 +216,6 @@ spec:
             {{- end }}
             {{- with .Values.config.podDebugImage }}
             - "-pod-debug-image={{ . }}"
-            {{- end }}
-            {{- if not $oidc.externalSecret.enabled}}
-            # Check if externalSecret is disabled
-            {{- if or (ne $oidc.clientID "") (ne $clientID "") }}
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            {{- end }}
-            {{- if or (ne $oidc.clientSecret "") (ne $clientSecret "") }}
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            {{- end }}
-            {{- if or (ne $oidc.issuerURL "") (ne $issuerURL "") }}
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            {{- end }}
-            {{- if or (ne $oidc.scopes "") (ne $scopes "") }}
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
-            {{- end }}
-            {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
-            # Check if callbackURL is non empty either from env or oidc.config
-            - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorClientID "") (ne $validatorClientID "") }}
-            # Check if validatorClientID is non empty either from env or oidc.config
-            - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorIssuerURL "") (ne $validatorIssuerURL "") }}
-            # Check if validatorIssuerURL is non empty either from env or oidc.config
-            - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
-            {{- end }}
-            {{- if or (ne ($oidc.useAccessToken | toString) "false") (ne $useAccessToken "") }}
-            # Check if useAccessToken is non false either from env or oidc.config
-            - "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)"
-            {{- end }}
-            {{- if or (eq ($oidc.usePKCE | toString) "true") (eq $usePKCE "true") }}
-            - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
-            {{- end }}
-            {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
-            - "-me-user-info-url=$(ME_USER_INFO_URL)"
-            {{- end }}
-            {{- else }}
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            {{- if $oidc.externalSecret.hasScopes }}
-            - "-oidc-scopes=$(OIDC_SCOPES)"
-            {{- end }}
-            {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
-            # Check if callbackURL is non empty either from env or oidc.config
-            - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"
-            {{- end }}
-            {{- if or (eq ($oidc.usePKCE | toString) "true") (eq $usePKCE "true") }}
-            - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorClientID "") (ne $validatorClientID "") }}
-            # Check if validatorClientID is non empty either from env or oidc.config
-            - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
-            {{- end }}
-            {{- if or (ne $oidc.validatorIssuerURL "") (ne $validatorIssuerURL "") }}
-            # Check if validatorIssuerURL is non empty either from env or oidc.config
-            - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
-            {{- end }}
-            {{- if or (eq ($oidc.useAccessToken | toString) "true") (eq $useAccessToken "true") }}
-            # Check if useAccessToken is non false either from env or oidc.config
-            - "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)"
-            {{- end }}
-            {{- if or (ne $oidc.meUserInfoURL "") (ne $meUserInfoURL "") }}
-            - "-me-user-info-url=$(ME_USER_INFO_URL)"
-            {{- end }}
             {{- end }}
             {{- with .Values.config.baseURL }}
             - "-base-url={{ . }}"

--- a/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
+++ b/charts/headlamp/tests/expected_templates/azure-oidc-with-validators.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -18,7 +18,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -39,7 +39,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -57,16 +57,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -99,36 +96,23 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: azure-client-id
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: azure-client-secret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: https://login.microsoftonline.com/tenant-id/v2.0
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: openid email profile
-            - name: OIDC_VALIDATOR_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID
               value: azure-validator-client-id
-            - name: OIDC_VALIDATOR_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL
               value: https://login.microsoftonline.com/tenant-id/v2.0
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
-            # Check if validatorClientID is non empty either from env or oidc.config
-            - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
-            # Check if validatorIssuerURL is non empty either from env or oidc.config
-            - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/default.yaml
+++ b/charts/headlamp/tests/expected_templates/default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/extra-args.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-args.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
             - -insecure-ssl
           ports:
             - name: http

--- a/charts/headlamp/tests/expected_templates/extra-manifests.yaml
+++ b/charts/headlamp/tests/expected_templates/extra-manifests.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -44,7 +44,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -65,7 +65,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -83,16 +83,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -130,7 +127,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/host-users-override.yaml
+++ b/charts/headlamp/tests/expected_templates/host-users-override.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
+++ b/charts/headlamp/tests/expected_templates/httproute-enabled.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -148,7 +144,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"

--- a/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
+++ b/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -70,16 +70,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -117,7 +114,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -126,10 +122,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
 ---
@@ -140,7 +148,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"

--- a/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url-directly.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -108,15 +105,13 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: ME_USER_INFO_URL
+            - name: HEADLAMP_CONFIG_ME_USER_INFO_URL
               value: /oauth2/userinfocustom1
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            - "-me-user-info-url=$(ME_USER_INFO_URL)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
+++ b/charts/headlamp/tests/expected_templates/me-user-info-url.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -28,7 +28,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -49,7 +49,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -67,16 +67,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -109,7 +106,7 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: ME_USER_INFO_URL
+            - name: HEADLAMP_CONFIG_ME_USER_INFO_URL
               valueFrom:
                 secretKeyRef:
                   name: oidc
@@ -119,8 +116,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            - "-me-user-info-url=$(ME_USER_INFO_URL)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override-oidc-create-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: mynamespace2
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -31,7 +31,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -52,7 +52,7 @@ metadata:
   name: headlamp
   namespace: mynamespace2
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -70,16 +70,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: mynamespace2
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -112,22 +109,22 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: oidc
                   key: clientID
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: oidc
                   key: clientSecret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               valueFrom:
                 secretKeyRef:
                   name: oidc
                   key: issuerURL
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               valueFrom:
                 secretKeyRef:
                   name: oidc
@@ -137,15 +134,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/namespace-override.yaml
+++ b/charts/headlamp/tests/expected_templates/namespace-override.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: mynamespace
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: mynamespace
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: mynamespace
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
+++ b/charts/headlamp/tests/expected_templates/non-azure-oidc.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -18,7 +18,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -39,7 +39,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -57,16 +57,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -99,28 +96,19 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: generic-oidc-client
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: generic-oidc-secret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: https://auth.example.com
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: openid email profile
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-create-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -31,7 +31,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -52,7 +52,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -70,16 +70,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -112,22 +109,22 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: oidc
                   key: clientID
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: oidc
                   key: clientSecret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               valueFrom:
                 secretKeyRef:
                   name: oidc
                   key: issuerURL
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               valueFrom:
                 secretKeyRef:
                   name: oidc
@@ -137,15 +134,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly-env.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -108,28 +105,19 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: testClientId
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: testClientSecret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: testIssuerURL
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: testScope
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-directly.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-directly.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -18,7 +18,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -39,7 +39,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -57,16 +57,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -99,28 +96,19 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: testClientId
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: testClientSecret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: testIssuerURL
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: testScope
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -18,7 +18,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -39,7 +39,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -57,16 +57,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -107,10 +104,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466
@@ -119,9 +112,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -18,7 +18,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -39,7 +39,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -57,16 +57,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -107,9 +104,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-pkce.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -18,7 +18,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -39,7 +39,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -57,16 +57,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -99,31 +96,21 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: testClientId
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: testClientSecret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: testIssuerURL
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: testScope
-            - name: OIDC_USE_PKCE
+            - name: HEADLAMP_CONFIG_OIDC_USE_PKCE
               value: "true"
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
-            - "-oidc-use-pkce=$(OIDC_USE_PKCE)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-validator-overrides.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -18,7 +18,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -39,7 +39,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -57,16 +57,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -99,40 +96,25 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
-            - name: OIDC_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
               value: testClientId
-            - name: OIDC_CLIENT_SECRET
+            - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
               value: testClientSecret
-            - name: OIDC_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
               value: testIssuerURL
-            - name: OIDC_SCOPES
+            - name: HEADLAMP_CONFIG_OIDC_SCOPES
               value: testScope
-            - name: OIDC_VALIDATOR_CLIENT_ID
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID
               value: overriddenClientID
-            - name: OIDC_VALIDATOR_ISSUER_URL
+            - name: HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL
               value: overriddenIssuerURL
-            - name: OIDC_USE_ACCESS_TOKEN
+            - name: HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN
               value: "true"
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
-            # Check if clientID is non empty either from env or oidc.config
-            - "-oidc-client-id=$(OIDC_CLIENT_ID)"
-            # Check if clientSecret is non empty either from env or oidc.config
-            - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
-            # Check if issuerURL is non empty either from env or oidc.config
-            - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            # Check if scopes are non empty either from env or oidc.config
-            - "-oidc-scopes=$(OIDC_SCOPES)"
-            # Check if validatorClientID is non empty either from env or oidc.config
-            - "-oidc-validator-client-id=$(OIDC_VALIDATOR_CLIENT_ID)"
-            # Check if validatorIssuerURL is non empty either from env or oidc.config
-            - "-oidc-validator-idp-issuer-url=$(OIDC_VALIDATOR_ISSUER_URL)"
-            # Check if useAccessToken is non false either from env or oidc.config
-            - "-oidc-use-access-token=$(OIDC_USE_ACCESS_TOKEN)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/pod-disruption.yaml
+++ b/charts/headlamp/tests/expected_templates/pod-disruption.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -26,7 +26,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -47,7 +47,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -68,7 +68,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -86,16 +86,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -133,7 +130,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -114,7 +111,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -123,10 +119,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -114,7 +111,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -123,10 +119,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -28,7 +28,7 @@ metadata:
   name: headlamp-plugin-config
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -42,7 +42,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -63,7 +63,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -81,16 +81,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -129,7 +126,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -138,10 +134,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -28,7 +28,7 @@ metadata:
   name: headlamp-plugin-config
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -42,7 +42,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -63,7 +63,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -81,16 +81,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -129,7 +126,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -138,10 +134,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -114,7 +111,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -123,10 +119,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -28,7 +28,7 @@ metadata:
   name: headlamp-plugin-config
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -42,7 +42,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -63,7 +63,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -81,16 +81,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -139,7 +136,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
+++ b/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -76,16 +76,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -123,7 +120,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466
@@ -132,9 +128,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/tls-added.yaml
+++ b/charts/headlamp/tests/expected_templates/tls-added.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
             - "-tls-cert-path=/headlamp-cert/headlamp-ca.crt"
             - "-tls-key-path=/headlamp-cert/headlamp-tls.key"
           ports:

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints-custom-selector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
+++ b/charts/headlamp/tests/expected_templates/topology-spread-constraints.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/expected_templates/volumes-added.yaml
+++ b/charts/headlamp/tests/expected_templates/volumes-added.yaml
@@ -6,7 +6,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: headlamp-admin
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -48,7 +48,7 @@ metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -66,16 +66,13 @@ spec:
     app.kubernetes.io/instance: headlamp
 ---
 # Source: headlamp/templates/deployment.yaml
-# This block of code is used to extract the values from the env.
-# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: headlamp
   namespace: default
   labels:
-    helm.sh/chart: headlamp-0.42.0
+    helm.sh/chart: headlamp-0.43.0
     app.kubernetes.io/name: headlamp
     app.kubernetes.io/instance: headlamp
     app.kubernetes.io/version: "0.42.0"
@@ -113,7 +110,6 @@ spec:
             - "-in-cluster-context-name=main"
             - "-plugins-dir=/headlamp/plugins"
             - "-session-ttl=86400"
-            # Check if externalSecret is disabled
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/test_cases/me-user-info-url-directly.yaml
+++ b/charts/headlamp/tests/test_cases/me-user-info-url-directly.yaml
@@ -1,3 +1,3 @@
 env:
-  - name: ME_USER_INFO_URL
+  - name: HEADLAMP_CONFIG_ME_USER_INFO_URL
     value: /oauth2/userinfocustom1

--- a/charts/headlamp/tests/test_cases/oidc-directly-env.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-directly-env.yaml
@@ -1,10 +1,10 @@
 # This is a test case where user can set env values directly for OIDC configuration.
 env:
-  - name: OIDC_CLIENT_ID
+  - name: HEADLAMP_CONFIG_OIDC_CLIENT_ID
     value: testClientId
-  - name: OIDC_CLIENT_SECRET
+  - name: HEADLAMP_CONFIG_OIDC_CLIENT_SECRET
     value: testClientSecret
-  - name: OIDC_ISSUER_URL
+  - name: HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL
     value: testIssuerURL
-  - name: OIDC_SCOPES
+  - name: HEADLAMP_CONFIG_OIDC_SCOPES
     value: testScope


### PR DESCRIPTION
## Summary
- remove the Helm chart logic that translates OIDC env values into container args
- let Headlamp read OIDC settings directly from env vars, including `HEADLAMP_CONFIG_*` values provided by users or external secrets
- refresh the Helm template snapshots to match the new rendered deployment output

## Backwards compatibility
- this is a breaking Helm chart change for users who currently provide OIDC settings via legacy env or secret keys such as `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_ISSUER_URL`, `OIDC_SCOPES`, or `ME_USER_INFO_URL`
- after this change, Headlamp reads the chart-provided OIDC configuration directly from `HEADLAMP_CONFIG_*` environment variables instead of translated `-oidc-*` command-line flags
- users configuring OIDC through `config.oidc.*` continue to work without changing their values, because the chart now emits the matching `HEADLAMP_CONFIG_*` env vars for them
- users providing OIDC values through `env:` or external secrets must rename those keys to the `HEADLAMP_CONFIG_*` equivalents before upgrading; the chart README now includes explicit upgrade notes for that migration
- the Helm chart version was bumped to `0.43.0` to reflect this compatibility change

## Testing
- rendered the chart with Helm for the default values and every chart test case
- verified the regenerated expected templates match the rendered output across all snapshots
- ran `helm lint` on the chart after rebasing onto the latest `main`

Fixes #4080
