### PR TITLE
frontend: Resource: Fix hooks called after early return in ContainerEnvironmentVariables

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1082,6 +1082,67 @@ export function ContainerEnvironmentVariables(props: EnvironmentVariablesProps) 
     new Map()
   );
 
+  // Extract all references upfront
+  const references = React.useMemo(
+    () => (container ? extractEnvVarReferences(container) : []),
+    [container]
+  );
+
+  // Get unique resource names to fetch
+  const secretsToFetch = React.useMemo(() => {
+    const secrets = new Set<string>();
+    references.forEach(ref => {
+      if ((ref.type === 'secret' || ref.type === 'secretRef') && ref.resourceName) {
+        secrets.add(ref.resourceName);
+      }
+    });
+    return Array.from(secrets);
+  }, [references]);
+
+  const configMapsToFetch = React.useMemo(() => {
+    const configMaps = new Set<string>();
+    references.forEach(ref => {
+      if ((ref.type === 'configMap' || ref.type === 'configMapRef') && ref.resourceName) {
+        configMaps.add(ref.resourceName);
+      }
+    });
+    return Array.from(configMaps);
+  }, [references]);
+
+  // Callbacks to handle fetched resources
+  const handleSecretFetched = React.useCallback(
+    (name: string, resource: KubeObject | null, error: ApiError | null) => {
+      setFetchedSecrets(prev => {
+        const next = new Map(prev);
+        next.set(name, { resource, error });
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleConfigMapFetched = React.useCallback(
+    (name: string, resource: KubeObject | null, error: ApiError | null) => {
+      setFetchedConfigMaps(prev => {
+        const next = new Map(prev);
+        next.set(name, { resource, error });
+        return next;
+      });
+    },
+    []
+  );
+
+  // Copy handler using notistack
+  const handleCopy = React.useCallback(
+    (text: string) => {
+      navigator.clipboard.writeText(text).then(
+        () => enqueueSnackbar(t('translation|Copied'), { variant: 'success' }),
+        err => console.error('Failed to copy: ', err)
+      );
+    },
+    [enqueueSnackbar, t]
+  );
+
   // Early return if no env vars
   if (
     (!container?.env && !container?.envFrom) ||
@@ -1100,69 +1161,6 @@ export function ContainerEnvironmentVariables(props: EnvironmentVariablesProps) 
     }
     return timestamp;
   })();
-
-  // Extract all references upfront (pure function, no hooks)
-  const references = extractEnvVarReferences(container);
-
-  // Get unique resource names to fetch
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const secretsToFetch = React.useMemo(() => {
-    const secrets = new Set<string>();
-    references.forEach(ref => {
-      if ((ref.type === 'secret' || ref.type === 'secretRef') && ref.resourceName) {
-        secrets.add(ref.resourceName);
-      }
-    });
-    return Array.from(secrets);
-  }, [references]);
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const configMapsToFetch = React.useMemo(() => {
-    const configMaps = new Set<string>();
-    references.forEach(ref => {
-      if ((ref.type === 'configMap' || ref.type === 'configMapRef') && ref.resourceName) {
-        configMaps.add(ref.resourceName);
-      }
-    });
-    return Array.from(configMaps);
-  }, [references]);
-
-  // Callbacks to handle fetched resources
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const handleSecretFetched = React.useCallback(
-    (name: string, resource: KubeObject | null, error: ApiError | null) => {
-      setFetchedSecrets(prev => {
-        const next = new Map(prev);
-        next.set(name, { resource, error });
-        return next;
-      });
-    },
-    []
-  );
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const handleConfigMapFetched = React.useCallback(
-    (name: string, resource: KubeObject | null, error: ApiError | null) => {
-      setFetchedConfigMaps(prev => {
-        const next = new Map(prev);
-        next.set(name, { resource, error });
-        return next;
-      });
-    },
-    []
-  );
-
-  // Copy handler using notistack
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const handleCopy = React.useCallback(
-    (text: string) => {
-      navigator.clipboard.writeText(text).then(
-        () => enqueueSnackbar(t('translation|Copied'), { variant: 'success' }),
-        err => console.error('Failed to copy: ', err)
-      );
-    },
-    [enqueueSnackbar, t]
-  );
 
   // Build variables from fetched resources
   const variables = buildEnvironmentVariables(


### PR DESCRIPTION
## Summary
Five hooks (useMemo x2, useCallback x3) were called after an early
return in ContainerEnvironmentVariables, violating React rules of hooks.

## Related Issue
Closes #5189

## Changes
- Moved all 5 hooks above the early return in ContainerEnvironmentVariables
- Removed 5 eslint-disable-next-line react-hooks/rules-of-hooks comments

## Steps to Test
1. Run npm run frontend:lint — no rules-of-hooks errors
2. Run npm run frontend:test — all tests pass
3. Navigate to a Pod → Environment Variables tab
4. Verify env vars load correctly

## Notes for the Reviewer
- Only 1 file changed
- No logic changes — hooks reordered only
- 1 file changed, 19 insertions, 24 deletions