### PR TITLE
backend: replace string error checks with errors.Is()

### DIFF
--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -18,12 +18,14 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,7 +60,7 @@ func MarshalCustomObject(info runtime.Object, contextName string) (kubeconfig.Cu
 func (c *HeadlampConfig) setKeyInCache(key string, context kubeconfig.Context) error {
 	// check context is present
 	_, err := c.KubeConfigStore.GetContext(key)
-	if err != nil && err.Error() == "key not found" {
+	if errors.Is(err, cache.ErrNotFound) {
 		// To ensure stateless clusters are not visible to other users, they are marked as internal clusters.
 		// They are stored in the proxy cache and accessed through the /config endpoint.
 		context.Internal = true


### PR DESCRIPTION
## Summary

Fixed a fragile error check in the stateless cluster code.

## Problem 

The code was checking for "key not found" by comparing error messages as strings:

**ORIGINAL:** `if err != nil && err.Error() == "key not found"`

This is brittle if someone changes the error message text, the check breaks. It's also inconsistent with the rest of the codebase which uses `errors.Is()`.

## Fix

Changed to use Go's standard error checking:

**CHANGED:** `if errors.Is(err, cache.ErrNotFound)`

This is how rest of the codebase handles this error.
_For example: cache.Get() also returns ErrNotFound when key doesn't exist._

## Files Changed
`backend/cmd/stateless.go`
