### PR TITLE
backend: Serve embedded SPA fallback as HTML

### DIFF
--- a/backend/pkg/spa/embeddedSPAHandler.go
+++ b/backend/pkg/spa/embeddedSPAHandler.go
@@ -32,13 +32,16 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Prepend "static" to the path as that's the root in our embed.FS
 	fullPath := filepath.Join("static", path)
+	servedPath := fullPath
 
 	content, err := h.serveFile(fullPath)
 	isServingIndex := false
 
 	if err != nil {
 		// If there's any error, serve the index file
-		content, err = h.serveFile(filepath.Join("static", h.indexPath))
+		servedPath = filepath.Join("static", h.indexPath)
+
+		content, err = h.serveFile(servedPath)
 		if err != nil {
 			http.Error(w, "Unable to read index file", http.StatusInternalServerError)
 			return
@@ -63,7 +66,7 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set the correct Content-Type header
-	ext := filepath.Ext(fullPath)
+	ext := filepath.Ext(servedPath)
 
 	contentType := mime.TypeByExtension(ext)
 	if contentType == "" {

--- a/backend/pkg/spa/embeddedSPAHandler_test.go
+++ b/backend/pkg/spa/embeddedSPAHandler_test.go
@@ -52,6 +52,10 @@ func TestEmbeddedSpaHandler(t *testing.T) {
 	t.Run("file_not_found", func(t *testing.T) {
 		testFileNotFound(t, testHTML)
 	})
+
+	t.Run("file_not_found_uses_index_content_type", func(t *testing.T) {
+		testFileNotFoundUsesIndexContentType(t, testHTML)
+	})
 }
 
 func testHeadlampBaseURLWithBaseURL(t *testing.T, testHTML string) {
@@ -103,4 +107,20 @@ func testFileNotFound(t *testing.T, testHTML string) {
 	// Check that the __baseUrl__ assignment was replaced in fallback case
 	assert.Contains(t, rr.Body.String(), "__baseUrl__ = '/headlamp';")
 	assert.Contains(t, rr.Body.String(), "headlampBaseUrl = __baseUrl__;")
+}
+
+func testFileNotFoundUsesIndexContentType(t *testing.T, testHTML string) {
+	handler := spa.NewEmbeddedHandler(createTestFS(map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(testHTML)},
+	}), "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/not-found.css", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Header().Get("Content-Type"), "text/html")
+	assert.Contains(t, rr.Body.String(), "__baseUrl__ = '/headlamp';")
 }


### PR DESCRIPTION
## Summary
Fixes the embedded SPA handler so fallback `index.html` responses use the content type of the file actually served.

## Related Issue
Fixes #5563

## Changes
- Track the embedded SPA path that is actually served.
- Use the served path extension when setting `Content-Type`.
- Add a regression test for missing `.css` asset fallback serving HTML.

## Steps to Test
1. Run `cd backend && go test ./pkg/spa`.
2. Run `npm run backend:test`.
3. Run `npm run backend:lint`.

## Screenshots
N/A

## Notes for the Reviewer
The bug only affects the embedded SPA fallback path. Missing asset routes were returning the `index.html` body while keeping the missing asset extension for MIME detection.