### PR TITLE
headlamp-plugin: Fix broken plugin tests

### DIFF
--- a/plugins/headlamp-plugin/test-headlamp-plugin.js
+++ b/plugins/headlamp-plugin/test-headlamp-plugin.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 /*
  * Copyright 2025 The Kubernetes Authors

--- a/plugins/pluginctl/src/multi-plugin-management.test.js
+++ b/plugins/pluginctl/src/multi-plugin-management.test.js
@@ -26,19 +26,19 @@ describe('MultiPluginManagement', () => {
   let installer;
   const PLUGIN_DATA = [
     {
-      name: 'appcatalog_headlamp_plugin',
-      source: 'https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin',
-      version: '0.0.3',
+      name: 'headlamp_opencost',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost',
+      version: '0.1.3',
     },
     {
-      name: 'ai_plugin',
-      source: 'https://artifacthub.io/packages/headlamp/test-123/ai_plugin',
-      version: '0.0.2',
+      name: 'headlamp_kompose',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/headlamp_kompose',
+      version: '0.1.1-beta',
     },
     {
-      name: 'prometheus_headlamp_plugin',
-      source: 'https://artifacthub.io/packages/headlamp/test-123/prometheus_headlamp_plugin',
-      version: '0.0.3',
+      name: 'headlamp_flux',
+      source: 'https://artifacthub.io/packages/headlamp/test-123/headlamp_flux',
+      version: '0.6.0',
     },
   ];
   beforeEach(async () => {

--- a/plugins/pluginctl/src/plugin-management.e2e.js
+++ b/plugins/pluginctl/src/plugin-management.e2e.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 /*
  * Copyright 2025 The Kubernetes Authors

--- a/plugins/pluginctl/src/plugin-management.e2e.js
+++ b/plugins/pluginctl/src/plugin-management.e2e.js
@@ -52,12 +52,12 @@ let plugins = JSON.parse(output);
 console.log('Initial plugins:', plugins);
 
 // Ensure the plugin is not installed
-const pluginName = 'prometheus';
+const pluginName = '@headlamp-k8s/minikube';
 let pluginExists = plugins.some(plugin => plugin.pluginName === pluginName);
 assert.strictEqual(pluginExists, false, 'Plugin should not be initially installed');
 
 // Install the plugin
-const pluginURL = 'https://artifacthub.io/packages/headlamp/test-123/prometheus_headlamp_plugin';
+const pluginURL = 'https://artifacthub.io/packages/headlamp/test-123/headlamp_minikube';
 output = runCommand(`node ../bin/pluginctl.js install ${pluginURL}`);
 console.log('Install output:', output);
 

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -49,7 +49,7 @@ describe('PluginManager Test Cases', () => {
 
   test('Install Plugin', async () => {
     await PluginManager.install(
-      'https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin',
+      'https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost',
       tempDir,
       '',
       mockProgressCallback
@@ -71,8 +71,8 @@ describe('PluginManager Test Cases', () => {
   });
 
   test('No Update available for Plugin', async () => {
-    // No updates available for "app-catalog" plugin
-    await PluginManager.update('app-catalog', tempDir, '', mockProgressCallback);
+    // No updates available for "opencost" plugin
+    await PluginManager.update('@headlamp-k8s/opencost', tempDir, '', mockProgressCallback);
     expect(mockProgressCallback).toHaveBeenCalledWith({
       type: 'error',
       message: 'No updates available',
@@ -80,18 +80,17 @@ describe('PluginManager Test Cases', () => {
   });
 
   test('Update Plugin', async () => {
-    // update the "app-catalog" plugin package.json with lower state
-    const packageJSONPath = `${tempDir}/appcatalog_headlamp_plugin/package.json`;
+    // update the "opencost" plugin package.json with lower version
+    const packageJSONPath = `${tempDir}/headlamp_opencost/package.json`;
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
     packageJSON.artifacthub.version = `${semver.major(
       packageJSON.artifacthub.version
-    )}.${semver.minor(packageJSON.artifacthub.version)}.${
-      semver.patch(packageJSON.artifacthub.version) - 1
-    }`; // Reduce the version using semver
+    )}.${semver.minor(packageJSON.artifacthub.version)}.${semver.patch(packageJSON.artifacthub.version) - 1
+      }`; // Reduce the version using semver
     // Write the updated package.json back to the file
     fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));
 
-    await PluginManager.update('app-catalog', tempDir, '', mockProgressCallback);
+    await PluginManager.update('@headlamp-k8s/opencost', tempDir, '', mockProgressCallback);
     expect(mockProgressCallback).toHaveBeenCalledWith({
       type: 'success',
       message: 'Plugin Updated',
@@ -102,7 +101,7 @@ describe('PluginManager Test Cases', () => {
     const tempDir = tmp.dirSync({ unsafeCleanup: true }).name;
 
     await PluginManager.install(
-      'https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin',
+      'https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost',
       tempDir,
       '',
       mockProgressCallback
@@ -112,7 +111,7 @@ describe('PluginManager Test Cases', () => {
       message: 'Plugin Installed',
     });
 
-    PluginManager.uninstall('app-catalog', tempDir, mockProgressCallback);
+    PluginManager.uninstall('@headlamp-k8s/opencost', tempDir, mockProgressCallback);
     expect(mockProgressCallback).toHaveBeenCalledWith({
       type: 'success',
       message: 'Plugin Uninstalled',

--- a/plugins/pluginctl/test-pluginctl.js
+++ b/plugins/pluginctl/test-pluginctl.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 /*
  * Copyright 2025 The Kubernetes Authors

--- a/plugins/pluginctl/test-pluginctl.js
+++ b/plugins/pluginctl/test-pluginctl.js
@@ -23,10 +23,10 @@ This tests unpublished @headlamp-k8s/pluginctl package in repo.
 
 Assumes being run within the plugins/pluginctl folder
 `;
-const PACKAGE_NAME = "appcatalog_headlamp_plugin";
+const PACKAGE_NAME = "headlamp_opencost";
 const PACKAGE_URL =
-  "https://artifacthub.io/packages/headlamp/test-123/appcatalog_headlamp_plugin";
-const PACKAGE_NAME_TO_UNINSTALL = "app-catalog";
+  "https://artifacthub.io/packages/headlamp/test-123/headlamp_opencost";
+const PACKAGE_NAME_TO_UNINSTALL = "@headlamp-k8s/opencost";
 
 function testPluginctl() {
   // remove some temporary files.


### PR DESCRIPTION
This change fixes `make plugins-test` which is broken due to deleted ArtifactHub test packages. The `test-123` ArtifactHub repo (used by plugin e2e/unit tests) had several packages removed (`appcatalog_headlamp_plugin`, `ai_plugin`, `prometheus_headlamp_plugin`), causing 404s and test failures. The shebang `#!/bin/env` also doesn't work on macOS.

### Changes

- Fix shebang `#!/bin/env` -> `#!/usr/bin/env` in `test-headlamp-plugin.js`, `plugin-management.e2e.js`, and `test-pluginctl.js`
- Replace deleted ArtifactHub test packages with live ones from the same `test-123` repo in `plugin-management.e2e.js`, `plugin-management.test.js`, `multi-plugin-management.test.js`, and `test-pluginctl.js`

### Testing

- [x] `make plugins-test` passes locally on macOS
- [x] All 14 tests in `plugin-management.test.js` pass
- [x] All 14 tests in `multi-plugin-management.test.js` pass
- [x] Plugin install/update/uninstall e2w flow completes successfully