### PR TITLE
frontend: Preserve unavailable cluster feedback

### DIFF
--- a/frontend/src/components/App/Home/clusterStatus.test.ts
+++ b/frontend/src/components/App/Home/clusterStatus.test.ts
@@ -33,6 +33,7 @@ describe('canSelectCluster', () => {
     expect(canSelectCluster(null)).toBe(true);
     expect(canSelectCluster(undefined)).toBe(false);
     expect(canSelectCluster(new ApiError('Unauthorized', { status: 401 }))).toBe(false);
+    expect(canSelectCluster(new ApiError('Forbidden', { status: 403 }))).toBe(false);
     expect(canSelectCluster(new ApiError('Bad Gateway', { status: 502 }))).toBe(false);
   });
 });

--- a/frontend/src/lib/k8s/api/v2/retry.test.ts
+++ b/frontend/src/lib/k8s/api/v2/retry.test.ts
@@ -22,6 +22,7 @@ describe('shouldRetryKubeRequest', () => {
   it('does not retry unauthorized or forbidden requests', () => {
     expect(shouldRetryKubeRequest(0, new ApiError('Unauthorized', { status: 401 }))).toBe(false);
     expect(shouldRetryKubeRequest(0, new ApiError('Forbidden', { status: 403 }))).toBe(false);
+    expect(shouldRetryKubeRequest(2, new ApiError('Forbidden', { status: 403 }))).toBe(false);
   });
 
   it('keeps the default retry limit for other errors', () => {


### PR DESCRIPTION
## Summary

This PR keeps regression coverage for unavailable cluster feedback and fast forbidden-response handling after the implementation landed on main.

## Related Issue

Part of #5467

## Changes

- Add a regression assertion that forbidden cluster status errors are not selectable.
- Add a regression assertion that forbidden resource requests do not retry after later failures.
- Keep this PR focused on the remaining test-only coverage.

## Steps to Test

```bash
cd frontend && npm test -- src/components/App/Home/clusterStatus.test.ts src/lib/k8s/api/v2/retry.test.ts
npm run frontend:lint
npm run frontend:test
```

## Notes for the Reviewer

- Rewritten as a single atomic commit following the contribution guidelines.
- The implementation changes described earlier have already landed on main; this PR only carries the remaining regression assertions.
- Local focused tests and frontend lint pass. A full `npm run frontend:test` run failed in existing Storybook tests unrelated to the changed files: `Settings/ColorPicker > Default`, `Sidebar/Sidebar > InClusterSidebarOpen`, `Sidebar/Sidebar > InClusterSidebarClosed`, `Sidebar/Sidebar > SelectedItemWithSidebarOmitted`, `Activity > Basic`, `AdvancedSearch/AdvancedSearch > Default`, and three `DaemonSet/List` snapshot cases.