### PR TITLE
backend: Validate Helm repository requests

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -51,6 +51,18 @@ type AddUpdateRepoRequest struct {
 	// https://github.com/helm/helm/blob/39ca699ca790e02ba36753dec6ba4177cc68d417/cmd/helm/repo_add.go#L169
 }
 
+func (r AddUpdateRepoRequest) Validate() error {
+	if strings.TrimSpace(r.Name) == "" {
+		return errors.New("name is required")
+	}
+
+	if strings.TrimSpace(r.URL) == "" {
+		return errors.New("url is required")
+	}
+
+	return nil
+}
+
 // Creates a filename if it's not there, including any missing directories.
 func createFileIfNotThere(fileName string) error {
 	_, err := os.Stat(fileName)
@@ -155,6 +167,14 @@ func (h *Handler) AddRepo(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "parsing request")
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	err = request.Validate()
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "validating request")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
@@ -381,6 +401,14 @@ func (h *Handler) UpdateRepository(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "parsing request")
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	err = request.Validate()
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "validating request")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return

--- a/backend/pkg/helm/repository_test.go
+++ b/backend/pkg/helm/repository_test.go
@@ -120,6 +120,32 @@ func TestAddRepository(t *testing.T) {
 		helmHandler.AddRepo(rr, addRepoRequest)
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
+
+	t.Run("missing_add_repo_name", func(t *testing.T) {
+		addRepoRequest, err := http.NewRequestWithContext(context.Background(),
+			"POST", "/clusters/minikube/helm/repositories/charts",
+			bytes.NewBufferString(`{"url":"https://kubernetes-sigs.github.io/headlamp/"}`))
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		helmHandler.AddRepo(rr, addRepoRequest)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "name is required")
+	})
+
+	t.Run("missing_add_repo_url", func(t *testing.T) {
+		addRepoRequest, err := http.NewRequestWithContext(context.Background(),
+			"POST", "/clusters/minikube/helm/repositories/charts",
+			bytes.NewBufferString(`{"name":"headlamp_test_repo"}`))
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		helmHandler.AddRepo(rr, addRepoRequest)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "url is required")
+	})
 }
 
 // TestRemoveRepository.
@@ -204,16 +230,39 @@ func TestUpdateRepo(t *testing.T) {
 	})
 
 	t.Run("invalid_update_repo_request", func(t *testing.T) {
-		updateRepoRequest, err := http.NewRequestWithContext(context.Background(), "PUT",
-			"/clusters/minikube/helm/repositories", bytes.NewBufferString("some invalid request string"))
-		require.NoError(t, err)
-
-		// response recorder
-		rr := httptest.NewRecorder()
-
-		helmHandler.UpdateRepository(rr, updateRepoRequest)
-		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		testInvalidUpdateRepoRequest(t, helmHandler, "some invalid request string", "")
 	})
+
+	t.Run("missing_update_repo_name", func(t *testing.T) {
+		testInvalidUpdateRepoRequest(t, helmHandler,
+			`{"url":"https://kubernetes-sigs-update-url.github.io/headlamp/"}`, "name is required")
+	})
+
+	t.Run("missing_update_repo_url", func(t *testing.T) {
+		testInvalidUpdateRepoRequest(t, helmHandler, `{"name":"headlamp_test_repo"}`, "url is required")
+	})
+}
+
+func testInvalidUpdateRepoRequest(
+	t *testing.T,
+	helmHandler *helm.Handler,
+	requestBody string,
+	expectedError string,
+) {
+	t.Helper()
+
+	updateRepoRequest, err := http.NewRequestWithContext(context.Background(), "PUT",
+		"/clusters/minikube/helm/repositories", bytes.NewBufferString(requestBody))
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	helmHandler.UpdateRepository(rr, updateRepoRequest)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	if expectedError != "" {
+		assert.Contains(t, rr.Body.String(), expectedError)
+	}
 }
 
 // TestListRepositories.


### PR DESCRIPTION
## Summary

  This PR fixes a backend validation bug in the Helm repository add/update endpoints. Requests with valid JSON but missing required fields like `name` or `url` now return `400 Bad Request` instead of reaching Helm internals and failing as `500 Internal Server Error`.

## Related Issue

Fixes #5532

## Changes

- Added validation for `AddUpdateRepoRequest`.
- Updated `AddRepo` and `UpdateRepository` to reject missing `name` or `url` before calling Helm repository logic.
- Added regression tests for missing `name` and missing `url` in both add and update requests.

## Steps to Test

1. Run `cd backend && go test -v ./pkg/helm`.
2. Run `npm run backend:test`.
3. Send an add repository request with `{}` or a missing `url` and confirm the response is `400 Bad Request`.
4. Send an update repository request with a missing `name` or `url` and confirm the response is `400 Bad Request`.

## Screenshots (if applicable)
Not applicable. This is a backend API validation change.

## Notes for the Reviewer

The change is intentionally scoped to request validation. Valid add/update requests continue through the existing Helm repository flow unchanged.
