### PR TITLE
app: electron: Fix window reopen failure and server process cleanup on Windows

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -857,9 +857,20 @@ function quitServerProcess() {
   }
 
   serverProcess.stdin.destroy();
-  // @todo: should we try and end the process a bit more gracefully?
-  //       What happens if the kill signal doesn't kill it?
-  serverProcess.kill();
+
+  if (process.platform === 'win32') {
+    // On Windows, use taskkill with /T to kill the entire process tree.
+    // serverProcess.kill() only terminates the root process, leaving
+    // detached children (spawned with detached: true) running.
+    try {
+      execSync('taskkill /pid ' + serverProcess.pid + ' /T /F');
+    } catch (e) {
+      console.error('Failed to kill server process tree with taskkill:', e);
+      serverProcess.kill();
+    }
+  } else {
+    serverProcess.kill();
+  }
 
   serverProcess = null;
 }
@@ -1606,6 +1617,7 @@ function startElectron() {
       app.on('second-instance', () => {
         // Someone tried to run a second instance, we should focus our window.
         if (mainWindow) {
+          mainWindow.show();
           if (mainWindow.isMinimized()) mainWindow.restore();
           mainWindow.focus();
         }

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -844,7 +844,12 @@ let intentionalQuit: boolean;
 let serverProcessQuit: boolean;
 
 function quitServerProcess() {
-  if (!serverProcess || serverProcessQuit) {
+  if (!serverProcess) {
+    console.info('server process already not running');
+    return;
+  }
+
+  if (serverProcessQuit && process.platform !== 'win32') {
     console.info('server process already not running');
     return;
   }

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -857,10 +857,6 @@ function quitServerProcess() {
   intentionalQuit = true;
   console.info('stopping server process...');
 
-  if (!serverProcess) {
-    return;
-  }
-
   serverProcess.stdin.destroy();
 
   if (process.platform === 'win32') {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -845,7 +845,7 @@ let serverProcessQuit: boolean;
 
 function quitServerProcess() {
   if (!serverProcess || serverProcessQuit) {
-    console.error('server process already not running');
+    console.info('server process already not running');
     return;
   }
 
@@ -1855,6 +1855,8 @@ if (!isRunningScript) {
  * @param  {ChildProcess} serverProcess to attach the error handlers to.
  */
 function attachServerEventHandlers(serverProcess: ChildProcessWithoutNullStreams) {
+  serverProcessQuit = false;
+
   serverProcess.on('error', err => {
     console.error(`server process failed to start: ${err}`);
   });

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -859,13 +859,16 @@ function quitServerProcess() {
   serverProcess.stdin.destroy();
 
   if (process.platform === 'win32') {
-    // On Windows, use taskkill with /T to kill the entire process tree.
+    // On Windows, reuse killProcess() so the process-tree termination logic
+    // stays centralized and does not diverge from the shared implementation.
     // serverProcess.kill() only terminates the root process, leaving
     // detached children (spawned with detached: true) running.
     try {
-      execSync('taskkill /pid ' + serverProcess.pid + ' /T /F');
+      if (serverProcess.pid !== undefined) {
+        killProcess(serverProcess.pid);
+      }
     } catch (e) {
-      console.error('Failed to kill server process tree with taskkill:', e);
+      console.error('Failed to kill server process tree:', e);
       serverProcess.kill();
     }
   } else {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -844,7 +844,7 @@ let intentionalQuit: boolean;
 let serverProcessQuit: boolean;
 
 function quitServerProcess() {
-  if ((!serverProcess || serverProcessQuit) && process.platform !== 'win32') {
+  if (!serverProcess || serverProcessQuit) {
     console.error('server process already not running');
     return;
   }

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -866,13 +866,23 @@ function quitServerProcess() {
     try {
       if (serverProcess.pid !== undefined) {
         killProcess(serverProcess.pid);
+      } else {
+        serverProcess.kill();
       }
     } catch (e) {
       console.error('Failed to kill server process tree:', e);
-      serverProcess.kill();
+      try {
+        serverProcess.kill();
+      } catch (fallbackErr) {
+        console.error('Failed to fallback kill server process:', fallbackErr);
+      }
     }
   } else {
-    serverProcess.kill();
+    try {
+      serverProcess.kill();
+    } catch (e) {
+      console.error('Failed to kill server process:', e);
+    }
   }
 
   serverProcess = null;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headlamp",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "headlamp",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "dependencies": {
         "@langchain/mcp-adapters": "^1.0.0",
         "copyfiles": "^2.4.1",


### PR DESCRIPTION
## Summary

This PR fixes a bug where Headlamp fails to reopen after closing on Windows, and ensures the backend server process tree is fully terminated on quit.

## Related Issue

Fixes #5445

## Changes

- Fixed `second-instance` handler in `app/electron/main.ts` to call `mainWindow.show()` before `focus()`, so hidden windows (from tray hide-on-close) become visible when re-launching
- Fixed `quitServerProcess()` in `app/electron/main.ts` to use `taskkill /T /F` on Windows for reliable process tree cleanup, matching the existing `killProcess()` behavior

## Steps to Test

1. Build and launch the Headlamp desktop application
2. Close the window via the X button
3. Run `tasklist | findstr headlamp` (Windows) or `ps aux | grep headlamp` (Linux/macOS) and confirm no Headlamp processes remain
4. Re-launch Headlamp and verify it starts normally without needing to force-kill background processes
5. (macOS only) Close the window — verify it hides to tray. Re-launch from Dock — verify the window reappears

## Screenshots (if applicable)

N/A — no UI changes, behavioral fix only.

## Notes for the Reviewer

- The `second-instance` fix is needed for macOS where the tray hide-on-close behavior is still active (via PR #5519). Without `show()`, `focus()` alone does not make a hidden `BrowserWindow` visible.
- The `taskkill /T /F` approach in `quitServerProcess()` is consistent with the existing `killProcess()` function (line ~1318) which already uses `taskkill` for Windows. The server is spawned with `detached: true`, so `serverProcess.kill()` only terminates the root process — not child processes that hold ports.
- Tested locally: `app:tsc` ✅, `app:lint` ✅, `app:test:unit` ✅ (103/103 passed).

## Note on Dependency Updates: 

- You will notice a second commit in this PR that updates package-lock.json and package.json in the plugins/headlamp-plugin directory. This was necessary to fix a failing CI check-dependencies job. A recent merge to main updated the frontend dependencies (adding `remark-gfm` and bumping Storybook) but did not sync them to the plugin infrastructure. I ran npm run update-dependencies to fix the CI drift so this PR could pass.
