### PR TITLE
fix: Replace String.fromCharCode.apply with TextDecoder in KubeConfigLoader

### DIFF
--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -398,9 +398,7 @@ function KubeConfigLoader() {
     reader.onerror = () => setError(t("translation|Couldn't read kubeconfig file"));
     reader.onload = () => {
       try {
-        const data = String.fromCharCode.apply(null, [
-          ...new Uint8Array(reader.result as ArrayBuffer),
-        ]);
+        const data = new TextDecoder().decode(reader.result as ArrayBuffer);
         const doc = yaml.load(data) as kubeconfig;
         if (!doc.clusters) {
           throw new Error(t('translation|No clusters found!'));


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when uploading a large KubeConfig file. `String.fromCharCode.apply` spreads the entire file as function
arguments, which exceeds the JavaScript call stack limit on large files and throws a `RangeError`.

Replaced with the `TextDecoder` API which is the modern standard for decoding binary data in the browser and has no stack size limit.

## Related Issue

Fixes #5594

## Changes

- Replaced `String.fromCharCode.apply(null, [...new Uint8Array(...)])` with `new TextDecoder().decode(reader.result as ArrayBuffer)`  in `KubeConfigLoader.tsx`

## Testing

1. Upload a small KubeConfig and confirm it works as before
2. Upload a large KubeConfig with many clusters or large CA certs
3. Confirm no `RangeError` and file loads correctly
4. Confirm existing snapshots and tests still pass