### PR TITLE
Fix/OIDC external secret scopes arg

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -305,7 +305,9 @@ spec:
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            {{- if $oidc.externalSecret.hasScopes }}
             - "-oidc-scopes=$(OIDC_SCOPES)"
+            {{- end }}
             {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}
             # Check if callbackURL is non empty either from env or oidc.config
             - "-oidc-callback-url=$(OIDC_CALLBACK_URL)"

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
@@ -110,6 +110,7 @@ spec:
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/test_cases/oidc-external-secret-with-scopes.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-external-secret-with-scopes.yaml
@@ -1,0 +1,11 @@
+# This is a test case for OIDC external secret with hasScopes enabled.
+# When hasScopes is true, the -oidc-scopes argument is included so that
+# the OIDC_SCOPES key from the external secret is passed to Headlamp.
+config:
+  oidc:
+    secret:
+      create: false
+    externalSecret:
+      enabled: true
+      name: oidc
+      hasScopes: true

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -229,6 +229,10 @@
                 "enabled": {
                   "type": "boolean",
                   "description": "Enable the external secret"
+                },
+                "hasScopes": {
+                  "type": "boolean",
+                  "description": "Set to true if the external secret contains an OIDC_SCOPES key"
                 }
               }
             }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -104,6 +104,10 @@ config:
     externalSecret:
       enabled: false
       name: ""
+      # -- Set to true if your external secret contains an OIDC_SCOPES key.
+      # When false (default), the -oidc-scopes argument is omitted so that
+      # a missing key does not produce an empty or unresolved argument.
+      hasScopes: false
 
     # -- URL to fetch additional user info for the /me endpoint.
     # For oauth2proxy /oauth2/userinfo can be used. Empty and it will not be used.


### PR DESCRIPTION
## Summary

This PR fixes the empty `-oidc-scopes` argument being unconditionally added to the Headlamp deployment when using `externalSecret` for OIDC configuration without an `OIDC_SCOPES` key in the secret.

## Related Issue

Fixes #4220

## Changes

- Added `externalSecret.hasScopes` boolean field (default `false`) to `values.yaml` and `values.schema.json`
- Updated `deployment.yaml` to conditionally include:
  ```yaml
  -oidc-scopes=$(OIDC_SCOPES)
  ```
  only when `hasScopes: true`
- Updated expected test template for `oidc-external-secret` to reflect the new default behavior
- Added new test case `oidc-external-secret-with-scopes` and its expected template for the `hasScopes: true` scenario

## Steps to Test

### 1. Install the Helm chart with an external OIDC secret that does not include `OIDC_SCOPES`

```yaml
config:
  oidc:
    secret:
      create: false
    externalSecret:
      enabled: true
      name: oidc
```

### 2. Verify

- Deployment args do **not** contain:
  ```yaml
  -oidc-scopes=$(OIDC_SCOPES)
  ```
- Login succeeds without an `invalid_request` error from the identity provider (IDP)

### 3. Test opt-in scopes behavior

Set:

```yaml
config:
  oidc:
    externalSecret:
      enabled: true
      name: oidc
      hasScopes: true
```

Verify the deployment args now contain:

```yaml
-oidc-scopes=$(OIDC_SCOPES)
```

## Screenshots

<img width="1505" height="306" alt="image" src="https://github.com/user-attachments/assets/7453ae34-033a-4989-8eca-7284d80c5601" />


## Notes for the Reviewer

- `hasScopes` defaults to `false`, which changes behavior for existing users who already have `OIDC_SCOPES` in their external secret
- Those users will now need to explicitly set:
  ```yaml
  externalSecret.hasScopes: true
  ```
  to restore the previous behavior
- The non-`externalSecret` code path is unaffected

## Validation

Run:

```bash
helm lint charts/headlamp
bash charts/headlamp/tests/test.sh
```