### PR TITLE
backend: Stream HTTP proxy responses to prevent OOM

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -735,6 +735,18 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			reader = resp.Body
 		}
 
+		// Read the first chunk before committing the response so early upstream
+		// failures can still return a 502 instead of an empty success response.
+		firstChunk := make([]byte, 32*1024)
+
+		n, readErr := reader.Read(firstChunk)
+		if readErr != nil && !errors.Is(readErr, io.EOF) && n == 0 {
+			logger.Log(logger.LevelError, nil, readErr, "reading response")
+			http.Error(w, readErr.Error(), http.StatusBadGateway)
+
+			return
+		}
+
 		if contentType := resp.Header.Get("Content-Type"); contentType != "" {
 			w.Header().Set("Content-Type", contentType)
 		}
@@ -749,10 +761,12 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		w.WriteHeader(resp.StatusCode)
 
-		// Stream the response with a limit to prevent memory exhaustion and decompression bombs.
-		// Note: If Content-Length is unknown and the limit is reached, the response will be truncated.
-		_, err = io.Copy(w, io.LimitReader(reader, maxProxyResponseSize))
-		if err != nil {
+		// Stream the body, putting the already-read first chunk back in front of
+		// the reader so a single size limit covers the whole response. The limit
+		// prevents memory exhaustion and decompression bombs; if the length is
+		// unknown and the limit is reached, the response is truncated.
+		body := io.MultiReader(bytes.NewReader(firstChunk[:n]), reader)
+		if _, err := io.Copy(w, io.LimitReader(body, maxProxyResponseSize)); err != nil {
 			logger.Log(logger.LevelError, nil, err, "streaming response")
 
 			return

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -567,8 +567,53 @@ func TestProxyURLAllowedCompilesConfiguredProxyURLs(t *testing.T) {
 	assert.NotEmpty(t, config.compiledProxyURLs)
 }
 
+func newLargeBodyUpstream(t *testing.T, size int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunk := bytes.Repeat([]byte("a"), 64*1024)
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+
+		written := 0
+		for written < size {
+			toWrite := chunk
+			if remaining := size - written; remaining < len(chunk) {
+				toWrite = chunk[:remaining]
+			}
+
+			n, err := w.Write(toWrite)
+			if err != nil {
+				return
+			}
+
+			written += n
+		}
+	}))
+}
+
+func newExternalProxyHandler(t *testing.T, upstream string) http.Handler {
+	t.Helper()
+
+	upstreamURL, err := url.Parse(upstream)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{upstreamURL.String()},
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache: cache.New[interface{}](),
+		},
+	})
+}
+
 func TestExternalProxyForwarding(t *testing.T) {
-	// Create a new server for testing that returns a specific status and content type
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
@@ -577,31 +622,14 @@ func TestExternalProxyForwarding(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
-	})
+	handler := newExternalProxyHandler(t, proxyServer.URL)
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -609,6 +637,48 @@ func TestExternalProxyForwarding(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 	assert.Equal(t, `{"error": "not found"}`, rr.Body.String())
+}
+
+func TestExternalProxyStreamsLargeBody(t *testing.T) {
+	// 32 MiB is far larger than any internal copy buffer, so a buffering
+	// regression is still caught, while staying small enough not to slow down
+	// or flake CI on resource-constrained runners.
+	const size = 32 * 1024 * 1024
+
+	upstream := newLargeBodyUpstream(t, size)
+	defer upstream.Close()
+
+	handler := newExternalProxyHandler(t, upstream.URL)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/externalproxy", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("proxy-to", upstream.URL)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status code = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	read, err := io.Copy(io.Discard, resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	if read != size {
+		t.Errorf("streamed %d bytes, want %d", read, size)
+	}
 }
 
 func TestExternalProxyTimeout(t *testing.T) {

--- a/backend/pkg/serviceproxy/connection.go
+++ b/backend/pkg/serviceproxy/connection.go
@@ -3,6 +3,7 @@ package serviceproxy
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"path"
 	"strings"
@@ -10,8 +11,8 @@ import (
 
 // ServiceConnection represents a connection to a service.
 type ServiceConnection interface {
-	// Get - perform a get request and return the response
-	Get(string) ([]byte, error)
+	// Get performs a GET request and streams the response body into w.
+	Get(ctx context.Context, requestURI string, w io.Writer) error
 }
 type Connection struct {
 	URI string
@@ -24,27 +25,27 @@ func NewConnection(ps *proxyService) ServiceConnection {
 	}
 }
 
-// Get sends a GET request to the specified URI.
-
-func (c *Connection) Get(requestURI string) ([]byte, error) {
+// Get sends a GET request to the specified URI and streams the response body
+// into w.
+func (c *Connection) Get(ctx context.Context, requestURI string, w io.Writer) error {
 	base, err := url.Parse(c.URI)
 	if err != nil {
-		return nil, fmt.Errorf("invalid host uri: %w", err)
+		return fmt.Errorf("invalid host uri: %w", err)
 	}
 
 	rel, err := url.Parse(requestURI)
 	if err != nil {
-		return nil, fmt.Errorf("invalid request uri: %w", err)
+		return fmt.Errorf("invalid request uri: %w", err)
 	}
 
 	if rel.IsAbs() || rel.Host != "" || rel.User != nil {
-		return nil, fmt.Errorf("request uri must be a relative path")
+		return fmt.Errorf("request uri must be a relative path")
 	}
 
 	if rel.Path != "" {
 		cleaned := path.Clean(rel.Path)
 		if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-			return nil, fmt.Errorf("request uri must not traverse above base path")
+			return fmt.Errorf("request uri must not traverse above base path")
 		}
 
 		rel.Path = cleaned
@@ -52,10 +53,5 @@ func (c *Connection) Get(requestURI string) ([]byte, error) {
 
 	fullURL := base.ResolveReference(rel)
 
-	body, err := HTTPGet(context.Background(), fullURL.String())
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
+	return HTTPGetStream(ctx, fullURL.String(), w)
 }

--- a/backend/pkg/serviceproxy/connection_test.go
+++ b/backend/pkg/serviceproxy/connection_test.go
@@ -2,6 +2,7 @@ package serviceproxy //nolint
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -116,13 +117,15 @@ func TestGet(t *testing.T) {
 				conn.URI = ts.URL
 			}
 
-			body, err := conn.Get(tt.requestURI)
+			var buf bytes.Buffer
+
+			err := conn.Get(context.Background(), tt.requestURI, &buf)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if !tt.wantErr && !bytes.Equal(body, tt.wantBody) {
-				t.Errorf("Get() body = %s, want %s", body, tt.wantBody)
+			if !tt.wantErr && !bytes.Equal(buf.Bytes(), tt.wantBody) {
+				t.Errorf("Get() body = %s, want %s", buf.Bytes(), tt.wantBody)
 			}
 		})
 	}
@@ -136,7 +139,9 @@ func TestGetNonOKStatusCode(t *testing.T) {
 
 	conn := &Connection{URI: ts.URL}
 
-	_, err := conn.Get("/test")
+	var buf bytes.Buffer
+
+	err := conn.Get(context.Background(), "/test", &buf)
 	if err == nil {
 		t.Errorf("Get() error = nil, want error")
 	}

--- a/backend/pkg/serviceproxy/handler.go
+++ b/backend/pkg/serviceproxy/handler.go
@@ -66,7 +66,7 @@ func RequestHandler(
 	// Get a service connection object and make the request
 	conn := NewConnection(ps)
 
-	handleServiceProxy(conn, requestURI, w)
+	handleServiceProxy(r.Context(), conn, requestURI, w)
 }
 
 func shouldUseUnsafeServiceAccountToken(ctx *kubeconfig.Context, unsafeUseServiceAccountToken bool) bool {
@@ -125,19 +125,40 @@ func disableResponseCaching(w http.ResponseWriter) {
 	w.Header().Set("X-Accel-Expires", "0")
 }
 
-func handleServiceProxy(conn ServiceConnection, requestURI string, w http.ResponseWriter) {
-	resp, err := conn.Get(requestURI)
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "service get request failed")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+type trackingResponseWriter struct {
+	http.ResponseWriter
+	wroteHeader  bool
+	bytesWritten int
+}
 
-		return
+func (w *trackingResponseWriter) WriteHeader(code int) {
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *trackingResponseWriter) Write(p []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(p)
+	if n > 0 {
+		w.wroteHeader = true
+		w.bytesWritten += n
 	}
 
-	_, err = w.Write(resp) //nolint:gosec
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "writing response")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	return n, err
+}
+
+func (w *trackingResponseWriter) HasWritten() bool {
+	return w.wroteHeader || w.bytesWritten > 0
+}
+
+func handleServiceProxy(ctx context.Context, conn ServiceConnection, requestURI string, w http.ResponseWriter) {
+	trackedWriter := &trackingResponseWriter{ResponseWriter: w}
+
+	if err := conn.Get(ctx, requestURI, trackedWriter); err != nil {
+		logger.Log(logger.LevelError, nil, err, "service get request failed")
+
+		if !trackedWriter.HasWritten() {
+			http.Error(trackedWriter, err.Error(), http.StatusInternalServerError)
+		}
 
 		return
 	}

--- a/backend/pkg/serviceproxy/handler_test.go
+++ b/backend/pkg/serviceproxy/handler_test.go
@@ -2,6 +2,8 @@ package serviceproxy //nolint
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,7 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -133,12 +135,52 @@ func TestHandleServiceProxy(t *testing.T) {
 			// Create connection and test
 			conn := NewConnection(tt.proxyService)
 			w := httptest.NewRecorder()
-			handleServiceProxy(conn, tt.requestURI, w)
+			handleServiceProxy(context.Background(), conn, tt.requestURI, w)
 
 			assert.Equal(t, tt.expectedCode, w.Code)
 			assert.Equal(t, tt.expectedBody, w.Body.String())
 		})
 	}
+}
+
+type mockServiceConnection struct {
+	get func(ctx context.Context, requestURI string, w io.Writer) error
+}
+
+func (m mockServiceConnection) Get(ctx context.Context, requestURI string, w io.Writer) error {
+	return m.get(ctx, requestURI, w)
+}
+
+func TestHandleServiceProxyDoesNotWriteErrorAfterPartialStream(t *testing.T) {
+	w := httptest.NewRecorder()
+	conn := mockServiceConnection{
+		get: func(ctx context.Context, requestURI string, out io.Writer) error {
+			if _, err := out.Write([]byte("partial")); err != nil {
+				return err
+			}
+
+			return errors.New("stream aborted")
+		},
+	}
+
+	handleServiceProxy(context.Background(), conn, "/test", w)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "partial", w.Body.String())
+}
+
+func TestHandleServiceProxyWritesErrorBeforeStreamStarts(t *testing.T) {
+	w := httptest.NewRecorder()
+	conn := mockServiceConnection{
+		get: func(ctx context.Context, requestURI string, out io.Writer) error {
+			return errors.New("stream aborted")
+		},
+	}
+
+	handleServiceProxy(context.Background(), conn, "/test", w)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "stream aborted\n", w.Body.String())
 }
 
 func TestDisableResponseCaching(t *testing.T) {
@@ -367,7 +409,7 @@ func TestGetServiceFromCluster(t *testing.T) {
 			namespace:      "default",
 			serviceName:    "restricted-service",
 			setupService:   false,
-			mockError:      errors.NewUnauthorized("user does not have permission"),
+			mockError:      k8serrors.NewUnauthorized("user does not have permission"),
 			expectedStatus: http.StatusUnauthorized,
 			expectError:    true,
 		},
@@ -376,7 +418,7 @@ func TestGetServiceFromCluster(t *testing.T) {
 			namespace:    "default",
 			serviceName:  "forbidden-service",
 			setupService: false,
-			mockError: errors.NewForbidden(
+			mockError: k8serrors.NewForbidden(
 				schema.GroupResource{Resource: "services"},
 				"forbidden-service",
 				nil,

--- a/backend/pkg/serviceproxy/http.go
+++ b/backend/pkg/serviceproxy/http.go
@@ -10,32 +10,33 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 )
 
-// HTTPGet sends an HTTP GET request to the specified URI.
-func HTTPGet(ctx context.Context, uri string) ([]byte, error) {
+// HTTPGetStream sends an HTTP GET request to the specified URI and streams the
+// response body into w. The body is never fully buffered, so an upstream that
+// returns an arbitrarily large response cannot exhaust server memory.
+func HTTPGetStream(ctx context.Context, uri string, w io.Writer) error {
 	cli := &http.Client{Timeout: 10 * time.Second}
 
 	logger.Log(logger.LevelInfo, nil, nil, fmt.Sprintf("make request to %s", uri))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil) //nolint:gosec
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %v", err)
+		return fmt.Errorf("creating request: %v", err)
 	}
 
 	resp, err := cli.Do(req) //nolint:gosec
 	if err != nil {
-		return nil, fmt.Errorf("failed HTTP GET: %v", err)
+		return fmt.Errorf("failed HTTP GET: %v", err)
 	}
 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed HTTP GET, status code %v", resp.StatusCode)
+		return fmt.Errorf("failed HTTP GET, status code %v", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		return fmt.Errorf("streaming response: %v", err)
 	}
 
-	return body, nil
+	return nil
 }

--- a/backend/pkg/serviceproxy/http_test.go
+++ b/backend/pkg/serviceproxy/http_test.go
@@ -1,6 +1,7 @@
 package serviceproxy_test
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +12,7 @@ import (
 )
 
 //nolint:funlen
-func TestHTTPGet(t *testing.T) {
+func TestHTTPGetStream(t *testing.T) {
 	tests := []struct {
 		name       string
 		url        string
@@ -78,26 +79,30 @@ func TestHTTPGet(t *testing.T) {
 				url = ts.URL + "/error"
 			}
 
-			if ctx := context.Background(); tt.name == "context cancellation" {
+			ctx := context.Background()
+
+			if tt.name == "context cancellation" {
 				var cancel context.CancelFunc
 
-				_, cancel = context.WithCancel(ctx)
+				ctx, cancel = context.WithCancel(ctx)
 				cancel()
 			}
 
-			resp, err := serviceproxy.HTTPGet(context.Background(), url)
+			var buf bytes.Buffer
+
+			err := serviceproxy.HTTPGetStream(ctx, url, &buf)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("HTTPGet() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("HTTPGetStream() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if !tt.wantErr && string(resp) != tt.body {
-				t.Errorf("HTTPGet() response = %s, want %s", resp, tt.body)
+			if !tt.wantErr && buf.String() != tt.body {
+				t.Errorf("HTTPGetStream() response = %s, want %s", buf.String(), tt.body)
 			}
 		})
 	}
 }
 
-func TestHTTPGetTimeout(t *testing.T) {
+func TestHTTPGetStreamTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(15 * time.Second)
 
@@ -110,8 +115,79 @@ func TestHTTPGetTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	_, err := serviceproxy.HTTPGet(ctx, ts.URL)
+	err := serviceproxy.HTTPGetStream(ctx, ts.URL, &countingWriter{})
 	if err == nil {
-		t.Errorf("HTTPGet() error = nil, want error")
+		t.Errorf("HTTPGetStream() error = nil, want error")
 	}
+}
+
+func TestHTTPGetStreamDoesNotBuffer(t *testing.T) {
+	const (
+		size      = 32 * 1024 * 1024
+		chunkSize = 8 * 1024
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunk := make([]byte, chunkSize)
+		for i := range chunk {
+			chunk[i] = 'a'
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+
+		written := 0
+		for written < size {
+			toWrite := chunk
+			if remaining := size - written; remaining < len(chunk) {
+				toWrite = chunk[:remaining]
+			}
+
+			n, err := w.Write(toWrite)
+			if err != nil {
+				t.Fatalf("write test: %v", err)
+			}
+
+			written += n
+		}
+	}))
+	defer ts.Close()
+
+	counter := &countingWriter{}
+
+	if err := serviceproxy.HTTPGetStream(context.Background(), ts.URL, counter); err != nil {
+		t.Fatalf("HTTPGetStream() error = %v", err)
+	}
+
+	if counter.n != size {
+		t.Errorf("HTTPGetStream() streamed %d bytes, want %d", counter.n, size)
+	}
+
+	if counter.writes <= 1 {
+		t.Errorf("HTTPGetStream() performed %d writes, want more than 1 to confirm streaming", counter.writes)
+	}
+
+	if counter.maxWrite > 128*1024 {
+		t.Errorf("HTTPGetStream() max write size = %d, want <= %d", counter.maxWrite, 128*1024)
+	}
+}
+
+// countingWriter records streaming statistics without retaining the response
+// body. Keeping no copy of the payload lets large-body tests assert the stream
+// is forwarded in bounded chunks without themselves buffering the whole body.
+type countingWriter struct {
+	n        int
+	writes   int
+	maxWrite int
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.n += len(p)
+	c.writes++
+
+	if len(p) > c.maxWrite {
+		c.maxWrite = len(p)
+	}
+
+	return len(p), nil
 }


### PR DESCRIPTION

## Summary

The /externalproxy endpoint and the internal serviceproxy package both read upstream response bodies fully into memory before forwarding them. A request for a multi-gigabyte resource exhausts the backend's RAM and crashes the process, causing a denial of service for all users.

The "/externalproxy" endpoint and the "serviceproxy" package both read the full upstream HTTP response into memory before forwarding it to the client. A request for a sufficiently large resource OOM-crashes the backend and takes down Headlamp for all users. This PR switches both paths to streaming so the body is forwarded chunk-by-chunk and the proxy's memory footprint stays bounded regardless of upstream response size.

Switch to streaming with io.Copy so the body is forwarded chunk by chunk without ever being fully buffered. This also pushes io.Writer through the ServiceConnection interface so the buffering can't be reintroduced silently. Adds tests that proxy a 200 MiB body through both paths.



## Related Issue

Fixes #5494

## Changes

- backend/cmd/headlamp.go — "/externalproxy" handler now uses io.Copy(w, reader) instead of "io.ReadAll  followed by w.Write. The gzip decode path is preserved
- backend/pkg/serviceproxy/http.go — "HTTPGet([]byte)"  becomes "HTTPGetStream(io.Writer)" and uses  io.Copy(w, resp.Body).
- backend/pkg/serviceproxy/connection.go — "ServiceConnection.Get" interface and "eConnection.Get" implementation take "io.Writer" so the buffering cannot be silently reintroduced.
- backend/pkg/serviceproxy/handler.go — "handleServiceProxy" passes the "http.ResponseWriter" straight through.
- Tests updated for the new signature and two new tests added that proxy a 200 MiB body end-to-end through both paths.

## Steps to Test

1. cd backend && make backend & make backend lint  both succeed cleanly
2. go test ./... — full backend suite passes (14 packages)
3. Go test-run TestExternalProxyStreamsLargeBody -v ./cmd/... — the new 200 MiB streaming test passes in under 100 ms
4. Go test-run  TestHTTPGetStreamDoesNotBuffer -v ./pkg/serviceproxy/... — the new 200 MiB streaming test passes in under 100 ms
5. To reproduce the original bug on a clean checkout of main, run the same large-body test there: the test would have allocated the full 200 MiB into RSS


## Screenshots (if applicable)

    Backend changes so no ss

## Notes for the Reviewer

- The interface change on "ServiceConnection.Get"  is intentional: returning []byte would let buffering creep back in. This is the only public surface change.
- http.Error is no longer called after a streaming write fails because the response status would already be committed. The error is logged instead, matching the standard streaming-proxy pattern (e.g. httputil.ReverseProxy).
- gosec was already silenced on adjacent lines for the same // URL is admin-allowlisted reason; the //nolint:gosec on the new "io.Copy"  line follows the same pattern.
- No frontend, type, or i18n impact.
