### PR TITLE
backend: Reuse a configured HTTP client in /externalproxy

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -167,6 +167,40 @@ const (
 	logFieldDurationMs = "duration_ms"
 )
 
+// externalProxyClient is the shared HTTP client used by the /externalproxy
+// handler. It is configured with transport-level timeouts so a slow or hung
+// upstream cannot block goroutines and exhaust file descriptors, and with a
+// larger per-host idle-connection pool than the net/http default so
+// connections can be reused under load.
+//
+// Redirects are not followed: an allowed upstream could otherwise return a
+// 30x pointing at a disallowed or internal address, which the client would
+// fetch server-side and bypass the /externalproxy allowlist. Returning
+// http.ErrUseLastResponse hands the 30x response back to the handler, which
+// forwards its status and Location header to the caller so the redirect can
+// still be followed client-side.
+//
+//nolint:gochecknoglobals // shared client reused across all proxy requests
+var externalProxyClient = &http.Client{
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	},
+}
+
 type clientConfig struct {
 	Clusters                []Cluster `json:"clusters"`
 	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
@@ -749,9 +783,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		w.Header().Set("Pragma", "no-cache")
 		w.Header().Set("X-Accel-Expires", "0")
 
-		client := http.Client{}
-
-		resp, err := client.Do(proxyReq) //nolint:gosec
+		resp, err := externalProxyClient.Do(proxyReq) //nolint:gosec
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "making request")
 			http.Error(w, err.Error(), http.StatusBadGateway)
@@ -801,6 +833,12 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			http.Error(w, "response too large", http.StatusBadGateway)
 
 			return
