### PR TITLE
frontend: EditorDialog: Clear error on undo

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -203,7 +203,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   function looksLikeJson(code: string) {
-    const trimmedCode = code.trimStart();
+    const trimmedCode = code.trimLeft();
     const firstChar = !!trimmedCode ? trimmedCode[0] : '';
     if (['{', '['].includes(firstChar)) {
       return true;

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -203,7 +203,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   function looksLikeJson(code: string) {
-    const trimmedCode = code.trimLeft();
+    const trimmedCode = code.trimStart();
     const firstChar = !!trimmedCode ? trimmedCode[0] : '';
     if (['{', '['].includes(firstChar)) {
       return true;
@@ -300,6 +300,7 @@ export default function EditorDialog(props: EditorDialogProps) {
 
   function onUndo() {
     setCode(originalCodeRef.current);
+    setError('');
   }
 
   const applyFunc = async (newItems: KubeObjectInterface[], clusterName: string) => {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -299,6 +299,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   function onUndo() {
+    window.clearTimeout(lastCodeCheckHandler.current);
     setCode(originalCodeRef.current);
     setError('');
   }


### PR DESCRIPTION
## Summary
Fixes a bug in the EditorDialog where the error message remains visible after reverting invalid YAML to a valid state using the "Undo Changes" button. This ensures the UI state is correctly reset and pending timeouts are cleared when the user reverts their changes.

## Related Issue
Fixes #5449

## Changes
- Updated `onUndo()` to clear pending timeouts and reset the error state.

## Testing
1. Open any resource in the editor (e.g. a ConfigMap).
2. Make an invalid change to trigger an error.
3. Click "Undo Changes".
4. Verify the error message disappears immediately.

**Screenshots:** 
<img width="1026" height="449" alt="1" src="https://github.com/user-attachments/assets/47eed747-4c44-4155-9d13-b740a3224f1d" />
<img width="1006" height="448" alt="2" src="https://github.com/user-attachments/assets/df9db105-1792-4165-b2f0-b321ffc532dd" />
<img width="984" height="456" alt="3" src="https://github.com/user-attachments/assets/3c324524-2b93-48a9-823d-273c58ab1f79" />

