### PR TITLE
docs: align runtime prerequisite versions with repository configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Ready to run Headlamp locally? Here's the full setup from scratch.
 
 ### Prerequisites
 
-Make sure you have Node.js (>= 20.11.1 with npm >= 10.0.0) and Go installed before starting; see the development dependencies for the full list.
+Make sure you have Node.js (>= 22.0.0 with npm >= 11.0.0) and Go installed before starting; see the development dependencies for the full list.
 
 ### Build and Run
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -14,8 +14,9 @@ See [platforms](../platforms.md) to find out which browsers, OS and flavors of K
 
 These are the required dependencies to get started. Other dependencies are pulled in by the golang or node package managers (see frontend/package.json, app/package.json, backend/go.mod and Dockerfile).
 
-- [Node.js](https://nodejs.org/en/download/) >= 20.11.1 (LTS recommended). Many of us use [nvm](https://github.com/nvm-sh/nvm) for installing multiple versions of Node.
-- [Go](https://go.dev/doc/install) (>= 1.25.8)
+- [Node.js](https://nodejs.org/en/download/) >= 22.0.0 (LTS recommended). Many of us use [nvm](https://github.com/nvm-sh/nvm) for installing multiple versions of Node.
+- [npm](https://www.npmjs.com/) (>= 11.0.0)
+- [Go](https://go.dev/doc/install) (>= 1.25.9)
 - [Kubernetes](https://kubernetes.io/), we suggest [minikube](https://minikube.sigs.k8s.io/docs/) as one good K8s installation for testing locally. Other k8s installations are supported (see [platforms](../platforms.md)).
 
 ## Build the code

--- a/docs/development/plugins/getting-started.md
+++ b/docs/development/plugins/getting-started.md
@@ -25,8 +25,8 @@ Headlamp plugins are JavaScript/TypeScript modules that extend the functionality
 
 Before starting plugin development, ensure you have:
 
-- **Node.js** (v20.18.1 or later) - [Download here](https://nodejs.org/)
-- **npm** (comes with Node.js)
+- **Node.js** (v22.0.0 or later) - [Download here](https://nodejs.org/)
+- **npm** (v11.0.0 or later) - npm is typically installed with Node.js, but may require a separate upgrade
 - **A running Headlamp instance** - Either the [desktop app](../../installation/desktop/) or [development setup](../index.md)
 - **Basic knowledge of JavaScript/TypeScript and React**
 

--- a/docs/tutorials/plugin-development/getting-started/running-from-source/index.md
+++ b/docs/tutorials/plugin-development/getting-started/running-from-source/index.md
@@ -56,9 +56,9 @@ Install these tools before proceeding:
 | Tool | Version | Installation |
 |------|---------|--------------|
 | **Git** | Latest | [git-scm.com](https://git-scm.com/downloads) |
-| **Node.js** | ≥20.11.1 LTS | [nodejs.org](https://nodejs.org/en/download) or use [nvm](https://github.com/nvm-sh/nvm) |
-| **npm** | ≥10.0.0 | Included with Node.js |
-| **Go** | ≥1.24 | [go.dev/doc/install](https://go.dev/doc/install) |
+| **Node.js** | ≥22.0.0 LTS  | [nodejs.org](https://nodejs.org/en/download) or use [nvm](https://github.com/nvm-sh/nvm) |
+| **npm**     | ≥11.0.0      | Included with Node.js |
+| **Go**      | ≥1.25.9      | [go.dev/doc/install](https://go.dev/doc/install) |
 
 ### Optional (for testing with a cluster)
 
@@ -71,9 +71,9 @@ Install these tools before proceeding:
 
 ```bash
 # Check versions
-node --version    # Should be v20.11.1 or higher
-npm --version     # Should be 10.0.0 or higher
-go version        # Should be go1.24 or higher
+node --version    # Should be v22.0.0 or higher
+npm --version     # Should be 11.0.0 or higher
+go version        # Should be go1.25.9 or higher
 git --version     # Any recent version
 ```
 
@@ -310,8 +310,9 @@ npm run backend:build
 
 ```bash
 # Check versions match requirements
-node --version  # Need ≥20.11.1
-go version      # Need ≥1.24
+node --version  # Need ≥22.0.0
+npm --version   # Need ≥11.0.0
+go version      # Need ≥1.25.9
 ```
 
 ### kubeconfig Not Found


### PR DESCRIPTION
## Summary

Updates outdated Node.js/npm/Go version references across development and contributor documentation to match the repository source-of-truth runtime requirements declared in `package.json` and `backend/go.mod`.

## What changed

Updated documentation references to align with:

* Node.js >=22.0.0
* npm >=11.0.0
* Go >=1.25.9

Affected documentation includes:

* `CONTRIBUTING.md`
* `docs/development/index.md`
* `docs/development/plugins/getting-started.md`
* `docs/tutorials/plugin-development/getting-started/running-from-source/index.md`

## Notes

* Preserved existing documentation wording/style conventions (`>=` vs `≥`, LTS wording, table formatting, etc.)
* Kept the diff intentionally minimal and focused only on runtime prerequisite alignment
* Verified formatting/lint locally

Fixes #5499

