### PR TITLE
backend: stateless: Assert parseKubeConfig writes a single response

### DIFF
--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -142,12 +142,39 @@ func TestParseKubeConfigInvalidJSONReturnsBadRequest(t *testing.T) {
 	)
 	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", token)
 
-	resp := httptest.NewRecorder()
+	resp := &writeCountingResponseRecorder{ResponseRecorder: httptest.NewRecorder()}
 	handler.ServeHTTP(resp, req)
 
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, 1, resp.writeHeaderCount)
+	assert.GreaterOrEqual(t, resp.writeCount, 1)
+	assert.Equal(t, "text/plain; charset=utf-8", resp.Header().Get("Content-Type"))
 	assert.Equal(t, "Invalid JSON request body\n", resp.Body.String())
 	assert.NotContains(t, resp.Body.String(), "clusters")
+}
+
+// writeCountingResponseRecorder wraps httptest.ResponseRecorder to count how
+// many times Write and WriteHeader are called, so tests can assert that a
+// handler writes one response header and the expected response body.
+type writeCountingResponseRecorder struct {
+	*httptest.ResponseRecorder
+	writeCount       int
+	writeHeaderCount int
+}
+
+func (r *writeCountingResponseRecorder) Write(b []byte) (int, error) {
+	if r.writeHeaderCount == 0 {
+		r.WriteHeader(http.StatusOK)
+	}
+
+	r.writeCount++
+
+	return r.ResponseRecorder.Write(b)
+}
+
+func (r *writeCountingResponseRecorder) WriteHeader(code int) {
+	r.writeHeaderCount++
+	r.ResponseRecorder.WriteHeader(code)
 }
 
 func TestParseKubeConfigRequiresKubeconfigs(t *testing.T) {


### PR DESCRIPTION
## Summary

Hardens the existing `parseKubeConfig` invalid-JSON test so it guards against the handler writing a second response after the `400 Bad Request`.

The production fix for this behaviour already landed on `main` independently, so this PR remains a test-only hardening of the regression coverage.

## Changes

- Wrap the test `ResponseRecorder` in a small `writeCountingResponseRecorder` that counts `Write` / `WriteHeader` calls.
- Assert exactly one `WriteHeader`, at least one `Write`, the `text/plain; charset=utf-8` content type, and the exact error body on the invalid-JSON path.

## Steps to Test

```bash
cd backend && go test ./cmd -run 'TestParseKubeConfig' -v
```

## Notes for the Reviewer

- Rewritten as a single atomic commit following the contribution guidelines.
- No production code changes; `backend/cmd/stateless.go` is untouched.