### PR TITLE
frontend: ContainerInfo: Fix key prop placement in ports list

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1650,8 +1650,8 @@ export function ContainerInfo(props: ContainerInfoProps) {
         value: (
           <Grid container>
             {container.ports?.map(({ containerPort, protocol, name }, index) => (
-              <>
-                <Grid item xs={12} key={`port_line_${index}`}>
+              <React.Fragment key={`port_line_${index}`}>
+                <Grid item xs={12}>
                   <Box display="flex" alignItems={'center'}>
                     <Box px={0.5} minWidth={120}>
                       {name && <ValueLabel>{`${name} `}</ValueLabel>}
@@ -1670,7 +1670,7 @@ export function ContainerInfo(props: ContainerInfoProps) {
                     </Box>
                   </Grid>
                 )}
-              </>
+              </React.Fragment>
             ))}
           </Grid>
         ),


### PR DESCRIPTION
## What?

Fix incorrect `key` prop placement in the `ContainerInfo` ports list inside `Resource.tsx`.

---

## Why?

The shorthand React fragment syntax (`<>...</>`) cannot accept props. The `key` prop was applied to the inner `<Grid>` element instead of the outermost element returned from `.map()`, which React ignores during reconciliation.

This triggers the following console warning on Pod detail pages that contain ports:

```txt
Warning: Each child in a list should have a unique "key" prop.
Check the render method of `ContainerInfo`.
```

---

## How?

Replace the shorthand fragment with `<React.Fragment key={...}>` so React can properly track list items during reconciliation.

```tsx
// Before
container.ports?.map(({ containerPort, protocol, name }, index) => (
  <>
    <Grid item xs={12} key={`port_line_${index}`}>
      ...
    </Grid>
  </>
))

// After
container.ports?.map(({ containerPort, protocol, name }, index) => (
  <React.Fragment key={`port_line_${index}`}>
    <Grid item xs={12}>
      ...
    </Grid>
  </React.Fragment>
))
```

---

## Testing

1. Open Headlamp and navigate to **Workloads → Pods**
2. Open any Pod that has ports defined (for example: `argocd-server`)
3. Open the browser DevTools console
4. Verify that the warning below no longer appears:

```txt
Warning: Each child in a list should have a unique "key" prop.
```

---

Fixes #5537