### PR TITLE
backend: externalproxy: Add timeout to HTTP client

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -610,7 +610,12 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		w.Header().Set("Pragma", "no-cache")
 		w.Header().Set("X-Accel-Expires", "0")
 
-		client := http.Client{}
+		proxyCtx, cancel := context.WithTimeout(r.Context(), 30 * time.Second)
+		defer cancel()
+
+		proxyReq = proxyReq.WithContext(proxyCtx)
+
+		client := http.Client{Timeout: 30 * time.Second}
 
 		resp, err := client.Do(proxyReq) //nolint:gosec
 		if err != nil {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -89,6 +89,11 @@ const ContextUpdateCacheTTL = 20 * time.Second // seconds
 
 const JWTExpirationTTL = 10 * time.Second // seconds
 
+// externalProxyTimeout is the maximum time to wait for a proxy response.
+//
+//nolint:gochecknoglobals // allow test override
+var externalProxyTimeout = 30 * time.Second
+
 const kubeConfigSource = "kubeconfig" // source for kubeconfig contexts
 
 const (
@@ -588,9 +593,10 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		ctx := context.Background()
+		proxyCtx, cancel := context.WithTimeout(r.Context(), externalProxyTimeout)
+		defer cancel()
 
-		proxyReq, err := http.NewRequestWithContext(ctx, r.Method, proxyURL, r.Body) //nolint:gosec
+		proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, proxyURL, r.Body) //nolint:gosec
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "creating request")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -610,12 +616,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		w.Header().Set("Pragma", "no-cache")
 		w.Header().Set("X-Accel-Expires", "0")
 
-		proxyCtx, cancel := context.WithTimeout(r.Context(), 30 * time.Second)
-		defer cancel()
-
-		proxyReq = proxyReq.WithContext(proxyCtx)
-
-		client := http.Client{Timeout: 30 * time.Second}
+		client := http.Client{}
 
 		resp, err := client.Do(proxyReq) //nolint:gosec
 		if err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -506,6 +506,48 @@ func TestExternalProxyForwarding(t *testing.T) {
 	assert.Equal(t, `{"error": "not found"}`, rr.Body.String())
 }
 
+func TestExternalProxyTimeout(t *testing.T) {
+	originalLimit := externalProxyTimeout
+	externalProxyTimeout = 50 * time.Millisecond
+
+	t.Cleanup(func() { externalProxyTimeout = originalLimit })
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond) // Block longer than the timeout
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer proxyServer.Close()
+
+	proxyURL, err := url.Parse(proxyServer.URL)
+	require.NoError(t, err)
+
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{proxyURL.String()},
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("proxy-to", proxyURL.String())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Body.String(), "context deadline exceeded")
+}
+
 func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 	type test struct {
 		handler http.Handler
@@ -1025,7 +1067,8 @@ func TestBaseURLReplace(t *testing.T) {
 		filepath.Join(tempDir,
 			"index.html"),
 		indexContent,
-		0o600)
+		0o600,
+	)
 
 	require.NoError(t, err)
 
@@ -1663,7 +1706,8 @@ func TestCacheMiddleware_CacheHitAndCacheMiss(t *testing.T) {
 	// 4. Wrap the proxy handler with the CacheMiddleWare
 	router := mux.NewRouter()
 	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
-		CacheMiddleWare(c)(proxyHandler))
+		CacheMiddleWare(c)(proxyHandler),
+	)
 
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1728,7 +1772,8 @@ func TestCacheMiddleware_AuthErrorResponse(t *testing.T) {
 
 	router := mux.NewRouter()
 	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
-		CacheMiddleWare(c)(proxyHandler))
+		CacheMiddleWare(c)(proxyHandler),
+	)
 
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -1787,7 +1832,8 @@ func TestCacheMiddleware_CacheInvalidation(t *testing.T) {
 
 	router := mux.NewRouter()
 	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
-		CacheMiddleWare(c)(proxyHandler))
+		CacheMiddleWare(c)(proxyHandler),
+	)
 
 	ts := httptest.NewServer(router)
 	defer ts.Close()


### PR DESCRIPTION
### Description:
The `/externalproxy` handler was making requests using an `http.Client` that had no timeout set. This is a bit risky because if an external website (like ArtifactHub) hangs or responds very slowly, Headlamp would wait forever. This could eventually lead to "goroutine leaks" and might even crash the server if too many requests get stuck.

This PR adds a 30-second timeout to that client to ensure that we always release system resources if a request takes too long. This follows the same safe pattern that is already used in other parts of the codebase (like in `serviceproxy/http.go`).

### Changes Made:
Updated the `http.Client` initialization in `backend/cmd/headlamp.go` to include a `Timeout` of 30 seconds.

