### PR TITLE
frontend: GlobalSearch: Fix WCAG contrast for search hint

### DIFF
--- a/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
@@ -52,7 +52,7 @@
                       value=""
                     />
                     <div
-                      class="MuiBox-root css-1rstwa7"
+                      class="MuiBox-root css-yqa0zz"
                     >
                       Press
                       <kbd

--- a/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
@@ -52,7 +52,7 @@
                       value=""
                     />
                     <div
-                      class="MuiBox-root css-1rstwa7"
+                      class="MuiBox-root css-yqa0zz"
                     >
                       Press
                       <kbd

--- a/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
@@ -52,7 +52,7 @@
                       value=""
                     />
                     <div
-                      class="MuiBox-root css-1rstwa7"
+                      class="MuiBox-root css-yqa0zz"
                     >
                       Press
                       <kbd

--- a/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
@@ -52,7 +52,7 @@
                       value=""
                     />
                     <div
-                      class="MuiBox-root css-1rstwa7"
+                      class="MuiBox-root css-yqa0zz"
                     >
                       Press
                       <kbd

--- a/frontend/src/components/globalSearch/GlobalSearch.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearch.tsx
@@ -112,7 +112,12 @@ export function GlobalSearch({ isIconButton }: { isIconButton?: boolean }) {
           </InputAdornment>
         ),
         endAdornment: (
-          <Box display="flex" flexShrink={0} gap={0.5} sx={{ opacity: 0.7, pointerEvents: 'none' }}>
+          <Box
+            display="flex"
+            flexShrink={0}
+            gap={0.5}
+            sx={{ color: theme.palette.navbar.searchHint, pointerEvents: 'none' }}
+          >
             <Trans>
               Press
               <Box

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearch.BasicExample.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearch.BasicExample.stories.storyshot
@@ -30,7 +30,7 @@
               value=""
             />
             <div
-              class="MuiBox-root css-1rstwa7"
+              class="MuiBox-root css-yqa0zz"
             >
               Press
               <kbd

--- a/frontend/src/lib/AppTheme.ts
+++ b/frontend/src/lib/AppTheme.ts
@@ -58,6 +58,8 @@ export interface AppTheme {
     background?: string;
     /** Text and icon color of the navbar */
     color?: string;
+    /** Global search shortcut hint (falls back in createMuiTheme if omitted) */
+    searchHint?: string;
   };
   /** General shape radius (things like buttons, popups, etc) */
   radius?: number;

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -34,6 +34,27 @@ describe('themes.ts', () => {
       expect(theme.palette.mode).toBe('dark');
       expect(theme.palette.background.default).toBe('#1f1f1f');
     });
+
+    it('should set searchHint defaults for light and dark themes', () => {
+      const lightTheme = createMuiTheme({ base: 'light', name: 'Light Theme' });
+      const darkTheme = createMuiTheme({ base: 'dark', name: 'Dark Theme' });
+
+      expect(lightTheme.palette.navbar.searchHint).toBe('#74747B');
+      expect(darkTheme.palette.navbar.searchHint).toBe('rgba(255, 255, 255, 0.7)');
+    });
+
+    it('should allow navbar searchHint override from AppTheme', () => {
+      const customTheme: AppTheme = {
+        base: 'dark',
+        name: 'Custom Theme',
+        navbar: {
+          searchHint: '#123456',
+        },
+      };
+      const theme = createMuiTheme(customTheme);
+
+      expect(theme.palette.navbar.searchHint).toBe('#123456');
+    });
   });
 
   describe('getThemeName', () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -105,6 +105,7 @@ export interface HeadlampSidebar {
 export interface HeadlampNavbar {
   background: string;
   color: string;
+  searchHint: string;
 }
 
 declare module '@mui/material/styles/createPalette.d' {
@@ -218,6 +219,7 @@ export function createMuiTheme(currentTheme: AppTheme) {
       navbar: {
         background: currentTheme.navbar?.background ?? '#FFF',
         color: currentTheme.navbar?.color ?? '#333',
+        searchHint: '#74747B',
       },
       clusterChooser: {
         button: {
@@ -446,6 +448,10 @@ export function createMuiTheme(currentTheme: AppTheme) {
         },
         notificationBorderColor: 'rgba(255,255,255,0.12)',
         mode: 'dark',
+        navbar: {
+          ...commonRules.palette.navbar,
+          searchHint: 'rgba(255, 255, 255, 0.7)',
+        },
         background: {
           default: currentTheme.background?.default ?? '#1f1f1f',
           paper: currentTheme.background?.surface ?? '#1f1f1f',

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -219,7 +219,7 @@ export function createMuiTheme(currentTheme: AppTheme) {
       navbar: {
         background: currentTheme.navbar?.background ?? '#FFF',
         color: currentTheme.navbar?.color ?? '#333',
-        searchHint: '#74747B',
+        searchHint: currentTheme.navbar?.searchHint ?? '#74747B',
       },
       clusterChooser: {
         button: {
@@ -450,7 +450,7 @@ export function createMuiTheme(currentTheme: AppTheme) {
         mode: 'dark',
         navbar: {
           ...commonRules.palette.navbar,
-          searchHint: 'rgba(255, 255, 255, 0.7)',
+          searchHint: currentTheme.navbar?.searchHint ?? 'rgba(255, 255, 255, 0.7)',
         },
         background: {
           default: currentTheme.background?.default ?? '#1f1f1f',

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -450,6 +450,8 @@ export function createMuiTheme(currentTheme: AppTheme) {
         mode: 'dark',
         navbar: {
           ...commonRules.palette.navbar,
+          background: currentTheme.navbar?.background ?? '#1f1f1f',
+          color: currentTheme.navbar?.color ?? '#fff',
           searchHint: currentTheme.navbar?.searchHint ?? 'rgba(255, 255, 255, 0.7)',
         },
         background: {


### PR DESCRIPTION
## Summary

Fixes insufficient contrast for the top-bar global search shortcut
hint ("Press … to search") by replacing opacity-based dimming with
an explicit theme color (`palette.navbar.searchHint`). Custom
`AppTheme` definitions can set `navbar.searchHint` when needed.

## Related Issue

Fixes #4593

## Changes

- Add `palette.navbar.searchHint` in `createMuiTheme` (light/dark
  defaults + optional `AppTheme.navbar.searchHint`).
- Use that token in `GlobalSearch` for the hint text color.
- Update affected Storybook snapshots (GlobalSearch + Layout).

## Steps to Test

1. Run the app with the default light theme; confirm the unfocused
   search field shows the hint with readable contrast.
2. Switch to a dark theme and confirm the hint still looks correct.

## Screenshot

<img width="1462" height="982" alt="image" src="https://github.com/user-attachments/assets/f53ce9c2-bfd6-403e-9186-60b3f3f6d158" />


## Notes for the Reviewer

- Snapshot diffs are Emotion class hash updates where GlobalSearch is
  embedded in Layout stories.