### PR TITLE
frontend: DateLabel: Show full creation timestamp as tooltip on age hover

### DIFF
--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -247,6 +247,7 @@ export function DateLabel(props: DateLabelProps) {
       hoverInfo={localeDate(date)}
       icon="mdi:calendar"
       iconProps={iconProps}
+      labelFirst
     />
   );
 }

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -247,7 +247,7 @@ export function DateLabel(props: DateLabelProps) {
       hoverInfo={localeDate(date)}
       icon="mdi:calendar"
       iconProps={iconProps}
-      labelFirst
+      iconPosition="end"
     />
   );
 }


### PR DESCRIPTION
## Summary

This PR adds a tooltip to the Age column across all resource list views 
so users can see the exact creation timestamp on hover without having to 
navigate into the resource detail page.

The issue was that the DateLabel component passed hoverInfo to 
HoverInfoLabel but the tooltip was only triggered by hovering over the 
calendar icon, not the age text itself. Adding the labelFirst prop fixes 
this so the tooltip is accessible from the text as well.

Since DateLabel is a shared component the fix applies automatically across 
all resource list views including Pods, Deployments, Services and ConfigMaps.

fixes #5577 

## Steps to test

1. Open Workloads > Pods in Headlamp
2. Hover over any value in the Age column
3. Verify tooltip appears showing the full creation timestamp
4. Repeat for Deployments, Services and ConfigMaps
5. Run npm run frontend:lint
6. Run npm run frontend:test