### PR TITLE
fix(k8s-node): move hooks out of static class method

### DIFF
--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -71,10 +71,7 @@ export function useNodeMetrics(cluster?: string): [KubeMetrics[] | null, ApiErro
 
   function setMetrics(data: KubeMetrics[]) {
     setNodeMetrics(data);
-
-    if (data !== null) {
-      setError(null);
-    }
+    setError(null);
   }
 
   useConnectApi(
@@ -94,10 +91,7 @@ export function useNodeSummaryStats(
 
   function setStats(stats: KubeNodeSummaryStats) {
     setSummaryStats(stats);
-
-    if (stats !== null) {
-      setError(null);
-    }
+    setError(null);
   }
 
   useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
@@ -110,6 +104,10 @@ class Node extends KubeObject<KubeNode> {
   static apiName = 'nodes';
   static apiVersion = 'v1';
   static isNamespaced = false;
+
+  static useMetrics = useNodeMetrics;
+
+  static useNodeSummaryStats = useNodeSummaryStats;
 
   get status(): KubeNode['status'] {
     return this.jsonData.status;

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -64,6 +64,47 @@ export interface KubeNode extends KubeObjectInterface {
   };
 }
 
+export function useNodeMetrics(cluster?: string): [KubeMetrics[] | null, ApiError | null] {
+  const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
+
+  const [error, setError] = useErrorState(setNodeMetrics);
+
+  function setMetrics(data: KubeMetrics[]) {
+    setNodeMetrics(data);
+
+    if (data !== null) {
+      setError(null);
+    }
+  }
+
+  useConnectApi(
+    metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError, cluster)
+  );
+
+  return [nodeMetrics, error];
+}
+
+export function useNodeSummaryStats(
+  nodeName?: string,
+  cluster?: string
+): [KubeNodeSummaryStats | null, ApiError | null] {
+  const [summaryStats, setSummaryStats] = React.useState<KubeNodeSummaryStats | null>(null);
+
+  const [error, setError] = useErrorState(setSummaryStats);
+
+  function setStats(stats: KubeNodeSummaryStats) {
+    setSummaryStats(stats);
+
+    if (stats !== null) {
+      setError(null);
+    }
+  }
+
+  useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
+
+  return [summaryStats, error];
+}
+
 class Node extends KubeObject<KubeNode> {
   static kind = 'Node';
   static apiName = 'nodes';
@@ -76,51 +117,6 @@ class Node extends KubeObject<KubeNode> {
 
   get spec(): KubeNode['spec'] {
     return this.jsonData.spec;
-  }
-
-  static useMetrics(cluster?: string): [KubeMetrics[] | null, ApiError | null] {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [error, setError] = useErrorState(setNodeMetrics);
-
-    function setMetrics(metrics: KubeMetrics[]) {
-      setNodeMetrics(metrics);
-
-      if (metrics !== null) {
-        setError(null);
-      }
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(
-      metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError, cluster)
-    );
-
-    return [nodeMetrics, error];
-  }
-
-  static useNodeSummaryStats(
-    nodeName?: string,
-    cluster?: string
-  ): [KubeNodeSummaryStats | null, ApiError | null] {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [summaryStats, setSummaryStats] = React.useState<KubeNodeSummaryStats | null>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [error, setError] = useErrorState(setSummaryStats);
-
-    function setStats(stats: KubeNodeSummaryStats) {
-      setSummaryStats(stats);
-
-      if (stats !== null) {
-        setError(null);
-      }
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
-
-    return [summaryStats, error];
   }
 
   getExternalIP(): string {


### PR DESCRIPTION
## Summary

This PR fixes #5246 

## Changes

Refactored Node metrics hooks into standalone React hook functions to satisfy react-hooks/rules-of-hooks. The Node model still exposes static hook aliases for backward compatibility, but hook implementation logic no longer lives inside the class.
