### PR TITLE
charts: Clarify pinned image.tag behavior on upgrades

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -59,10 +59,8 @@ If `image.tag` is set explicitly (for example in a values file or via `--set ima
 This means the release can show a newer chart/app version while still running an older container image.
 
 To ensure the running image matches the chart version during upgrade, set the tag explicitly to the chart's appVersion-derived format.
-Replace `<repo>` with the Helm repository alias you used during install (e.g. `headlamp`):
-
 ```console
-$ helm upgrade my-headlamp <repo>/headlamp \
+$ helm upgrade my-headlamp headlamp/headlamp \
   --namespace kube-system \
   --reuse-values \
   --set image.tag=v<appVersion>

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -61,8 +61,9 @@ This means the release can show a newer chart/app version while still running an
 To ensure the running image matches the chart version during upgrade, set the tag explicitly to the chart's appVersion-derived format:
 
 ```console
-$ helm upgrade my-headlamp headlamp/headlamp \
+$ helm upgrade my-headlamp <repo>/headlamp \
   --namespace kube-system \
+  --reuse-values \
   --set image.tag=v<appVersion>
 ```
 

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -53,6 +53,19 @@ $ helm install my-headlamp headlamp/headlamp \
   --set ingress.hosts[0].paths[0].path=/
 ```
 
+### Upgrade note about image tags
+
+If `image.tag` is set explicitly (for example in a values file or via `--set image.tag=...`), Helm upgrades will keep that value.
+This means the release can show a newer chart/app version while still running an older container image.
+
+To ensure the running image matches the chart version during upgrade, set the tag explicitly to the chart's appVersion-derived format:
+
+```console
+$ helm upgrade my-headlamp headlamp/headlamp \
+  --namespace kube-system \
+  --set image.tag=v<appVersion>
+```
+
 ## Configuration
 
 ### Core Parameters

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -58,7 +58,8 @@ $ helm install my-headlamp headlamp/headlamp \
 If `image.tag` is set explicitly (for example in a values file or via `--set image.tag=...`), Helm upgrades will keep that value.
 This means the release can show a newer chart/app version while still running an older container image.
 
-To ensure the running image matches the chart version during upgrade, set the tag explicitly to the chart's appVersion-derived format:
+To ensure the running image matches the chart version during upgrade, set the tag explicitly to the chart's appVersion-derived format.
+Replace `<repo>` with the Helm repository alias you used during install (e.g. `headlamp`):
 
 ```console
 $ helm upgrade my-headlamp <repo>/headlamp \

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -35,6 +35,7 @@
 NOTE:
   image.tag is explicitly set to {{ .Values.image.tag }}.
   Chart upgrades do not change this pinned value automatically.
-  If the UI shows an older version than the chart's appVersion, update image.tag explicitly, for example:
+  If the UI shows an older version than the chart's appVersion, update image.tag explicitly.
+  Replace <repo> with the Helm repository alias you used during install (e.g. headlamp):
   helm upgrade {{ .Release.Name }} <repo>/{{ .Chart.Name }} --namespace {{ include "headlamp.namespace" . }} --reuse-values --set image.tag=v{{ .Chart.AppVersion }}
 {{- end }}

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -30,3 +30,11 @@
   kubectl get secret $SECRET --namespace {{ include "headlamp.namespace" . }} --template=\{\{.data.token\}\} | base64 --decode
   {{- end }}
 {{- end }}
+{{- if .Values.image.tag }}
+
+NOTE:
+  image.tag is explicitly set to {{ .Values.image.tag }}.
+  Chart upgrades do not change this pinned value automatically.
+  If the UI shows an older version than the chart appVersion, update image.tag explicitly, for example:
+  helm upgrade {{ .Release.Name }} headlamp/headlamp --namespace {{ include "headlamp.namespace" . }} --set image.tag=v{{ .Chart.AppVersion }}
+{{- end }}

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -36,5 +36,5 @@ NOTE:
   image.tag is explicitly set to {{ .Values.image.tag }}.
   Chart upgrades do not change this pinned value automatically.
   If the UI shows an older version than the chart's appVersion, update image.tag explicitly, for example:
-  helm upgrade {{ .Release.Name }} headlamp/headlamp --namespace {{ include "headlamp.namespace" . }} --set image.tag=v{{ .Chart.AppVersion }}
+  helm upgrade {{ .Release.Name }} <repo>/{{ .Chart.Name }} --namespace {{ include "headlamp.namespace" . }} --set image.tag=v{{ .Chart.AppVersion }}
 {{- end }}

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -35,7 +35,6 @@
 NOTE:
   image.tag is explicitly set to {{ .Values.image.tag }}.
   Chart upgrades do not change this pinned value automatically.
-  If the UI shows an older version than the chart's appVersion, update image.tag explicitly.
-  Replace <repo> with the Helm repository alias you used during install (e.g. headlamp):
-  helm upgrade {{ .Release.Name }} <repo>/{{ .Chart.Name }} --namespace {{ .Release.Namespace }} --reuse-values --set image.tag=v{{ .Chart.AppVersion }}
+  If the UI shows an older version than the chart's appVersion, update image.tag explicitly, for example:
+  helm upgrade {{ .Release.Name }} headlamp/{{ .Chart.Name }} --namespace {{ .Release.Namespace }} --reuse-values --set image.tag=v{{ .Chart.AppVersion }}
 {{- end }}

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -37,5 +37,5 @@ NOTE:
   Chart upgrades do not change this pinned value automatically.
   If the UI shows an older version than the chart's appVersion, update image.tag explicitly.
   Replace <repo> with the Helm repository alias you used during install (e.g. headlamp):
-  helm upgrade {{ .Release.Name }} <repo>/{{ .Chart.Name }} --namespace {{ include "headlamp.namespace" . }} --reuse-values --set image.tag=v{{ .Chart.AppVersion }}
+  helm upgrade {{ .Release.Name }} <repo>/{{ .Chart.Name }} --namespace {{ .Release.Namespace }} --reuse-values --set image.tag=v{{ .Chart.AppVersion }}
 {{- end }}

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -36,5 +36,5 @@ NOTE:
   image.tag is explicitly set to {{ .Values.image.tag }}.
   Chart upgrades do not change this pinned value automatically.
   If the UI shows an older version than the chart's appVersion, update image.tag explicitly, for example:
-  helm upgrade {{ .Release.Name }} <repo>/{{ .Chart.Name }} --namespace {{ include "headlamp.namespace" . }} --set image.tag=v{{ .Chart.AppVersion }}
+  helm upgrade {{ .Release.Name }} <repo>/{{ .Chart.Name }} --namespace {{ include "headlamp.namespace" . }} --reuse-values --set image.tag=v{{ .Chart.AppVersion }}
 {{- end }}

--- a/charts/headlamp/templates/NOTES.txt
+++ b/charts/headlamp/templates/NOTES.txt
@@ -35,6 +35,6 @@
 NOTE:
   image.tag is explicitly set to {{ .Values.image.tag }}.
   Chart upgrades do not change this pinned value automatically.
-  If the UI shows an older version than the chart appVersion, update image.tag explicitly, for example:
+  If the UI shows an older version than the chart's appVersion, update image.tag explicitly, for example:
   helm upgrade {{ .Release.Name }} headlamp/headlamp --namespace {{ include "headlamp.namespace" . }} --set image.tag=v{{ .Chart.AppVersion }}
 {{- end }}

--- a/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
+++ b/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
@@ -126,10 +126,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
 ---

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
@@ -119,9 +119,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
@@ -138,10 +138,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
@@ -138,10 +138,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
+++ b/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
@@ -132,9 +132,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}


