### PR TITLE
frontend: SettingsCluster: wrap namespace placeholder with i18n

### DIFF
--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -489,7 +489,7 @@ export default function SettingsCluster() {
                       value = value.replace(' ', '');
                       setNewAllowedNamespace(value);
                     }}
-                    placeholder={t('translation|Namespace')}
+                    placeholder={t('glossary|Namespace')}
                     error={!isValidNewAllowedNamespace}
                     value={newAllowedNamespace}
                     helperText={

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -489,7 +489,7 @@ export default function SettingsCluster() {
                       value = value.replace(' ', '');
                       setNewAllowedNamespace(value);
                     }}
-                    placeholder="namespace"
+                    placeholder={t('translation|Namespace')}
                     error={!isValidNewAllowedNamespace}
                     value={newAllowedNamespace}
                     helperText={

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
@@ -295,7 +295,7 @@
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   form="[object Object]"
                   id=":mock-test-id:"
-                  placeholder="namespace"
+                  placeholder="Namespace"
                   type="text"
                   value=""
                 />

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
@@ -295,7 +295,7 @@
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   form="[object Object]"
                   id=":mock-test-id:"
-                  placeholder="namespace"
+                  placeholder="Namespace"
                   type="text"
                   value=""
                 />

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
@@ -295,7 +295,7 @@
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   form="[object Object]"
                   id=":mock-test-id:"
-                  placeholder="namespace"
+                  placeholder="Namespace"
                   type="text"
                   value=""
                 />

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
@@ -295,7 +295,7 @@
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   form="[object Object]"
                   id=":mock-test-id:"
-                  placeholder="namespace"
+                  placeholder="Namespace"
                   type="text"
                   value=""
                 />

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
@@ -318,7 +318,7 @@
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   form="[object Object]"
                   id=":mock-test-id:"
-                  placeholder="namespace"
+                  placeholder="Namespace"
                   type="text"
                   value=""
                 />

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
@@ -318,7 +318,7 @@
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
                   form="[object Object]"
                   id=":mock-test-id:"
-                  placeholder="namespace"
+                  placeholder="Namespace"
                   type="text"
                   value=""
                 />


### PR DESCRIPTION
## Summary
This PR fixes a missing i18n translation by wrapping the hardcoded `"namespace"` placeholder in `SettingsCluster.tsx` with the `t()` function.

## Related Issue
fixes #5546

## Changes
- Wrapped `placeholder="namespace"` with `t('glossary|Namespace')` in `frontend/src/components/App/Settings/SettingsCluster.tsx`

## Steps to Test
1. Change Headlamp language to a non-English locale
2. Navigate to Settings → Cluster → Allowed Namespaces
3. Observe the input placeholder is now translated instead of showing hardcoded English

## Screenshots (if applicable)
N/A

## Notes for the Reviewer
- `useTranslation` was already imported in the component — only this placeholder was missed
- Used existing key `t('translation|Namespace')` from the locale files — no new key added
