### PR TITLE
frontend: Fix ClusterChooser selected cluster label

### DIFF
--- a/frontend/src/components/cluster/ClusterChooser.test.tsx
+++ b/frontend/src/components/cluster/ClusterChooser.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext } from '../../test';
+import ClusterChooser from './ClusterChooser';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: 'en',
+    },
+  }),
+}));
+
+const theme = createMuiTheme({ name: 'test' });
+
+function renderClusterChooser(props: Partial<React.ComponentProps<typeof ClusterChooser>> = {}) {
+  return render(
+    <TestContext>
+      <ThemeProvider theme={theme}>
+        <ClusterChooser clickHandler={vi.fn()} cluster="cluster-a" {...props} />
+      </ThemeProvider>
+    </TestContext>
+  );
+}
+
+describe('ClusterChooser', () => {
+  it('uses the selected cluster label when one selected cluster differs from the route cluster', () => {
+    renderClusterChooser({
+      selectedClusters: ['cluster-b'],
+    });
+
+    expect(screen.getByText('cluster-b')).toBeInTheDocument();
+    expect(screen.queryByText('cluster-a')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cluster/ClusterChooser.tsx
+++ b/frontend/src/components/cluster/ClusterChooser.tsx
@@ -45,7 +45,7 @@ const ClusterChooser = React.forwardRef(function ClusterChooser(
     ? selected.length <= MAX_INLINE_CLUSTERS
       ? selected.join(', ')
       : t('{{count}} clusters', { count: selected.length })
-    : cluster || t('Cluster');
+    : selected[0] ?? cluster ?? t('Cluster');
 
   return (
     <Button


### PR DESCRIPTION
## Summary

This PR fixes the ClusterChooser toolbar label so it correctly shows the selected cluster when `selectedClusters` contains exactly one cluster. Previously, the component ignored that single selected cluster and fell back to the route `cluster` prop, which could show the wrong cluster name.

## Related Issue

Fixes #5523

## Changes

- Updated `ClusterChooser` to prefer `selectedClusters[0]` before falling back to the route `cluster`.
- Added a regression test for the case where the selected cluster differs from the active route cluster.
- Kept the existing multi-cluster display behavior unchanged.

## Steps to Test

1. Run `npm run frontend:test -- ClusterChooser.test.tsx --run`.
2. Run `npm run frontend:tsc`.
3. Run `npm run frontend:lint`.
4. In a multi-cluster setup, select exactly one cluster that is different from the current route cluster and confirm the toolbar shows the selected
  cluster name.

## Screenshots (if applicable)

Not applicable. This is a label-selection logic fix with no visual styling changes.

## Notes for the Reviewer

The new test covers the reported regression directly: `selectedClusters={['cluster-b']}` with `cluster="cluster-a"` should render `cluster-b`.