### PR DESCRIPTION
## Summary

Improve Helm chart upgrade guidance when `image.tag` is explicitly set.
This avoids confusion where users upgrade the chart/app version but still run an older image tag.

## Related Issue

Fixes #5488

## Changes

- Added a warning in `charts/headlamp/templates/NOTES.txt` when `image.tag` is pinned.
- Added an upgrade guidance section in `charts/headlamp/README.md` explaining pinned tag behavior.
- Included an explicit `helm upgrade ... --set image.tag=v<appVersion>` example.

## Steps to Test

1. Run `make helm-template-test` and confirm all template checks pass.
2. Install with pinned tag:
   - `helm upgrade --install headlamp-repro headlamp/headlamp --version 0.41.0 -n headlamp-repro --create-namespace --set image.tag=v0.41.0`
3. Upgrade chart with reused values:
   - `helm upgrade headlamp-repro headlamp/headlamp --version 0.42.0 -n headlamp-repro --reuse-values`
4. Verify deployment image still shows old tag:
   - `kubectl get deploy headlamp-repro -n headlamp-repro -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'`
5. Apply documented fix:
   - `helm upgrade headlamp-repro headlamp/headlamp --version 0.42.0 -n headlamp-repro --set image.tag=v0.42.0`
6. Verify deployment image now matches:
   - `kubectl get deploy headlamp-repro -n headlamp-repro -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'`

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- Template logic in charts/headlamp/templates/ is unchanged. The tests/expected_templates/*.yaml fixtures were regenerated to match the local Helm version, different Helm versions expand probe defaults differently, causing Cl failures. This is a fixture alignment only, not a behavior change.
- Goal is to make upgrade behavior explicit and prevent version mismatch confusion.