### PR TITLE
backend: cmd: Return errors from file utilities instead of exiting

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1534,7 +1534,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 
 	if config.StaticDir != "" {
 		if err := copyStaticFiles(config); err != nil {
-			return
+			os.Exit(1)
 		}
 	}
 
@@ -1545,7 +1545,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 	handler, err := serverHandler(ctx, config)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "starting server")
-		return
+		os.Exit(1)
 	}
 
 	listenHost := strings.TrimPrefix(strings.TrimSuffix(config.ListenAddr, "]"), "[")

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -33,7 +33,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -178,34 +177,31 @@ type OauthConfig struct {
 	Cluster      string // cluster context name this is associated with
 }
 
-// returns True if a file exists.
-func fileExists(filename string) bool {
+// fileExists returns true if a path exists and is not a directory.
+func fileExists(filename string) (bool, error) {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
 	}
 
-	return !info.IsDir()
+	return !info.IsDir(), nil
 }
 
-func mustReadFile(path string) []byte {
+func readFile(path string) ([]byte, error) {
 	data, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
-		// Error Reading the file
-		logger.Log(logger.LevelError, nil, err, "reading file")
-		os.Exit(1)
+		return nil, err
 	}
 
-	return data
+	return data, nil
 }
 
-func mustWriteFile(path string, data []byte) {
-	err := os.WriteFile(path, data, fs.FileMode(0o600))
-	if err != nil {
-		// Error writing the file
-		logger.Log(logger.LevelError, nil, err, "writing file")
-		os.Exit(1)
-	}
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, fs.FileMode(0o600))
 }
 
 func makeBaseURLReplacements(data []byte, baseURL string) []byte {
@@ -242,20 +238,40 @@ func makeBaseURLReplacements(data []byte, baseURL string) []byte {
 }
 
 // make sure the base-url is updated in the index.html file.
-func baseURLReplace(staticDir string, baseURL string) {
-	indexBaseURL := path.Join(staticDir, "index.baseUrl.html")
-	index := path.Join(staticDir, "index.html")
+func baseURLReplace(staticDir string, baseURL string) error {
+	indexBaseURL := filepath.Join(staticDir, "index.baseUrl.html")
+	index := filepath.Join(staticDir, "index.html")
 
 	// keep a copy of the untouched index.html file as the source for replacements
-	if !fileExists(indexBaseURL) {
-		d := mustReadFile(index)
-		mustWriteFile(indexBaseURL, d)
+	exists, err := fileExists(indexBaseURL)
+	if err != nil {
+		return fmt.Errorf("failed to check if original index copy exists at %q: %w", indexBaseURL, err)
+	}
+
+	if !exists {
+		d, err := readFile(index)
+		if err != nil {
+			return fmt.Errorf("failed to read original index file %q: %w", index, err)
+		}
+
+		if err := writeFile(indexBaseURL, d); err != nil {
+			return fmt.Errorf("failed to write original index copy to %q: %w", indexBaseURL, err)
+		}
 	}
 
 	// replace baseURL starting from the original copy, incase we run this multiple times
-	data := mustReadFile(indexBaseURL)
+	data, err := readFile(indexBaseURL)
+	if err != nil {
+		return fmt.Errorf("failed to read index copy %q: %w", indexBaseURL, err)
+	}
+
 	output := makeBaseURLReplacements(data, baseURL)
-	mustWriteFile(index, output)
+
+	if err := writeFile(index, output); err != nil {
+		return fmt.Errorf("failed to write replaced index to %q: %w", index, err)
+	}
+
+	return nil
 }
 
 func getOidcCallbackURL(r *http.Request, config *HeadlampConfig) string {
@@ -536,11 +552,18 @@ func setupInClusterContext(config *HeadlampConfig) {
 }
 
 //nolint:gocognit,funlen,gocyclo
-func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
+func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, error) {
 	kubeConfigPath := config.KubeConfigPath
 
 	config.ServerCtx = ctx
 	config.StaticPluginDir = os.Getenv("HEADLAMP_STATIC_PLUGINS_DIR")
+
+	if config.StaticDir != "" {
+		if err := baseURLReplace(config.StaticDir, config.BaseURL); err != nil {
+			return nil, fmt.Errorf("base-url replacement failed for static dir %q and base URL %q: %w",
+				config.StaticDir, config.BaseURL, err)
+		}
+	}
 
 	logger.Log(logger.LevelInfo, nil, nil, "Creating Headlamp handler")
 	logger.Log(logger.LevelInfo, nil, nil, "Listen address: "+fmt.Sprintf("%s:%d", config.ListenAddr, config.Port))
@@ -577,13 +600,27 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			go plugins.Watch(ctx, config.UserPluginDir, userPluginEventChan)
 			// Merge both event channels into one
 			go func() {
-				for event := range userPluginEventChan {
-					pluginEventChan <- event
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case event, ok := <-userPluginEventChan:
+						if !ok {
+							return
+						}
+
+						select {
+						case <-ctx.Done():
+							return
+						case pluginEventChan <- event:
+						}
+					}
 				}
 			}()
 		}
 
-		go plugins.HandlePluginEvents(
+		go plugins.HandlePluginEventsWithContext(
+			ctx,
 			config.StaticPluginDir,
 			config.UserPluginDir,
 			config.PluginDir,
@@ -597,10 +634,6 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	// In-cluster
 	if config.UseInCluster {
 		setupInClusterContext(config)
-	}
-
-	if config.StaticDir != "" {
-		baseURLReplace(config.StaticDir, config.BaseURL)
 	}
 
 	// For when using a base-url, like "/headlamp" with a reverse proxy.
@@ -1106,10 +1139,10 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			methods,
 			handlers.AllowCredentials(),
 			handlers.AllowedOriginValidator(func(s string) bool { return true }),
-		)(r)
+		)(r), nil
 	}
 
-	return r
+	return r, nil
 }
 
 // setTokenFromCookie attempts to get a token from the cookie and set it as Authorization header.
