### PR TITLE
fix(AuthVisible): move hooks above early return to satisfy Rules of H…

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -67,7 +67,7 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
-  const cluster = (item as KubeObject)?.cluster ?? (getCluster() ?? undefined);
+  const cluster = (item as KubeObject)?.cluster ?? getCluster() ?? undefined;
 
   const { data } = useQuery<any>({
     enabled: !!item && isAuthVerbValid,

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -101,7 +101,6 @@ export default function AuthVisible(props: AuthVisibleProps) {
         reason: data.status?.reason ?? '',
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
   if (!isAuthVerbValid) {

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -101,6 +101,7 @@ export default function AuthVisible(props: AuthVisibleProps) {
         reason: data.status?.reason ?? '',
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
   if (!isAuthVerbValid) {

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -88,7 +88,7 @@ export default function AuthVisible(props: AuthVisibleProps) {
         }
 
         if (item instanceof KubeObject) {
-          return item.getAuthorization(authVerb, {
+          return await item.getAuthorization(authVerb, {
             subresource,
             namespace,
           });

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -66,11 +66,13 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
+  const cluster = (item as any)?.cluster;
 
   const { data } = useQuery<any>({
     enabled: !!item && isAuthVerbValid,
     queryKey: [
       'authVisible',
+      cluster,
       itemName,
       itemClass?.apiName,
       itemClass?.apiVersion,
@@ -80,14 +82,14 @@ export default function AuthVisible(props: AuthVisibleProps) {
     ],
     queryFn: async () => {
       try {
-        const res = await item!.getAuthorization(
-          authVerb,
-          { subresource, namespace },
-          (item as any).cluster
-        );
-        return res;
+        if (!item) {
+          return null;
+        }
+
+        return await item.getAuthorization(authVerb, { subresource, namespace }, cluster);
       } catch (e: any) {
         onError?.(e);
+        return null;
       }
     },
   });

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -16,6 +16,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
+import { getCluster } from '../../../lib/cluster';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import { KubeObjectClass } from '../../../lib/k8s/KubeObject';
 
@@ -66,7 +67,7 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
-  const cluster = (item as any)?.cluster;
+  const cluster = (item as KubeObject)?.cluster ?? getCluster();
 
   const { data } = useQuery<any>({
     enabled: !!item && isAuthVerbValid,
@@ -84,6 +85,13 @@ export default function AuthVisible(props: AuthVisibleProps) {
       try {
         if (!item) {
           return null;
+        }
+
+        if (item instanceof KubeObject) {
+          return item.getAuthorization(authVerb, {
+            subresource,
+            namespace,
+          });
         }
 
         return await item.getAuthorization(authVerb, { subresource, namespace }, cluster);

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -67,7 +67,7 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
-  const cluster = (item as KubeObject)?.cluster ?? getCluster();
+  const cluster = (item as KubeObject)?.cluster ?? (getCluster() ?? undefined);
 
   const { data } = useQuery<any>({
     enabled: !!item && isAuthVerbValid,

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -92,15 +92,17 @@ export default function AuthVisible(props: AuthVisibleProps) {
     },
   });
 
-  const visible = data?.status?.allowed ?? false;
+  const visible = isAuthVerbValid && (data?.status?.allowed ?? false);
 
   useEffect(() => {
-    if (data) {
-      onAuthResult?.({
-        allowed: visible,
-        reason: data.status?.reason ?? '',
-      });
+    if (!isAuthVerbValid || !data) {
+      return;
     }
+    onAuthResult?.({
+      allowed: visible,
+      reason: data.status?.reason ?? '',
+    });
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 


### PR DESCRIPTION
Fixes #5187 

## Changes

Moves `useQuery` and `useEffect` above the early return in `AuthVisible` to ensure hooks are always executed in the same order on every render, fixing the `react-hooks/rules-of-hooks` ESLint error while preserving existing authorization logic via conditional `enabled` handling in `useQuery`.


