### PR TITLE
frontend: Clean up raw Kubernetes API error messages in snackbar

### DIFF
--- a/frontend/src/components/common/ActionsNotifier.tsx
+++ b/frontend/src/components/common/ActionsNotifier.tsx
@@ -92,6 +92,7 @@ function PureActionsNotifier({ dispatch, clusterActions }: PureActionsNotifierPr
           key: uniqueKey,
           autoHideDuration: clusterAction.autoHideDuration || CLUSTER_ACTION_GRACE_PERIOD,
           action,
+          style: { whiteSpace: 'pre-line' },
           ...clusterAction.snackbarProps,
         });
       }

--- a/frontend/src/components/common/__snapshots__/ActionsNotifier.Some.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ActionsNotifier.Some.stories.storyshot
@@ -18,7 +18,7 @@
               aria-describedby="notistack-snackbar"
               class="go1888806478 notistack-MuiContent notistack-MuiContent-default go167266335 go3844575157"
               role="alert"
-              style="-webkit-transform: none; transform: none; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+              style="white-space: pre-line; -webkit-transform: none; transform: none; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
             >
               <div
                 class="go946087465"

--- a/frontend/src/redux/clusterActionSlice.test.ts
+++ b/frontend/src/redux/clusterActionSlice.test.ts
@@ -174,6 +174,183 @@ describe('clusterActionSlice', () => {
 
       expect(callback).toHaveBeenCalled();
     });
