### PR TITLE
frontend: UploadDialog: Fix missing return after setError on failed URL fetch

### DIFF
--- a/frontend/src/components/common/Resource/UploadDialog.test.tsx
+++ b/frontend/src/components/common/Resource/UploadDialog.test.tsx
@@ -30,6 +30,7 @@ const renderComponent = (setCode = vi.fn(), setUploadFiles = vi.fn()) => {
 describe('UploadDialog', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('Load from URL', () => {
@@ -46,8 +47,7 @@ describe('UploadDialog', () => {
       const setCode = vi.fn();
       renderComponent(setCode);
 
-      fireEvent.click(screen.getByText('Upload File/URL'));
-      fireEvent.click(screen.getByText('Load from URL'));
+      fireEvent.click(screen.getByRole('tab', { name: /load from url/i }));
 
       fireEvent.change(screen.getByLabelText(/enter url/i), {
         target: { value: 'https://example.com/nonexistent.yaml' },
@@ -75,8 +75,7 @@ describe('UploadDialog', () => {
       const setCode = vi.fn();
       renderComponent(setCode);
 
-      fireEvent.click(screen.getByText('Upload File/URL'));
-      fireEvent.click(screen.getByText('Load from URL'));
+      fireEvent.click(screen.getByRole('tab', { name: /load from url/i }));
 
       fireEvent.change(screen.getByLabelText(/enter url/i), {
         target: { value: 'https://example.com/valid.yaml' },

--- a/frontend/src/components/common/Resource/UploadDialog.test.tsx
+++ b/frontend/src/components/common/Resource/UploadDialog.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../../test';
+import { UploadDialog } from './UploadDialog';
+
+const renderComponent = (setCode = vi.fn(), setUploadFiles = vi.fn()) => {
+  return render(
+    <TestContext>
+      <UploadDialog setCode={setCode} setUploadFiles={setUploadFiles} />
+    </TestContext>
+  );
+};
+
+describe('UploadDialog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Load from URL', () => {
+    it('shows error and does not call setCode when fetch returns a non-2xx response', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          statusText: 'Not Found',
+          text: vi.fn().mockResolvedValue('404: Not Found'),
+        })
+      );
+
+      const setCode = vi.fn();
+      renderComponent(setCode);
+
+      fireEvent.click(screen.getByText('Upload File/URL'));
+      fireEvent.click(screen.getByText('Load from URL'));
+
+      fireEvent.change(screen.getByLabelText(/enter url/i), {
+        target: { value: 'https://example.com/nonexistent.yaml' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /load/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to fetch file/i)).toBeInTheDocument();
+      });
+
+      expect(setCode).not.toHaveBeenCalled();
+    });
+
+    it('calls setCode with file content when fetch succeeds', async () => {
+      const yamlContent = 'apiVersion: v1\nkind: Pod';
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          text: vi.fn().mockResolvedValue(yamlContent),
+        })
+      );
+
+      const setCode = vi.fn();
+      renderComponent(setCode);
+
+      fireEvent.click(screen.getByText('Upload File/URL'));
+      fireEvent.click(screen.getByText('Load from URL'));
+
+      fireEvent.change(screen.getByLabelText(/enter url/i), {
+        target: { value: 'https://example.com/valid.yaml' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /load/i }));
+
+      await waitFor(() => {
+        expect(setCode).toHaveBeenCalledWith({ format: 'yaml', code: yamlContent });
+      });
+    });
+  });
+});

--- a/frontend/src/components/common/Resource/UploadDialog.tsx
+++ b/frontend/src/components/common/Resource/UploadDialog.tsx
@@ -201,7 +201,10 @@ const UploadFromUrl = ({
     try {
       const res = await fetch(u.toString());
       if (!res.ok) {
-        setError(t(`translation|Failed to fetch file: ${res.statusText}`));
+        setError(
+          t('translation|Failed to fetch file: {{statusText}}', { statusText: res.statusText })
+        );
+        return;
       }
       const text = await res.text();
       onLoaded(text);

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -481,6 +481,7 @@
   "{{count}} files selected_one": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -481,6 +481,7 @@
   "{{count}} files selected_one": "{{count}} files selected",
   "{{count}} files selected_other": "{{count}} files selected",
   "Please enter a valid URL.": "Please enter a valid URL.",
+  "Failed to fetch file: {{statusText}}": "Failed to fetch file: {{statusText}}",
   "Unexpected error while fetching the file.": "Unexpected error while fetching the file.",
   "Enter URL": "Enter URL",
   "Upload File": "Upload File",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -486,6 +486,7 @@
   "{{count}} files selected_many": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -486,6 +486,7 @@
   "{{count}} files selected_many": "{{count}} fichiers sélectionnés",
   "{{count}} files selected_other": "{{count}} fichiers sélectionnés",
   "Please enter a valid URL.": "Veuillez entrer une URL valide.",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "Erreur inattendue lors de la récupération du fichier.",
   "Enter URL": "Entrer l'URL",
   "Upload File": "Télécharger un fichier",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -481,6 +481,7 @@
   "{{count}} files selected_one": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -486,6 +486,7 @@
   "{{count}} files selected_many": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -476,6 +476,7 @@
   "Select File": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -476,6 +476,7 @@
   "Select File": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -486,6 +486,7 @@
   "{{count}} files selected_many": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -481,6 +481,7 @@
   "{{count}} files selected_one": "",
   "{{count}} files selected_other": "",
   "Please enter a valid URL.": "",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "",
   "Enter URL": "",
   "Upload File": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -476,6 +476,7 @@
   "Select File": "選擇檔案",
   "{{count}} files selected_other": "已選擇 {{count}} 個檔案",
   "Please enter a valid URL.": "請輸入有效的 URL。",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "抓取檔案時發生意外錯誤。",
   "Enter URL": "輸入 URL",
   "Upload File": "上傳檔案",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -476,6 +476,7 @@
   "Select File": "选择文件",
   "{{count}} files selected_other": "已选择 {{count}} 个文件",
   "Please enter a valid URL.": "请输入有效的 URL。",
+  "Failed to fetch file: {{statusText}}": "",
   "Unexpected error while fetching the file.": "获取文件时发生意外错误。",
   "Enter URL": "输入 URL",
   "Upload File": "上传文件",


### PR DESCRIPTION
## Summary

This PR fixes a bug where a failed URL fetch in the "Load from URL" dialog would silently load the raw error response body into the editor instead of stopping execution after displaying the error.

## Related Issue

Fixes #5561

## Changes

- Added a missing `return` after `setError()` in `loadFromUrl()` in `frontend/src/components/common/Resource/UploadDialog.tsx`
- Fixed i18n interpolation from a template literal to the correct `t('...{{var}}...', { var: value })` pattern

## Steps to Test

1. Open Headlamp and connect to a cluster
2. Click **+ Create** at the bottom left
3. Click **Upload File/URL** → switch to the **Load from URL** tab
4. Enter a URL that returns a 404, e.g. `https://raw.githubusercontent.com/kubernetes-sigs/headlamp/main/nonexistent.yaml`
5. Click **Load**
6. Observe that the error message is shown and the editor remains empty (previously `404: Not Found` was loaded into the editor)

## Screenshots (Before)
<img width="1918" height="1156" alt="Screenshot 2026-05-11 193433" src="https://github.com/user-attachments/assets/fae1a743-8232-400c-a0ab-9a2ee9307ec2" />
<img width="1918" height="1155" alt="Screenshot 2026-05-11 193441" src="https://github.com/user-attachments/assets/aea7671b-f817-446c-b7c5-33ae72d4e4ea" />

## Screenshots (After)
<img width="965" height="443" alt="Screenshot 2026-05-11 193559" src="https://github.com/user-attachments/assets/11bb491f-343f-41bf-b421-63aa7426f893" />
<img width="1915" height="1080" alt="Screenshot 2026-05-11 193802" src="https://github.com/user-attachments/assets/01009ccd-864a-4eb9-9dc1-c8ac05138dab" />





## Notes for the Reviewer

- The fix also corrects the i18n interpolation pattern in the error message — previously `res.statusText` was embedded directly into the translation key via a template literal, making it untranslatable. It now uses the standard `{{statusText}}` interpolation used elsewhere in the file.
