### PR TITLE
frontend: ReleaseNotesModal: Render markdown with GFM table support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -79,6 +79,7 @@
         "react-router-dom": "^5.3.0",
         "react-window": "^1.8.11",
         "recharts": "^2.1.4",
+        "remark-gfm": "^4.0.1",
         "semver": "^7.3.5",
         "shx": "^0.4.0",
         "simple-eval": "^2.0.0",
@@ -121,8 +122,8 @@
         "vitest-websocket-mock": "^0.4.0"
       },
       "engines": {
-        "node": ">=20.11.1",
-        "npm": ">=10.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=11.0.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-darwin-arm64": "*",
@@ -10990,6 +10991,16 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/matcher-collection": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -11083,6 +11094,34 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -11101,6 +11140,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11339,6 +11479,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -13721,6 +13982,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -13748,6 +14027,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,6 +80,7 @@
     "react-router-dom": "^5.3.0",
     "react-window": "^1.8.11",
     "recharts": "^2.1.4",
+    "remark-gfm": "^4.0.1",
     "semver": "^7.3.5",
     "shx": "^0.4.0",
     "simple-eval": "^2.0.0",

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.stories.tsx
@@ -24,7 +24,8 @@ export default {
 
 export const Show = {
   args: {
-    releaseNotes: '# Release Notes\n\n## Hello\n\n### Sub-heading\n\nworld',
+    releaseNotes:
+      '# Release Notes\n\n## Hello\n\n### Sub-heading\n\nworld\n\n## Changes\n\n| Feature | Status | Notes |\n|---------|--------|-------|\n| Dark mode | ✅ Done | Available in settings |\n| Tables | ✅ Done | Now rendered properly |\n| Images | ✅ Done | Bounded to container |\n\n## Code Example\n\n```yaml\napiVersion: v1\nkind: Pod\n```\n\n> **Note:** This is a blockquote with important information.',
     appVersion: '1.9.9',
   },
 };

--- a/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
+++ b/frontend/src/components/common/ReleaseNotes/ReleaseNotesModal.tsx
@@ -23,6 +23,7 @@ import Link from '@mui/material/Link';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { DialogTitle } from '../Dialog';
 
 export interface ReleaseNotesModalProps {
@@ -51,21 +52,52 @@ export default function ReleaseNotesModal(props: ReleaseNotesModalProps) {
       <DialogContent dividers>
         <Box
           sx={{
-            img: {
-              display: 'block',
-              maxWidth: '100%',
+            '& img': { display: 'block', maxWidth: '100%', height: 'auto' },
+            '& table': {
+              borderCollapse: 'collapse',
+              width: '100%',
+              marginBottom: 2,
             },
+            '& th, & td': {
+              border: '1px solid',
+              borderColor: 'divider',
+              padding: '6px 12px',
+              textAlign: 'left',
+            },
+            '& th': { backgroundColor: 'action.hover', fontWeight: 'bold' },
+            '& tr:nth-of-type(even)': { backgroundColor: 'action.hover' },
+            '& code': {
+              fontFamily: 'monospace',
+              backgroundColor: 'action.hover',
+              padding: '2px 4px',
+              borderRadius: 1,
+              fontSize: '0.875em',
+            },
+            '& pre': {
+              backgroundColor: 'action.hover',
+              padding: 2,
+              borderRadius: 1,
+              overflow: 'auto',
+              '& code': { backgroundColor: 'transparent', padding: 0 },
+            },
+            '& blockquote': {
+              borderLeft: '4px solid',
+              borderColor: 'divider',
+              margin: 0,
+              paddingLeft: 2,
+              color: 'text.secondary',
+            },
+            '& h1, & h2, & h3, & h4, & h5, & h6': { marginTop: 2, marginBottom: 1 },
           }}
         >
           <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
             components={{
-              a: ({ children, href }) => {
-                return (
-                  <Link href={href} target="_blank">
-                    {children}
-                  </Link>
-                );
-              },
+              a: ({ children, href }) => (
+                <Link href={href} target="_blank" rel="noopener noreferrer">
+                  {children}
+                </Link>
+              ),
             }}
           >
             {releaseNotes}

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotes.Default.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotes.Default.stories.storyshot
@@ -140,7 +140,7 @@
           class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-fm9d3m"
+            class="MuiBox-root css-wicc6q"
           >
             <h2>
               Hello

--- a/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
+++ b/frontend/src/components/common/ReleaseNotes/__snapshots__/ReleaseNotesModal.Show.stories.storyshot
@@ -68,7 +68,7 @@
           class="MuiDialogContent-root MuiDialogContent-dividers css-1t4vnk2-MuiDialogContent-root"
         >
           <div
-            class="MuiBox-root css-fm9d3m"
+            class="MuiBox-root css-wicc6q"
           >
             <h1>
               Release Notes
@@ -88,6 +88,93 @@
             <p>
               world
             </p>
+            
+
+            <h2>
+              Changes
+            </h2>
+            
+
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    Feature
+                  </th>
+                  <th>
+                    Status
+                  </th>
+                  <th>
+                    Notes
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    Dark mode
+                  </td>
+                  <td>
+                    ✅ Done
+                  </td>
+                  <td>
+                    Available in settings
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    Tables
+                  </td>
+                  <td>
+                    ✅ Done
+                  </td>
+                  <td>
+                    Now rendered properly
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    Images
+                  </td>
+                  <td>
+                    ✅ Done
+                  </td>
+                  <td>
+                    Bounded to container
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            
+
+            <h2>
+              Code Example
+            </h2>
+            
+
+            <pre>
+              <code
+                class="language-yaml"
+              >
+                apiVersion: v1
+kind: Pod
+
+              </code>
+            </pre>
+            
+
+            <blockquote>
+              
+
+              <p>
+                <strong>
+                  Note:
+                </strong>
+                 This is a blockquote with important information.
+              </p>
+              
+
+            </blockquote>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes the release notes dialog rendering raw markdown as plain text.
Added `remark-gfm` plugin to the existing `ReactMarkdown` usage so
GitHub Flavored Markdown (tables, strikethrough, task lists) renders
properly. Added MUI theme-aware `sx` styling for all markdown elements.

## Related Issue

Fixes #5513

## Changes

- Added `remark-gfm` as a dependency (companion to already-declared `react-markdown`)
- Passed `remarkPlugins={[remarkGfm]}` to `<ReactMarkdown>` in `ReleaseNotesModal.tsx`
- Added MUI theme-aware `sx` styling for tables (borders, alternating row shading), code blocks (monospace, background), blockquotes (left border), headings, and images (max-width bounded) — all using theme tokens, no hardcoded colours
- Updated Storybook story with table, code block, and blockquote for visual verification
- Updated 2 snapshots to reflect new rendered HTML

## Steps to Test

1. Run Headlamp and trigger a version update (or use Storybook: `ReleaseNotesModal` → `Show` story)
2. Observe the release notes dialog
3. Tables should render with borders and header background
4. Code blocks should render with monospace font and background
5. Images should be bounded to container width

## Screenshots (if applicable)

<!-- Before: pipe-separated text | Feature | Status | -->
<!-- After: fully rendered HTML table with borders and theme-aware styling -->

## Notes for the Reviewer

- `remark-gfm` is the standard companion plugin for `react-markdown` — no unusual dependencies introduced
- All styling uses MUI theme tokens (`action.hover`, `primary.main`) — no hardcoded hex values
- The i18n tooling reordered keys in 12 locale files — no new strings were added
- 2 snapshots updated to reflect new rendered markdown HTML (expected)