+		}
+
+		// Forward Location so the caller can act on redirect (30x) responses,
+		// which are passed through unfollowed rather than chased server-side.
+		if location := resp.Header.Get("Location"); location != "" {
+			w.Header().Set("Location", location)
 		}
 
 		w.WriteHeader(resp.StatusCode)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -36,6 +36,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -746,6 +747,171 @@ func TestExternalProxyStreamsLargeBody(t *testing.T) {
 
 	if read != size {
 		t.Errorf("streamed %d bytes, want %d", read, size)
+	}
+}
+
+func TestExternalProxyDoesNotFollowRedirects(t *testing.T) {
+	var secretHits int32
+
+	// A server that must never be reached server-side: it stands in for a
+	// disallowed or internal address a redirect could try to point at.
+	secret := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&secretHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer secret.Close()
+
+	// The allowed upstream redirects to the secret server.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, secret.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	handler := newExternalProxyHandler(t, upstream.URL)
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("proxy-to", upstream.URL)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Errorf("status code = %d, want %d (the redirect must be forwarded, not followed)",
+			rr.Code, http.StatusFound)
+	}
+
+	if hits := atomic.LoadInt32(&secretHits); hits != 0 {
+		t.Errorf("redirect target was fetched %d time(s); the allowlist must not be bypassable via redirects",
+			hits)
+	}
+
+	if location := rr.Header().Get("Location"); location != secret.URL {
+		t.Errorf("Location header = %q, want %q (the redirect must stay usable client-side)",
+			location, secret.URL)
+	}
+}
+
+func TestExternalProxyResponseHeaderTimeout(t *testing.T) {
+	originalTransport := externalProxyClient.Transport
+
+	baseTransport, ok := originalTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("externalProxyClient.Transport = %T, want *http.Transport", originalTransport)
+	}
+
+	clonedTransport := baseTransport.Clone()
+	clonedTransport.ResponseHeaderTimeout = 200 * time.Millisecond
+	externalProxyClient.Transport = clonedTransport
+
+	defer func() {
+		externalProxyClient.CloseIdleConnections()
+		externalProxyClient.Transport = originalTransport
+		externalProxyClient.CloseIdleConnections()
+	}()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler := newExternalProxyHandler(t, upstream.URL)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// A per-request deadline keeps the suite fail-fast: if the handler ever
+	// regresses and blocks, the request errors out instead of hanging until
+	// the overall go test timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", srv.URL+"/externalproxy", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("proxy-to", upstream.URL)
+
+	start := time.Now()
+
+	resp, err := http.DefaultClient.Do(req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status code = %d, want %d (timeout should produce 502)",
+			resp.StatusCode, http.StatusBadGateway)
+	}
+
+	if elapsed > 1*time.Second {
+		t.Errorf("request took %v, expected to fail fast (well under upstream's 2s sleep)", elapsed)
+	}
+}
+
+func TestExternalProxyReusesConnections(t *testing.T) {
+	var connCount int32
+
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		_, _ = w.Write([]byte("OK"))
+	}))
+
+	upstream.Config.ConnState = func(c net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			atomic.AddInt32(&connCount, 1)
+		}
+	}
+
+	upstream.Start()
+	defer upstream.Close()
+
+	handler := newExternalProxyHandler(t, upstream.URL)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	for i := 0; i < 5; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+		req, err := http.NewRequestWithContext(ctx, "GET", srv.URL+"/externalproxy", nil)
+		if err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+
+		req.Header.Set("proxy-to", upstream.URL)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("request %d: status code = %d, want %d", i, resp.StatusCode, http.StatusOK)
+		}
+
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		cancel()
+	}
+
+	got := atomic.LoadInt32(&connCount)
+	if got > 2 {
+		t.Errorf("upstream saw %d new connections across 5 sequential requests, "+
+			"expected ~1 with Keep-Alive enabled", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

The /externalproxy handler was newing up an http.Client{} on every incoming request, with no timeout and no custom transport. That meant a slow or hanging upstream would block the request goroutine forever, slowly leaking goroutines and file descriptors, and the default transport's pool limits applied per-host so under load the same TCP connections were getting torn down and rebuilt instead of reused.

This PR replaces that per-request client with a single shared package-level http.Client backed by a tuned http.Transport. The transport sets a ResponseHeaderTimeout so stalling upstreams get cut off, dial / TLS / continue timeouts so handshake failures don't hang either, and a larger idle-connection pool so Keep-Alive can actually reuse sockets.

I deliberately avoided setting a Client.Timeout because that includes body read time and would break legitimate long streaming responses (logs, anything tailed). The transport-level timeouts protect against the slow-headers case without that side effect, which is the same approach httputil.ReverseProxy takes.

## Related Issue

Fixes #5512

## Changes

- backend/cmd/headlamp.go: added a package-level externalProxyClient with a configured http.Transport (ResponseHeaderTimeout 30s, DialContext timeout 30s, MaxIdleConnsPerHost 10, etc.) and switched the /externalproxy handler to use it. The handler also forwards the Location header so 30x redirect responses stay usable client-side.
- backend/cmd/headlamp_test.go: added three tests.
  - TestExternalProxyResponseHeaderTimeout drives a slow upstream that sleeps 2s and confirms the proxy returns 502 in well under a second.
  - TestExternalProxyReusesConnections fires five sequential requests through the proxy and asserts the upstream sees roughly one new TCP connection (proves Keep-Alive is being used).
  - TestExternalProxyDoesNotFollowRedirects asserts that a 30x upstream response is forwarded as-is with the Location header intact, rather than being followed server-side.

## Steps to Test

1. cd backend then make backend and make backend-lint, both should be clean (0 issues from golangci-lint).
2. go test ./..., the full backend suite passes (14 packages).
3. go test -run TestExternalProxyResponseHeaderTimeout -v ./cmd/..., should pass and show the timeout firing before the upstream's own sleep returns.
4. go test -run TestExternalProxyReusesConnections -v ./cmd/..., should pass and confirm the upstream connection counter stays low.
5. go test -run TestExternalProxyDoesNotFollowRedirects -v ./cmd/..., should pass and confirm the Location header is forwarded and the response status stays in the 30x range.

## Screenshots (if applicable)

N/A, backend-only change.

## Notes for the Reviewer

- The shared client is exposed at package scope on purpose so tests can swap timeouts on it (the timeout test temporarily lowers ResponseHeaderTimeout to 200ms so the suite stays fast). Restored in defer.
- I did not touch the gzip handling block or the response writing block, those are unrelated to this issue.
- Pool sizes (MaxIdleConns 100, MaxIdleConnsPerHost 10) are conservative and just bigger than the net/http defaults of 100 and 2, happy to tune if you'd prefer different numbers.
- No frontend, type, or i18n impact.