### PR TITLE
frontend: fix listener leak in setupBackstageMessageReceiver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ lint: backend-lint frontend-lint
 lint-fix: backend-lint-fix frontend-lint-fix
 
 plugins-test:
+	cd plugins/headlamp-plugin && npm install --ignore-scripts && npm run build
 	cd plugins/headlamp-plugin && npm install && ./test-headlamp-plugin.js
 	cd plugins/headlamp-plugin && ./test-plugins-examples.sh
 	cd plugins/pluginctl/src && npm install && node ./plugin-management.e2e.js

--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -110,7 +110,7 @@ function HomeComponent(props: HomeComponentProps) {
   React.useEffect(() => {
     if (isBackstage()) {
       window.parent.postMessage({ type: 'HEADLAMP_READY' }, '*');
-      setupBackstageMessageReceiver();
+      return setupBackstageMessageReceiver();
     }
   }, []);
 

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -113,9 +113,9 @@ const BACKSTAGE_ACK_TIMEOUT_MS = 1000;
  * setupBackstageMessageReceiver sets up a listener for messages from the backstage app
  * and sets the backend token if it is received
  *
- * @returns void
+ * @returns a cleanup function that removes the event listener, or undefined if not in Backstage
  */
-export function setupBackstageMessageReceiver() {
+export function setupBackstageMessageReceiver(): (() => void) | undefined {
   if (isBackstage()) {
     const handleMessage = async (event: MessageEvent) => {
       try {
@@ -146,5 +146,6 @@ export function setupBackstageMessageReceiver() {
     };
 
     window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "app:verify-build-mac": "cd app && npm run verify-build-mac",
     "app:verify-build-windows": "cd app && npm run verify-build-windows",
     "tools:install": "cd tools && cd i18n && npm install && cd .. && cd releaser && npm install",
-    "plugins:test": "cd plugins/headlamp-plugin && npm install && ./test-headlamp-plugin.js && ./test-plugins-examples.sh && cd ../pluginctl/src && npm install && node ./plugin-management.e2e.js && cd .. && npx jest src/multi-plugin-management.test.js && npx jest src/plugin-management.test.js && npm run test",
+    "plugins:test": "cd plugins/headlamp-plugin && npm install --ignore-scripts && npm run build && npm install && ./test-headlamp-plugin.js && ./test-plugins-examples.sh && cd ../pluginctl/src && npm install && node ./plugin-management.e2e.js && cd .. && npx jest src/multi-plugin-management.test.js && npx jest src/plugin-management.test.js && npm run test",
     "image:build": "sh -c 'docker buildx build --pull --platform=local -t ghcr.io/headlamp-k8s/headlamp:$(git describe --tags --always --dirty) -f Dockerfile .'",
     "image:verify-image-digests": "node tools/verify-image-digests.js"
   },

--- a/plugins/headlamp-plugin/test-headlamp-plugin.js
+++ b/plugins/headlamp-plugin/test-headlamp-plugin.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 /*
  * Copyright 2025 The Kubernetes Authors

--- a/plugins/pluginctl/src/plugin-management.e2e.js
+++ b/plugins/pluginctl/src/plugin-management.e2e.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 /*
  * Copyright 2025 The Kubernetes Authors

--- a/plugins/pluginctl/test-pluginctl.js
+++ b/plugins/pluginctl/test-pluginctl.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 /*
  * Copyright 2025 The Kubernetes Authors


### PR DESCRIPTION
## Summary

Fixes a listener leak where `setupBackstageMessageReceiver` returned `void`,
giving the `useEffect` in `HomeComponent` no cleanup path. Every remount of
the Home page inside a Backstage iframe added another
`window.addEventListener('message', handleMessage)` that was never removed,
causing a single `BACKSTAGE_AUTH_TOKEN` message to be processed once per
accumulated mount.

## Changes

- `setupBackstageMessageReceiver` now returns `(() => void) | undefined`
  and calls `window.removeEventListener` in that function
- `HomeComponent` useEffect returns the cleanup directly via
  `return setupBackstageMessageReceiver()`

## Steps to Test

1. Run Headlamp inside a Backstage iframe
2. Navigate away from Home and back 5 times to trigger 5 remounts
3. Send a `BACKSTAGE_AUTH_TOKEN` message from the parent frame
4. Confirm the token handler fires exactly once (previously fired 5 times)

fixes #5516 
