### PR TITLE
frontend: relations: Remove staticRelations from useMemo deps

### DIFF
--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -313,6 +313,5 @@ const staticRelations = [
 export function useGetAllRelations(): Relation[] {
   const crdRelations = useGetCRToOwnerRelations();
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => [...staticRelations, ...crdRelations], [crdRelations, staticRelations]);
+  return useMemo(() => [...staticRelations, ...crdRelations], [crdRelations]);
 }


### PR DESCRIPTION
## Summary

This PR removes the `react-hooks/exhaustive-deps` suppression in `frontend/src/components/resourceMap/sources/definitions/relations.tsx` by dropping `staticRelations` (a module-scope `const` array) from the `useMemo` deps array. The suppression was needed because the deps array listed a stable module-level constant; removing that listing lets eslint accept the remaining deps without the directive.

## Related Issue

Fixes #5582 (sub-issue of umbrella #5183).

## Changes

- Dropped `staticRelations` from the deps array of the `useMemo` in `useGetAllRelations` at line 317.
- Removed the matching `// eslint-disable-next-line react-hooks/exhaustive-deps` directive.

### Why this is safe

`staticRelations` is defined at module scope (line 283) as a `const` array. Its identity is fixed for the entire app lifetime, so listing it in the deps array is unnecessary and does not affect when the memo recomputes. The memo continues to recompute whenever `crdRelations` changes, which is the only reactive input.

## Steps to Test

1. `cd frontend && npm install`
2. `npm run lint`: passes; no `react-hooks/exhaustive-deps` violation surfaces for this hook.
3. `npm run tsc`: passes.
4. Visual smoke: start Headlamp against a cluster with any CRDs, open the resource map. Relations between resources render identically.

## Screenshots (if applicable)

N/A. No functional change.

## Notes for the Reviewer

- Single-file diff, +1 / -2 lines.
- DCO sign-off applied (`Signed-off-by:` in the commit).
- Listed as an unchecked `exhaustive-deps` bullet in umbrella issue #5183.