### PR TITLE
fix: Validate port, log level, and TLS paths in Config.Validate()

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -157,6 +157,10 @@ func (c *Config) Validate() error {
 		return errors.New("session-ttl cannot be greater than 1 year")
 	}
 
+	if err := c.validatePortLogLevelAndTLS(); err != nil {
+		return err
+	}
+
 	if c.TracingEnabled != nil && *c.TracingEnabled {
 		if c.ServiceName == "" {
 			return errors.New("service-name is required when tracing is enabled")
@@ -242,6 +246,63 @@ func (c *Config) validateServiceAccountTokenFlags() error {
 	if c.ServiceAccountTokenPath != "" && !c.UnsafeUseServiceAccountToken {
 		return errors.New("--service-account-token-path requires " +
 			"--unsafe-use-service-account-token to be enabled")
+	}
+
+	return nil
+}
+
+func (c *Config) validatePortLogLevelAndTLS() error {
+	if c.Port < 1 || c.Port > 65535 {
+		return errors.New("port must be between 1 and 65535")
+	}
+
+	validLogLevels := map[string]bool{
+		"debug":    true,
+		"info":     true,
+		"warn":     true,
+		"error":    true,
+	}
+
+	if c.LogLevel != "" && !validLogLevels[c.LogLevel] {
+		return fmt.Errorf("invalid log-level %q: "+
+			"must be one of debug, info, warn, error", c.LogLevel)
+	}
+
+	if c.TLSCertPath != "" && c.TLSKeyPath == "" {
+		return errors.New("tls-cert-path and tls-key-path must be provided together")
+	}
+	if c.TLSKeyPath != "" && c.TLSCertPath == "" {
+		return errors.New("tls-cert-path and tls-key-path must be provided together")
+	}
+
+	if c.TLSCertPath != "" {
+		info, err := os.Stat(c.TLSCertPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("tls-cert-path %q does not exist", c.TLSCertPath)
+			}
+
+			return fmt.Errorf("tls-cert-path %q: %w", c.TLSCertPath, err)
+		}
+
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("tls-cert-path %q is not a regular file", c.TLSCertPath)
+		}
+	}
+
+	if c.TLSKeyPath != "" {
+		info, err := os.Stat(c.TLSKeyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("tls-key-path %q does not exist", c.TLSKeyPath)
+			}
+
+			return fmt.Errorf("tls-key-path %q: %w", c.TLSKeyPath, err)
+		}
+
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("tls-key-path %q is not a regular file", c.TLSKeyPath)
+		}
 	}
 
 	return nil
@@ -396,6 +457,11 @@ func setMeDefaults(config *Config) {
 	)
 }
 
+// normalizeLogLevel ensures the log level is lowercased and trimmed.
+func normalizeLogLevel(config *Config) {
+	config.LogLevel = strings.ToLower(strings.TrimSpace(config.LogLevel))
+}
+
 // Parse Loads the config from flags and env.
 // env vars should start with HEADLAMP_CONFIG_ and use _ as separator
 // If a value is set both in flags and env then flag takes priority.
@@ -449,6 +515,7 @@ func Parse(args []string) (*Config, error) {
 	}
 
 	setMeDefaults(&config)
