### PR TITLE
frontend: useKubeObjectList: Fix watch leak for cluster-scoped resources

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -127,6 +127,23 @@ const mockClass = class {
   constructor(public jsonData: any) {}
 } as any;
 
+const mockNodeClass = class {
+  static apiVersion = 'v1';
+  static apiName = 'nodes';
+
+  static apiEndpoint = {
+    apiInfo: [
+      {
+        group: '',
+        resource: 'nodes',
+        version: 'v1',
+      },
+    ],
+  };
+
+  constructor(public jsonData: any) {}
+} as any;
+
 describe('useWatchKubeObjectLists', () => {
   beforeEach(() => {
     vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
@@ -328,6 +345,43 @@ describe('useKubeObjectList', () => {
     expect(spy.mock.calls[1][0].connections.length).toBe(2); // new connections with 'a' and 'b' namespaces
     expect(spy.mock.calls[2][0].connections.length).toBe(2); // rerender with new props
     expect(spy.mock.calls[3][0].connections.length).toBe(1); // updated connections after we removed namespace 'b'
+  });
+
+  it('should clean up cluster-scoped resources when cluster is removed', async () => {
+    const spy = vi.spyOn(websocket, 'useWebSockets');
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'nodes', 'cluster-1', '', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'cluster-1',
+    });
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'nodes', 'cluster-2', '', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'cluster-2',
+    });
+
+    const result = renderHook(
+      (props: { requests: Array<{ cluster: string; namespaces?: string[] }> }) =>
+        useKubeObjectList({
+          kubeObjectClass: mockNodeClass,
+          requests: props.requests,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        ),
+        initialProps: {
+          requests: [{ cluster: 'cluster-1' }, { cluster: 'cluster-2' }],
+        },
+      }
+    );
+
+    expect(spy.mock.calls[1][0].connections.length).toBe(2);
+
+    result.rerender({ requests: [{ cluster: 'cluster-1' }] });
+
+    expect(spy.mock.calls[3][0].connections.length).toBe(1);
+    expect(spy.mock.calls[3][0].connections[0].cluster).toBe('cluster-1');
   });
 });
 

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -529,11 +529,12 @@ export function useKubeObjectList<K extends KubeObject>({
 
   const listsToStopWatching = listsToWatch.filter(
     watching =>
-      requests.find(request =>
-        watching.cluster === request?.cluster && request.namespaces && watching.namespace
-          ? request.namespaces?.includes(watching.namespace)
-          : true
-      ) === undefined
+      requests.find(request => {
+        if (watching.cluster !== request?.cluster) return false;
+        return !request.namespaces?.length
+          ? !watching.namespace
+          : !!watching.namespace && request.namespaces.includes(watching.namespace);
+      }) === undefined
   );
 
   if (listsToStopWatching.length > 0) {


### PR DESCRIPTION
## Summary

Fixed a watch subscription leak in `useKubeObjectList` affecting cluster-scoped resources (e.g., Nodes, ClusterRoles) when a cluster is deselected.

## Related Issue

Fixes #5520

## Changes

- Updated `frontend/src/lib/k8s/api/v2/useKubeObjectList.ts` to correctly compare watch states against cluster requests, fixing a boolean fallthrough bug in cleanup logic.
- Added unit test in `frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx` to verify cluster-scoped watches are properly cleaned up when clusters are removed.

## Steps to Test

Run unit tests:

```bash
npm run frontend:test -- src/lib/k8s/api/v2/useKubeObjectList.test.tsx
```

Manual verification:

1. Open Headlamp with multiple clusters configured.
2. Navigate to a cluster-scoped resource page (e.g., Nodes).
3. Open browser DevTools → Network → WS.
4. Deselect one cluster from the cluster selector.
5. Verify the corresponding WebSocket/watch subscription is terminated.

> The previous logic used a ternary operator that defaulted to true if a cluster mismatch occurred, which prevented listsToStopWatching from identifying stale subscriptions. The new logic explicitly matches the cluster and namespace scope.