### PR TITLE
backend: serviceproxy: Preserve upstream status codes

### DIFF
--- a/backend/pkg/serviceproxy/connection.go
+++ b/backend/pkg/serviceproxy/connection.go
@@ -3,7 +3,7 @@ package serviceproxy
 import (
 	"context"
 	"fmt"
-	"io"
+	"net/http"
 	"net/url"
 	"path"
 	"strings"
@@ -11,8 +11,9 @@ import (
 
 // ServiceConnection represents a connection to a service.
 type ServiceConnection interface {
-	// Get performs a GET request and streams the response body into w.
-	Get(ctx context.Context, requestURI string, w io.Writer) error
+	// Get performs a GET request and forwards the upstream status code,
+	// Content-Type, and response body into w.
+	Get(ctx context.Context, requestURI string, w http.ResponseWriter) error
 }
 type Connection struct {
 	URI string
@@ -25,9 +26,9 @@ func NewConnection(ps *proxyService) ServiceConnection {
 	}
 }
 
-// Get sends a GET request to the specified URI and streams the response body
-// into w.
-func (c *Connection) Get(ctx context.Context, requestURI string, w io.Writer) error {
+// Get sends a GET request to the specified URI and forwards the upstream
+// status code, Content-Type, and response body into w.
+func (c *Connection) Get(ctx context.Context, requestURI string, w http.ResponseWriter) error {
 	base, err := url.Parse(c.URI)
 	if err != nil {
 		return fmt.Errorf("invalid host uri: %w", err)

--- a/backend/pkg/serviceproxy/connection_test.go
+++ b/backend/pkg/serviceproxy/connection_test.go
@@ -66,7 +66,7 @@ var getTests = []struct {
 	{
 		name:       "invalid request URI",
 		uri:        "http://example.com",
-		requestURI: " invalid-request-uri",
+		requestURI: "%zz",
 		wantBody:   nil,
 		wantErr:    true,
 	},
@@ -117,15 +117,15 @@ func TestGet(t *testing.T) {
 				conn.URI = ts.URL
 			}
 
-			var buf bytes.Buffer
+			w := httptest.NewRecorder()
 
-			err := conn.Get(context.Background(), tt.requestURI, &buf)
+			err := conn.Get(context.Background(), tt.requestURI, w)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if !tt.wantErr && !bytes.Equal(buf.Bytes(), tt.wantBody) {
-				t.Errorf("Get() body = %s, want %s", buf.Bytes(), tt.wantBody)
+			if !tt.wantErr && !bytes.Equal(w.Body.Bytes(), tt.wantBody) {
+				t.Errorf("Get() body = %s, want %s", w.Body.Bytes(), tt.wantBody)
 			}
 		})
 	}
@@ -134,14 +134,39 @@ func TestGet(t *testing.T) {
 func TestGetNonOKStatusCode(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
+
+		if _, err := w.Write([]byte("upstream error")); err != nil {
+			t.Fatal(err)
+		}
 	}))
 	defer ts.Close()
 
 	conn := &Connection{URI: ts.URL}
+	w := httptest.NewRecorder()
 
-	var buf bytes.Buffer
+	err := conn.Get(context.Background(), "/test", w)
+	if err != nil {
+		t.Errorf("Get() error = %v, want nil", err)
+	}
 
-	err := conn.Get(context.Background(), "/test", &buf)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Get() status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestGetUsesContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	conn := &Connection{URI: ts.URL}
+	w := httptest.NewRecorder()
+
+	err := conn.Get(ctx, "/test", w)
 	if err == nil {
 		t.Errorf("Get() error = nil, want error")
 	}

--- a/backend/pkg/serviceproxy/handler_test.go
+++ b/backend/pkg/serviceproxy/handler_test.go
@@ -3,7 +3,6 @@ package serviceproxy //nolint
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,9 +25,11 @@ func TestHandleServiceProxy(t *testing.T) {
 		proxyService   *proxyService
 		requestURI     string
 		mockResponse   string
+		mockHeader     string
 		mockStatusCode int
 		expectedCode   int
 		expectedBody   string
+		expectedHeader string
 		useMockServer  bool
 	}{
 		// Success cases
@@ -37,9 +38,11 @@ func TestHandleServiceProxy(t *testing.T) {
 			proxyService:   &proxyService{URIPrefix: "http://example.com"},
 			requestURI:     "/test",
 			mockResponse:   "Hello, World!",
+			mockHeader:     "text/plain",
 			mockStatusCode: http.StatusOK,
 			expectedCode:   http.StatusOK,
 			expectedBody:   "Hello, World!",
+			expectedHeader: "text/plain",
 			useMockServer:  true,
 		},
 		{
@@ -47,9 +50,11 @@ func TestHandleServiceProxy(t *testing.T) {
 			proxyService:   &proxyService{URIPrefix: "http://api.example.com"},
 			requestURI:     "/api/v1/data",
 			mockResponse:   `{"status": "success", "data": "test"}`,
+			mockHeader:     "application/json",
 			mockStatusCode: http.StatusOK,
 			expectedCode:   http.StatusOK,
 			expectedBody:   `{"status": "success", "data": "test"}`,
+			expectedHeader: "application/json",
 			useMockServer:  true,
 		},
 		{
@@ -57,9 +62,11 @@ func TestHandleServiceProxy(t *testing.T) {
 			proxyService:   &proxyService{URIPrefix: "https://service.example.com"},
 			requestURI:     "/api?param=value&test=123",
 			mockResponse:   "Query processed",
+			mockHeader:     "text/plain",
 			mockStatusCode: http.StatusOK,
 			expectedCode:   http.StatusOK,
 			expectedBody:   "Query processed",
+			expectedHeader: "text/plain",
 			useMockServer:  true,
 		},
 		{
@@ -67,9 +74,11 @@ func TestHandleServiceProxy(t *testing.T) {
 			proxyService:   &proxyService{URIPrefix: "http://empty.example.com"},
 			requestURI:     "/empty",
 			mockResponse:   "",
+			mockHeader:     "text/plain",
 			mockStatusCode: http.StatusOK,
 			expectedCode:   http.StatusOK,
 			expectedBody:   "",
+			expectedHeader: "text/plain",
 			useMockServer:  true,
 		},
 		// Error cases
@@ -78,9 +87,11 @@ func TestHandleServiceProxy(t *testing.T) {
 			proxyService:   &proxyService{URIPrefix: "http://example.com"},
 			requestURI:     "/notfound",
 			mockResponse:   "error response",
+			mockHeader:     "text/plain",
 			mockStatusCode: http.StatusNotFound,
-			expectedCode:   http.StatusInternalServerError,
-			expectedBody:   "failed HTTP GET, status code 404\n",
+			expectedCode:   http.StatusNotFound,
+			expectedBody:   "error response",
+			expectedHeader: "text/plain",
 			useMockServer:  true,
 		},
 		{
@@ -88,9 +99,11 @@ func TestHandleServiceProxy(t *testing.T) {
 			proxyService:   &proxyService{URIPrefix: "http://example.com"},
 			requestURI:     "/error",
 			mockResponse:   "error response",
+			mockHeader:     "text/plain",
 			mockStatusCode: http.StatusInternalServerError,
 			expectedCode:   http.StatusInternalServerError,
-			expectedBody:   "failed HTTP GET, status code 500\n",
+			expectedBody:   "error response",
+			expectedHeader: "text/plain",
 			useMockServer:  true,
 		},
 		{
@@ -120,6 +133,7 @@ func TestHandleServiceProxy(t *testing.T) {
 			// Create a mock HTTP server for cases that need it
 			if tt.useMockServer {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", tt.mockHeader)
 					w.WriteHeader(tt.mockStatusCode)
 
 					if _, err := w.Write([]byte(tt.mockResponse)); err != nil {
@@ -139,22 +153,26 @@ func TestHandleServiceProxy(t *testing.T) {
 
 			assert.Equal(t, tt.expectedCode, w.Code)
 			assert.Equal(t, tt.expectedBody, w.Body.String())
+
+			if tt.expectedHeader != "" {
+				assert.Equal(t, tt.expectedHeader, w.Header().Get("Content-Type"))
+			}
 		})
 	}
 }
 
 type mockServiceConnection struct {
-	get func(ctx context.Context, requestURI string, w io.Writer) error
+	get func(ctx context.Context, requestURI string, w http.ResponseWriter) error
 }
 
-func (m mockServiceConnection) Get(ctx context.Context, requestURI string, w io.Writer) error {
+func (m mockServiceConnection) Get(ctx context.Context, requestURI string, w http.ResponseWriter) error {
 	return m.get(ctx, requestURI, w)
 }
 
 func TestHandleServiceProxyDoesNotWriteErrorAfterPartialStream(t *testing.T) {
 	w := httptest.NewRecorder()
 	conn := mockServiceConnection{
-		get: func(ctx context.Context, requestURI string, out io.Writer) error {
+		get: func(ctx context.Context, requestURI string, out http.ResponseWriter) error {
 			if _, err := out.Write([]byte("partial")); err != nil {
 				return err
 			}
@@ -172,7 +190,7 @@ func TestHandleServiceProxyDoesNotWriteErrorAfterPartialStream(t *testing.T) {
 func TestHandleServiceProxyWritesErrorBeforeStreamStarts(t *testing.T) {
 	w := httptest.NewRecorder()
 	conn := mockServiceConnection{
-		get: func(ctx context.Context, requestURI string, out io.Writer) error {
+		get: func(ctx context.Context, requestURI string, out http.ResponseWriter) error {
 			return errors.New("stream aborted")
 		},
 	}
@@ -181,6 +199,23 @@ func TestHandleServiceProxyWritesErrorBeforeStreamStarts(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, "stream aborted\n", w.Body.String())
+}
+
+func TestHandleServiceProxyWritesErrorWhenUpstreamBodyFailsBeforeStreamStarts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	conn := NewConnection(&proxyService{URIPrefix: server.URL})
+	w := httptest.NewRecorder()
+
+	handleServiceProxy(context.Background(), conn, "/", w)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "streaming response")
 }
 
 func TestDisableResponseCaching(t *testing.T) {

--- a/backend/pkg/serviceproxy/http.go
+++ b/backend/pkg/serviceproxy/http.go
@@ -10,10 +10,11 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 )
 
-// HTTPGetStream sends an HTTP GET request to the specified URI and streams the
-// response body into w. The body is never fully buffered, so an upstream that
-// returns an arbitrarily large response cannot exhaust server memory.
-func HTTPGetStream(ctx context.Context, uri string, w io.Writer) error {
+// HTTPGetStream sends an HTTP GET request to the specified URI and forwards the
+// upstream status code, Content-Type, and response body into w. The body is
+// never fully buffered, so an upstream that returns an arbitrarily large
+// response cannot exhaust server memory.
+func HTTPGetStream(ctx context.Context, uri string, w http.ResponseWriter) error {
 	cli := &http.Client{Timeout: 10 * time.Second}
 
 	logger.Log(logger.LevelInfo, nil, nil, fmt.Sprintf("make request to %s", uri))
@@ -30,13 +31,54 @@ func HTTPGetStream(ctx context.Context, uri string, w io.Writer) error {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed HTTP GET, status code %v", resp.StatusCode)
-	}
-
-	if _, err := io.Copy(w, resp.Body); err != nil {
+	if err := streamResponseBody(resp.Body, w, resp.StatusCode, resp.Header.Get("Content-Type")); err != nil {
 		return fmt.Errorf("streaming response: %w", err)
 	}
 
 	return nil
+}
+
+func streamResponseBody(body io.Reader, w http.ResponseWriter, statusCode int, contentType string) error {
+	buf := make([]byte, 32*1024)
+
+	for {
+		n, readErr := body.Read(buf)
+		if n > 0 {
+			writeResponseHeader(w, statusCode, contentType)
+
+			if _, err := w.Write(buf[:n]); err != nil {
+				return err
+			}
+
+			if readErr != nil {
+				if readErr == io.EOF {
+					return nil
+				}
+
+				return readErr
+			}
+
+			_, err := io.CopyBuffer(w, body, buf)
+
+			return err
+		}
+
+		if readErr != nil {
+			if readErr == io.EOF {
+				writeResponseHeader(w, statusCode, contentType)
+
+				return nil
+			}
+
+			return readErr
+		}
+	}
+}
+
+func writeResponseHeader(w http.ResponseWriter, statusCode int, contentType string) {
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+
+	w.WriteHeader(statusCode)
 }

--- a/backend/pkg/serviceproxy/http_test.go
+++ b/backend/pkg/serviceproxy/http_test.go
@@ -1,7 +1,6 @@
 package serviceproxy_test
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -14,59 +13,58 @@ import (
 //nolint:funlen
 func TestHTTPGetStream(t *testing.T) {
 	tests := []struct {
-		name       string
-		url        string
-		statusCode int
-		body       string
-		wantErr    bool
+		name        string
+		url         string
+		statusCode  int
+		body        string
+		contentType string
+		wantErr     bool
+		wantStatus  int
 	}{
 		{
-			name:       "valid URL",
-			url:        "http://example.com",
-			statusCode: http.StatusOK,
-			body:       "Hello, World!",
-			wantErr:    false,
+			name:        "valid URL",
+			url:         "http://example.com",
+			statusCode:  http.StatusOK,
+			body:        "Hello, World!",
+			contentType: "text/plain",
+			wantErr:     false,
+			wantStatus:  http.StatusOK,
 		},
 		{
 			name:       "invalid URL",
 			url:        " invalid-url",
-			statusCode: 0,
-			body:       "",
-			wantErr:    true,
-		},
-		{
-			name:       "server returns error response",
-			url:        "http://example.com/error",
 			statusCode: http.StatusInternalServerError,
 			body:       "",
 			wantErr:    true,
 		},
 		{
-			name:       "context cancellation",
-			url:        "http://example.com/cancel",
-			statusCode: http.StatusOK,
-			body:       "Hello, World!",
-			wantErr:    true,
+			name:        "server returns error response",
+			url:         "http://example.com/error",
+			statusCode:  http.StatusInternalServerError,
+			body:        "upstream error",
+			contentType: "text/plain",
+			wantErr:     false,
+			wantStatus:  http.StatusInternalServerError,
+		},
+		{
+			name:        "server returns not found response",
+			url:         "http://example.com/not-found",
+			statusCode:  http.StatusNotFound,
+			body:        "upstream not found",
+			contentType: "text/plain",
+			wantErr:     false,
+			wantStatus:  http.StatusNotFound,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch {
-				case tt.url == "http://example.com/error":
-					w.WriteHeader(http.StatusInternalServerError)
-				case tt.name == "context cancellation":
-					<-r.Context().Done()
-					w.WriteHeader(http.StatusOK)
+				w.Header().Set("Content-Type", tt.contentType)
+				w.WriteHeader(tt.statusCode)
 
-					if _, err := w.Write([]byte(tt.body)); err != nil {
-						t.Fatal(err)
-					}
-				default:
-					if _, err := w.Write([]byte(tt.body)); err != nil {
-						t.Fatalf("write test: %v", err)
-					}
+				if _, err := w.Write([]byte(tt.body)); err != nil {
+					t.Fatalf("write test: %v", err)
 				}
 			}))
 			defer ts.Close()
@@ -77,28 +75,44 @@ func TestHTTPGetStream(t *testing.T) {
 				url = tt.url
 			case "http://example.com/error":
 				url = ts.URL + "/error"
+			case "http://example.com/not-found":
+				url = ts.URL + "/not-found"
 			}
 
-			ctx := context.Background()
+			w := httptest.NewRecorder()
 
-			if tt.name == "context cancellation" {
-				var cancel context.CancelFunc
-
-				ctx, cancel = context.WithCancel(ctx)
-				cancel()
-			}
-
-			var buf bytes.Buffer
-
-			err := serviceproxy.HTTPGetStream(ctx, url, &buf)
+			err := serviceproxy.HTTPGetStream(context.Background(), url, w)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("HTTPGetStream() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if !tt.wantErr && buf.String() != tt.body {
-				t.Errorf("HTTPGetStream() response = %s, want %s", buf.String(), tt.body)
+			if !tt.wantErr && w.Body.String() != tt.body {
+				t.Errorf("HTTPGetStream() response = %s, want %s", w.Body.String(), tt.body)
+			}
+
+			if !tt.wantErr && w.Code != tt.wantStatus {
+				t.Errorf("HTTPGetStream() status = %d, want %d", w.Code, tt.wantStatus)
+			}
+
+			if !tt.wantErr && w.Header().Get("Content-Type") != tt.contentType {
+				t.Errorf("HTTPGetStream() content type = %s, want %s", w.Header().Get("Content-Type"), tt.contentType)
 			}
 		})
+	}
+}
+
+func TestHTTPGetStreamContextCancellation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := serviceproxy.HTTPGetStream(ctx, ts.URL, httptest.NewRecorder())
+	if err == nil {
+		t.Errorf("HTTPGetStream() error = nil, want error")
 	}
 }
 
@@ -115,7 +129,7 @@ func TestHTTPGetStreamTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	err := serviceproxy.HTTPGetStream(ctx, ts.URL, &countingWriter{})
+	err := serviceproxy.HTTPGetStream(ctx, ts.URL, &countingResponseWriter{})
 	if err == nil {
 		t.Errorf("HTTPGetStream() error = nil, want error")
 	}
@@ -153,7 +167,7 @@ func TestHTTPGetStreamDoesNotBuffer(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	counter := &countingWriter{}
+	counter := &countingResponseWriter{}
 
 	if err := serviceproxy.HTTPGetStream(context.Background(), ts.URL, counter); err != nil {
 		t.Fatalf("HTTPGetStream() error = %v", err)
@@ -170,18 +184,41 @@ func TestHTTPGetStreamDoesNotBuffer(t *testing.T) {
 	if counter.maxWrite > 128*1024 {
 		t.Errorf("HTTPGetStream() max write size = %d, want <= %d", counter.maxWrite, 128*1024)
 	}
+
+	if counter.statusCode != http.StatusOK {
+		t.Errorf("HTTPGetStream() status = %d, want %d", counter.statusCode, http.StatusOK)
+	}
+
+	if counter.header.Get("Content-Type") != "application/octet-stream" {
+		t.Errorf("HTTPGetStream() content type = %s, want application/octet-stream", counter.header.Get("Content-Type"))
+	}
 }
 
-// countingWriter records streaming statistics without retaining the response
-// body. Keeping no copy of the payload lets large-body tests assert the stream
-// is forwarded in bounded chunks without themselves buffering the whole body.
-type countingWriter struct {
-	n        int
-	writes   int
-	maxWrite int
+// countingResponseWriter records streaming statistics without retaining the
+// response body. Keeping no copy of the payload lets large-body tests assert
+// the stream is forwarded in bounded chunks without themselves buffering the
+// whole body.
+type countingResponseWriter struct {
+	header     http.Header
+	statusCode int
+	n          int
+	writes     int
+	maxWrite   int
 }
 
-func (c *countingWriter) Write(p []byte) (int, error) {
+func (c *countingResponseWriter) Header() http.Header {
+	if c.header == nil {
+		c.header = http.Header{}
+	}
+
+	return c.header
+}
+
+func (c *countingResponseWriter) WriteHeader(statusCode int) {
+	c.statusCode = statusCode
+}
+
+func (c *countingResponseWriter) Write(p []byte) (int, error) {
 	c.n += len(p)
 	c.writes++
 


### PR DESCRIPTION
## Summary

This PR fixes the backend service proxy so it preserves upstream non-200 HTTP responses instead of converting them into `500 Internal Server Error`.
Previously, if a proxied in-cluster service returned something like `404 Not Found`, Headlamp reported it as a backend `500`. That made normal upstream service responses look like Headlamp backend failures.

## Related Issue

Fixes #5588

## Changes

- Updated the service proxy response handling to keep the upstream status code.
- Updated serviceproxy tests to verify that upstream `404` and `500` responses are forwarded correctly.


## Steps to Test

1. Run the backend serviceproxy tests:

 ```bash
     GOCACHE=/private/tmp/headlamp-gocache go test ./pkg/serviceproxy
```
2. Verify that the tests pass.
3. Optionally, proxy a service endpoint that returns 404 and confirm Headlamp returns 404 instead of 500.

## Screenshots (if applicable)
N/A

## Notes for the Reviewer

- The patch is intentionally scoped to status code/body handling.
- It does not address the separate response-buffering/OOM concern tracked in #5494.
- Only Content-Type is forwarded from the upstream response to keep header behavior minimal.


