### PR TITLE
frontend: CustomResourceInstancesList: drop useMemo to clear exhaustive-deps suppression

### DIFF
--- a/frontend/src/components/crd/CustomResourceInstancesList.test.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CustomResourceDefinition from '../../lib/k8s/crd';
+import { TestContext } from '../../test';
+import { CrInstanceList } from './CustomResourceInstancesList';
+
+vi.mock('../../lib/k8s/crd', () => ({
+  default: {
+    useList: vi.fn(),
+  },
+}));
+
+vi.mock('../../redux/filterSlice', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    useNamespaces: () => [] as string[],
+  };
+});
+
+vi.mock('react-i18next', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key.split('|').pop() ?? key,
+    }),
+  };
+});
+
+// Mock heavy presentational components so the test focuses on branch logic
+// rather than re-rendering MUI/theme internals.
+vi.mock('../common/', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    Loader: ({ title }: { title: string }) => <div data-testid="mock-loader">{title}</div>,
+    ResourceListView: ({
+      title,
+      errorMessage,
+      data,
+    }: {
+      title: string;
+      errorMessage?: string;
+      data: Array<Record<string, any>>;
+    }) => (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="rlv-title">{title}</span>
+        <span data-testid="rlv-row-count">{data?.length ?? 0}</span>
+        {errorMessage ? <span data-testid="rlv-error-message">{errorMessage}</span> : null}
+      </div>
+    ),
+  };
+});
+
+interface QueryResult {
+  items?: Array<Record<string, any>>;
+  isLoading?: boolean;
+  isFetching?: boolean;
+  isError?: boolean;
+}
+
+function makeMockCrd(name: string, queryResult: QueryResult) {
+  const useList = vi.fn(() => ({
+    items: queryResult.items ?? [],
+    isLoading: queryResult.isLoading ?? false,
+    isFetching: queryResult.isFetching ?? false,
+    isError: queryResult.isError ?? false,
+  }));
+  return {
+    cluster: 'test-cluster',
+    metadata: { name, namespace: 'default' },
+    jsonData: { status: { acceptedNames: { categories: [] } } },
+    makeCRClass: () => ({ useList }),
+  };
+}
+
+function setOuterCrdsList(crds: ReturnType<typeof makeMockCrd>[]) {
+  (CustomResourceDefinition.useList as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    items: crds,
+    error: null,
+    isLoading: false,
+  });
+}
+
+function renderList() {
+  return render(
+    <TestContext>
+      <CrInstanceList />
+    </TestContext>
+  );
+}
+
+describe('CrInstanceList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a loader while any CRD instance list is loading', () => {
+    const loadingCrd = makeMockCrd('foo.example.com', { isLoading: true });
+    const readyCrd = makeMockCrd('bar.example.com', { items: [] });
+    setOuterCrdsList([loadingCrd, readyCrd]);
+
+    renderList();
+
+    expect(screen.getByTestId('mock-loader')).toHaveTextContent(
+      'Loading custom resource instances'
+    );
+  });
+
+  it('renders the empty state when no CRD has any instances', () => {
+    const crdA = makeMockCrd('foo.example.com', { items: [] });
+    const crdB = makeMockCrd('bar.example.com', { items: [] });
+    setOuterCrdsList([crdA, crdB]);
+
+    renderList();
+
+    expect(screen.getByText('No custom resources instances found.')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when every CRD list errored out (all-failed)', () => {
+    const crdA = makeMockCrd('foo.example.com', { isError: true });
+    const crdB = makeMockCrd('bar.example.com', { isError: true });
+    setOuterCrdsList([crdA, crdB]);
+
+    renderList();
+
+    expect(screen.getByText('No custom resources instances found.')).toBeInTheDocument();
+  });
+
+  it('renders the partial-failure warning alert when only some CRDs errored out', () => {
+    const failingCrd = makeMockCrd('failing.example.com', { isError: true });
+    const okCrd = makeMockCrd('ok.example.com', {
+      items: [
+        {
+          kind: 'OkResource',
+          metadata: { name: 'ok-instance-1', namespace: 'default' },
+          cluster: 'test-cluster',
+        },
+      ],
+    });
+    setOuterCrdsList([failingCrd, okCrd]);
+
+    renderList();
+
+    expect(screen.getByText('Failed to load custom resource instances')).toBeInTheDocument();
+    expect(screen.getByText(/failing\.example\.com/)).toBeInTheDocument();
+    expect(screen.getByTestId('rlv-row-count')).toHaveTextContent('1');
+  });
+
+  it('renders instances and skips the warning alert on the happy path', () => {
+    const crd = makeMockCrd('happy.example.com', {
+      items: [
+        {
+          kind: 'HappyResource',
+          metadata: { name: 'happy-instance-1', namespace: 'default' },
+          cluster: 'test-cluster',
+        },
+        {
+          kind: 'HappyResource',
+          metadata: { name: 'happy-instance-2', namespace: 'default' },
+          cluster: 'test-cluster',
+        },
+      ],
+    });
+    setOuterCrdsList([crd]);
+
+    renderList();
+
+    expect(screen.queryByText('Failed to load custom resource instances')).not.toBeInTheDocument();
+    expect(screen.getByTestId('rlv-row-count')).toHaveTextContent('2');
+  });
+});

--- a/frontend/src/components/crd/CustomResourceInstancesList.tsx
+++ b/frontend/src/components/crd/CustomResourceInstancesList.tsx
@@ -16,7 +16,7 @@
 
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CRD from '../../lib/k8s/crd';
 import { KubeObject } from '../../lib/k8s/KubeObject';
