### PR TITLE
backend: config: Preserve plugin watch env

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -328,9 +328,9 @@ func unmarshalConfig(k *koanf.Koanf, config *Config) error {
 	return nil
 }
 
-// patchWatchPluginsChanges disables plugin watching if running in-cluster and user didn't set the flag.
-func patchWatchPluginsChanges(config *Config, explicitFlags map[string]bool) {
-	if config.InCluster && !explicitFlags["watch-plugins-changes"] {
+// patchWatchPluginsChanges disables plugin watching if running in-cluster and user didn't set the flag or env var.
+func patchWatchPluginsChanges(config *Config, explicitFlags map[string]bool, watchPluginsChangesEnvSet bool) {
+	if config.InCluster && !explicitFlags["watch-plugins-changes"] && !watchPluginsChangesEnvSet {
 		config.WatchPluginsChanges = false
 	}
 }
@@ -427,6 +427,8 @@ func Parse(args []string) (*Config, error) {
 	explicitFlags := recordExplicitFlags(f)
 
 	// 4. Load config from environment variables.
+	_, watchPluginsChangesEnvSet := os.LookupEnv("HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES")
+
 	if err := loadConfigFromEnv(k); err != nil {
 		return nil, err
 	}
@@ -442,7 +444,7 @@ func Parse(args []string) (*Config, error) {
 	}
 
 	// 7. Post-process: patch plugin flag and kubeconfig path.
-	patchWatchPluginsChanges(&config, explicitFlags)
+	patchWatchPluginsChanges(&config, explicitFlags, watchPluginsChangesEnvSet)
 
 	if err := setKubeConfigPath(&config); err != nil {
 		return nil, err

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -226,19 +226,46 @@ var ParseWithEnvTests = []struct {
 			assert.Equal(t, "X-Env-Token-Header", conf.ProxyAuthTokenHeader)
 		},
 	},
+	{
+		name: "watch_plugins_changes_env_kept_in_cluster",
+		args: []string{"go run ./cmd", "--in-cluster"},
+		env: map[string]string{
+			"HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES": "true",
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, true, conf.WatchPluginsChanges)
+		},
+	},
+	{
+		name: "watch_plugins_changes_env_kept_in_cluster_from_env",
+		args: []string{"go run ./cmd"},
+		env: map[string]string{
+			"HEADLAMP_CONFIG_IN_CLUSTER":            "true",
+			"HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES": "true",
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, true, conf.InCluster)
+			assert.Equal(t, true, conf.WatchPluginsChanges)
+		},
+	},
+	{
+		name: "watch_plugins_changes_env_false_kept_in_cluster",
+		args: []string{"go run ./cmd", "--in-cluster"},
+		env: map[string]string{
+			"HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES": "false",
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, false, conf.WatchPluginsChanges)
+		},
+	},
 }
 
 func TestParseWithEnv(t *testing.T) {
 	for _, tt := range ParseWithEnvTests {
 		t.Run(tt.name, func(t *testing.T) {
 			for key, value := range tt.env {
-				require.NoError(t, os.Setenv(key, value))
+				t.Setenv(key, value)
 			}
-			defer func(env map[string]string) {
-				for key := range env {
-					require.NoError(t, os.Unsetenv(key))
-				}
-			}(tt.env)
 
 			conf, err := config.Parse(tt.args)
 			require.NoError(t, err)


### PR DESCRIPTION
## Summary

This PR fixes in-cluster plugin watch configuration so `HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES` is respected when explicitly set through the environment.

## Related Issue

Fixes #5590

## Changes

- Treat `HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES` as an explicit plugin-watch setting during config post-processing.
- Preserve CLI flag precedence over environment values.
- Add regression coverage for flag-driven in-cluster mode, env-only in-cluster mode, and explicit false values.
- Use `t.Setenv` in env config tests so previous process env values are restored safely.

## Steps to Test

```bash
npm run backend:format
cd backend && go test ./pkg/config -v
npm run backend:lint
npm run backend:test
```

## Screenshots

N/A

## Notes for the Reviewer

- Rewritten as a single atomic commit following the contribution guidelines.
- No frontend or UI changes.