### PR TITLE
frontend: OauthPopup: Clean up popup event listeners

### DIFF
--- a/frontend/src/components/oidcauth/OauthPopup.test.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Button from '@mui/material/Button';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import OauthPopup from './OauthPopup';
+
+describe('OauthPopup', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('removes the storage listener when the component unmounts', () => {
+    const popupWindow = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Window;
+
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={vi.fn()}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+    const storageListener = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'storage'
+    )?.[1];
+
+    expect(openSpy).toHaveBeenCalled();
+    expect(storageListener).toBeTypeOf('function');
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', storageListener);
+    expect(popupWindow.close).toHaveBeenCalled();
+  });
+
+  it('removes the storage listener when the popup closes without completing auth', () => {
+    const popupListeners: Record<string, () => void> = {};
+    const popupWindow = {
+      addEventListener: vi.fn((eventName: string, listener: () => void) => {
+        popupListeners[eventName] = listener;
+      }),
+      removeEventListener: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const onClose = vi.fn();
+
+    render(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={vi.fn()}
+        onClose={onClose}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+    popupListeners.beforeunload?.();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes the popup and removes listeners when auth completes', () => {
+    const popupListeners: Record<string, () => void> = {};
+    const popupWindow = {
+      addEventListener: vi.fn((eventName: string, listener: () => void) => {
+        popupListeners[eventName] = listener;
+      }),
+      removeEventListener: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const onCode = vi.fn();
+
+    render(
+      <OauthPopup button={Button} url="https://example.com/auth" title="Auth Popup" onCode={onCode}>
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+    const storageListener = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'storage'
+    )?.[1];
+    expect(storageListener).toBeTypeOf('function');
+
+    localStorage.setItem('auth_status', 'code=oauth-code');
+    window.dispatchEvent(new StorageEvent('storage'));
+
+    expect(onCode).toHaveBeenCalledWith('code=oauth-code');
+    expect(localStorage.getItem('auth_status')).toBeNull();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', storageListener);
+    expect(popupWindow.removeEventListener).toHaveBeenCalledWith(
+      'beforeunload',
+      popupListeners.beforeunload
+    );
+    expect(popupWindow.close).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -37,19 +37,46 @@ const defaultOauthPopupProps = {
 };
 
 const OauthPopup: React.FC<OauthPopupProps> = props => {
-  let externalWindow: Window | null;
+  const externalWindowRef = React.useRef<Window | null>(null);
+  const storageListenerRef = React.useRef<(() => void) | null>(null);
+  const beforeUnloadListenerRef = React.useRef<(() => void) | null>(null);
 
-  React.useEffect(
-    () => {
-      return () => {
-        if (externalWindow) {
-          externalWindow.close();
+  const cleanupPopup = React.useCallback(
+    (closeWindow = false) => {
+      const popupWindow = externalWindowRef.current;
+
+      if (storageListenerRef.current) {
+        window.removeEventListener('storage', storageListenerRef.current);
+        storageListenerRef.current = null;
+      }
+
+      if (popupWindow && beforeUnloadListenerRef.current) {
+        try {
+          popupWindow.removeEventListener('beforeunload', beforeUnloadListenerRef.current);
+        } catch (e) {
+          console.error('Error occurred while removing beforeunload event listener', e);
         }
-      };
+        beforeUnloadListenerRef.current = null;
+      }
+
+      if (closeWindow && popupWindow) {
+        popupWindow.close();
+        externalWindowRef.current = null;
+        return;
+      }
+
+      if (popupWindow?.closed) {
+        externalWindowRef.current = null;
+      }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [externalWindowRef]
   );
+
+  React.useEffect(() => {
+    return () => {
+      cleanupPopup(true);
+    };
+  }, [cleanupPopup]);
 
   const createPopup = () => {
     const { url, title, width, height, onCode } = { ...defaultOauthPopupProps, ...props };
@@ -58,7 +85,8 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
 
     const windowFeatures = `toolbar=0,scrollbars=1,status=1,resizable=0,location=1,menuBar=0,width=${width},height=${height},top=${top},left=${left}`;
 
-    externalWindow = window.open(url, title, windowFeatures);
+    cleanupPopup(true);
+    externalWindowRef.current = window.open(url, title, windowFeatures);
 
     const storageListener = () => {
       try {
@@ -66,30 +94,29 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
         if (authStatus) {
           onCode(authStatus);
           localStorage.removeItem('auth_status');
-          if (externalWindow) {
-            externalWindow.close();
-          }
-          window.removeEventListener('storage', storageListener);
+          cleanupPopup(true);
         }
       } catch (e) {
         console.error('Error occurred while closing auth window', e);
-        window.removeEventListener('storage', storageListener);
+        cleanupPopup();
       }
     };
 
+    storageListenerRef.current = storageListener;
     window.addEventListener('storage', storageListener);
 
-    if (externalWindow) {
+    if (externalWindowRef.current) {
       try {
-        externalWindow.addEventListener(
-          'beforeunload',
-          () => {
-            if (!!props.onClose) {
-              props.onClose();
-            }
-          },
-          false
-        );
+        const beforeUnloadListener = () => {
+          cleanupPopup();
+          externalWindowRef.current = null;
+          if (!!props.onClose) {
+            props.onClose();
+          }
+        };
+
+        externalWindowRef.current.addEventListener('beforeunload', beforeUnloadListener, false);
+        beforeUnloadListenerRef.current = beforeUnloadListener;
       } catch (e) {
         console.error('Error occurred while adding beforeunload event listener');
       }


### PR DESCRIPTION
## Summary
- centralize OAuth popup cleanup so the storage listener is always removed
- clean up listeners when auth completes, when the popup closes manually, and when the component unmounts
- add regression tests for popup-close and unmount cleanup behavior

## Testing
- npm test -- --run src/components/oidcauth/OauthPopup.test.tsx
- npx eslint -c package.json --ext .tsx src/components/oidcauth/OauthPopup.tsx src/components/oidcauth/OauthPopup.test.tsx

Fixes #5403