### PR TITLE
Frontend: fix unstable React reconciliation in ContainerInfo ports list

### DIFF
--- a/frontend/src/components/common/Resource/Resource.tsx
+++ b/frontend/src/components/common/Resource/Resource.tsx
@@ -1649,29 +1649,47 @@ export function ContainerInfo(props: ContainerInfoProps) {
         name: t('Ports'),
         value: (
           <Grid container>
-            {container.ports?.map(({ containerPort, protocol, name }, index) => (
-              <>
-                <Grid item xs={12} key={`port_line_${index}`}>
-                  <Box display="flex" alignItems={'center'}>
-                    <Box px={0.5} minWidth={120}>
-                      {name && <ValueLabel>{`${name} `}</ValueLabel>}
-                      <ValueLabel>{`${protocol}:`}</ValueLabel>
-                      <ValueLabel>{containerPort}</ValueLabel>
-                    </Box>
-                    {!!resource && ['Service', 'Pod'].includes(resource.kind) && (
-                      <PortForward containerPort={containerPort} resource={resource} />
-                    )}
-                  </Box>
-                </Grid>
-                {index < container.ports!.length - 1 && (
+            {container.ports?.map(({ containerPort, protocol, name, hostPort, hostIP }, index) => {
+              const baseKey = `${name ?? 'unnamed'}-${protocol ?? 'TCP'}-${containerPort}-${
+                hostPort ?? 'no-host-port'
+              }-${hostIP ?? 'no-host-ip'}`;
+
+              const duplicateIndex =
+                container.ports
+                  ?.slice(0, index)
+                  .filter(
+                    port =>
+                      `${port.name ?? 'unnamed'}-${port.protocol ?? 'TCP'}-${port.containerPort}-${
+                        port.hostPort ?? 'no-host-port'
+                      }-${port.hostIP ?? 'no-host-ip'}` === baseKey
+                  ).length ?? 0;
+
+              const key = duplicateIndex === 0 ? baseKey : `${baseKey}-${duplicateIndex}`;
+
+              return (
+                <React.Fragment key={key}>
                   <Grid item xs={12}>
-                    <Box mt={2} mb={2}>
-                      <Divider role="separator" />
+                    <Box display="flex" alignItems={'center'}>
+                      <Box px={0.5} minWidth={120}>
+                        {name && <ValueLabel>{`${name} `}</ValueLabel>}
+                        <ValueLabel>{`${protocol}:`}</ValueLabel>
+                        <ValueLabel>{containerPort}</ValueLabel>
+                      </Box>
+                      {!!resource && ['Service', 'Pod'].includes(resource.kind) && (
+                        <PortForward containerPort={containerPort} resource={resource} />
+                      )}
                     </Box>
                   </Grid>
-                )}
-              </>
-            ))}
+                  {index < container.ports!.length - 1 && (
+                    <Grid item xs={12}>
+                      <Box mt={2} mb={2}>
+                        <Divider role="separator" />
+                      </Box>
+                    </Grid>
+                  )}
+                </React.Fragment>
+              );
+            })}
           </Grid>
         ),
         hide: _.isEmpty(container.ports),


### PR DESCRIPTION
## Summary

Fixes unstable React reconciliation behavior in the `ContainerInfo` ports list by moving the `key` prop to the outermost mapped element returned from the ports iterator.

## What changed

* Replaced the shorthand fragment (`<>...</>`) in the ports `.map()` callback with an explicit keyed `React.Fragment`
* Moved the `key` prop from the inner `<Grid>` element to the top-level mapped element
* Used a stable composite key based on container port/protocol values
* Removed the now-redundant inner `key` prop

## Why this matters

Previously, the mapped ports list returned an un-keyed top-level fragment, which caused React reconciliation warnings and could potentially lead to unstable list reconciliation behavior during rerenders or container updates.

This change ensures React can correctly track list identity during updates and removes reconciliation warnings without altering rendering behavior or layout.

## Notes

* Kept the diff intentionally minimal and isolated to the affected rendering block
* No UI/layout behavior changes
* Verified linting locally

Fixes #5540
Fixes #5540
