### PR TITLE
fix: Replace deprecated trimLeft() with trimStart() in EditorDialog

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -203,7 +203,7 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   function looksLikeJson(code: string) {
-    const trimmedCode = code.trimLeft();
+    const trimmedCode = code.trimStart();
     const firstChar = !!trimmedCode ? trimmedCode[0] : '';
     if (['{', '['].includes(firstChar)) {
       return true;


### PR DESCRIPTION
## Summary
Replaces deprecated `trimLeft()` with the ES2019 standard `trimStart()` in the `looksLikeJson` helper in `EditorDialog.tsx`.
Functionally identical but uses the correct standard method.

## Related Issue
Fixes #5492

## Changes
- Replaced `trimLeft()` with `trimStart()` in `EditorDialog.tsx`

## Testing
1. Open any resource in the editor (e.g. a ConfigMap)
2. Verify the editor correctly detects JSON vs YAML content
3. Confirm no change in editor behaviour