### PR TITLE
frontend: ClusterChooserPopup: Make cluster filter case-insensitive

### DIFF
--- a/frontend/src/components/cluster/ClusterChooserPopup.tsx
+++ b/frontend/src/components/cluster/ClusterChooserPopup.tsx
@@ -109,7 +109,9 @@ function ClusterChooserPopup(props: ChooserPopupPros) {
   const [recentClusters, clustersToShow] = React.useMemo(() => {
     let allClusters = Object.values(clusters || {});
     if (filter !== '') {
-      allClusters = allClusters.filter(cluster => cluster.name.includes(filter));
+      allClusters = allClusters.filter(cluster =>
+        cluster.name.toLowerCase().includes(filter.toLowerCase())
+      );
     }
 
     const recentClustersNames = !!filter ? [] : getRecentClusters();


### PR DESCRIPTION
## Summary
Fixes #5600  makes the cluster chooser filter case-insensitive.

## Changes
- Converted both cluster name and filter to lowercase before comparison

## Testing
1. Open the cluster chooser popup
2. Type a cluster name in any case (upper, lower, mixed)
3. Verify matching works regardless of case