### PR TITLE
frontend: SearchSettings: Wrap Refetch Interval label with i18n

### DIFF
--- a/frontend/src/components/advancedSearch/SearchSettings.tsx
+++ b/frontend/src/components/advancedSearch/SearchSettings.tsx
@@ -26,7 +26,7 @@ import {
   TextField,
 } from '@mui/material';
 import { useRef, useState } from 'react';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 export function SearchSettings({
   maxItemsPerResource,
@@ -39,6 +39,7 @@ export function SearchSettings({
   refetchIntervalMs: number;
   setRefetchIntervalMs: (n: number) => void;
 }) {
+  const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const maxItemsInputRef = useRef<HTMLInputElement>(null);
   const refetchInputRef = useRef<HTMLSelectElement>(null);
@@ -86,7 +87,7 @@ export function SearchSettings({
             <Select
               labelId="refetch-label"
               id="refetch-select"
-              label="Refetch Interval"
+              label={t('translation|Refetch Interval')}
               defaultValue={refetchIntervalMs}
               inputRef={refetchInputRef}
             >


### PR DESCRIPTION
## Summary
This PR fixes a missing i18n translation by wrapping the hardcoded `"Refetch Interval"` label in `SearchSettings.tsx` with the `t()` function.

## Related Issue
fixes #5548

## Changes
- Added `useTranslation` import to `frontend/src/components/advancedSearch/SearchSettings.tsx`
- Wrapped `label="Refetch Interval"` with `t('translation|Refetch Interval')`

## Steps to Test
1. Change Headlamp language to a non-English locale
2. Navigate to the advanced search settings
3. Observe the "Refetch Interval" label is now translated instead of showing hardcoded English

## Screenshots (if applicable)
N/A

## Notes for the Reviewer
- The `InputLabel` directly above already uses `<Trans>Refetch Interval</Trans>` correctly — only the `Select` label prop was missed
- `"Refetch Interval"` key already exists in the locale files — no new key added
