### PR TITLE
helm: configure default pod debug image

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -102,6 +102,7 @@ type clientConfig struct {
 	Clusters                []Cluster `json:"clusters"`
 	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
 	AllowKubeconfigChanges  bool      `json:"allowKubeconfigChanges"`
+	DefaultPodDebugImage    string    `json:"defaultPodDebugImage"`
 }
 
 type OauthConfig struct {
@@ -1938,6 +1939,7 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 		Clusters:                c.getClusters(),
 		IsDynamicClusterEnabled: c.EnableDynamicClusters,
 		AllowKubeconfigChanges:  c.AllowKubeconfigChanges,
+		DefaultPodDebugImage:    c.PodDebugImage,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -105,6 +105,28 @@ func getResponseFromRestrictedEndpoint(handler http.Handler, method, url string,
 	return rr, nil
 }
 
+func TestGetConfigIncludesDefaultPodDebugImage(t *testing.T) {
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeconfig.NewContextStore(),
+				PodDebugImage:   "registry.example.com/debug:latest",
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil)
+	recorder := httptest.NewRecorder()
+
+	c.getConfig(recorder, req)
+
+	var config clientConfig
+
+	err := json.Unmarshal(recorder.Body.Bytes(), &config)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com/debug:latest", config.DefaultPodDebugImage)
+}
+
 //nolint:gocognit,funlen
 func TestDynamicClusters(t *testing.T) {
 	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -102,6 +102,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		TLSCertPath:            conf.TLSCertPath,
 		TLSKeyPath:             conf.TLSKeyPath,
 		SessionTTL:             conf.SessionTTL,
+		PodDebugImage:          conf.PodDebugImage,
 		OidcUseCookie:          conf.OidcUseCookie,
 	}
 }

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	UserPluginsDir            string `koanf:"user-plugins-dir"`
 	BaseURL                   string `koanf:"base-url"`
 	SessionTTL                int    `koanf:"session-ttl"`
+	PodDebugImage             string `koanf:"pod-debug-image"`
 	ProxyURLs                 string `koanf:"proxy-urls"`
 	OidcClientID              string `koanf:"oidc-client-id"`
 	OidcValidatorClientID     string `koanf:"oidc-validator-client-id"`
@@ -449,6 +450,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.String("base-url", "", "Base URL path. eg. /headlamp")
 	f.Int("session-ttl", defaultSessionTTL, "The time in seconds for the session to be valid"+
 		"(Default: 86400/24h, Min: 1 , Max: 31536000/1yr )")
+	f.String("pod-debug-image", "", "Default image to use when creating pod debug containers")
 	f.String("listen-addr", "", "Address to listen on; default is empty, which means listening to any address")
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -51,9 +51,10 @@ func TestParseBasic(t *testing.T) {
 		},
 		{
 			name: "with_args",
-			args: []string{"go run ./cmd", "--port=3456"},
+			args: []string{"go run ./cmd", "--port=3456", "--pod-debug-image=registry.example.com/debug:latest"},
 			verify: func(t *testing.T, conf *config.Config) {
 				assert.Equal(t, uint(3456), conf.Port)
+				assert.Equal(t, "registry.example.com/debug:latest", conf.PodDebugImage)
 				assert.Equal(t, config.DefaultMeUsernamePath, conf.MeUsernamePath)
 			},
 		},

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -64,5 +64,6 @@ type HeadlampCFG struct {
 	TLSCertPath            string
 	TLSKeyPath             string
 	SessionTTL             int
+	PodDebugImage          string
 	OidcUseCookie          bool
 }

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -74,6 +74,7 @@ $ helm install my-headlamp headlamp/headlamp \
 | config.sessionTTL  | int    | `86400`               | The time in seconds for the internal session to remain valid (Default: 86400/24h, Min: 1 , Max: 31536000/1yr) |
 | config.pluginsDir  | string | `"/headlamp/plugins"` | Directory to load Headlamp plugins from                                   |
 | config.enableHelm  | bool   | `false`               | Enable Helm operations like install, upgrade and uninstall of Helm charts |
+| config.podDebugImage | string | `""`                | Default image to use when creating pod debug containers                    |
 | config.extraArgs   | array  | `[]`                  | Additional arguments for Headlamp server                                  |
 | config.tlsCertPath | string | `""`                  | Certificate for serving TLS                                               |
 | config.tlsKeyPath  | string | `""`                  | Key for serving TLS                                                       |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -261,6 +261,9 @@ spec:
             {{- if hasKey .Values.config "sessionTTL" }}
             - "-session-ttl={{ .Values.config.sessionTTL }}"
             {{- end }}