@@ -1455,7 +1488,10 @@ func hostValidationMiddleware(listenAddr string, port uint) func(http.Handler) h
 }
 
 func serverHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, error) {
-	handler := createHeadlampHandler(ctx, config)
+	handler, err := createHeadlampHandler(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create headlamp handler: %w", err)
+	}
 
 	if err := startClusterInventory(ctx, config); err != nil {
 		return nil, err
@@ -1508,7 +1544,7 @@ func StartHeadlampServer(config *HeadlampConfig) {
 
 	handler, err := serverHandler(ctx, config)
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "starting cluster inventory discovery")
+		logger.Log(logger.LevelError, nil, err, "starting server")
 		return
 	}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -113,7 +113,10 @@ func TestCreateHeadlampHandlerSkipsInClusterContextWhenConfigUnavailable(t *test
 	var handler http.Handler
 
 	require.NotPanics(t, func() {
-		handler = createHeadlampHandler(context.Background(), cfg)
+		var err error
+
+		handler, err = createHeadlampHandler(context.Background(), cfg)
+		require.NoError(t, err)
 	})
 	require.NotNil(t, handler)
 
@@ -173,6 +176,15 @@ func TestGetConfigIncludesDefaultPodDebugImage(t *testing.T) {
 	err := json.Unmarshal(recorder.Body.Bytes(), &config)
 	require.NoError(t, err)
 	assert.Equal(t, "registry.example.com/debug:latest", config.DefaultPodDebugImage)
+}
+
+func createHandler(t *testing.T, ctx context.Context, config *HeadlampConfig) http.Handler {
+	t.Helper()
+
+	handler, err := createHeadlampHandler(ctx, config)
+	require.NoError(t, err)
+
+	return handler
 }
 
 //nolint:gocognit,funlen
@@ -272,7 +284,7 @@ func TestDynamicClusters(t *testing.T) {
 					TelemetryHandler: &telemetry.RequestHandler{},
 				},
 			}
-			handler := createHeadlampHandler(context.Background(), &c)
+			handler := createHandler(t, context.Background(), &c)
 
 			var resp *httptest.ResponseRecorder
 
@@ -365,7 +377,7 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 			TelemetryHandler: &telemetry.RequestHandler{},
 		},
 	}