@@ -37,35 +37,27 @@ function CrInstancesView({ crds }: { crds: CRD[]; key: string }) {
 
   const [isWarningClosed, setIsWarningClosed] = useState(false);
 
-  const { crInstancesList, getCRDForCR, isLoading, crdsFailedToLoad, allFailed } = useMemo(() => {
-    const isLoading = queries.some(it => it.isLoading || it.isFetching);
+  const isLoading = queries.some(it => it.isLoading || it.isFetching);
 
-    // Collect the names of CRD that failed to load lists
-    const crdsFailedToLoad: string[] = [];
-    queries.forEach((it, i) => {
-      if (it.isError) {
-        crdsFailedToLoad.push(crds[i].metadata.name);
-      }
-    });
+  // Collect the names of CRDs that failed to load lists
+  const crdsFailedToLoad: string[] = [];
+  queries.forEach((it, i) => {
+    if (it.isError) {
+      crdsFailedToLoad.push(crds[i].metadata.name);
+    }
+  });
+  const allFailed = crdsFailedToLoad.length === queries.length;
 
-    // Create a map to be able to link to CRD by CR kind
-    const crKindToCRDMap = queries.reduce((acc, { items }, index) => {
-      if (items?.[0]) {
-        acc[items[0].kind] = crds[index];
-      }
-      return acc;
-    }, {} as Record<string, CRD>);
-    const getCRDForCR = (cr: KubeObject) => crKindToCRDMap[cr.kind];
+  // Create a map to be able to link to CRD by CR kind
+  const crKindToCRDMap = queries.reduce((acc, { items }, index) => {
+    if (items?.[0]) {
+      acc[items[0].kind] = crds[index];
+    }
+    return acc;
+  }, {} as Record<string, CRD>);
+  const getCRDForCR = (cr: KubeObject) => crKindToCRDMap[cr.kind];
 
-    return {
-      crInstancesList: queries.flatMap(it => it.items ?? []),
-      getCRDForCR,
-      isLoading,
-      crdsFailedToLoad,
-      allFailed: crdsFailedToLoad.length === queries.length,
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, queries);
+  const crInstancesList = queries.flatMap(it => it.items ?? []);
 
   if (isLoading) {
     return <Loader title={t('translation|Loading custom resource instances')} />;


### PR DESCRIPTION
## Summary

This PR fixes the `react-hooks/exhaustive-deps` suppression in `frontend/src/components/crd/CustomResourceInstancesList.tsx` by removing a `useMemo` that was invalidating every render anyway and omitting `crds` from its deps. It also adds component-level test coverage for the file in response to review feedback.

## Related Issue

Fixes #5543 (sub-issue of umbrella #5183).

## Changes

**`CustomResourceInstancesList.tsx`** (commit `c14297e2`):

- Dropped the `useMemo` wrapper inside `CrInstancesView` and the matching `// eslint-disable-next-line react-hooks/exhaustive-deps` directive.
- Hoisted the previously-memoized computations (`isLoading`, `crdsFailedToLoad`, `allFailed`, `crKindToCRDMap`/`getCRDForCR`, `crInstancesList`) to plain `const`s.
- Removed the now-unused `useMemo` import.

**`CustomResourceInstancesList.test.tsx`** (commit `bb4636cf`, new file):

- New vitest + `@testing-library/react` suite covering the five reachable branches of `CrInstanceList`: loading, empty (no instances), all-failed (resolves to empty because `flatMap` of items is empty), partial-failure warning Alert, and the happy path.
- `Loader` and `ResourceListView` are mocked at the test boundary so assertions check the data flow into them rather than re-rendering MUI/theme internals. Same approach as `CustomResourceDetails.test.tsx` in the same directory.

### Why drop the memo rather than expand the deps

The deps array passed to `useMemo` was the local `queries` array (`dataClassCrds.map(it => it.data)`), freshly built each render. Each query object inside it also has new identity per render, so the memo was being invalidated every render regardless. The body also read `crds` without listing it as a dep. The work itself is a single pass over a small array (a `.some()`, a `.forEach()`, a `.reduce()`, and a `.flatMap()`), so the memoization wasn't buying anything. Dropping it both removes the suppression and the per-render allocation of the `queries` deps array.

If a maintainer would prefer the conservative variant (keep the memo and expand deps to stable primitives derived from each query, e.g. `[crds, ...queries.map(q => q.dataUpdatedCount), ...queries.map(q => q.isError)]`), happy to switch.

## Steps to Test

1. `cd frontend && npm install`
2. `npm run lint`: the file lints cleanly; no `react-hooks/exhaustive-deps` violation surfaces.
3. `npm run tsc`: passes.
4. `npx vitest run src/components/crd/CustomResourceInstancesList.test.tsx`: the five new tests pass.
5. `npx vitest run src/components/crd`: neighbouring `CustomResourceDetails.test.tsx` (2 tests) still passes.
6. Visual smoke: start Headlamp against a cluster with any CRD that has instances (or apply Gateway API CRDs), navigate to **Custom Resources → Custom Resource Instances**. The list renders identically; loading state, empty state, and failed-CRD warning Alert all behave as before.

## Screenshots (if applicable)

N/A. No visual change.

## Notes for the Reviewer

- Two commits: the hooks fix (1 file, +22 / -30) and the test addition (1 file, +189).
- DCO sign-off applied on both commits.
- Listed as an unchecked `exhaustive-deps` bullet in umbrella issue #5183.