### PR TITLE
Use `sh` as the default `Node` debugger `command`

### DIFF
--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -35,7 +35,13 @@ interface NodeShellTerminalProps {
   onClose?: () => void;
 }
 
-const shellPod = (name: string, namespace: string, nodeName: string, nodeShellImage: string) => {
+const shellPod = (
+  name: string,
+  namespace: string,
+  nodeName: string,
+  nodeShellImage: string,
+  command: string[] = ['sh']
+) => {
   return {
     kind: 'Pod',
     apiVersion: 'v1',
@@ -59,6 +65,7 @@ const shellPod = (name: string, namespace: string, nodeName: string, nodeShellIm
         {
           name: 'debugger',
           image: nodeShellImage,
+          command,
           terminationMessagePolicy: 'File',
           tty: true,
           stdin: true,


### PR DESCRIPTION
## Summary

By default, the `debugger` container of `Node` debuggers created by Headlamp don't have the `command` set in the `Pod` spec. As a result, the following issues can manifest under specific circumstances[^1]:

1. Default `CMD`/`ENTRYPOINT` of certain images exit immediately. As a result, Headlamp will fail to attach a terminal session, as the container exits almost instantly.

2. While the container `command` can be omitted for images that define a `CMD`/`ENTRYPOINT`, using custom images that define neither would result in the `Pod` failing to start:

	```
	Error: failed to generate container "..." spec: failed to generate spec: no command specified
	```

In both cases, the Headlamp UI terminal only displays:

```
Trying to open a shell
```

This same behaviour is not exhibited by Headlamp's pod debug feature, which spawns ephemeral containers and explicitly defaults their `command` to `sh`:

https://github.com/kubernetes-sigs/headlamp/blob/0b4eeacc97ff0293e8c920ecda28df44fdd39d9d/frontend/src/components/pod/PodDebugTerminal.tsx#L104

This PR applies the same default to the `Node` debugger Pod, aligning the two features behavior-wise.

## Changes

- Updated `frontend/src/components/node/NodeShellTerminal.tsx`

## Steps to Test

1. Launch locally with Minikube:

    ```sh
    $ minikube start \
      --container-runtime=containerd \
      --docker-opt containerd=/var/run/containerd/containerd.sock \
      --kubernetes-version=v1.35.0
    $ tmux new-session -d -s frontend 'make frontend-install run-frontend'
    $ tmux new-session -d -s backend 'make backend run-backend'
    ```

2. Open Headlamp UI in the browser.
3. Set the <kbd>Linux Image</kbd> to something like `cgr.dev/chainguard/busybox:latest-glibc` under <kbd>Settings</kbd> › <kbd>Cluster Settings</kbd> › <kbd>Node Shell Settings</kbd>.
4. Switch to <kbd>Cluster</kbd> › <kbd>Nodes</kbd> and select `minikube`.
5. Trigger the <kbd>Debug Node</kbd> action in the node details, the terminal should open and accept prompts.

[^1]:
    As to why these went unnoticed, it probably has to do with the default image (`busybox:latest`) having `CMD`:

    ```shell
    $ docker inspect busybox:latest | jq '.[].Config.Cmd.[]'
    "sh"
    ```
