### PR TITLE
frontend: CustomResourceList: Document why t is excluded from cols deps

### DIFF
--- a/frontend/src/components/crd/CustomResourceList.tsx
+++ b/frontend/src/components/crd/CustomResourceList.tsx
@@ -145,26 +145,31 @@ export function CustomResourceListTable(props: CustomResourceTableProps) {
     return cols;
   }, [crd, apiGroup]);
 
-  const cols = React.useMemo(() => {
-    const colsToDisplay: ResourceTableProps<KubeObject<KubeCRD>>['columns'] = [
-      {
-        label: t('translation|Name'),
-        getValue: resource => resource.metadata.name,
-        render: resource => <CustomResourceLink resource={resource} crd={crd} />,
-      },
-      ...(isMultiCluster ? (['cluster'] as ColumnType[]) : ([] as ColumnType[])),
-      ...additionalPrinterCols,
-      'labels',
-      'age',
-    ];
+  const cols = React.useMemo(
+    () => {
+      const colsToDisplay: ResourceTableProps<KubeObject<KubeCRD>>['columns'] = [
+        {
+          label: t('translation|Name'),
+          getValue: resource => resource.metadata.name,
+          render: resource => <CustomResourceLink resource={resource} crd={crd} />,
+        },
+        ...(isMultiCluster ? (['cluster'] as ColumnType[]) : ([] as ColumnType[])),
+        ...additionalPrinterCols,
+        'labels',
+        'age',
+      ];
 
-    if (crd.isNamespacedScope) {
-      colsToDisplay.splice(1, 0, 'namespace');
-    }
+      if (crd.isNamespacedScope) {
+        colsToDisplay.splice(1, 0, 'namespace');
+      }
 
-    return colsToDisplay;
+      return colsToDisplay;
+    },
+    // `t` is intentionally omitted from the deps array; including it has been
+    // observed to break this hook in practice (see #5183).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [crd, additionalPrinterCols, isMultiCluster]);
+    [crd, additionalPrinterCols, isMultiCluster]
+  );
 
   if (!CRClass) {
     return <Empty>{t('translation|No custom resources found')}</Empty>;


### PR DESCRIPTION
## Summary

This PR documents the existing `react-hooks/exhaustive-deps` suppression in `frontend/src/components/crd/CustomResourceList.tsx` with a comment explaining why `t` is intentionally excluded from the `cols` `useMemo` deps array. Per maintainer feedback, including `t` in this deps array breaks the hook in practice, so the suppression remains in place but is now self-documenting for future contributors.

## Related Issue

Fixes #5575 (sub-issue of umbrella #5183).

## Changes

- Replaced the bare `// eslint-disable-next-line react-hooks/exhaustive-deps` directive with a two-line comment noting that `t` is intentionally omitted and pointing readers to umbrella #5183 for context.
- Reformatted the `useMemo` call to a multi-line shape so the new comments sit directly above the `eslint-disable-next-line` and the deps array (per Copilot review feedback) rather than after `return colsToDisplay;` where they read like dead code.
- No functional change.

### Iteration history

The first revision added `t` to the deps array (the conventional react-i18next fix). Maintainer @illume noted in review that including `t` here breaks the hook in practice, so the change was reverted and replaced with this documentation-only approach. Layout subsequently adjusted per Copilot's inline suggestion so the rationale sits clearly above the suppression rather than after the `return`.

## Steps to Test

1. `cd frontend && npm install`
2. `npm run lint`: passes (the existing suppression continues to silence the rule for this hook).
3. `npm run tsc`: passes.
4. `npx vitest run src/components/crd`: existing crd tests still pass.

## Screenshots (if applicable)

N/A. No functional change.

## Notes for the Reviewer

- Single-file diff. Functional change is the new explanatory comment; the rest of the diff is a prettier-driven re-indent caused by moving the deps array onto its own line.
- DCO sign-off applied (`Signed-off-by:` in the commit).
- Force-pushed twice on this PR: once to swap the deps approach for documentation per @illume's review, and once to address Copilot's comment-placement feedback.