+
+    it('should strip regex suffix from Kubernetes API validation errors', async () => {
+      const callback = vi.fn(() => {
+        throw new Error(
+          `Unprocessable Entity - Deployment.apps "myapp" is invalid: ` +
+            `[metadata.labels: Invalid value: "bad val": a valid label must be alphanumeric, ` +
+            `regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?']`
+        );
+      });
+
+      const action: CallbackAction = {
+        callback,
+        errorMessage: 'Failed to apply.',
+        startOptions: {},
+        successOptions: { variant: 'success' },
+        errorOptions: { variant: 'error' },
+        cancelledOptions: {},
+      };
+
+      vi.useFakeTimers();
+      const dispatchedAction = store.dispatch(executeClusterAction(action));
+      vi.advanceTimersByTime(CLUSTER_ACTION_GRACE_PERIOD);
+      await dispatchedAction;
+
+      const actions = store.getActions();
+      const errorAction = actions.find(
+        a => a.type === updateClusterAction.type && a.payload?.state === 'error'
+      );
+      expect(errorAction?.payload?.message).not.toContain('regex used for validation');
+      expect(errorAction?.payload?.message).toContain('metadata.labels');
+    });
+
+    it('should format multi-error K8s validation list into bullet lines', async () => {
+      const callback = vi.fn(() => {
+        throw new Error(
+          `Unprocessable Entity - Deployment.apps "myapp" is invalid: ` +
+            `[spec.template.spec.containers[0].image: Invalid value: "bad image": invalid, ` +
+            `spec.selector: Invalid value: {}: field is immutable]`
+        );
+      });
+
+      const action: CallbackAction = {
+        callback,
+        errorMessage: 'Failed to apply.',
+        startOptions: {},
+        successOptions: { variant: 'success' },
+        errorOptions: { variant: 'error' },
+        cancelledOptions: {},
+      };
+
+      vi.useFakeTimers();
+      const dispatchedAction = store.dispatch(executeClusterAction(action));
+      vi.advanceTimersByTime(CLUSTER_ACTION_GRACE_PERIOD);
+      await dispatchedAction;
+
+      const actions = store.getActions();
+      const errorAction = actions.find(
+        a => a.type === updateClusterAction.type && a.payload?.state === 'error'
+      );
+      const msg: string = errorAction?.payload?.message ?? '';
+      expect(msg).toContain('• spec.template.spec.containers[0].image');
+      expect(msg).toContain('• spec.selector');
+      const bulletCount = (msg.match(/•/g) ?? []).length;
+      expect(bulletCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should split multi-error list when later fields contain indexed paths', async () => {
+      const callback = vi.fn(() => {
+        throw new Error(
+          `Unprocessable Entity - Deployment.apps "myapp" is invalid: ` +
+            `[spec.replicas: Invalid value: -1: must be greater than or equal to 0, ` +
+            `spec.template.spec.containers[0].name: Required value, ` +
+            `spec.template.spec.containers[1].image: Invalid value: "": must not be empty]`
+        );
+      });
+
+      const action: CallbackAction = {
+        callback,
+        errorMessage: 'Failed to apply.',
+        startOptions: {},
+        successOptions: { variant: 'success' },
+        errorOptions: { variant: 'error' },
+        cancelledOptions: {},
+      };
+
+      vi.useFakeTimers();
+      const dispatchedAction = store.dispatch(executeClusterAction(action));
+      vi.advanceTimersByTime(CLUSTER_ACTION_GRACE_PERIOD);
+      await dispatchedAction;
+
+      const actions = store.getActions();
+      const errorAction = actions.find(
+        a => a.type === updateClusterAction.type && a.payload?.state === 'error'
+      );
+      const msg: string = errorAction?.payload?.message ?? '';
+      expect(msg).toContain('• spec.replicas');
+      expect(msg).toContain('• spec.template.spec.containers[0].name');
+      expect(msg).toContain('• spec.template.spec.containers[1].image');
+      const bulletCount = (msg.match(/•/g) ?? []).length;
+      expect(bulletCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should not let a bracket inside a quoted value affect depth tracking', async () => {
+      const callback = vi.fn(() => {
+        throw new Error(
+          `Unprocessable Entity - Deployment.apps "myapp" is invalid: ` +
+            `[spec.foo: Invalid value: "bad[value": invalid, ` +
+            `spec.bar: Required value]`
+        );
+      });
+
+      const action: CallbackAction = {
+        callback,
+        errorMessage: 'Failed to apply.',
+        startOptions: {},
+        successOptions: { variant: 'success' },
+        errorOptions: { variant: 'error' },
+        cancelledOptions: {},
+      };
+
+      vi.useFakeTimers();
+      const dispatchedAction = store.dispatch(executeClusterAction(action));
+      vi.advanceTimersByTime(CLUSTER_ACTION_GRACE_PERIOD);
+      await dispatchedAction;
+
+      const actions = store.getActions();
+      const errorAction = actions.find(
+        a => a.type === updateClusterAction.type && a.payload?.state === 'error'
+      );
+      const msg: string = errorAction?.payload?.message ?? '';
+      expect(msg).toContain('• spec.foo');
+      expect(msg).toContain('• spec.bar');
+      const bulletCount = (msg.match(/•/g) ?? []).length;
+      expect(bulletCount).toBe(2);
+    });
+
+    it('should not split a single error whose value contains Go struct fields', async () => {
+      // K8s sometimes embeds Go-style struct printouts (e.g. v1.LabelSelector with
+      // MatchLabels: / MatchExpressions: fields) inside `Invalid value: ...`. A naive
+      // splitter would treat ", MatchExpressions:" as a new error and produce bogus
+      // bullets — this is a single field error and must stay on one line.
+      const goValue =
+        'v1.LabelSelector{MatchLabels:map[string]string{"app":"x"}, ' +
+        'MatchExpressions:[]v1.LabelSelectorRequirement(nil)}';
+      const callback = vi.fn(() => {
+        throw new Error(
+          `Unprocessable Entity - Deployment.apps "myapp" is invalid: ` +
+            `[spec.selector: Invalid value: ${goValue}: field is immutable]`
+        );
+      });
+
+      const action: CallbackAction = {
+        callback,
+        errorMessage: 'Failed to apply.',
+        startOptions: {},
+        successOptions: { variant: 'success' },
+        errorOptions: { variant: 'error' },
+        cancelledOptions: {},
+      };
+
+      vi.useFakeTimers();
+      const dispatchedAction = store.dispatch(executeClusterAction(action));
+      vi.advanceTimersByTime(CLUSTER_ACTION_GRACE_PERIOD);
+      await dispatchedAction;
+
+      const actions = store.getActions();
+      const errorAction = actions.find(
+        a => a.type === updateClusterAction.type && a.payload?.state === 'error'
+      );
+      const msg: string = errorAction?.payload?.message ?? '';
+      // The whole Go value (including MatchExpressions) must remain on the same bullet.
+      expect(msg).toContain('• spec.selector');
+      expect(msg).toContain('MatchExpressions');
+      // And the result must contain exactly one bullet.
+      const bulletCount = (msg.match(/•/g) ?? []).length;
+      expect(bulletCount).toBe(1);
+    });
   });
 
   describe('updateClusterAction', () => {

--- a/frontend/src/redux/clusterActionSlice.ts
+++ b/frontend/src/redux/clusterActionSlice.ts
@@ -152,6 +152,40 @@ const controllers = new Map<string, AbortController>();
 /** The amount of time to wait before allowing the action to be cancelled. */
 export const CLUSTER_ACTION_GRACE_PERIOD = 5000;
 
+// Splits the body of a K8s "is invalid: [...]" multi-error into one entry per
+// field error. A naive regex split on `, ` followed by `\w+:` falsely splits Go
+// struct value printouts that the API server embeds in `Invalid value:` (e.g.
+// `v1.LabelSelector{MatchLabels:..., MatchExpressions:...}`). To avoid that, we
+// track `{}` / `[]` depth and only split at top level, and only when the next
+// token starts with a lowercase field path — Go struct fields start uppercase,
+// so they cannot accidentally trigger a split.
+export function splitK8sValidationErrors(inner: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '"' && inner[i - 1] !== '\\') {
+      inString = !inString;
+    } else if (!inString) {
+      if (ch === '{' || ch === '[') depth++;
+      else if (ch === '}' || ch === ']') depth = Math.max(0, depth - 1);
+      else if (
+        depth === 0 &&
+        ch === ',' &&
+        inner[i + 1] === ' ' &&
+        /^[a-z][\w./[\]-]*:/.test(inner.slice(i + 2))
+      ) {
+        parts.push(inner.slice(start, i));
+        start = i + 2;
+      }
+    }
+  }
+  parts.push(inner.slice(start));
+  return parts;
+}
+
 /**
  * Uses the callback to execute an action and dispatches actions
  * to update the UI based on the result.
@@ -239,7 +273,23 @@ export const executeClusterAction = createAsyncThunk(
     function dispatchError(err?: Error | string | null) {
       let message = errorMessage || '';
       if (err) {
-        const originalMessage = typeof err === 'string' ? err : err.message;
+        const rawMessage = typeof err === 'string' ? err : err.message;
+        const originalMessage = rawMessage
+          ? (() => {
+              const cleaned = rawMessage.replace(/,?\s*regex used for validation is '[^']*'/g, '');
+              // K8s multi-error format: "... is invalid: [field1: msg1, field2: msg2]"
+              const match = cleaned.match(/^(.*?is invalid:)\s*\[(.+)\]\s*$/s);
+              if (match) {
+                const prefix = match[1];
+                const inner = match[2];
+                const bullets = splitK8sValidationErrors(inner)
+                  .map(s => `• ${s.trim()}`)
+                  .join('\n');
+                return `${prefix}\n${bullets}`.trim();
+              }
+              return cleaned.trim();
+            })()
+          : rawMessage;
         if (originalMessage) {
           const separator = message ? (message.endsWith('.') ? ' ' : '. ') : '';
           message = `${message}${separator}${originalMessage}`;


### PR DESCRIPTION
## Summary

This PR fixes the resource editor snackbar displaying raw Kubernetes API error messages including machine-readable regex validation patterns. Errors are now stripped of regex noise and split into readable bullet lines.

## Related Issue

Fixes #5568 

## Changes

## Changes
- `frontend/src/redux/clusterActionSlice.ts`: Strip `regex used for validation is '...'` suffix from all Kubernetes API error messages before displaying them in the snackbar
- `frontend/src/redux/clusterActionSlice.ts`: Split multiple validation errors (when the message contains the `[field: error, field: error]` format) into bullet points instead of one unreadable line

## Steps to Test
1. Run `npm run frontend` from the root
2. Trigger a Kubernetes API validation error (e.g. apply an invalid resource)
3. The snackbar should show a clean message without the `regex used for validation is '...'` suffix
4. If the error contains multiple validation failures, each should appear as a separate bullet point



## Screenshots (if applicable)
<img width="1872" height="215" alt="Screenshot 2026-05-12 004704" src="https://github.com/user-attachments/assets/ac2a5fea-8597-4ff1-acfa-8c651e9aff33" />


<!-- Attach before/after screenshots of the error snackbar -->

## Notes for the Reviewer

- This affects all Kubernetes API error messages shown via `clusterAction` across the entire app, not just the editor
- The regex stripping and bullet formatting only activates when the error contains the `[...]` multi-error format from the Kubernetes API — single-error messages are unaffected
