### PR TITLE
fix: Clear error state when clicking Undo Changes in EditorDialog

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -299,7 +299,9 @@ export default function EditorDialog(props: EditorDialogProps) {
   }
 
   function onUndo() {
+    window.clearTimeout(lastCodeCheckHandler.current);
     setCode(originalCodeRef.current);
+    setError('');
   }
 
   const applyFunc = async (newItems: KubeObjectInterface[], clusterName: string) => {


### PR DESCRIPTION
## Summary
When a user types invalid YAML in the editor, an error message appears. Clicking "Undo Changes" correctly reverts the code but
the error message remained visible, confusing the user into thinking the valid YAML was still broken.

## Related Issue
Fixes #5449

## Changes
- Updated `onUndo()` to clear the error state and any pending timeouts when reverting changes

## Testing
1. Open any resource in the editor (e.g. a ConfigMap)
2. Type invalid YAML to trigger the red error message
3. Click "Undo Changes" and confirm the error disappears immediately along with the reverted code