### PR TITLE
frontend: Fix ArrowUp wrap-around in ClusterChooserPopup keyboard navigation

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -196,15 +196,29 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
   function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     switch (e.key) {
       case 'ArrowUp': {
-        setActiveDescendantIndex(
-          idx => (idx - 1) % (recentClusters.length + clustersToShow.length)
-        );
+        setActiveDescendantIndex(idx => {
+          const total = recentClusters.length + clustersToShow.length;
+          if (total === 0) {
+            return -1;
+          }
+
+          if (idx <= 0) {
+            return total - 1;
+          }
+
+          return (idx - 1 + total) % total;
+        });
         break;
       }
       case 'ArrowDown': {
-        setActiveDescendantIndex(
-          idx => (idx + 1) % (recentClusters.length + clustersToShow.length)
-        );
+        setActiveDescendantIndex(idx => {
+          const total = recentClusters.length + clustersToShow.length;
+          if (total === 0) {
+            return -1;
+          }
+
+          return (idx + 1) % total;
+        });
         break;
       }
       case 'Enter': {


### PR DESCRIPTION
## Summary

This PR fixes keyboard navigation in the `ClusterChooserPopup` — pressing **ArrowUp** while the first item is focused now correctly wraps to the last item instead of breaking navigation entirely.

## Related Issue

Fixes #5525

## Changes

- Fixed the `ArrowUp` key handler in `ClusterChooserPopup` to use `(idx - 1 + total) % total` instead of `(idx - 1) % total`.

## Steps to Test

1. Open Headlamp with two or more clusters configured.
2. Click the cluster chooser button in the top bar to open the popup.
3. Press **ArrowDown** to move focus to the first cluster item (index 0).
4. Press **ArrowUp** — verify focus wraps to the **last** cluster in the list.
5. Press **ArrowDown** from the last item — verify it wraps back to the first (existing behaviour, unchanged).
6. Press **Enter** on a focused cluster — verify it gets selected correctly.

## Screenshots (if applicable)

Not applicable. This is a keyboard navigation bug fix with no UI layout change.

## Notes for the Reviewer

JavaScript's `%` operator preserves the sign of the left operand, so `(0 - 1) % total` evaluates to `-1`, not `total - 1`. The component's `getActiveDescendantCluster()` treats `-1` as "no selection" and returns `null`, silently stopping navigation. Adding `total` before the modulo guarantees a non-negative result in all cases.