### PR TITLE
backend: k8cache: Skip caching 5xx infrastructure error responses

### DIFF
--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -236,6 +236,10 @@ func StoreK8sResponseInCache(k8scache cache.Cache[string],
 	r *http.Request,
 	key string,
 ) error {
+	if rcw.StatusCode >= 500 {
+		return nil
+	}
+
 	capturedHeaders := rcw.Header()
 	encoding := capturedHeaders.Get("Content-Encoding")
 	bodyBytes := rcw.Body.Bytes()

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -856,3 +856,25 @@ func TestExtractNamespace_QueryStringOnNamespacedURL(t *testing.T) {
 		})
 	}
 }
+
+func TestStoreK8sResponseInCache_5xxResponseShouldNotBeCached(t *testing.T) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/api/v1/pods"}
+	rw := httptest.NewRecorder()
+	rcw := k8cache.NewResponseCapture(rw)
+
+	// Simulate a load balancer 502 — body has no K8s "Failure" string
+	rcw.WriteHeader(http.StatusBadGateway)
+	_, _ = rcw.Write([]byte(`<html><body>Bad Gateway</body></html>`))
+
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, targetURL.Path, nil,
+	)
+
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "infra-error-key")
+	assert.NoError(t, err)
+
+	// Key must NOT be in cache — infrastructure errors should not be cached
+	_, getErr := mockCache.Get(context.Background(), "infra-error-key")
+	assert.Error(t, getErr, "5xx infrastructure errors should not be cached")
+}


### PR DESCRIPTION
## Summary

Infrastructure-layer 5xx responses (load balancer 502, reverse proxy 503/504) were being cached for 10 minutes because the only guard was a `"Failure"` string check — which only catches Kubernetes API errors. Added a status code check so 5xx responses are never cached.

## Related Issue

Fixes #5565

## Changes

- Added `rcw.StatusCode < 500` check before the existing `"Failure"` string check in `StoreK8sResponseInCache`
- Added regression test: 502 response with a non-K8s HTML body should not be cached

## Steps to Test

1. Run `cd backend && go test ./pkg/k8cache/ -v`
2. All existing tests pass
3. New test `TestStoreK8sResponseInCache_NonK8sErrorResponseShouldNotBeCached` verifies a 502 with non-K8s body is not cached

## Notes for the Reviewer

- The check is `< 500` rather than `>= 200 && < 300` because caching non-2xx responses (like 4xx) is existing behavior that other tests rely on (`TestServeFromCacheOrForwardToK8s` caches a 418). The `"Failure"` string check already handles K8s 4xx errors. If narrowing to 2xx-only is preferred, that test would need updating — happy to do that in this PR if needed.