### PR TITLE
backend: drainNode: Report pod deletion errors during drain

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -65,6 +65,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -2628,7 +2629,7 @@ func (c *HeadlampConfig) handleNodeDrain(w http.ResponseWriter, r *http.Request)
 	c.drainNode(clientset, drainPayload.NodeName, drainPayload.Cluster)
 }
 
-func (c *HeadlampConfig) drainNode(clientset *kubernetes.Clientset, nodeName string, cluster string) {
+func (c *HeadlampConfig) drainNode(clientset kubernetes.Interface, nodeName string, cluster string) {
 	go func() {
 		nodeClient := clientset.CoreV1().Nodes()
 		ctx := context.Background()
@@ -2659,17 +2660,30 @@ func (c *HeadlampConfig) drainNode(clientset *kubernetes.Clientset, nodeName str
 
 		var gracePeriod int64 = 0
 
+		var deleteErrors []string
+
 		for _, pod := range pods.Items {
 			// ignore daemonsets
 			if pod.Labels["kubernetes.io/created-by"] == "daemonset-controller" {
 				continue
 			}
 
-			_ = clientset.CoreV1().Pods(pod.Namespace).Delete(ctx,
-				pod.Name, v1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+			if err := clientset.CoreV1().Pods(pod.Namespace).Delete(ctx,
+				pod.Name, v1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); err != nil && !apierrors.IsNotFound(err) {
+				deleteErrors = append(deleteErrors, fmt.Sprintf("%s/%s: %v", pod.Namespace, pod.Name, err))
+			}
 		}
 
-		_ = c.Cache.SetWithTTL(ctx, cacheKey, "success", cacheItemTTL)
+		if len(deleteErrors) > 0 {
+			errMsg := fmt.Sprintf("error: failed to delete %d pod(s)", len(deleteErrors))
+			logger.Log(logger.LevelError, nil, nil,
+				fmt.Sprintf("node drain: failed to delete %d pod(s): %s",
+					len(deleteErrors), strings.Join(deleteErrors, "; ")))
+
+			_ = c.Cache.SetWithTTL(ctx, cacheKey, errMsg, cacheItemTTL)
+		} else {
+			_ = c.Cache.SetWithTTL(ctx, cacheKey, "success", cacheItemTTL)
+		}
 	}()
 }
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -50,6 +50,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -529,6 +531,149 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 				status, http.StatusOK)
 		}
 	}
+}
+
+func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
+	podOk := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-ok",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	podDaemonset := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-daemonset",
+			Namespace: "default",
+			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	podFail := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-fail",
+			Namespace: "kube-system",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	fakeClient := fake.NewClientset(node, podOk, podDaemonset, podFail)
+
+	// Inject error for deleting pod-fail
+	fakeClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+		deleteAction := action.(k8stesting.DeleteAction)
+		if deleteAction.GetName() == "pod-fail" {
+			return true, nil, fmt.Errorf("pod is protected by PodDisruptionBudget")
+		}
+
+		return false, nil, nil
+	})
+
+	testCache := cache.New[interface{}]()
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			Cache: testCache,
+		},
+	}
+
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
+	ctx := context.Background()
+
+	c.drainNode(fakeClient, "test-node", "test-cluster")
+
+	require.Eventually(t, func() bool {
+		cacheItem, err := testCache.Get(ctx, cacheKey)
+		if err != nil {
+			return false
+		}
+
+		status, ok := cacheItem.(string)
+
+		return ok && strings.HasPrefix(status, "error:")
+	}, 5*time.Second, 50*time.Millisecond)
+
+	cacheItem, err := testCache.Get(ctx, cacheKey)
+	require.NoError(t, err)
+
+	status, ok := cacheItem.(string)
+	require.True(t, ok)
+
+	assert.True(t, strings.HasPrefix(status, "error:"),
+		"expected error status, got: %s", status)
+	assert.Contains(t, status, "failed to delete")
+}
+
+func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	podDaemonset := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-daemonset",
+			Namespace: "default",
+			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	fakeClient := fake.NewClientset(node, pod1, podDaemonset)
+
+	testCache := cache.New[interface{}]()
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			Cache: testCache,
+		},
+	}
+
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
+	ctx := context.Background()
+
+	c.drainNode(fakeClient, "test-node", "test-cluster")
+
+	require.Eventually(t, func() bool {
+		cacheItem, err := testCache.Get(ctx, cacheKey)
+		if err != nil {
+			return false
+		}
+
+		status, ok := cacheItem.(string)
+
+		return ok && status == "success"
+	}, 2*time.Second, 50*time.Millisecond)
+
+	cacheItem, err := testCache.Get(ctx, cacheKey)
+	require.NoError(t, err)
+
+	status, ok := cacheItem.(string)
+	require.True(t, ok)
+
+	assert.Equal(t, "success", status)
 }
 
 func TestDeletePlugin(t *testing.T) {


### PR DESCRIPTION
## Summary

`drainNode` discarded all pod deletion errors with `_ =` and unconditionally cached `"success"` as the drain status. Operators polling `/drain-node-status` were told the drain completed successfully even when pods failed to delete and were still running on the node. This PR collects deletion errors, reports them through the existing cache/status mechanism, and logs per-pod details for debugging.

## Related Issue

Fixes #5485

## Changes

- **`backend/cmd/headlamp.go`**
  - Collect pod deletion errors in a `[]string` during the drain loop instead of discarding with `_ =`
  - Cache `"error: failed to delete N pod(s)"` when any deletion fails; `"success"` only when all succeed
  - Log detailed per-pod errors (`namespace/name: reason`) via `logger.Log` for operator debugging
  - Change `drainNode` parameter from `*kubernetes.Clientset` to `kubernetes.Interface` — consistent with `serviceproxy` and `k8cache` packages which already use `kubernetes.Interface`, and enables unit testing with a fake clientset

- **`backend/cmd/headlamp_test.go`**
  - `TestDrainNodePodDeletionFailure`: fake clientset with a reactor that fails one pod deletion, asserts cache contains error status (not `"success"`)
  - `TestDrainNodeAllPodsDeletedSuccessfully`: all pods delete cleanly, asserts cache contains `"success"`

No frontend changes — the frontend already handles `"error: ..."` prefixed strings correctly via the snackbar in `Details.tsx:147`.

## Steps to Test

1. `cd backend && go test -run "TestDrainNodePod|TestDrainNodeAll" -v ./cmd/`
2. Both tests should pass
3. `npm run backend:lint` — no lint issues
4. `npm run backend:test` — full suite passes

## Notes for the Reviewer

- The existing test `TestDrainAndCordonNode` does not exercise the `drainNode` goroutine — it manually injects `"success"` into the cache and only tests the HTTP endpoint round-trip. The new tests call `drainNode` directly with a fake clientset.
- The `*kubernetes.Clientset` → `kubernetes.Interface` change is a single-word signature change. `*kubernetes.Clientset` satisfies `kubernetes.Interface`, so the caller in `handleNodeDrain` requires no modification.
- The cache message is kept short (`"error: failed to delete N pod(s)"`) so it displays cleanly in the frontend snackbar. Detailed per-pod errors go to the server log only.