### PR TITLE
frontend: fix stale Pod status icon updates after readiness transitions

### DIFF
--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -36,13 +36,15 @@ import { TooltipIcon } from '../common/Tooltip';
 import LightTooltip from '../common/Tooltip/TooltipLight';
 
 function getPodStatus(pod: Pod) {
-  const phase = pod.status.phase;
+  const phase = pod.status?.phase;
   let status: StatusLabelProps['status'] = '';
 
   if (phase === 'Failed') {
     status = 'error';
   } else if (phase === 'Succeeded' || phase === 'Running') {
-    const readyCondition = pod.status.conditions.find(condition => condition.type === 'Ready');
+    const readyCondition = (pod.status?.conditions || []).find(
+      condition => condition.type === 'Ready'
+    );
     if (readyCondition?.status === 'True' || phase === 'Succeeded') {
       status = 'success';
     } else {
@@ -275,8 +277,9 @@ export function PodListRenderer(props: PodListProps) {
           // include ready condition status so the cell re-renders when icon state changes
           getValue: pod => {
             const status = pod.getDetailedStatus();
-            const readyCondition = pod.status?.conditions?.find(c => c.type === 'Ready');
-            return `${status.reason}:${readyCondition?.status ?? ''}`;
+            const readyCondition = (pod.status?.conditions || []).find(c => c.type === 'Ready');
+            const phase = pod.status?.phase || '';
+            return `${phase}:${status.reason}:${readyCondition?.status ?? ''}`;
           },
           render: makePodStatusLabel,
         },

--- a/frontend/src/lib/k8s/pod.test.ts
+++ b/frontend/src/lib/k8s/pod.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import Pod from './pod';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('Pod class', () => {
+  const mockPodData = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: 'test-pod',
+      namespace: 'default',
+      resourceVersion: '123',
+    },
+    spec: {
+      containers: [{ name: 'container-1' }, { name: 'container-2' }],
+    },
+    status: {
+      phase: 'Running',
+      containerStatuses: [
+        {
+          name: 'container-1',
+          ready: false,
+          restartCount: 0,
+          state: { terminated: { reason: 'Completed', exitCode: 0 } },
+        },
+        {
+          name: 'container-2',
+          ready: true,
+          restartCount: 0,
+          state: { running: { startedAt: '2020-01-01T00:00:00Z' } },
+        },
+      ],
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+        },
+      ],
+    },
+  };
+
+  it('correctly identifies a healthy pod with lowercase condition status in edge cases', () => {
+    const data = JSON.parse(JSON.stringify(mockPodData));
+    const pod = new Pod(data);
+    const status = pod.getDetailedStatus();
+    // hasRunning is true, reason became Completed from container-1, so it checks Ready condition
+    expect(status.reason).toBe('Running');
+  });
+
+  it('falls back to NotReady if Ready condition is False in edge cases', () => {
+    const data = JSON.parse(JSON.stringify(mockPodData));
+    data.status.conditions[0].status = 'False';
+    const pod = new Pod(data);
+    const status = pod.getDetailedStatus();
+    expect(status.reason).toBe('NotReady');
+  });
+
+  it('handles missing conditions gracefully', () => {
+    const data = JSON.parse(JSON.stringify(mockPodData));
+    delete data.status.conditions;
+    const pod = new Pod(data);
+    expect(() => pod.getDetailedStatus()).not.toThrow();
+  });
+});

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -356,9 +356,9 @@ class Pod extends KubeObject<KubePod> {
     return false;
   }
 
-  private hasPodReadyCondition(conditions: any): boolean {
+  private hasPodReadyCondition(conditions: KubeCondition[]): boolean {
     for (const condition of conditions) {
-      if (condition.type === 'Ready' && condition.Status === 'True') {
+      if (condition.type === 'Ready' && condition.status === 'True') {
         return true;
       }
     }
@@ -493,7 +493,7 @@ class Pod extends KubeObject<KubePod> {
 
       // change pod status back to "Running" if there is at least one container still reporting as "Running" status
       if (reason === 'Completed' && hasRunning) {
-        if (this.hasPodReadyCondition(this.status?.conditions)) {
+        if (this.hasPodReadyCondition(this.status?.conditions ?? [])) {
           reason = 'Running';
         } else {
           reason = 'NotReady';


### PR DESCRIPTION
## Summary

This PR fixes a regression where Pod status icons in the list view remained stale (yellow/warning) even after a Pod became healthy and passed readiness checks.

The issue was caused by a combination of incorrect readiness condition handling and insufficient re-render invalidation for material-react-table (MRT) during Kubernetes watch (`MODIFIED`) events.

## Related Issue

Fixes #5455

## Changes

* Fixed a casing bug in `Pod.hasPodReadyCondition` by changing `condition.Status` to the correct `condition.status`
* Updated the Pod status column `getValue()` logic to include:

  * Pod phase
  * detailed status reason
  * Ready condition status
* Preserved the existing `detailedStatusCache` optimization based on `resourceVersion`
* Added null-safe handling for transient/missing Pod status fields during rapid watch updates
* Added regression tests covering:

  * lowercase `condition.status` readiness handling
  * healthy pod readiness transitions
  * fallback `NotReady` behavior
  * missing conditions edge cases
* Improved real-time Pod status consistency during rollout/restart scenarios

## Steps to Test

1. Open the Pods list view in Headlamp
2. Restart a Deployment or create a Pod with delayed readiness probes
3. Observe the Pod initially showing a warning/not-ready status
4. Wait for the Pod to become healthy (`1/1 Running`)
5. Verify the status icon updates immediately without requiring navigation or refresh
6. Verify readiness transitions update correctly in real time

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

* The MRT `getValue()` invalidation key intentionally includes readiness-related state to ensure status cells re-render correctly during Kubernetes watch updates.
* The existing `resourceVersion`-based `detailedStatusCache` optimization was intentionally preserved because Kubernetes `MODIFIED` events already invalidate cached state correctly.
* This fix focuses on preserving render correctness while avoiding unnecessary recomputation or high-cardinality filter values in large Pod lists.