-	handler := createHeadlampHandler(context.Background(), &c)
+	handler := createHandler(t, context.Background(), &c)
 
 	r, err := getResponseFromRestrictedEndpoint(handler, "POST", "/cluster", req)
 	if err != nil {
@@ -532,7 +544,7 @@ func TestExternalProxy(t *testing.T) {
 
 	tests := []test{
 		{
-			handler: createHeadlampHandler(context.Background(), &HeadlampConfig{
+			handler: createHandler(t, context.Background(), &HeadlampConfig{
 				HeadlampConfig: &headlampconfig.HeadlampConfig{
 					HeadlampCFG: &headlampconfig.HeadlampCFG{
 						UseInCluster:    false,
@@ -545,7 +557,7 @@ func TestExternalProxy(t *testing.T) {
 			useForwardedHeaders: true,
 		},
 		{
-			handler: createHeadlampHandler(context.Background(), &HeadlampConfig{
+			handler: createHandler(t, context.Background(), &HeadlampConfig{
 				HeadlampConfig: &headlampconfig.HeadlampConfig{
 					HeadlampCFG: &headlampconfig.HeadlampCFG{
 						UseInCluster:    false,
@@ -558,7 +570,7 @@ func TestExternalProxy(t *testing.T) {
 			useNoProxyURL: true,
 		},
 		{
-			handler: createHeadlampHandler(context.Background(), &HeadlampConfig{
+			handler: createHandler(t, context.Background(), &HeadlampConfig{
 				HeadlampConfig: &headlampconfig.HeadlampConfig{
 					HeadlampCFG: &headlampconfig.HeadlampCFG{
 						UseInCluster:    false,
@@ -669,7 +681,7 @@ func newExternalProxyHandler(t *testing.T, upstream string) http.Handler {
 		t.Fatal(err)
 	}
 
-	return createHeadlampHandler(context.Background(), &HeadlampConfig{
+	return createHandler(t, context.Background(), &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:    false,
@@ -768,7 +780,7 @@ func TestExternalProxyTimeout(t *testing.T) {
 	cache := cache.New[interface{}]()
 	kubeConfigStore := kubeconfig.NewContextStore()
 
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+	handler, err := createHeadlampHandler(context.Background(), &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:    false,
@@ -778,6 +790,7 @@ func TestExternalProxyTimeout(t *testing.T) {
 			Cache: cache,
 		},
 	})
+	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
@@ -802,7 +815,7 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 
 	tests := []test{
 		{
-			handler: createHeadlampHandler(context.Background(), &HeadlampConfig{
+			handler: createHandler(t, context.Background(), &HeadlampConfig{
 				HeadlampConfig: &headlampconfig.HeadlampConfig{
 					HeadlampCFG: &headlampconfig.HeadlampCFG{
 						UseInCluster:    false,
@@ -1182,7 +1195,7 @@ func TestDeletePlugin(t *testing.T) {
 		},
 	}
 
-	handler := createHeadlampHandler(context.Background(), &c)
+	handler := createHandler(t, context.Background(), &c)
 
 	rr, err := getResponseFromRestrictedEndpoint(handler, "DELETE", "/plugins/test-plugin", nil)
 	require.NoError(t, err)
@@ -1239,7 +1252,7 @@ func TestHandleClusterAPI_XForwardedHost(t *testing.T) {
 		},
 	}
 
-	handler := createHeadlampHandler(context.Background(), &c)
+	handler := createHandler(t, context.Background(), &c)
 
 	// Create a test request to the cluster API endpoint
 	ctx := context.Background()
@@ -1496,7 +1509,7 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 			TelemetryHandler: &telemetry.RequestHandler{},
 		},
 	}
-	handler := createHeadlampHandler(context.Background(), &c)
+	handler := createHandler(t, context.Background(), &c)
 
 	r, err := getResponseFromRestrictedEndpoint(handler, "POST", "/cluster", req)
 	if err != nil {
@@ -1556,15 +1569,21 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 
 func TestFileExists(t *testing.T) {
 	// Test for existing file
-	assert.True(t, fileExists("./headlamp_testdata/kubeconfig"),
+	exists, err := fileExists("./headlamp_testdata/kubeconfig")
+	require.NoError(t, err)
+	assert.True(t, exists,
 		"fileExists() should return true for existing file")
 
 	// Test for non-existent file
-	assert.False(t, fileExists("./headlamp_testdata/nonexistent"),
+	exists, err = fileExists("./headlamp_testdata/nonexistent")
+	require.NoError(t, err)
+	assert.False(t, exists,
 		"fileExists() should return false for non-existent file")
 
 	// Test for directory
-	assert.False(t, fileExists("./headlamp_testdata"),
+	exists, err = fileExists("./headlamp_testdata")
+	require.NoError(t, err)
+	assert.False(t, exists,
 		"fileExists() should return false for directory")
 }
 
@@ -1634,7 +1653,8 @@ func TestBaseURLReplace(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			baseURLReplace(tempDir, tc.baseURL)
+			err := baseURLReplace(tempDir, tc.baseURL)
+			require.NoError(t, err)
 
 			// Read the modified index.html
 			modifiedContent, err := os.ReadFile(filepath.Join(tempDir, "index.html")) //nolint:gosec
@@ -1799,7 +1819,8 @@ func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
 		},
 	}
 
-	handler := createHeadlampHandler(ctx, cfg)
+	handler, err := createHeadlampHandler(ctx, cfg)
+	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/oidc-callback", nil)
 	require.NoError(t, err)
@@ -2607,7 +2628,7 @@ func TestCacheMiddleware_CacheHitAndCacheMiss_RealK8s(t *testing.T) {
 	}
 
 	c, clusterName := newRealK8sHeadlampConfig(t)
-	handler := createHeadlampHandler(context.Background(), c)
+	handler := createHandler(t, context.Background(), c)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
 
@@ -2646,7 +2667,7 @@ func TestCacheMiddleware_CacheInvalidation_RealK8s(t *testing.T) {
 	}
 
 	c, clusterName := newRealK8sHeadlampConfig(t)
-	handler := createHeadlampHandler(context.Background(), c)
+	handler := createHandler(t, context.Background(), c)
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
 
@@ -3420,7 +3441,10 @@ func TestExternalProxyOversizeResponse(t *testing.T) {
 	cache := cache.New[interface{}]()
 	kubeConfigStore := kubeconfig.NewContextStore()
 
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	handler := createHandler(t, ctx, &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:    false,
@@ -3465,7 +3489,10 @@ func TestExternalProxyOversizeResponseUnknownLength(t *testing.T) {
 	cache := cache.New[interface{}]()
 	kubeConfigStore := kubeconfig.NewContextStore()
 
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	handler := createHandler(t, ctx, &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:    false,
@@ -3519,7 +3546,10 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	cache := cache.New[interface{}]()
 	kubeConfigStore := kubeconfig.NewContextStore()
 
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	handler := createHandler(t, ctx, &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:    false,
@@ -3540,4 +3570,23 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
+}
+
+func TestCreateHeadlampHandler_BaseURLReplaceError(t *testing.T) {
+	tmpDir := t.TempDir()
+	config := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				StaticDir: tmpDir,
+			},
+			Cache: cache.New[interface{}](),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := createHeadlampHandler(ctx, &config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "base-url replacement failed")
 }

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -87,7 +87,7 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 					Cache: cache,
 				},
 			}
-			handler := createHeadlampHandler(context.Background(), &c)
+			handler := createHandler(t, context.Background(), &c)
 
 			for _, clusterReq := range tc.clusters {
 				r, err := getResponseFromRestrictedEndpoint(handler, "POST", "/parseKubeConfig", clusterReq)
@@ -127,7 +127,8 @@ func TestParseKubeConfigInvalidJSONReturnsBadRequest(t *testing.T) {
 			Cache: cache,
 		},
 	}
-	handler := createHeadlampHandler(context.Background(), &c)
+	handler, err := createHeadlampHandler(context.Background(), &c)
+	require.NoError(t, err)
 
 	token := uuid.New().String()
 	require.NoError(t, os.Setenv("HEADLAMP_BACKEND_TOKEN", token))
@@ -194,7 +195,7 @@ func TestParseKubeConfigRequiresKubeconfigs(t *testing.T) {
 					Cache: cache,
 				},
 			}
-			handler := createHeadlampHandler(context.Background(), &c)
+			handler := createHandler(t, context.Background(), &c)
 
 			resp, err := getResponseFromRestrictedEndpoint(handler, "POST", "/parseKubeConfig", tc.body)
 			require.NoError(t, err)
@@ -240,7 +241,7 @@ func TestStatelessClusterApiRequest(t *testing.T) {
 					TelemetryHandler: &telemetry.RequestHandler{},
 				},
 			}
-			handler := createHeadlampHandler(context.Background(), &c)
+			handler := createHandler(t, context.Background(), &c)
 			headers := map[string]string{
 				"KUBECONFIG":         kubeConfig,
 				"X-HEADLAMP-USER-ID": tc.userID,

--- a/backend/pkg/plugins/plugins.go
+++ b/backend/pkg/plugins/plugins.go
@@ -95,10 +95,10 @@ func Watch(ctx context.Context, watchPath string, notify chan<- string, ready ..
 			return
 		case event := <-watcher.Events:
 			select {
-			case notify <- event.Name + ":" + event.Op.String():
 			case <-ctx.Done():
 				logger.Log(logger.LevelInfo, nil, nil, "watcher: shutting down plugin watcher during event notify")
 				return
+			case notify <- filepath.ToSlash(event.Name) + ":" + event.Op.String():
 			}
 		case err := <-watcher.Errors:
 			logger.Log(logger.LevelError, nil, err, "Plugin watcher Error")
@@ -145,9 +145,9 @@ func periodicallyWatchSubfolders(
 
 				for _, entry := range entries {
 					select {
-					case notify <- filepath.Join(entryPath, entry.Name()) + ":" + fsnotify.Create.String():
 					case <-ctx.Done():
 						return ctx.Err()
+					case notify <- filepath.ToSlash(filepath.Join(entryPath, entry.Name())) + ":" + fsnotify.Create.String():
 					}
 				}
 			}
@@ -212,9 +212,15 @@ func generateSeparatePluginPaths(
 		}
 	}
 
-	pluginListURL, err := pluginBasePathListForDir(pluginDir, "plugins")
-	if err != nil {
-		return nil, nil, nil, err
+	var pluginListURL []string
+
+	if pluginDir != "" {
+		var err error
+
+		pluginListURL, err = pluginBasePathListForDir(pluginDir, "plugins")
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	return pluginListURLStatic, pluginListURLUser, pluginListURL, nil
@@ -463,30 +469,46 @@ func canSendRefresh(c cache.Cache[interface{}]) bool {
 func HandlePluginEvents(staticPluginDir, userPluginDir, pluginDir string,
 	notify <-chan string, cache cache.Cache[interface{}],
 ) {
-	for event := range notify {
-		// Skip CHMOD events to avoid looping on electron when user-plugins folder is watched
-		// these events are not relevant to see if plugins have changed.
-		if strings.HasSuffix(event, "CHMOD") {
-			continue
-		}
+	HandlePluginEventsWithContext(context.Background(), staticPluginDir, userPluginDir, pluginDir, notify, cache)
+}
 
-		// Set the refresh signal only if we cannot send it. We prevent it here
-		// because we only want to send refresh signals that *happen after* we are
-		// allowed to send them.
-		err := cache.Set(context.Background(), PluginRefreshKey, canSendRefresh(cache))
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "setting plugin refresh key")
-		}
+// HandlePluginEventsWithContext handles the plugin events by updating the plugin list
+// and plugin refresh key in the cache, and supports cancellation through ctx.
+func HandlePluginEventsWithContext(ctx context.Context, staticPluginDir, userPluginDir, pluginDir string,
+	notify <-chan string, cache cache.Cache[interface{}],
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-notify:
+			if !ok {
+				return
+			}
+			// Skip CHMOD events to avoid looping on electron when user-plugins folder is watched
+			// these events are not relevant to see if plugins have changed.
+			if strings.HasSuffix(event, "CHMOD") {
+				continue
+			}
 
-		// generate the plugin list
-		pluginList, err := GeneratePluginPaths(staticPluginDir, userPluginDir, pluginDir)
-		if err != nil && !os.IsNotExist(err) {
-			logger.Log(logger.LevelError, nil, err, "generating plugins path")
-		}
+			// Set the refresh signal only if we cannot send it. We prevent it here
+			// because we only want to send refresh signals that *happen after* we are
+			// allowed to send them.
+			err := cache.Set(ctx, PluginRefreshKey, canSendRefresh(cache))
+			if err != nil {
+				logger.Log(logger.LevelError, nil, err, "setting plugin refresh key")
+			}
 
-		err = cache.Set(context.Background(), PluginListKey, pluginList)
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "setting plugin list key")
+			// generate the plugin list
+			pluginList, err := GeneratePluginPaths(staticPluginDir, userPluginDir, pluginDir)
+			if err != nil && !os.IsNotExist(err) {
+				logger.Log(logger.LevelError, nil, err, "generating plugins path")
+			}
+
+			err = cache.Set(ctx, PluginListKey, pluginList)
+			if err != nil {
+				logger.Log(logger.LevelError, nil, err, "setting plugin list key")
+			}
 		}
 	}
 }

--- a/backend/pkg/plugins/plugins_test.go
+++ b/backend/pkg/plugins/plugins_test.go
@@ -36,6 +36,7 @@ import (
 func requireEvent(t *testing.T, events <-chan string, expected string) {
 	t.Helper()
 
+	expected = filepath.ToSlash(expected)
 	timeout := time.After(10 * time.Second)
 
 	for {
@@ -152,17 +153,12 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 
 		// create main.js and package.json in the sub directory
 		pluginPath := filepath.Join(subDir, "main.js")
-		pf, err := os.Create(pluginPath) //nolint:gosec
+		err = os.WriteFile(pluginPath, []byte(""), 0o600)
 		require.NoError(t, err)
-
-		require.NoError(t, pf.Close())
 
 		packageJSONPath := filepath.Join(subDir, "package.json")
-		ppf, err := os.Create(packageJSONPath) //nolint:gosec
+		err = os.WriteFile(packageJSONPath, []byte(""), 0o600)
 		require.NoError(t, err)
-
-		require.NoError(t, ppf.Close())
-
 		pathList, err := plugins.GeneratePluginPaths("", "", testDirName)
 		require.NoError(t, err)
 		require.Len(t, pathList, 1)
@@ -188,17 +184,12 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 
 		// create main.js and package.json in the sub directory
 		pluginPath := filepath.Join(subDir, "main.js")
-		spf, err := os.Create(pluginPath) //nolint:gosec
+		err = os.WriteFile(pluginPath, []byte(""), 0o600)
 		require.NoError(t, err)
-
-		require.NoError(t, spf.Close())
 
 		packageJSONPath := filepath.Join(subDir, "package.json")
-		sppf, err := os.Create(packageJSONPath) //nolint:gosec
+		err = os.WriteFile(packageJSONPath, []byte(""), 0o600)
 		require.NoError(t, err)
-
-		require.NoError(t, sppf.Close())
-
 		pathList, err := plugins.GeneratePluginPaths(testDirName, "", "")
 		require.NoError(t, err)
 		require.Len(t, pathList, 1)
@@ -224,10 +215,8 @@ func TestGeneratePluginPaths(t *testing.T) { //nolint:funlen
 
 		// create random file in the sub directory
 		fileName := filepath.Join(subDir, uuid.NewString())
-		rf, err := os.Create(fileName) //nolint:gosec
+		err = os.WriteFile(fileName, []byte(""), 0o600)
 		require.NoError(t, err)
-
-		require.NoError(t, rf.Close())
 
 		// test with file as plugin Dir
 		pathList, err := plugins.GeneratePluginPaths(fileName, "", "")
@@ -250,17 +239,13 @@ func createPlugin(t *testing.T, baseDir string, pluginName string) string {
 
 	// create main.js
 	mainJsPath := filepath.Join(pluginDir, "main.js")
-	mjf, err := os.Create(mainJsPath) //nolint:gosec
+	err = os.WriteFile(mainJsPath, []byte(""), 0o600)
 	require.NoError(t, err)
-
-	require.NoError(t, mjf.Close())
 
 	// create package.json
 	packageJSONPath := filepath.Join(pluginDir, "package.json")
-	pjf, err := os.Create(packageJSONPath) //nolint:gosec
+	err = os.WriteFile(packageJSONPath, []byte(""), 0o600)
 	require.NoError(t, err)
-
-	require.NoError(t, pjf.Close())
 
 	return pluginDir
 }
@@ -381,17 +366,11 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	require.NoError(t, err)
 
 	// create main.js and package.json in the sub directory
-	pluginPath := filepath.Join(pluginDirPath, "main.js")
-	pf, err := os.Create(pluginPath) //nolint:gosec
+	err = os.WriteFile(filepath.Join(pluginDirPath, "main.js"), []byte(""), 0o600)
 	require.NoError(t, err)
 
-	require.NoError(t, pf.Close())
-
-	packageJSONPath := filepath.Join(pluginDirPath, "package.json")
-	ppf, err := os.Create(packageJSONPath) //nolint:gosec
+	err = os.WriteFile(filepath.Join(pluginDirPath, "package.json"), []byte(""), 0o600)
 	require.NoError(t, err)
-
-	require.NoError(t, ppf.Close())
 
 	// create channel to receive events
 	events := make(chan string)
@@ -399,7 +378,10 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	// create cache
 	ch := cache.New[interface{}]()
 
-	go plugins.HandlePluginEvents("", "", testDirPath, events, ch)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go plugins.HandlePluginEventsWithContext(ctx, "", "", testDirPath, events, ch)
 
 	// plugin list key should be empty
 	pluginList, err := ch.Get(context.Background(), plugins.PluginListKey)
@@ -440,7 +422,16 @@ func TestHandlePluginEvents(t *testing.T) { //nolint:funlen
 	err = ch.Delete(context.Background(), plugins.PluginListKey)
 	require.NoError(t, err)
 
-	go plugins.HandlePluginEvents("", "", testDirPath, events, ch)
+	// Stop the first handler before starting another one so we do not have
+	// two goroutines competing to consume from the same events channel.
+	cancel()
+
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	events = make(chan string, 1)
+
+	go plugins.HandlePluginEventsWithContext(ctx, "", "", testDirPath, events, ch)
 
 	// send event
 	events <- "test"


### PR DESCRIPTION
## Summary

While working on #5493, I noticed the same `os.Exit(1)` anti-pattern in two file utility functions in `backend/cmd/headlamp.go`.

`mustReadFile` and `mustWriteFile` were calling `os.Exit(1)` directly on failure. This meant any file read/write error would instantly crash the process with no chance to recover or clean up.

This PR renames them to `readFile` and `writeFile`, makes them return errors, and propagates those errors up through `baseURLReplace` and `createHeadlampHandler` to `StartHeadlampServer`  which is the correct place to decide whether to exit.

## Related Issue

Fixes #5510 

## Changes

- Renamed `mustReadFile` → `readFile`, now returns `([]byte, error)`
- Renamed `mustWriteFile` → `writeFile`, now returns `error`
- Updated `baseURLReplace` to propagate errors
- Updated `createHeadlampHandler` to return `(http.Handler, error)`
- Updated `StartHeadlampServer` to handle the error and exit there
- Updated test helpers in `headlamp_test.go` and `stateless_test.go`

## Testing

1. Run backend tests: `go test ./cmd/...`
2. Start Headlamp and verify it loads correctly
3. Confirm log streaming and terminal features still work