### PR TITLE
electron: quit app on window close outside macOS

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1569,10 +1569,13 @@ function startElectron() {
     });
 
     mainWindow.on('close', event => {
-      if (hasTray && !isQuitting) {
+      if (process.platform === 'darwin' && hasTray && !isQuitting) {
         event.preventDefault();
         mainWindow?.hide();
+        return;
       }
+      isQuitting = true;
+      app.quit();
     });
 
     mainWindow.on('closed', () => {


### PR DESCRIPTION
## Summary

Fixes window close behavior on Linux and Windows.
Clicking the window close button (X) now fully quits the app instead of keeping Headlamp running in the background.

## Related Issue

Closes #5445

## Changes

- updated electron window close behavior
- fixed app remaining active in the background after clicking the window close button
- preserved existing macOS tray behavior

## Steps to Test

1. Build and launch the Headlamp desktop application
1. Run `ps aux | grep -i headlamp` and confirm Headlamp processes are running
1. Click the window close button (X)
1. Run `ps aux | grep -i headlamp` again
1. Verify that Electron and headlamp-server processes are no longer running

## Screenshots 

Build and run 
<img width="1337" height="385" alt="Screenshot from 2026-05-10 13-36-20" src="https://github.com/user-attachments/assets/4f5a118a-6565-4391-9e0f-da3b91d2c4a9" />

Verify processes before and after closing the application using the window close button (X)

<img width="1841" height="301" alt="Screenshot from 2026-05-10 13-35-31" src="https://github.com/user-attachments/assets/86d4f18b-bb43-4786-899d-b37233ddff5b" />




## Notes for the Reviewer

Tested on Ubuntu 22.04.5 LTS using both development mode and packaged production build.