### PR TITLE
frontend: Multiplexer: Fix setInterval leak when WebSocket connection fails

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -412,6 +412,26 @@ describe('WebSocket Multiplexer', () => {
   });
 
   describe('WebSocket error handling', () => {
+    it('should reject concurrent callers when in-progress connection fails', async () => {
+      vi.useFakeTimers();
+
+      // Manually set connecting = true to simulate an in-progress attempt
+      WebSocketManager.connecting = true;
+
+      // Start a concurrent caller — it enters the polling branch
+      const concurrentPromise = WebSocketManager.connect();
+
+      // Simulate the primary connection failing by resetting connecting to false
+      WebSocketManager.connecting = false;
+
+      // Advance timers so the setInterval tick fires and detects the failure
+      await vi.advanceTimersByTimeAsync(200);
+
+      await expect(concurrentPromise).rejects.toThrow('WebSocket connection failed');
+
+      vi.useRealTimers();
+    });
+
     it('should handle polling timeout', async () => {
       const OriginalWebSocket = window.WebSocket;
 

--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -415,21 +415,23 @@ describe('WebSocket Multiplexer', () => {
     it('should reject concurrent callers when in-progress connection fails', async () => {
       vi.useFakeTimers();
 
-      // Manually set connecting = true to simulate an in-progress attempt
-      WebSocketManager.connecting = true;
+      try {
+        // Manually set connecting = true to simulate an in-progress attempt
+        WebSocketManager.connecting = true;
 
-      // Start a concurrent caller — it enters the polling branch
-      const concurrentPromise = WebSocketManager.connect();
+        // Start a concurrent caller — it enters the polling branch
+        const concurrentPromise = WebSocketManager.connect();
 
-      // Simulate the primary connection failing by resetting connecting to false
-      WebSocketManager.connecting = false;
+        // Simulate the primary connection failing by resetting connecting to false
+        WebSocketManager.connecting = false;
 
-      // Advance timers so the setInterval tick fires and detects the failure
-      await vi.advanceTimersByTimeAsync(200);
+        // Advance timers so the setInterval tick fires and detects the failure
+        await vi.advanceTimersByTimeAsync(200);
 
-      await expect(concurrentPromise).rejects.toThrow('WebSocket connection failed');
-
-      vi.useRealTimers();
+        await expect(concurrentPromise).rejects.toThrow('WebSocket connection failed');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should handle polling timeout', async () => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -65,8 +65,7 @@ export const WebSocketManager = {
    *
    * Known limitations:
    * 1. Polls every 100ms which may not be optimal for performance
-   * 2. No timeout - could theoretically run forever if connection never opens
-   * 3. May miss state changes that happen between polls
+   * 2. May miss state changes that happen between polls
    *
    * A more robust solution would use event listeners and Promise caching,
    * but that adds complexity and potential race conditions to handle.
@@ -82,11 +81,14 @@ export const WebSocketManager = {
 
     // Wait for existing connection attempt if in progress
     if (this.connecting) {
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         const checkConnection = setInterval(() => {
           if (this.socketMultiplexer?.readyState === WebSocket.OPEN) {
             clearInterval(checkConnection);
-            resolve(this.socketMultiplexer);
+            resolve(this.socketMultiplexer!);
+          } else if (!this.connecting) {
+            clearInterval(checkConnection);
+            reject(new Error('WebSocket connection failed'));
           }
         }, 100);
       });

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -66,6 +66,9 @@ export const WebSocketManager = {
    * Known limitations:
    * 1. Polls every 100ms which may not be optimal for performance
    * 2. May miss state changes that happen between polls
+   * 3. Has no timeout while waiting on an in-progress connection attempt; callers
+   *    will reject if that attempt fails and clears `this.connecting`, but can wait
+   *    indefinitely if it never reaches open, error, or close
    *
    * A more robust solution would use event listeners and Promise caching,
    * but that adds complexity and potential race conditions to handle.

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -101,7 +101,14 @@ export const WebSocketManager = {
     const wsUrl = `${getBaseWsUrl()}${MULTIPLEXER_ENDPOINT}`;
 
     return new Promise((resolve, reject) => {
-      const socket = new WebSocket(wsUrl);
+      let socket: WebSocket;
+      try {
+        socket = new WebSocket(wsUrl);
+      } catch (e) {
+        this.connecting = false;
+        reject(e);
+        return;
+      }
 
       socket.onopen = () => {
         this.socketMultiplexer = socket;

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -106,7 +106,7 @@ export const WebSocketManager = {
         socket = new WebSocket(wsUrl);
       } catch (e) {
         this.connecting = false;
-        reject(e);
+        reject(e instanceof Error ? e : new Error(String(e)));
         return;
       }
 


### PR DESCRIPTION
## Summary

This PR fixes a `setInterval` leak in `WebSocketManager.connect()` where concurrent callers waiting for an in-progress WebSocket connection would spin forever if the connection failed.

## Related Issue

Fixes #5559

## Changes

- Fixed `WebSocketManager.connect()` in `frontend/src/lib/k8s/api/v2/multiplexer.ts` to reject waiting Promises and clear the polling interval when the WebSocket connection fails

## Steps to Test

1. Open Headlamp with a Kubernetes cluster configured
2. Open browser DevTools → Network tab and block WebSocket connections (or point Headlamp at an unreachable cluster)
3. Navigate to any resource list page (e.g. Workloads → Pods) to trigger concurrent `WebSocketManager.subscribe()` calls
4. Open DevTools → Performance profiler and verify no `setInterval` callbacks keep firing after the connection fails ,an error should be propagated instead of a silent hang

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The fix piggybacks on the existing `this.connecting = false` reset that `socket.onerror` already performs , the interval now checks `!this.connecting` on each tick to detect failure and reject, keeping the change minimal and consistent with the existing pattern
