### PR TITLE
chart: Add hostAliases support to pod template

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -359,6 +359,7 @@ volumeMounts:
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | tolerations | list | `[]` | Pod tolerations |
 | affinity | object | `{}` | Pod affinity settings |
+| hostAliases | list | `[]` | Optional list of host/IP mappings injected into the pod's /etc/hosts. Useful when an external host (e.g. an OIDC issuer behind cluster ingress) is not resolvable via cluster DNS. |
 | topologySpreadConstraints | list | `[]` | Topology spread constraints for pod assignment |
 | podAnnotations | object | `{}` | Pod annotations |
 | podLabels | object | `{}` | Pod labels |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -445,6 +445,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- range $constraint := . }}

--- a/charts/headlamp/tests/expected_templates/host-aliases.yaml
+++ b/charts/headlamp/tests/expected_templates/host-aliases.yaml
@@ -1,0 +1,150 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.42.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}
+      hostAliases:
+        - hostnames:
+          - keycloak.test
+          - sso.local
+          ip: 10.0.0.5
+        - hostnames:
+          - registry.internal
+          ip: 192.168.1.10

--- a/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
+++ b/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
@@ -126,10 +126,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
 ---

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
@@ -119,9 +119,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
@@ -138,10 +138,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
@@ -138,10 +138,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
+++ b/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
@@ -132,9 +132,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/test_cases/host-aliases.yaml
+++ b/charts/headlamp/tests/test_cases/host-aliases.yaml
@@ -1,0 +1,8 @@
+hostAliases:
+  - ip: 10.0.0.5
+    hostnames:
+      - keycloak.test
+      - sso.local
+  - ip: 192.168.1.10
+    hostnames:
+      - registry.internal

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -757,6 +757,28 @@
           }
         }
       }
+    },
+    "hostAliases": {
+      "type": "array",
+      "description": "Host aliases to add to the pod's /etc/hosts file",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ip": {
+            "type": "string",
+            "description": "IP address the hostnames resolve to"
+          },
+          "hostnames": {
+            "type": "array",
+            "description": "Hostnames that resolve to the given IP",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["ip", "hostnames"],
+        "additionalProperties": false
+      }
     }
   }
 }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -349,6 +349,9 @@ tolerations: []
 # -- Affinity settings for pod assignment
 affinity: {}
 
+# -- Host aliases to add to the pod's /etc/hosts file
+hostAliases: []
+
 # -- Topology Spread Constraints for pod assignment
 topologySpreadConstraints: []
 #  - maxSkew: 1


### PR DESCRIPTION
## Summary

This PR adds an optional hostAliases value to the Helm chart which is rendered into the deployment's pod template spec when set.

## Related Issue

Fixes #4786  

## Changes

- added  hostAliases to chart values
- rendered  hostAliases  in the deployment template
- document the new value in the chart README
- add template test coverage

## Steps to Test

1. Run bash charts/headlamp/tests/test.sh
2. Render the chart to helm template headlamp ./charts/headlamp -f ./charts/headlamp/tests/test_cases/host-aliases.yaml
3. Verify spec.template.spec.hostAliases is present in the rendered Deployment.

## Screenshots (if applicable)


## Notes for the Reviewer

When "oidc-idp-issuer-url" or any other external URL passed to Headlamp points at a hostname that's not resolvable. Inside the cluster, for example if  an issuer is exposed via Ingress at "keycloak.test", the pod cannot reach it. Adding entries to "/etc/hosts" via pod-level "hostAliases" is the standard Kubernetes way to handle this without modifying cluster DNS.
The default is an empty list. No change to existing deployments.