+            {{- with .Values.config.podDebugImage }}
+            - "-pod-debug-image={{ . }}"
+            {{- end }}
             {{- if not $oidc.externalSecret.enabled}}
             # Check if externalSecret is disabled
             {{- if or (ne $oidc.clientID "") (ne $clientID "") }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -180,6 +180,10 @@
           "minimum": 1,
           "maximum": 31536000
         },
+        "podDebugImage": {
+          "type": "string",
+          "description": "Default image to use when creating pod debug containers"
+        },
         "oidc": {
           "type": "object",
           "description": "OIDC configuration",

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -113,6 +113,8 @@ config:
   pluginsDir: "/headlamp/plugins"
   enableHelm: false
   watchPlugins: false
+  # -- Default image to use when creating pod debug containers. If empty, Headlamp uses its built-in default.
+  podDebugImage: ""
   # tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
   # tlsKeyPath: "/headlamp-cert/headlamp-tls.key"
   # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.

--- a/frontend/src/components/App/Settings/PodDebugSettings.tsx
+++ b/frontend/src/components/App/Settings/PodDebugSettings.tsx
@@ -26,6 +26,7 @@ import {
   loadClusterSettings,
   storeClusterSettings,
 } from '../../../helpers/clusterSettings';
+import { useTypedSelector } from '../../../redux/hooks';
 import { HoverInfoLabel } from '../../common/Label';
 import { NameValueTable } from '../../common/NameValueTable';
 import SectionBox from '../../common/SectionBox';
@@ -55,6 +56,8 @@ export default function PodDebugSettings(props: SettingsProps) {
   const [clusterSettings, setClusterSettings] = useState<ClusterSettings | null>(null);
   const [userImage, setUserImage] = useState('');
   const [userIsEnabled, setUserIsEnabled] = useState<boolean | null>(null);
+  const defaultPodDebugImage =
+    useTypedSelector(state => state.config?.defaultPodDebugImage) || DEFAULT_POD_DEBUG_IMAGE;
 
   const podDebugLabelID = 'pod-debug-enabled-label';
 
@@ -84,7 +87,7 @@ export default function PodDebugSettings(props: SettingsProps) {
   const storeNewImage = useCallback(
     (image: string) => {
       let actualImage = image;
-      if (image === DEFAULT_POD_DEBUG_IMAGE) {
+      if (image === defaultPodDebugImage) {
         actualImage = '';
         setUserImage(actualImage);
       }
@@ -99,7 +102,7 @@ export default function PodDebugSettings(props: SettingsProps) {
         return newSettings;
       });
     },
-    [setClusterSettings, setUserImage]
+    [defaultPodDebugImage, setClusterSettings, setUserImage]
   );
 
   function storeNewEnabled(enabled: boolean) {
@@ -167,7 +170,7 @@ export default function PodDebugSettings(props: SettingsProps) {
                   setUserImage(value);
                 }}
                 value={userImage}
-                placeholder={DEFAULT_POD_DEBUG_IMAGE}
+                placeholder={defaultPodDebugImage}
                 helperText={t(
                   'translation|The default image is used for creating ephemeral debug containers.'
                 )}

--- a/frontend/src/components/pod/PodDebugTerminal.tsx
+++ b/frontend/src/components/pod/PodDebugTerminal.tsx
@@ -19,12 +19,14 @@ import DialogContent from '@mui/material/DialogContent';
 import Typography from '@mui/material/Typography';
 import _ from 'lodash';
 import { useSnackbar } from 'notistack';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DEFAULT_POD_DEBUG_IMAGE, loadClusterSettings } from '../../helpers/clusterSettings';
 import { getCluster } from '../../lib/cluster';
 import Pod from '../../lib/k8s/pod';
 import { Channel, useTerminalStream, XTerminalConnected } from '../../lib/k8s/useTerminalStream';
+import { useTypedSelector } from '../../redux/hooks';
 
 /**
  * Props for PodDebugTerminal.
@@ -174,10 +176,20 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
   const exitSentRef = useRef(false);
   const pendingExitRef = useRef(false);
   const containerCreatedRef = useRef(false);
+  const defaultPodDebugImage = useTypedSelector(state => state.config.defaultPodDebugImage);
+  const defaultPodDebugImageRef = useRef(defaultPodDebugImage);
+  const onCloseRef = useRef<() => void>(() => {});
+  const isSuccessfulExitRef = useRef<(channel: number, text: string) => boolean>(() => false);
+  const isShellNotFoundRef = useRef<(channel: number, text: string) => boolean>(() => false);
+  const shellConnectFailedRef = useRef<(xtermc: XTerminalConnected) => void>(() => {});
+  const terminalRef = useRef<MutableRefObject<XTerminalConnected | null> | null>(null);
 
-  const { xtermRef, streamRef, send } = useTerminalStream({
-    containerRef: terminalContainerRef,
-    connectStream: async onDataCallback => {
+  useEffect(() => {
+    defaultPodDebugImageRef.current = defaultPodDebugImage;
+  }, [defaultPodDebugImage]);
+
+  const connectStream = useCallback(
+    async (onDataCallback: (data: ArrayBuffer) => void) => {
       const cluster = getCluster();
       if (!cluster) {
         enqueueSnackbar(t('translation|No cluster selected'), { variant: 'error' });
@@ -186,7 +198,8 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
 
       const clusterSettings = loadClusterSettings(cluster);
       const config = clusterSettings.podDebugTerminal;
-      const debugImage = config?.debugImage || DEFAULT_POD_DEBUG_IMAGE;
+      const debugImage =
+        config?.debugImage || defaultPodDebugImageRef.current || DEFAULT_POD_DEBUG_IMAGE;
       const isEnabled = config?.isEnabled ?? true;
 
       if (!isEnabled) {
@@ -202,13 +215,15 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
       if (runningDebugContainer) {
         containerName = runningDebugContainer.name;
         containerCreatedRef.current = true;
-        xtermRef.current?.xterm.writeln(
+        terminalRef.current?.current?.xterm.writeln(
           t('translation|Attaching to existing debug container...') + '\r\n'
         );
       } else {
         containerName = generateContainerName(item);
 
-        xtermRef.current?.xterm.writeln(t('translation|Creating ephemeral debug container...'));
+        terminalRef.current?.current?.xterm.writeln(
+          t('translation|Creating ephemeral debug container...')
+        );
 
         const { containerName: readyContainerName } = await debugPod(
           item,
@@ -221,7 +236,9 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
               }),
               { variant: 'error' }
             );
-            xtermRef.current?.xterm.writeln(`\r\n${t('translation|Error')}: ${errorMessage}\r\n`);
+            terminalRef.current?.current?.xterm.writeln(
+              `\r\n${t('translation|Error')}: ${errorMessage}\r\n`
+            );
           }
         );
 
@@ -230,7 +247,9 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
         }
 
         containerCreatedRef.current = true;
-        xtermRef.current?.xterm.writeln(t('translation|Attaching to debug container...'));
+        terminalRef.current?.current?.xterm.writeln(
+          t('translation|Attaching to debug container...')
+        );
       }
 
       const stream = item.attach(containerName, onDataCallback, {});
@@ -239,13 +258,27 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
         stream,
       };
     },
-    onClose: wrappedOnClose,
-    errorHandlers: {
-      isSuccessfulExit: isSuccessfulExitError,
-      isShellNotFound: isShellNotFoundError,
-      onConnectionFailed: shellConnectFailed,
-    },
+    [enqueueSnackbar, item, t]
+  );
+
+  const errorHandlers = useMemo(
+    () => ({
+      isSuccessfulExit: (channel: number, text: string) =>
+        isSuccessfulExitRef.current(channel, text),
+      isShellNotFound: (channel: number, text: string) => isShellNotFoundRef.current(channel, text),
+      onConnectionFailed: (xtermc: XTerminalConnected) => shellConnectFailedRef.current(xtermc),
+    }),
+    []
+  );
+  const handleTerminalClose = useCallback(() => onCloseRef.current(), []);
+
+  const { xtermRef, streamRef, send } = useTerminalStream({
+    containerRef: terminalContainerRef,
+    connectStream,
+    onClose: handleTerminalClose,
+    errorHandlers,
   });
+  terminalRef.current = xtermRef;
 
   const sendExitIfPossible = useCallback(() => {
     if (exitSentRef.current) {
@@ -342,6 +375,11 @@ export function PodDebugTerminal(props: PodDebugTerminalProps) {
     xterm.clear();
     xterm.write(t('translation|Failed to connect…\r\n'));
   }
+
+  onCloseRef.current = wrappedOnClose;
+  isSuccessfulExitRef.current = isSuccessfulExitError;
+  isShellNotFoundRef.current = isShellNotFoundError;
+  shellConnectFailedRef.current = shellConnectFailed;
 
   useEffect(() => {
     const handleBeforeUnload = () => {

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -49,6 +49,7 @@ const makeStore = () => {
         },
         isDynamicClusterEnabled: false,
         allowKubeconfigChanges: false,
+        defaultPodDebugImage: '',
       },
       projects: {
         headerActions: {},

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -42,6 +42,7 @@ const makeStore = () => {
         } as any,
         isDynamicClusterEnabled: true,
         allowKubeconfigChanges: false,
+        defaultPodDebugImage: '',
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',

--- a/frontend/src/redux/configSlice.test.ts
+++ b/frontend/src/redux/configSlice.test.ts
@@ -50,6 +50,32 @@ describe('configSlice', () => {
     expect(nextState.isDynamicClusterEnabled).toBe(true);
   });
 
+  it('should handle setConfig with defaultPodDebugImage', () => {
+    const clusters: ConfigState['clusters'] = {
+      'cluster-1': { name: 'cluster-1' } as Cluster,
+    };
+    const nextState = configReducer(
+      initialState,
+      setConfig({
+        clusters,
+        defaultPodDebugImage: 'registry.example.com/debug:latest',
+      })
+    );
+
+    expect(nextState.defaultPodDebugImage).toBe('registry.example.com/debug:latest');
+  });
+
+  it('should handle clearing defaultPodDebugImage', () => {
+    const state = {
+      ...initialState,
+      defaultPodDebugImage: 'registry.example.com/debug:latest',
+    };
+
+    const nextState = configReducer(state, setConfig({ clusters: {}, defaultPodDebugImage: '' }));
+
+    expect(nextState.defaultPodDebugImage).toBe('');
+  });
+
   it('should preserve isDynamicClusterEnabled when setConfig is called without it', () => {
     let state = configReducer(
       initialState,

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -54,6 +54,11 @@ export interface ConfigState {
    */
   allowKubeconfigChanges: boolean;
   /**
+   * Default image used for pod debug containers when no per-cluster override is configured.
+   * An empty string indicates that no default image is configured.
+   */
+  defaultPodDebugImage: string;
+  /**
    * Settings is a map of settings names to settings values.
    */
   settings: {
@@ -145,6 +150,7 @@ export const initialState: ConfigState = {
   allClusters: null,
   isDynamicClusterEnabled: false,
   allowKubeconfigChanges: false,
+  defaultPodDebugImage: '',
   settings: {
     tableRowsPerPageOptions:
       storedSettings.tableRowsPerPageOptions ?? defaultTableRowsPerPageOptions,
@@ -169,6 +175,7 @@ const configSlice = createSlice({
         clusters: ConfigState['clusters'];
         isDynamicClusterEnabled?: boolean;
         allowKubeconfigChanges?: boolean;
+        defaultPodDebugImage?: string;
       }>
     ) {
       state.clusters = action.payload.clusters;
@@ -177,6 +184,9 @@ const configSlice = createSlice({
       }
       if (action.payload.allowKubeconfigChanges !== undefined) {
         state.allowKubeconfigChanges = action.payload.allowKubeconfigChanges;
+      }
+      if (action.payload.defaultPodDebugImage !== undefined) {
+        state.defaultPodDebugImage = action.payload.defaultPodDebugImage;
       }
     },
     /**


### PR DESCRIPTION
## Summary

This PR adds support for configuring the default pod debug image through the Helm chart values. The configured image is passed to Headlamp, exposed through the frontend config, and used as the default image for pod debug containers when no per-cluster override is set.

## Related Issue

Fixes : Refs #5467 

## Changes

- Added config.podDebugImage to the Helm chart values and schema.
- Passed the configured value to Headlamp with the --pod-debug-image argument.
- Added backend config support for pod-debug-image.
- Exposed the configured default pod debug image through /config.
- Updated pod debug settings and terminal logic to use the configured default image.
- Added backend and frontend tests for the new config path.

## Steps to Test

1. Render the Helm chart with a custom pod debug image:
helm template test ./charts/headlamp --set config.podDebugImage=registry.example.com/debug:latest

2. Confirm the rendered deployment includes:
-pod-debug-image=registry.example.com/debug:latest

3. Run the focused frontend test:
 npm run frontend:test -- configSlice

4. Run the focused backend tests:
cd backend && go test -v -p 1 ./cmd ./pkg/config

## Screenshots (if applicable)

Not applicable. This is a configuration behavior change with no intended UI layout change.

## Notes for the Reviewer

This PR addresses only the configurable default pod debug image portion of #5467. The unavailable cluster handling and faster unauthorized feedback items will be handled separately.
