### PR TITLE
frontend: Replace deprecated onKeyPress with onKeyDown in three components

### DIFF
--- a/frontend/src/components/App/Settings/ClusterNameEditor.tsx
+++ b/frontend/src/components/App/Settings/ClusterNameEditor.tsx
@@ -252,7 +252,7 @@ export function ClusterNameEditor({
                     </ConfirmButton>
                   </Box>
                 ),
-                onKeyPress: event => {
+                onKeyDown: event => {
                   if (event.key === 'Enter' && isValidCurrentName) {
                     handleUpdateClusterName(source);
                   }

--- a/frontend/src/components/App/Settings/SettingsCluster.tsx
+++ b/frontend/src/components/App/Settings/SettingsCluster.tsx
@@ -521,7 +521,7 @@ export default function SettingsCluster() {
                           <InlineIcon icon="mdi:plus-circle" />
                         </IconButton>
                       ),
-                      onKeyPress: event => {
+                      onKeyDown: event => {
                         if (event.key === 'Enter') {
                           storeNewAllowedNamespace(newAllowedNamespace);
                         }

--- a/frontend/src/components/portforward/PortForwardStartDialog.tsx
+++ b/frontend/src/components/portforward/PortForwardStartDialog.tsx
@@ -79,7 +79,7 @@ export default function PortForwardStartDialog(props: PortForwardStartDialogProp
     onConfirm(trimmedValue || undefined);
   }
 
-  function handleKeyPress(event: React.KeyboardEvent) {
+  function handleKeyDown(event: React.KeyboardEvent) {
     if (event.key === 'Enter') {
       handleConfirm();
     }
@@ -103,7 +103,7 @@ export default function PortForwardStartDialog(props: PortForwardStartDialogProp
           fullWidth
           value={portValue}
           onChange={e => setPortValue(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           error={!!errorText}
           helperText={errorText || helper}
           inputProps={{ inputMode: 'numeric', pattern: '[0-9]*' }}


### PR DESCRIPTION
## Summary
Fixes #5601 replaces deprecated `onKeyPress` with `onKeyDown` in three components.

## Changes
- `PortForwardStartDialog.tsx`: `onKeyPress` → `onKeyDown`
- `ClusterNameEditor.tsx`: `onKeyPress` → `onKeyDown`
- `SettingsCluster.tsx`: `onKeyPress` → `onKeyDown`

## Testing
1. Open Port Forward dialog → press Enter to confirm → works
2. Open Settings → Cluster → rename field → press Enter → works
3. Open Settings → Cluster → allowed namespaces → press Enter → works