+	normalizeLogLevel(&config)
 
 	// 8. Validate flags that depend on build-time behaviour.
 	if err := validateOpenBrowser(&config, explicitFlags); err != nil {

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -971,4 +972,218 @@ func TestGetDefaultKubeConfigPath(t *testing.T) {
 	path, err := config.GetDefaultKubeConfigPath()
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(tmpDir, ".kube", "config"), path)
+}
+
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "port_zero",
+			args:          []string{"go run ./cmd", "--port=0"},
+			expectError:   true,
+			errorContains: "port must be between 1 and 65535",
+		},
+		{
+			name:          "port_too_high",
+			args:          []string{"go run ./cmd", "--port=65536"},
+			expectError:   true,
+			errorContains: "port must be between 1 and 65535",
+		},
+		{
+			name:        "port_max_valid",
+			args:        []string{"go run ./cmd", "--port=65535"},
+			expectError: false,
+		},
+		{
+			name:        "port_min_valid",
+			args:        []string{"go run ./cmd", "--port=1"},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+			}
+		})
+	}
+}
+
+func TestValidateLogLevel(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "invalid_log_level",
+			args:          []string{"go run ./cmd", "--log-level=verbose"},
+			expectError:   true,
+			errorContains: "must be one of debug, info, warn, error",
+		},
+		{
+			name:        "valid_log_level_info",
+			args:        []string{"go run ./cmd", "--log-level=info"},
+			expectError: false,
+		},
+		{
+			name:        "valid_log_level_warn",
+			args:        []string{"go run ./cmd", "--log-level=warn"},
+			expectError: false,
+		},
+		{
+			name:        "valid_log_level_error",
+			args:        []string{"go run ./cmd", "--log-level=error"},
+			expectError: false,
+		},
+		{
+			name:        "valid_log_level_normalization",
+			args:        []string{"go run ./cmd", "--log-level= INFO "},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+
+				if tt.name == "valid_log_level_normalization" {
+					assert.Equal(t, "info", conf.LogLevel)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateTLSPathsNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	missingCert := filepath.Join(tmpDir, "missing-cert.pem")
+	missingKey := filepath.Join(tmpDir, "missing-key.pem")
+	existingCert := filepath.Join(tmpDir, "existing-cert.pem")
+	require.NoError(t, os.WriteFile(existingCert, []byte("test"), 0o600))
+
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "missing_cert_file",
+			args:          []string{"go run ./cmd", "--tls-cert-path=" + missingCert},
+			expectError:   true,
+			errorContains: "tls-cert-path and tls-key-path must be provided together",
+		},
+		{
+			name:          "missing_key_file",
+			args:          []string{"go run ./cmd", "--tls-key-path=" + missingKey},
+			expectError:   true,
+			errorContains: "tls-cert-path and tls-key-path must be provided together",
+		},
+		{
+			name:          "missing_both_files",
+			args:          []string{"go run ./cmd", "--tls-cert-path=" + missingCert, "--tls-key-path=" + missingKey},
+			expectError:   true,
+			errorContains: fmt.Sprintf("tls-cert-path %q does not exist", missingCert),
+		},
+		{
+			name:          "existing_cert_missing_key",
+			args:          []string{"go run ./cmd", "--tls-cert-path=" + existingCert, "--tls-key-path=" + missingKey},
+			expectError:   true,
+			errorContains: fmt.Sprintf("tls-key-path %q does not exist", missingKey),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+			}
+		})
+	}
+}
+
+func TestValidateTLSPathsValidAndDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	validCert := filepath.Join(tmpDir, "cert.pem")
+	require.NoError(t, os.WriteFile(validCert, []byte("test"), 0o600))
+
+	validKey := filepath.Join(tmpDir, "key.pem")
+	require.NoError(t, os.WriteFile(validKey, []byte("test"), 0o600))
+
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "valid_cert_only",
+			args:          []string{"go run ./cmd", "--tls-cert-path=" + validCert},
+			expectError:   true,
+			errorContains: "tls-cert-path and tls-key-path must be provided together",
+		},
+		{
+			name:          "valid_key_only",
+			args:          []string{"go run ./cmd", "--tls-key-path=" + validKey},
+			expectError:   true,
+			errorContains: "tls-cert-path and tls-key-path must be provided together",
+		},
+		{
+			name:        "valid_cert_and_key",
+			args:        []string{"go run ./cmd", "--tls-cert-path=" + validCert, "--tls-key-path=" + validKey},
+			expectError: false,
+		},
+		{
+			name:          "cert_path_is_directory",
+			args:          []string{"go run ./cmd", "--tls-cert-path=" + tmpDir, "--tls-key-path=" + validKey},
+			expectError:   true,
+			errorContains: "is not a regular file",
+		},
+		{
+			name:          "key_path_is_directory",
+			args:          []string{"go run ./cmd", "--tls-cert-path=" + validCert, "--tls-key-path=" + tmpDir},
+			expectError:   true,
+			errorContains: "is not a regular file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Enhances startup robustness by adding missing validation checks to `Config.Validate()` in `backend/pkg/config/config.go`.

Previously, misconfigured flags like an invalid port, unsupported log level, or missing TLS certificate path would only fail at
runtime with a confusing error. This PR catches them immediately at startup with a clear, actionable message.

## Related Issue

Fixes #5596 

## Changes

- Added port range validation — `port` must be between 1 and 65535
- Added log level validation — must be one of `debug`, `info`, `warn`, or `error`
- Added TLS path existence checks — validates `tls-cert-path` and `tls-key-path` files exist before the server attempts to bind
- Added unit tests for all three new validations

## Testing

1. Run config validation tests:
   `go test ./pkg/config/...`
2. Start the backend with an invalid port:
   `go run ./cmd/headlamp --port=70000`
   Confirm it exits immediately with a clear error
3. Start with an invalid log level:
   `go run ./cmd/headlamp --log-level=verbose`
   Confirm it exits with a clear error
4. Start with a missing TLS cert path:
   `go run ./cmd/headlamp --tls-cert-path=/missing/cert.pem`
   Confirm it exits with a clear error instead of a runtime panic