### PR TITLE
frontend: reject decimal table row counts

### DIFF
--- a/frontend/src/components/App/Settings/NumRowsInput.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.tsx
@@ -28,7 +28,13 @@ import TextField from '@mui/material/TextField';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { getTablesRowsPerPage, setTablesRowsPerPage } from '../../../helpers/tablesRowsPerPage';
+import {
+  getTablesRowsPerPage,
+  maxTablesRowsPerPage,
+  minTablesRowsPerPage,
+  parseTablesRowsPerPage,
+  setTablesRowsPerPage,
+} from '../../../helpers/tablesRowsPerPage';
 import { defaultTableRowsPerPageOptions, setAppSettings } from '../../../redux/configSlice';
 
 export default function NumRowsInput(props: { defaultValue: number[]; nameLabelID?: string }) {
@@ -36,6 +42,7 @@ export default function NumRowsInput(props: { defaultValue: number[]; nameLabelI
   const { defaultValue, nameLabelID } = props;
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [options, setOptions] = useState(defaultValue);
+  const [minRows, maxRows] = [minTablesRowsPerPage, maxTablesRowsPerPage];
   const focusedRef = useCallback((node: HTMLElement) => {
     if (node !== null) {
       node.focus();
@@ -58,9 +65,8 @@ export default function NumRowsInput(props: { defaultValue: number[]; nameLabelI
     return val;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  const [customValue, setCustomValue] = useState<number | undefined>(storedCustomValue);
+  const [customValue, setCustomValue] = useState(storedCustomValue.toString());
   const [errorMessage, setErrorMessage] = useState('');
-  const [minRows, maxRows] = [5, 1000];
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -103,35 +109,35 @@ export default function NumRowsInput(props: { defaultValue: number[]; nameLabelI
           error={!!errorMessage}
           placeholder={t('translation|Custom row value')}
           helperText={errorMessage || suggestionMsg}
-          inputProps={{ min: minRows, max: maxRows }}
+          inputProps={{ min: minRows, max: maxRows, step: 1 }}
           inputRef={focusedRef}
           onChange={e => {
-            const val = parseInt(e.target.value);
-            if (Number.isInteger(val)) {
-              if (val < 5 || val > maxRows) {
-                setErrorMessage(suggestionMsg);
-              } else {
-                setErrorMessage('');
-              }
-              setCustomValue(val);
-            } else {
-              setCustomValue(undefined);
+            const val = parseTablesRowsPerPage(e.target.value);
+            setCustomValue(e.target.value);
+            if (val === null) {
+              setErrorMessage(e.target.value ? suggestionMsg : '');
+              return;
             }
+
+            setErrorMessage('');
           }}
         />
         <Box display="inline-flex" alignItems="center" mx={1}>
           <Button
             variant="contained"
-            disabled={!!errorMessage}
+            disabled={!!errorMessage || parseTablesRowsPerPage(customValue) === null}
             size="small"
             onClick={() => {
-              if (customValue === undefined) {
+              const parsedCustomValue = parseTablesRowsPerPage(customValue);
+              if (parsedCustomValue === null) {
                 return;
               }
-              const newOptions = [...new Set([...defaultTableRowsPerPageOptions, customValue])];
+              const newOptions = [
+                ...new Set([...defaultTableRowsPerPageOptions, parsedCustomValue]),
+              ];
               newOptions.sort((a, b) => a - b);
               setOptions(newOptions);
-              setSelectedValue(customValue);
+              setSelectedValue(parsedCustomValue);
             }}
           >
             {t('translation|Apply')}

--- a/frontend/src/helpers/tablesRowsPerPage.test.ts
+++ b/frontend/src/helpers/tablesRowsPerPage.test.ts
@@ -14,40 +14,67 @@
  * limitations under the License.
  */
 
-import { getTablesRowsPerPage, setTablesRowsPerPage } from './tablesRowsPerPage';
+import { getTablesRowsPerPage, parseTablesRowsPerPage } from './tablesRowsPerPage';
+
+describe('parseTablesRowsPerPage', () => {
+  test('accepts whole numbers', () => {
+    expect(parseTablesRowsPerPage('10')).toBe(10);
+  });
+
+  test('accepts values at the row count bounds', () => {
+    expect(parseTablesRowsPerPage('5')).toBe(5);
+    expect(parseTablesRowsPerPage('1000')).toBe(1000);
+  });
+
+  test('rejects decimal values', () => {
+    expect(parseTablesRowsPerPage('10.5')).toBeNull();
+  });
+
+  test('rejects non-numeric values', () => {
+    expect(parseTablesRowsPerPage('abc')).toBeNull();
+  });
+
+  test('rejects partially numeric values', () => {
+    expect(parseTablesRowsPerPage('12abc')).toBeNull();
+  });
+
+  test('rejects values below the minimum', () => {
+    expect(parseTablesRowsPerPage('0')).toBeNull();
+    expect(parseTablesRowsPerPage('4')).toBeNull();
+  });
+
+  test('rejects values above the maximum', () => {
+    expect(parseTablesRowsPerPage('1001')).toBeNull();
+  });
+
+  test('rejects unsafe integers', () => {
+    expect(parseTablesRowsPerPage('9007199254740992')).toBeNull();
+  });
+});
 
 describe('getTablesRowsPerPage', () => {
-  beforeEach(() => {
+  afterEach(() => {
     localStorage.clear();
   });
 
-  it('returns the default when localStorage is empty', () => {
-    expect(getTablesRowsPerPage(15)).toBe(15);
+  test('returns the default value when stored value is decimal', () => {
+    localStorage.setItem('tables_rows_per_page', '10.5');
+
+    expect(getTablesRowsPerPage(5)).toBe(5);
   });
 
-  it('returns the stored value when localStorage holds a valid number', () => {
-    setTablesRowsPerPage(25);
-    expect(getTablesRowsPerPage(15)).toBe(25);
+  test('returns the stored value when it is valid', () => {
+    localStorage.setItem('tables_rows_per_page', '10');
+
+    expect(getTablesRowsPerPage(5)).toBe(10);
   });
 
-  it('returns the default when localStorage contains a non-numeric string', () => {
-    localStorage.setItem('tables_rows_per_page', 'not-a-number');
-    expect(getTablesRowsPerPage(15)).toBe(15);
-  });
+  test.each(['abc', '12abc', '', ' ', '0', '4', '1001', '9007199254740992'])(
+    'returns the default value when stored value is invalid: %s',
+    value => {
+      localStorage.setItem('tables_rows_per_page', value);
 
-  it('returns the default when localStorage contains an empty string', () => {
-    localStorage.setItem('tables_rows_per_page', '');
-    expect(getTablesRowsPerPage(15)).toBe(15);
-  });
-
-  it('returns the parsed integer when localStorage contains a partial numeric string like "12abc"', () => {
-    localStorage.setItem('tables_rows_per_page', '12abc');
-    // parseInt('12abc') === 12, which is a valid integer
-    const result = getTablesRowsPerPage(15);
-    expect(result).toBe(12);
-
-    const options = [15, 25, 50];
-    // 12 is a valid integer but NOT in options — callers must clamp to options
-    expect(options.includes(result)).toBe(false);
-  });
+      expect(getTablesRowsPerPage(5)).toBe(5);
+    }
+  );
 });

--- a/frontend/src/helpers/tablesRowsPerPage.ts
+++ b/frontend/src/helpers/tablesRowsPerPage.ts
@@ -15,22 +15,41 @@
  */
 
 const tablesRowsPerPageKey = 'tables_rows_per_page';
+export const minTablesRowsPerPage = 5;
+export const maxTablesRowsPerPage = 1000;
+
+export function parseTablesRowsPerPage(value: string): number | null {
+  const trimmedValue = value.trim();
+  if (!trimmedValue || !/^\d+$/.test(trimmedValue)) {
+    return null;
+  }
+
+  const rowsPerPage = Number(trimmedValue);
+  if (
+    !Number.isSafeInteger(rowsPerPage) ||
+    rowsPerPage < minTablesRowsPerPage ||
+    rowsPerPage > maxTablesRowsPerPage
+  ) {
+    return null;
+  }
+
+  return rowsPerPage;
+}
 
 /**
  * Gets the number of rows per page for tables from local storage.
  *
- * @param defaultRowsPerPage - The default number of rows per page if not set in local storage.
+ * @param defaultRowsPerPage - The default number of rows per page if local storage is empty or invalid.
  * @returns {number} - The number of rows per page.
- * If not set, returns the default value.
+ * If not set or invalid, returns the default value.
  */
-export function getTablesRowsPerPage(defaultRowsPerPage: number = 5) {
+export function getTablesRowsPerPage(defaultRowsPerPage: number = minTablesRowsPerPage) {
   const perPageStr = localStorage.getItem(tablesRowsPerPageKey);
   if (!perPageStr) {
     return defaultRowsPerPage;
   }
 
-  const parsed = parseInt(perPageStr);
-  return Number.isNaN(parsed) ? defaultRowsPerPage : parsed;
+  return parseTablesRowsPerPage(perPageStr) ?? defaultRowsPerPage;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes validation for the custom “Number of rows for tables” setting so decimal values are rejected instead of being silently truncated.

## Related Issue

Fixes #5501

## Changes

- Updated NumRowsInput to validate the raw input value before applying it.
- Added shared rows-per-page parsing logic in tablesRowsPerPage.
- Fixed persisted rows-per-page values so invalid decimal values fall back to the default instead of being truncated.
- Added regression tests for decimal and invalid rows-per-page values.

## Steps to Test

1. Open Headlamp and go to Settings.
2. Find “Number of rows for tables”.
3. Select “Custom value”.
4. Enter a decimal value such as 10.5.
5. Confirm that the value is rejected and cannot be applied.
6. Enter a valid whole number such as 10 and confirm it can be applied.

## Test command run locally:

```bash
npm run frontend:test -- tablesRowsPerPage
```

## Screenshots

Decimal values now remain visible as entered, show validation, and keep Apply disabled instead of silently applying the `parseInt`-truncated integer.

![Number of rows for tables rejects 10.5](https://gist.githubusercontent.com/harrshita123/2d80996294142bae38ea8b0589bf5999/raw/pr-5504-decimal-validation.svg)

## Notes for the Reviewer

The current user-visible issue is not only that `10.5` displays as `10` after applying; it is that the UI silently accepts a value the user did not enter, and persisted invalid values such as `10.5` or `12abc` can also be parsed as valid integers. This fix avoids `parseInt` for this setting so both the UI input path and the persisted localStorage value path consistently require whole numbers between 5 and 1000.
