### PR TITLE
frontend: resourceMap: Prefer custom node details page

### DIFF
--- a/frontend/src/components/resourceMap/details/GraphNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/GraphNodeDetails.tsx
@@ -40,9 +40,12 @@ function NodeDetailsRenderer({ node }: { node?: GraphNode }) {
   const hasContent = node && (node.detailsComponent || node.kubeObject);
   if (!hasContent) return null;
 
+  if (node.detailsComponent) {
+    return <node.detailsComponent node={node} />;
+  }
+
   return (
     <>
-      {node.detailsComponent && <node.detailsComponent node={node} />}
       {node.kubeObject && (
         <KubeObjectDetails
           resource={node.kubeObject}


### PR DESCRIPTION
## Summary
This PR fixes resource map node details rendering so a node-provided `detailsComponent` replaces the default kube object details instead of rendering both.
This affects plugin-provided map nodes that include both `detailsComponent` and `kubeObject`. Without this change, Headlamp can render duplicate fallback details for built-in resources, unnecessary fallback content for plugin resources, and incorrect fallback details when a plugin resource shares a kind with a built-in Kubernetes resource.
## Changes
- Updated `GraphNodeDetails` to render `detailsComponent` as the full node details view when provided.
- Kept the existing `KubeObjectDetails` fallback for nodes without a custom details component.
- Prevented plugin map nodes from triggering unnecessary requests or incorrect default kube object details after their custom details render.
## Steps to Test
1. Open the resource map with a plugin source that provides custom node details.
2. Click a plugin map node that has both `detailsComponent` and `kubeObject`.
3. Verify only the custom detail view renders in the side panel.
4. Verify no extra fallback kube object detail request or warning is triggered for that node.
## Screenshots (if applicable)
Before (Console Logs after clicking on Job to get job detail view):
<img width="1883" height="778" alt="image" src="https://github.com/user-attachments/assets/ad033c71-a661-4e26-8606-6f767c49f5e6" />
After (Console Logs after clicking on Job to get job detail view):
<img width="1880" height="719" alt="image" src="https://github.com/user-attachments/assets/1e89f145-bb93-49b6-b72d-5ec029f169cf" />
Also another thing is that it loads the other view in the end of the actual working job details view which doesn't work
Before:
<img width="1476" height="733" alt="image" src="https://github.com/user-attachments/assets/0cf80a99-65bf-499c-a074-9631e90ebfad" />
After:
<img width="1203" height="489" alt="image" src="https://github.com/user-attachments/assets/b9996e6b-8d85-4490-97ee-5dc612a7efb6" />
