### PR TITLE
Add disclaimers regarding `Event` lifetime

### DIFF
--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -28,6 +28,7 @@ import { useFilterFunc } from '../../lib/util';
 import { useNamespaces } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { OverviewChart } from '../../redux/overviewChartsSlice';
+import EventsLifetimeInfo from '../common/EventsLifetimeInfo';
 import { DateLabel } from '../common/Label';
 import { StatusLabel } from '../common/Label';
 import Link from '../common/Link';
@@ -178,6 +179,7 @@ function EventsSection() {
       headerProps={{
         noNamespaceFilter: false,
         titleSideActions: [
+          <EventsLifetimeInfo key="event-lifetime-info" />,
           <FormControlLabel
             checked={isWarningEventSwitchChecked}
             label={t('Only warnings ({{ numWarnings }})', { numWarnings })}

--- a/frontend/src/components/cluster/__snapshots__/Overview.EmptyState.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.EmptyState.stories.storyshot
@@ -548,6 +548,17 @@
                     <div
                       class="MuiBox-root css-ldp2l3"
                     >
+                      <button
+                        aria-label="Events lifetime information"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
                       <label
                         class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                       >

--- a/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.ErrorState.stories.storyshot
@@ -548,6 +548,17 @@
                     <div
                       class="MuiBox-root css-ldp2l3"
                     >
+                      <button
+                        aria-label="Events lifetime information"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
                       <label
                         class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                       >

--- a/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Overview.Events.stories.storyshot
@@ -548,6 +548,17 @@
                     <div
                       class="MuiBox-root css-ldp2l3"
                     >
+                      <button
+                        aria-label="Events lifetime information"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
                       <label
                         class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
                       >

--- a/frontend/src/components/common/EventsLifetimeInfo.tsx
+++ b/frontend/src/components/common/EventsLifetimeInfo.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Icon } from '@iconify/react';
+import IconButton from '@mui/material/IconButton';
+import { useTranslation } from 'react-i18next';
+import { LightTooltip } from './Tooltip';
+
+export default function EventsLifetimeInfo() {
+  const { t } = useTranslation('translation');
+  return (
+    <LightTooltip
+      title={t(
+        "translation|Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration."
+      )}
+      interactive
+    >
+      <IconButton
+        aria-label={t('translation|Events lifetime information')}
+        size="small"
+        sx={{
+          fontSize: '1.75rem',
+          verticalAlign: 'middle',
+          mr: 1,
+        }}
+      >
+        <Icon icon="mdi:information-outline" />
+      </IconButton>
+    </LightTooltip>
+  );
+}

--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -20,6 +20,7 @@ import Event, { KubeEvent } from '../../lib/k8s/event';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import { localeDate, timeAgo } from '../../lib/util';
 import { HeadlampEventType, useEventCallback } from '../../redux/headlampEventSlice';
+import EventsLifetimeInfo from '../common/EventsLifetimeInfo';
 import { HoverInfoLabel } from '../common/Label';
 import SectionBox from '../common/SectionBox';
 import SimpleTable from '../common/SimpleTable';
@@ -56,7 +57,14 @@ export default function ObjectEventList(props: ObjectEventListProps) {
   }, []);
 
   return (
-    <SectionBox title={t('glossary|Events')}>
+    <SectionBox
+      title={t('glossary|Events')}
+      headerProps={{
+        noPadding: false,
+        headerStyle: 'subsection',
+        titleSideActions: [<EventsLifetimeInfo key="event-lifetime-info" />],
+      }}
+    >
       <SimpleTable
         columns={[
           {

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.ErrorFetching.stories.storyshot
@@ -19,7 +19,19 @@
             </h2>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Events lifetime information"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.NoEventsForObject.stories.storyshot
@@ -19,7 +19,19 @@
             </h2>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Events lifetime information"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -19,7 +19,19 @@
             </h2>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Events lifetime information"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/common/index.test.ts
+++ b/frontend/src/components/common/index.test.ts
@@ -28,6 +28,7 @@ const avoidCheck = [
   'AlertNotification',
   'ErrorBoundary',
   'DropZoneBox',
+  'EventsLifetimeInfo',
   // Internal helper used by the LogViewer/Terminal components. Plugins that
   // want to override terminal colors should set the `terminal` field on the
   // AppTheme they pass to `registerAppTheme(...)` instead.

--- a/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.Empty.stories.storyshot
@@ -253,7 +253,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/Details.WithBase.stories.storyshot
@@ -334,7 +334,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -1285,7 +1285,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
@@ -230,7 +230,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
@@ -383,7 +383,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
@@ -383,7 +383,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/daemonset/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/Details.Default.stories.storyshot
@@ -925,7 +925,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/daemonset/__snapshots__/Details.NoTolerations.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/Details.NoTolerations.stories.storyshot
@@ -811,7 +811,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceDetails.Default.stories.storyshot
@@ -356,7 +356,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointDetails.Default.stories.storyshot
@@ -477,7 +477,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyDetails.Basic.stories.storyshot
@@ -294,7 +294,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyDetails.Basic.stories.storyshot
@@ -363,7 +363,19 @@ cookieName: session-id"
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/ClassDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassDetails.Basic.stories.storyshot
@@ -279,7 +279,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
@@ -796,7 +796,19 @@ api.example.com"
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/GatewayDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayDetails.Basic.stories.storyshot
@@ -428,7 +428,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Basic.stories.storyshot
@@ -656,7 +656,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Empty.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteDetails.Empty.stories.storyshot
@@ -318,7 +318,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantDetails.Basic.stories.storyshot
@@ -294,7 +294,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -602,7 +602,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.Basic.stories.storyshot
@@ -222,7 +222,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassDetails.WithDefault.stories.storyshot
@@ -244,7 +244,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithResource.stories.storyshot
@@ -378,7 +378,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithTLS.stories.storyshot
@@ -404,7 +404,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/Details.WithWildcardTLS.stories.storyshot
@@ -267,7 +267,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
@@ -248,7 +248,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
@@ -325,7 +325,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceDetails.Active.stories.storyshot
@@ -409,7 +409,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/Details.Default.stories.storyshot
@@ -458,7 +458,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
@@ -1588,7 +1588,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
@@ -1588,7 +1588,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbDetails.Default.stories.storyshot
@@ -328,7 +328,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassDetails.Default.stories.storyshot
@@ -270,7 +270,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaDetails.Default.stories.storyshot
@@ -325,7 +325,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/role/__snapshots__/BindingDetails.ClusterRoleBinding.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingDetails.ClusterRoleBinding.stories.storyshot
@@ -333,7 +333,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/role/__snapshots__/BindingDetails.RoleBinding.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingDetails.RoleBinding.stories.storyshot
@@ -372,7 +372,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/role/__snapshots__/Details.ClusterRole.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/Details.ClusterRole.stories.storyshot
@@ -300,7 +300,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/role/__snapshots__/Details.Role.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/Details.Role.stories.storyshot
@@ -337,7 +337,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/Details.Base.stories.storyshot
@@ -222,7 +222,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.Empty.stories.storyshot
@@ -267,7 +267,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/Details.WithBase.stories.storyshot
@@ -438,7 +438,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.Default.stories.storyshot
@@ -608,7 +608,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ErrorWithEndpoints.stories.storyshot
@@ -469,7 +469,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.ExternalName.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.ExternalName.stories.storyshot
@@ -435,7 +435,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.LoadBalancer.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.LoadBalancer.stories.storyshot
@@ -618,7 +618,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.NodePort.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.NodePort.stories.storyshot
@@ -577,7 +577,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8RAnnotations.stories.storyshot
@@ -833,7 +833,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceDetails.WithA8ROwnerOnly.stories.storyshot
@@ -569,7 +569,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.Default.stories.storyshot
@@ -470,7 +470,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithComplexSelector.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithComplexSelector.stories.storyshot
@@ -480,7 +480,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithMultipleContainers.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithMultipleContainers.stories.storyshot
@@ -470,7 +470,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/statefulset/__snapshots__/Details.WithOnDeleteStrategy.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/Details.WithOnDeleteStrategy.stories.storyshot
@@ -470,7 +470,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimDetails.Base.stories.storyshot
@@ -312,7 +312,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
@@ -263,7 +263,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeDetails.Base.stories.storyshot
@@ -309,7 +309,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -696,7 +696,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithService.stories.storyshot
@@ -571,7 +571,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -568,7 +568,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithService.stories.storyshot
@@ -557,7 +557,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigDetails.WithURL.stories.storyshot
@@ -554,7 +554,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -280,6 +280,8 @@
   "Failed to copy to clipboard": "فشل النسخ إلى الحافظة",
   "Copy": "نسخ",
   "Open Issue on GitHub": "فتح مشكلة على GitHub",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "بحث",
   "Download": "تنزيل",
   "Reconnect": "إعادة الاتصال",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -276,6 +276,8 @@
   "Failed to copy to clipboard": "ক্লিপবোর্ডে কপি করতে ব্যর্থ",
   "Copy": "Copy",
   "Open Issue on GitHub": "GitHub-এ Issue খুলুন",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "সন্ধান করুন",
   "Download": "Download",
   "Reconnect": "পুনরায় সংযোগ",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -276,6 +276,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "Standardmäßig werden Kubernetes-Events eine Stunde lang aufbewahrt. Je nach Cluster-Konfiguration kann diese Zeitspanne abweichen.",
+  "Events lifetime information": "Informationen zur Lebensdauer von Events",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -276,6 +276,8 @@
   "Failed to copy to clipboard": "Failed to copy to clipboard",
   "Copy": "Copy",
   "Open Issue on GitHub": "Open Issue on GitHub",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.",
+  "Events lifetime information": "Events lifetime information",
   "Find": "Find",
   "Download": "Download",
   "Reconnect": "Reconnect",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -277,6 +277,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -277,6 +277,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -277,6 +277,8 @@
   "Failed to copy to clipboard": "Failed to copy to clipboard",
   "Copy": "Copy",
   "Open Issue on GitHub": "Open Issue on GitHub",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "Find",
   "Download": "Download",
   "Reconnect": "Reconnect",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -276,6 +276,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -277,6 +277,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "Gli eventi di Kubernetes hanno una durata predefinita di 1 ora. Tale durata può variare a seconda della configurazione del cluster.",
+  "Events lifetime information": "Informazioni sulla durata degli eventi",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -275,6 +275,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -275,6 +275,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -277,6 +277,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -278,6 +278,8 @@
   "Failed to copy to clipboard": "Не удалось скопировать в буфер обмена",
   "Copy": "Копировать",
   "Open Issue on GitHub": "Открыть задачу на GitHub",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "Найти",
   "Download": "Скачать",
   "Reconnect": "Переподключиться",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -276,6 +276,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -276,6 +276,8 @@
   "Failed to copy to clipboard": "کلپ بورڈ میں کاپی نہیں ہو سکا",
   "Copy": "کاپی کریں",
   "Open Issue on GitHub": "GitHub پر مسئلہ کھولیں",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "تلاش کریں",
   "Download": "ڈاؤن لوڈ کریں",
   "Reconnect": "دوبارہ رابطہ کریں",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -275,6 +275,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -275,6 +275,8 @@
   "Failed to copy to clipboard": "",
   "Copy": "",
   "Open Issue on GitHub": "",
+  "Kubernetes events have a lifetime of 1 hour by default. This duration may vary depending on your cluster's configuration.": "",
+  "Events lifetime information": "",
   "Find": "",
   "Download": "",
   "Reconnect": "",


### PR DESCRIPTION
## Summary

Add a small disclaimer tooltip next to the title of "Events" tables regarding `Event` resource lifetime in Kubernetes. Helpful to teach newbie users about `Event` retention, and a good reminder even for more veteran users.

## Changes

- Updated "Events" section in resource details to include the disclaimer.
- Updated "Events" section in "Cluster" page to include the disclaimer.
- Added translations.

## Steps to Test

1. Launch locally with Minikube:

    ```sh
    $ minikube start \
      --container-runtime=containerd \
      --docker-opt containerd=/var/run/containerd/containerd.sock \
      --kubernetes-version=v1.35.0
    $ tmux new-session -d -s frontend 'make frontend-install run-frontend'
    $ tmux new-session -d -s backend 'make backend run-backend'
    ```

2. Open Headlamp UI in the browser.
3. Navigate to the <kbd>Clusters</kbd> page and hover over the information icon to view.
4. Under <kbd>Workloads</kbd>, select any resource to view its details, hover over the information icon to view.

## Screenshots

<img width="1488" height="600" alt="events-cluster" src="https://github.com/user-attachments/assets/ffa79f80-7c31-4e85-9aab-7a561071279b" />

<img width="1488" height="855" alt="events-resource" src="https://github.com/user-attachments/assets/02e47aae-bbe6-43a2-bd5e-2a3377527e9b" />

## Notes for the Reviewer

- Translations were only added for languages that I know and could verify the authenticity of the translation.