### PR TITLE
frontend: SettingsClusters: Wrap title with i18n t() function

### DIFF
--- a/frontend/src/components/App/Settings/SettingsClusters.tsx
+++ b/frontend/src/components/App/Settings/SettingsClusters.tsx
@@ -25,7 +25,7 @@ export default function SettingsClusters() {
   const { t } = useTranslation(['translation']);
 
   return (
-    <SectionBox title="Cluster Settings">
+    <SectionBox title={t('translation|Cluster Settings')}>
       <SimpleTable
         columns={[
           {


### PR DESCRIPTION
## Summary
This PR fixes a missing i18n translation by wrapping the hardcoded `"Cluster Settings"` title in `SettingsClusters.tsx` with the `t()` function.

## Related Issue
fixes #5552

## Changes
- Wrapped `title="Cluster Settings"` with `t('translation|Cluster Settings')` in `frontend/src/components/App/Settings/SettingsClusters.tsx`

## Steps to Test
1. Change Headlamp language to a non-English locale
2. Navigate to Settings → Clusters
3. Observe the section title is now translated instead of showing hardcoded English

## Screenshots (if applicable)
N/A

## Notes for the Reviewer
- The `"Cluster Settings"` key already exists in `frontend/src/i18n/locales/en/translation.json` — no new locale key was added
- `useTranslation` was already imported in the component, only the title prop was missed
