### PR TITLE
Frontend: Add connected Pods section to Service details

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1709,7 +1709,7 @@ export interface OwnedPodsSectionProps {
 }
 
 export function OwnedPodsSection(props: OwnedPodsSectionProps) {
-  const { resource, hideColumns, noSearch, onPodsUpdate } = props;
+  const { resource, hideColumns, noSearch } = props;
   let namespace;
 
   if (resource.kind === 'Namespace') {
@@ -1717,8 +1717,18 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
   } else {
     namespace = resource.metadata.namespace;
   }
+
   let labelSelector = '';
-  if (resource?.jsonData?.spec?.selector) {
+
+  if (resource.kind === 'Service') {
+    const serviceSelector = resource?.jsonData?.spec?.selector;
+
+    if (serviceSelector && Object.keys(serviceSelector).length > 0) {
+      labelSelector = labelSelectorToQuery({
+        matchLabels: serviceSelector,
+      });
+    }
+  } else if (resource?.jsonData?.spec?.selector) {
     labelSelector = labelSelectorToQuery(resource?.jsonData?.spec?.selector);
   } else if (resource.kind === 'JobSet') {
     labelSelector = `jobset.sigs.k8s.io/jobset-name=${resource.metadata.name}`;
@@ -1730,35 +1740,40 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
     fieldSelector: resource.kind === 'Node' ? `spec.nodeName=${resource.metadata.name}` : undefined,
     cluster: resource.cluster,
   };
+
   const podMetricsQueryData = {
     ...queryData,
     // The metrics.k8s.io pod metrics list endpoint does not support spec.nodeName field selectors.
     fieldSelector: undefined,
   };
 
-  const { items: pods, errors } = Pod.useList(queryData);
+  const hasValidSelector = resource.kind !== 'Service' || !!labelSelector;
+
+  const { items: pods, errors } = Pod.useList(
+    hasValidSelector
+      ? queryData
+      : {
+          ...queryData,
+          labelSelector: 'headlamp.dev/no-match=true',
+        }
+  );
+
   const { items: podMetrics } = PodMetrics.useList({
-    ...podMetricsQueryData,
+    ...(hasValidSelector
+      ? podMetricsQueryData
+      : {
+          ...podMetricsQueryData,
+          labelSelector: 'headlamp.dev/no-match=true',
+        }),
     refetchInterval: METRIC_REFETCH_INTERVAL_MS,
   });
-  const resourceRef = React.useRef(resource);
-  const resourceIdentity = [
-    resource.cluster,
-    resource.kind,
-    resource.metadata.uid ?? '',
-    resource.metadata.namespace ?? '',
-    resource.metadata.name,
-  ].join('|');
 
-  React.useEffect(() => {
-    resourceRef.current = resource;
-  }, [resource]);
-
-  React.useEffect(() => {
-    onPodsUpdate?.(resourceRef.current, pods, errors ?? null);
-  }, [onPodsUpdate, resourceIdentity, pods, errors]);
+  if (!labelSelector && resource.kind === 'Service') {
+    return null;
+  }
 
   const onlyOneNamespace = !!resource.metadata.namespace || resource.kind === 'Namespace';
+
   const hideNamespaceFilter = onlyOneNamespace || noSearch;
 
   return (

--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1709,7 +1709,7 @@ export interface OwnedPodsSectionProps {
 }
 
 export function OwnedPodsSection(props: OwnedPodsSectionProps) {
-  const { resource, hideColumns, noSearch } = props;
+  const { resource, hideColumns, noSearch, onPodsUpdate } = props;
   let namespace;
 
   if (resource.kind === 'Namespace') {
@@ -1767,6 +1767,24 @@ export function OwnedPodsSection(props: OwnedPodsSectionProps) {
         }),
     refetchInterval: METRIC_REFETCH_INTERVAL_MS,
   });
+
+  const resourceRef = React.useRef(resource);
+
+  const resourceIdentity = [
+    resource.cluster,
+    resource.kind,
+    resource.metadata.uid ?? '',
+    resource.metadata.namespace ?? '',
+    resource.metadata.name,
+  ].join('|');
+
+  React.useEffect(() => {
+    resourceRef.current = resource;
+  }, [resource]);
+
+  React.useEffect(() => {
+    onPodsUpdate?.(resourceRef.current, pods, errors ?? null);
+  }, [onPodsUpdate, resourceIdentity, pods, errors]);
 
   if (!labelSelector && resource.kind === 'Service') {
     return null;

--- a/frontend/src/components/service/Details.tsx
+++ b/frontend/src/components/service/Details.tsx
@@ -26,7 +26,7 @@ import Service from '../../lib/k8s/service';
 import Empty from '../common/EmptyContent';
 import { ValueLabel } from '../common/Label';
 import Link from '../common/Link';
-import { DetailsGrid, MetadataDictGrid } from '../common/Resource';
+import { DetailsGrid, MetadataDictGrid, OwnedPodsSection } from '../common/Resource';
 import PortForward from '../common/Resource/PortForward';
 import { SectionBox } from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
@@ -87,7 +87,17 @@ export default function ServiceDetails(props: {
           return [];
         }
 
+        const sections = [];
+
+        if (item?.spec?.selector && Object.keys(item.spec.selector).length > 0) {
+          sections.push({
+            id: 'headlamp.service-connected-pods',
+            section: <OwnedPodsSection resource={item} />,
+          });
+        }
+
         return [
+          ...sections,
           {
             id: 'headlamp.service-ports',
             section: (

--- a/frontend/src/components/service/ServiceDetails.stories.tsx
+++ b/frontend/src/components/service/ServiceDetails.stories.tsx
@@ -186,6 +186,18 @@ export const Default = Template.bind({});
 Default.parameters = {
   msw: {
     handlers: {
+      metrics: http.get(
+        'http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/default/pods',
+        () =>
+          HttpResponse.json({
+            items: [],
+          })
+      ),
+      pods: http.get('http://localhost:4466/api/v1/namespaces/default/pods', () =>
+        HttpResponse.json({
+          items: [],
+        })
+      ),
       story: [
         http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
@@ -221,6 +233,18 @@ export const ErrorWithEndpoints = Template.bind({});
 ErrorWithEndpoints.parameters = {
   msw: {
     handlers: {
+      metrics: http.get(
+        'http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/default/pods',
+        () =>
+          HttpResponse.json({
+            items: [],
+          })
+      ),
+      pods: http.get('http://localhost:4466/api/v1/namespaces/default/pods', () =>
+        HttpResponse.json({
+          items: [],
+        })
+      ),
       story: [
         http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
@@ -247,6 +271,18 @@ export const WithA8RAnnotations = TemplateA8R.bind({});
 WithA8RAnnotations.parameters = {
   msw: {
     handlers: {
+      metrics: http.get(
+        'http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/default/pods',
+        () =>
+          HttpResponse.json({
+            items: [],
+          })
+      ),
+      pods: http.get('http://localhost:4466/api/v1/namespaces/default/pods', () =>
+        HttpResponse.json({
+          items: [],
+        })
+      ),
       story: [
         http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
@@ -284,6 +320,18 @@ export const WithA8ROwnerOnly = TemplateA8ROwnerOnly.bind({});
 WithA8ROwnerOnly.parameters = {
   msw: {
     handlers: {
+      metrics: http.get(
+        'http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/default/pods',
+        () =>
+          HttpResponse.json({
+            items: [],
+          })
+      ),
+      pods: http.get('http://localhost:4466/api/v1/namespaces/default/pods', () =>
+        HttpResponse.json({
+          items: [],
+        })
+      ),
       story: [
         http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
@@ -252,6 +252,13 @@
       >
         <div
           class="MuiBox-root css-p0cik4"
+        />
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
         >
           <div
             class="MuiBox-root css-j1fy4m"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
@@ -252,6 +252,13 @@
       >
         <div
           class="MuiBox-root css-p0cik4"
+        />
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
         >
           <div
             class="MuiBox-root css-j1fy4m"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
@@ -592,6 +592,13 @@
       >
         <div
           class="MuiBox-root css-p0cik4"
+        />
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
         >
           <div
             class="MuiBox-root css-j1fy4m"

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
@@ -328,6 +328,13 @@
       >
         <div
           class="MuiBox-root css-p0cik4"
+        />
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
         >
           <div
             class="MuiBox-root css-j1fy4m"


### PR DESCRIPTION
## Summary

Adds a Connected Pods section to the Service details view by reusing the existing `OwnedPodsSection` infrastructure.

## What changed

* Enhanced `OwnedPodsSection` to support Kubernetes Service selectors
* Adapted Service `spec.selector` maps into `LabelSelector` format before passing to `labelSelectorToQuery`
* Added Connected Pods section to Service details view
* Reused existing Pod fetching, metrics, and rendering logic
* Added safeguards for Services without selectors to avoid unintended namespace-wide Pod queries

## Why this approach

This implementation intentionally reuses existing Headlamp Pod resource patterns instead of introducing a separate Pod table implementation. This preserves:

* existing Pod metrics integration
* consistent Pod table UX
* loading/error handling behavior
* existing workload functionality

## Edge cases handled

* Services without selectors do not render the section
* Empty selector queries are prevented
* Existing workload and JobSet behavior remains unchanged

## Testing

Tested locally with:

* Services with selectors
* Services without selectors (e.g. ExternalName)
* Existing workload details views


