### PR TITLE
Replace uncommon Unicode glyph in `Ingress` components

### DIFF
--- a/frontend/src/components/ingress/Details.tsx
+++ b/frontend/src/components/ingress/Details.tsx
@@ -233,7 +233,7 @@ export default function IngressDetails(props: {
               <LabelListItem
                 labels={ingress.spec?.tls?.map(
                   (tls: { hosts: string[]; secretName: string }) =>
-                    `${tls.secretName} 🞂 ${tls.hosts.join(', ')}`
+                    `${tls.secretName} › ${tls.hosts.join(', ')}`
                 )}
               />
             ),

--- a/frontend/src/components/ingress/List.tsx
+++ b/frontend/src/components/ingress/List.tsx
@@ -39,7 +39,7 @@ function RulesDisplay(props: { ingress: Ingress }) {
           } else if (!!backend.resource) {
             target = `${backend.resource.kind}:${backend.resource.name}`;
           }
-          return `${path} 🞂 ${target}`;
+          return `${path} › ${target}`;
         }) ?? '';
       labels = labels.concat(text);
     });

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -214,11 +214,11 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
                   >
                     <span
-                      aria-label="testsecret-tls 🞂 https-example.foo.com"
+                      aria-label="testsecret-tls › https-example.foo.com"
                       class=""
                       data-mui-internal-clone-element="true"
                     >
-                      testsecret-tls 🞂 https-example.foo.com
+                      testsecret-tls › https-example.foo.com
                     </span>
                   </dd>
                   <dt

--- a/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
@@ -214,11 +214,11 @@
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
                   >
                     <span
-                      aria-label="wildcard-cert 🞂 *.one.domain.tld, *.two.domain.tld"
+                      aria-label="wildcard-cert › *.one.domain.tld, *.two.domain.tld"
                       class=""
                       data-mui-internal-clone-element="true"
                     >
-                      wildcard-cert 🞂 *.one.domain.tld, *.two.domain.tld
+                      wildcard-cert › *.one.domain.tld, *.two.domain.tld
                     </span>
                   </dd>
                   <dt

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -740,12 +740,12 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ccolv7-MuiTableCell-root"
               >
                 <span
-                  aria-label="/ 🞂 service1:80
-/second 🞂 service2:someport"
+                  aria-label="/ › service1:80
+/second › service2:someport"
                   class=""
                   data-mui-internal-clone-element="true"
                 >
-                  / 🞂 service1:80, /second 🞂 service2:someport
+                  / › service1:80, /second › service2:someport
                 </span>
               </td>
               <td
@@ -847,11 +847,11 @@
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ccolv7-MuiTableCell-root"
               >
                 <span
-                  aria-label="/ 🞂 Service:service1"
+                  aria-label="/ › Service:service1"
                   class=""
                   data-mui-internal-clone-element="true"
                 >
-                  / 🞂 Service:service1
+                  / › Service:service1
                 </span>
               </td>
               <td


### PR DESCRIPTION
## Summary

Headlmap's `Ingress` details and list display a path-to-target mapping. To visually represent this, the "Black Right-Pointing Isosceles Right Triangle" ([`U+1F782`](https://codepoints.net/U+1F782)) is used. This glyph is part of the more recently introduced "Geometric Shapes Extended" category from [Unicode 7.0](https://www.unicode.org/versions/Unicode7.0.0). While supported by Headlamp's default font, specifying a different font in a custom theme that doesn't support it leads to it being rendered as a crossed-out square ("tofu"). This PR replaces the existing glyph with "Single Right-Pointing Angle Quotation Mark" ([`U+203A`](https://codepoints.net/U+203A)) from the more widely supported "General Punctuation" category.

## Changes

- Updated `Details.tsx` and `List.tsx` for `frontend/src/components/ingress`.
- Updated Storybook assets to match the component changes.

## Steps to Test

1. Launch locally with Minikube:

    ```shell
    $ minikube start \
      --addons=ingress \
      --container-runtime=containerd \
      --docker-opt containerd=/var/run/containerd/containerd.sock \
      --kubernetes-version=v1.35.0
    $ tmux new-session -d -s frontend 'make frontend-install run-frontend'
    $ tmux new-session -d -s backend 'make backend run-backend'
    ```

2. Open Headlamp UI in the browser.
3. Navigate to <kbd>Network</kbd> › <kbd>Ingresses</kbd> and create a new `Ingress` resource:

    ```yaml
    apiVersion: networking.k8s.io/v1
    kind: Ingress
    metadata:
      name: test
    spec:
      ingressClassName: nginx
      rules:
        - host: example.com
          http:
            paths:
              - path: /
                pathType: Prefix
                backend:
                  service:
                    name: test
                    port:
                      number: 80
    ```

## Screenshots

<table>
  <tbody>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
    <tr>
      <td>
        <img width="860" height="385" alt="before" src="https://github.com/user-attachments/assets/7737538f-4e34-41e0-bcb2-bae5bc658450" />        
      </td>
      <td>
        <img width="860" height="385" alt="after" src="https://github.com/user-attachments/assets/b49b4360-f76c-41fb-b901-b67a76b9ab64" />
      </td>
    </tr>
  </tbody>
</table>

## Notes for the Reviewer

- I've also considered using the "Triangular Bullet" ([`U+2023`](https://codepoints.net/U+2023)) glyph from the same category, but the chevron seemed like a cleaner choice to me.