### PR TITLE
frontend: Reject invalid table row counts

### DIFF
--- a/frontend/src/components/App/Settings/NumRowsInput.test.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../../test';
+import NumRowsInput from './NumRowsInput';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { minRows?: number; maxRows?: number }) =>
+      (key.split('|')[1] || key)
+        .replace('{{ minRows }}', `${values?.minRows}`)
+        .replace('{{ maxRows }}', `${values?.maxRows}`),
+  }),
+}));
+
+function renderNumRowsInput() {
+  render(
+    <TestContext>
+      <NumRowsInput defaultValue={[5, 15, 25]} />
+    </TestContext>
+  );
+}
+
+describe('NumRowsInput', () => {
+  it('rejects decimal custom row values', () => {
+    renderNumRowsInput();
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('option', { name: 'Custom value' }));
+
+    const input = screen.getByPlaceholderText('Custom row value');
+    const applyButton = screen.getByRole('button', { name: 'Apply' });
+
+    fireEvent.change(input, { target: { value: '10' } });
+
+    expect(input).toHaveValue(10);
+    expect(input).not.toHaveAttribute('aria-invalid', 'true');
+    expect(applyButton).toBeEnabled();
+
+    fireEvent.change(input, { target: { value: '10.5' } });
+
+    expect(input).toHaveValue(10.5);
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(applyButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes the table row-count setting so custom values must be valid whole numbers. Previously, decimal and mixed values such as `10.5` or `5abc` could be silently truncated by `parseInt`, which meant the stored value could differ from what the user typed.

## Related Issue

Fixes #5522

## Changes

- Added strict parsing for table rows-per-page values.
- Updated `NumRowsInput` to reject decimal and non-integer custom values with a visible validation message.
- Disabled the Apply button while the custom row value is invalid.
- Updated persisted row-count loading to fall back to the configured default when localStorage contains an invalid value.
- Added regression tests for both the Settings input and localStorage parsing.

## Steps to Test

1. Run `npm run frontend:test -- NumRowsInput.test.tsx tablesRowsPerPage.test.ts --run`.
2. Run `npm run frontend:tsc`.
3. Run `npm run frontend:lint`.
4. In Settings, choose **Custom value** under **Number of rows for tables**, enter `10.5`, and confirm Apply stays disabled with a validation message.

## Screenshots (if applicable)

Not included. This is a validation behavior change with no visual styling update.

## Notes for the Reviewer

The parser now accepts only bare positive integer strings, so invalid persisted values fall back to the configured default instead of being partially parsed.