### PR TITLE
frontend: Add mutating admission policy resources

### DIFF
--- a/frontend/src/components/Sidebar/useSidebarItems.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.tsx
@@ -413,6 +413,14 @@ export const useSidebarItems = (sidebarName: string = DefaultSidebars.IN_CLUSTER
             label: t('glossary|Mutating Webhook Configurations'),
           },
           {
+            name: 'mutatingAdmissionPolicies',
+            label: t('glossary|Mutating Admission Policies'),
+          },
+          {
+            name: 'mutatingAdmissionPolicyBindings',
+            label: t('glossary|Mutating Admission Policy Bindings'),
+          },
+          {
             name: 'validatingWebhookConfigurations',
             label: t('glossary|Validating Webhook Configurations'),
           },

--- a/frontend/src/components/mutatingAdmissionPolicy/Details.tsx
+++ b/frontend/src/components/mutatingAdmissionPolicy/Details.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import MutatingAdmissionPolicy from '../../lib/k8s/mutatingAdmissionPolicy';
+import { ConditionsTable, DetailsGrid } from '../common/Resource';
+import SectionBox from '../common/SectionBox';
+import SimpleTable from '../common/SimpleTable';
+
+export default function MutatingAdmissionPolicyDetails(props: { name?: string; cluster?: string }) {
+  const params = useParams<{ name: string }>();
+  const { name = params.name, cluster } = props;
+  const { t } = useTranslation(['glossary', 'translation']);
+
+  return (
+    <DetailsGrid
+      resourceType={MutatingAdmissionPolicy}
+      name={name}
+      cluster={cluster}
+      withEvents
+      extraInfo={item =>
+        item && [
+          {
+            name: t('API Version'),
+            value: item.metadata.apiVersion,
+          },
+          {
+            name: t('Failure Policy'),
+            value: item.spec.failurePolicy,
+          },
+          {
+            name: t('Reinvocation Policy'),
+            value: item.spec.reinvocationPolicy,
+          },
+          {
+            name: t('translation|Param Kind'),
+            value: item.spec.paramKind
+              ? `${item.spec.paramKind.apiVersion || ''} ${item.spec.paramKind.kind || ''}`.trim()
+              : '-',
+          },
+        ]
+      }
+      extraSections={item =>
+        item && [
+          {
+            id: 'headlamp.mutating-admission-policy-mutations',
+            section: (
+              <SectionBox title={t('translation|Mutations')}>
+                <SimpleTable
+                  data={item.spec.mutations || []}
+                  columns={[
+                    {
+                      label: t('translation|Patch Type'),
+                      getter: mutation => mutation.patchType,
+                    },
+                    {
+                      label: t('translation|Expression'),
+                      getter: mutation =>
+                        mutation.applyConfiguration?.expression || mutation.jsonPatch?.expression,
+                    },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+          {
+            id: 'headlamp.mutating-admission-policy-match-constraints',
+            section: (
+              <SectionBox title={t('translation|Match Constraints')}>
+                <SimpleTable
+                  data={item.spec.matchConstraints?.resourceRules || []}
+                  columns={[
+                    {
+                      label: t('API Groups'),
+                      getter: rule => rule.apiGroups?.join(', '),
+                    },
+                    {
+                      label: t('API Versions'),
+                      getter: rule => rule.apiVersions?.join(', '),
+                    },
+                    {
+                      label: t('translation|Operations'),
+                      getter: rule => rule.operations?.join(', '),
+                    },
+                    {
+                      label: t('Resources'),
+                      getter: rule => rule.resources?.join(', '),
+                    },
+                    {
+                      label: t('Scope'),
+                      getter: rule => rule.scope,
+                    },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+          {
+            id: 'headlamp.mutating-admission-policy-match-conditions',
+            section: (
+              <SectionBox title={t('translation|Match Conditions')}>
+                <SimpleTable
+                  data={item.spec.matchConditions || []}
+                  columns={[
+                    {
+                      label: t('translation|Name'),
+                      getter: condition => condition.name,
+                    },
+                    {
+                      label: t('translation|Expression'),
+                      getter: condition => condition.expression,
+                    },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+          {
+            id: 'headlamp.mutating-admission-policy-conditions',
+            section: (
+              <SectionBox title={t('translation|Conditions')}>
+                <ConditionsTable resource={item.jsonData} showLastUpdate={false} />
+              </SectionBox>
+            ),
+          },
+        ]
+      }
+    />
+  );
+}

--- a/frontend/src/components/mutatingAdmissionPolicy/List.tsx
+++ b/frontend/src/components/mutatingAdmissionPolicy/List.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import MutatingAdmissionPolicy from '../../lib/k8s/mutatingAdmissionPolicy';
+import ResourceListView from '../common/Resource/ResourceListView';
+
+export default function MutatingAdmissionPolicyList() {
+  const { t } = useTranslation(['glossary', 'translation']);
+
+  return (
+    <ResourceListView
+      title={t('glossary|Mutating Admission Policies')}
+      resourceClass={MutatingAdmissionPolicy}
+      columns={[
+        'name',
+        {
+          id: 'mutations',
+          label: t('translation|Mutations'),
+          gridTemplate: 'min-content',
+          getValue: item => item.spec.mutations?.length || 0,
+        },
+        {
+          id: 'failurePolicy',
+          label: t('Failure Policy'),
+          gridTemplate: 'min-content',
+          getValue: item => item.spec.failurePolicy,
+        },
+        {
+          id: 'reinvocationPolicy',
+          label: t('Reinvocation Policy'),
+          gridTemplate: 'min-content',
+          getValue: item => item.spec.reinvocationPolicy,
+        },
+        'labels',
+        'age',
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/mutatingAdmissionPolicyBinding/Details.tsx
+++ b/frontend/src/components/mutatingAdmissionPolicyBinding/Details.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import MutatingAdmissionPolicyBinding from '../../lib/k8s/mutatingAdmissionPolicyBinding';
+import { DetailsGrid } from '../common/Resource';
+import SectionBox from '../common/SectionBox';
+import SimpleTable from '../common/SimpleTable';
+
+export default function MutatingAdmissionPolicyBindingDetails(props: {
+  name?: string;
+  cluster?: string;
+}) {
+  const params = useParams<{ name: string }>();
+  const { name = params.name, cluster } = props;
+  const { t } = useTranslation(['translation']);
+
+  return (
+    <DetailsGrid
+      resourceType={MutatingAdmissionPolicyBinding}
+      name={name}
+      cluster={cluster}
+      withEvents
+      extraInfo={item =>
+        item && [
+          {
+            name: t('API Version'),
+            value: item.metadata.apiVersion,
+          },
+          {
+            name: t('translation|Policy Name'),
+            value: item.spec.policyName,
+          },
+          {
+            name: t('translation|Param Ref'),
+            value: item.spec.paramRef?.name || '-',
+          },
+          {
+            name: t('translation|Parameter Not Found Action'),
+            value: item.spec.paramRef?.parameterNotFoundAction,
+          },
+        ]
+      }
+      extraSections={item =>
+        item && [
+          {
+            id: 'headlamp.mutating-admission-policy-binding-match-resources',
+            section: (
+              <SectionBox title={t('translation|Match Resources')}>
+                <SimpleTable
+                  data={item.spec.matchResources?.resourceRules || []}
+                  columns={[
+                    {
+                      label: t('API Groups'),
+                      getter: rule => rule.apiGroups?.join(', '),
+                    },
+                    {
+                      label: t('API Versions'),
+                      getter: rule => rule.apiVersions?.join(', '),
+                    },
+                    {
+                      label: t('translation|Operations'),
+                      getter: rule => rule.operations?.join(', '),
+                    },
+                    {
+                      label: t('Resources'),
+                      getter: rule => rule.resources?.join(', '),
+                    },
+                    {
+                      label: t('Scope'),
+                      getter: rule => rule.scope,
+                    },
+                  ]}
+                />
+              </SectionBox>
+            ),
+          },
+        ]
+      }
+    />
+  );
+}

--- a/frontend/src/components/mutatingAdmissionPolicyBinding/List.tsx
+++ b/frontend/src/components/mutatingAdmissionPolicyBinding/List.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import MutatingAdmissionPolicyBinding from '../../lib/k8s/mutatingAdmissionPolicyBinding';
+import ResourceListView from '../common/Resource/ResourceListView';
+
+export default function MutatingAdmissionPolicyBindingList() {
+  const { t } = useTranslation(['glossary', 'translation']);
+
+  return (
+    <ResourceListView
+      title={t('glossary|Mutating Admission Policy Bindings')}
+      resourceClass={MutatingAdmissionPolicyBinding}
+      columns={[
+        'name',
+        {
+          id: 'policyName',
+          label: t('translation|Policy Name'),
+          getValue: item => item.spec.policyName,
+        },
+        {
+          id: 'paramRef',
+          label: t('translation|Param Ref'),
+          getValue: item => item.spec.paramRef?.name,
+        },
+        'labels',
+        'age',
+      ]}
+    />
+  );
+}

--- a/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
+++ b/frontend/src/components/resourceMap/details/KubeNodeDetails.tsx
@@ -38,6 +38,8 @@ import IngressClassDetails from '../../ingress/ClassDetails';
 import IngressDetails from '../../ingress/Details';
 import { LeaseDetails } from '../../lease/Details';
 import { LimitRangeDetails } from '../../limitRange/Details';
+import MutatingAdmissionPolicyDetails from '../../mutatingAdmissionPolicy/Details';
+import MutatingAdmissionPolicyBindingDetails from '../../mutatingAdmissionPolicyBinding/Details';
 import NamespaceDetails from '../../namespace/Details';
 import { NetworkPolicyDetails } from '../../networkpolicy/Details';
 import NodeDetails from '../../node/Details';
@@ -98,6 +100,8 @@ const kindComponentMap: Record<
   VolumeAttributesClass: VolumeAttributesClassDetails,
   PersistentVolume: VolumeDetails,
   VerticalPodAutoscaler: VpaDetails,
+  MutatingAdmissionPolicy: MutatingAdmissionPolicyDetails,
+  MutatingAdmissionPolicyBinding: MutatingAdmissionPolicyBindingDetails,
   MutatingWebhookConfiguration: MutatingWebhookConfigList,
   ValidatingWebhookConfiguration: ValidatingWebhookConfigurationDetails,
   IngressClass: IngressClassDetails,

--- a/frontend/src/components/resourceMap/graph/graphModel.tsx
+++ b/frontend/src/components/resourceMap/graph/graphModel.tsx
@@ -219,6 +219,8 @@ const DEFAULT_NODE_WEIGHTS = {
   // Network supporting resources (cascading from Service/NetworkPolicy)
   Endpoints: 780,
   EndpointSlice: 780,
+  MutatingAdmissionPolicy: 780,
+  MutatingAdmissionPolicyBinding: 780,
   MutatingWebhookConfiguration: 780,
   ValidatingWebhookConfiguration: 780,
   IngressClass: 780,

--- a/frontend/src/components/resourceMap/kubeIcon/KubeIcon.tsx
+++ b/frontend/src/components/resourceMap/kubeIcon/KubeIcon.tsx
@@ -135,6 +135,8 @@ const kindGroups = {
     'Lease',
     'ResourceQuota',
     'LimitRange',
+    'MutatingAdmissionPolicy',
+    'MutatingAdmissionPolicyBinding',
     'MutatingWebhookConfiguration',
     'ValidatingWebhookConfiguration',
   ]),

--- a/frontend/src/components/resourceMap/sources/definitions/sources.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/sources.tsx
@@ -38,6 +38,8 @@ import JobSet from '../../../../lib/k8s/jobSet';
 import { KubeObjectClass } from '../../../../lib/k8s/KubeObject';
 import { Lease } from '../../../../lib/k8s/lease';
 import { LimitRange } from '../../../../lib/k8s/limitRange';
+import MutatingAdmissionPolicy from '../../../../lib/k8s/mutatingAdmissionPolicy';
+import MutatingAdmissionPolicyBinding from '../../../../lib/k8s/mutatingAdmissionPolicyBinding';
 import MutatingWebhookConfiguration from '../../../../lib/k8s/mutatingWebhookConfiguration';
 import NetworkPolicy from '../../../../lib/k8s/networkpolicy';
 import PersistentVolumeClaim from '../../../../lib/k8s/persistentVolumeClaim';
@@ -229,6 +231,8 @@ export function useGetAllSources(): GraphSource[] {
         sources: [
           makeKubeSource(ConfigMap),
           makeKubeSource(Secret),
+          makeKubeSource(MutatingAdmissionPolicy),
+          makeKubeSource(MutatingAdmissionPolicyBinding),
           makeKubeSource(MutatingWebhookConfiguration),
           makeKubeSource(ValidatingWebhookConfiguration),
           makeKubeSource(HPA),

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -229,6 +229,8 @@
   "Runtime Classes": "Runtime Classes",
   "Leases": "Leases",
   "Mutating Webhook Configurations": "Mutating Webhook Configurations",
+  "Mutating Admission Policies": "Mutating Admission Policies",
+  "Mutating Admission Policy Bindings": "Mutating Admission Policy Bindings",
   "Validating Webhook Configurations": "Validating Webhook Configurations",
   "Git Version": "Git Version",
   "Git Tree State": "Git Tree State",

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -44,6 +44,8 @@ import Job from './job';
 import JobSet from './jobSet';
 import { Lease } from './lease';
 import { LimitRange } from './limitRange';
+import MutatingAdmissionPolicy from './mutatingAdmissionPolicy';
+import MutatingAdmissionPolicyBinding from './mutatingAdmissionPolicyBinding';
 import Namespace from './namespace';
 import NetworkPolicy from './networkpolicy';
 import Node from './node';
@@ -79,6 +81,8 @@ export const ResourceClasses = {
   EndpointSlice,
   LimitRange,
   Lease,
+  MutatingAdmissionPolicy,
+  MutatingAdmissionPolicyBinding,
   ResourceQuota,
   HorizontalPodAutoscaler: HPA,
   PodDisruptionBudget,

--- a/frontend/src/lib/k8s/mutatingAdmissionPolicy.test.ts
+++ b/frontend/src/lib/k8s/mutatingAdmissionPolicy.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import MutatingAdmissionPolicy from './mutatingAdmissionPolicy';
+import MutatingAdmissionPolicyBinding from './mutatingAdmissionPolicyBinding';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('MutatingAdmissionPolicy resources', () => {
+  it('uses admissionregistration API versions from stable to older feature versions', () => {
+    expect(MutatingAdmissionPolicy.apiVersion).toEqual([
+      'admissionregistration.k8s.io/v1',
+      'admissionregistration.k8s.io/v1beta1',
+      'admissionregistration.k8s.io/v1alpha1',
+    ]);
+    expect(MutatingAdmissionPolicyBinding.apiVersion).toEqual(MutatingAdmissionPolicy.apiVersion);
+  });
+
+  it('creates a usable base MutatingAdmissionPolicy object', () => {
+    expect(MutatingAdmissionPolicy.getBaseObject()).toMatchObject({
+      apiVersion: 'admissionregistration.k8s.io/v1',
+      kind: 'MutatingAdmissionPolicy',
+      metadata: {
+        name: '',
+      },
+      spec: {
+        failurePolicy: 'Fail',
+        matchConstraints: {
+          resourceRules: [
+            {
+              apiGroups: [],
+              apiVersions: [],
+              operations: [],
+              resources: [],
+            },
+          ],
+        },
+        mutations: [
+          {
+            patchType: 'ApplyConfiguration',
+            applyConfiguration: {
+              expression: '',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('creates a usable base MutatingAdmissionPolicyBinding object', () => {
+    expect(MutatingAdmissionPolicyBinding.getBaseObject()).toMatchObject({
+      apiVersion: 'admissionregistration.k8s.io/v1',
+      kind: 'MutatingAdmissionPolicyBinding',
+      metadata: {
+        name: '',
+      },
+      spec: {
+        policyName: '',
+      },
+    });
+  });
+});

--- a/frontend/src/lib/k8s/mutatingAdmissionPolicy.ts
+++ b/frontend/src/lib/k8s/mutatingAdmissionPolicy.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeCondition } from './cluster';
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+import type { KubeRuleWithOperations } from './mutatingWebhookConfiguration';
+
+export interface KubeMutatingAdmissionPolicy extends KubeObjectInterface {
+  spec: {
+    failurePolicy?: string;
+    matchConditions?: {
+      name: string;
+      expression: string;
+    }[];
+    matchConstraints?: {
+      excludeResourceRules?: KubeRuleWithOperations[];
+      resourceRules?: KubeRuleWithOperations[];
+    };
+    mutations?: {
+      applyConfiguration?: {
+        expression: string;
+      };
+      jsonPatch?: {
+        expression: string;
+      };
+      patchType: string;
+    }[];
+    paramKind?: {
+      apiVersion?: string;
+      kind?: string;
+    };
+    reinvocationPolicy?: string;
+  };
+  status?: {
+    conditions?: KubeCondition[];
+    observedGeneration?: number;
+    typeChecking?: {
+      expressionWarnings?: {
+        fieldRef: string;
+        warning: string;
+      }[];
+    };
+  };
+}
+
+class MutatingAdmissionPolicy extends KubeObject<KubeMutatingAdmissionPolicy> {
+  static kind = 'MutatingAdmissionPolicy';
+  static apiName = 'mutatingadmissionpolicies';
+  static apiVersion = [
+    'admissionregistration.k8s.io/v1',
+    'admissionregistration.k8s.io/v1beta1',
+    'admissionregistration.k8s.io/v1alpha1',
+  ];
+  static isNamespaced = false;
+
+  static getBaseObject(): KubeMutatingAdmissionPolicy {
+    const baseObject = super.getBaseObject() as KubeMutatingAdmissionPolicy;
+    baseObject.spec = {
+      failurePolicy: 'Fail',
+      matchConstraints: {
+        resourceRules: [
+          {
+            apiGroups: [],
+            apiVersions: [],
+            operations: [],
+            resources: [],
+          },
+        ],
+      },
+      mutations: [
+        {
+          patchType: 'ApplyConfiguration',
+          applyConfiguration: {
+            expression: '',
+          },
+        },
+      ],
+    };
+    return baseObject;
+  }
+
+  get spec(): KubeMutatingAdmissionPolicy['spec'] {
+    return this.jsonData.spec;
+  }
+}
+
+export default MutatingAdmissionPolicy;

--- a/frontend/src/lib/k8s/mutatingAdmissionPolicyBinding.ts
+++ b/frontend/src/lib/k8s/mutatingAdmissionPolicyBinding.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { KubeObjectInterface } from './KubeObject';
+import { KubeObject } from './KubeObject';
+import type { KubeRuleWithOperations } from './mutatingWebhookConfiguration';
+
+export interface KubeMutatingAdmissionPolicyBinding extends KubeObjectInterface {
+  spec: {
+    matchResources?: {
+      excludeResourceRules?: KubeRuleWithOperations[];
+      resourceRules?: KubeRuleWithOperations[];
+    };
+    paramRef?: {
+      name?: string;
+      namespace?: string;
+      parameterNotFoundAction?: string;
+      selector?: {
+        matchExpressions?: {
+          key: string;
+          operator: string;
+          values?: string[];
+        }[];
+        matchLabels?: {
+          [key: string]: string;
+        };
+      };
+    };
+    policyName: string;
+  };
+}
+
+class MutatingAdmissionPolicyBinding extends KubeObject<KubeMutatingAdmissionPolicyBinding> {
+  static kind = 'MutatingAdmissionPolicyBinding';
+  static apiName = 'mutatingadmissionpolicybindings';
+  static apiVersion = [
+    'admissionregistration.k8s.io/v1',
+    'admissionregistration.k8s.io/v1beta1',
+    'admissionregistration.k8s.io/v1alpha1',
+  ];
+  static isNamespaced = false;
+
+  static getBaseObject(): KubeMutatingAdmissionPolicyBinding {
+    const baseObject = super.getBaseObject() as KubeMutatingAdmissionPolicyBinding;
+    baseObject.spec = {
+      policyName: '',
+    };
+    return baseObject;
+  }
+
+  get spec(): KubeMutatingAdmissionPolicyBinding['spec'] {
+    return this.jsonData.spec;
+  }
+}
+
+export default MutatingAdmissionPolicyBinding;

--- a/frontend/src/lib/router/index.tsx
+++ b/frontend/src/lib/router/index.tsx
@@ -71,6 +71,10 @@ import { LeaseDetails } from '../../components/lease/Details';
 import { LeaseList } from '../../components/lease/List';
 import { LimitRangeDetails } from '../../components/limitRange/Details';
 import { LimitRangeList } from '../../components/limitRange/List';
+import MutatingAdmissionPolicyDetails from '../../components/mutatingAdmissionPolicy/Details';
+import MutatingAdmissionPolicyList from '../../components/mutatingAdmissionPolicy/List';
+import MutatingAdmissionPolicyBindingDetails from '../../components/mutatingAdmissionPolicyBinding/Details';
+import MutatingAdmissionPolicyBindingList from '../../components/mutatingAdmissionPolicyBinding/List';
 import NamespaceDetails from '../../components/namespace/Details';
 import NamespacesList from '../../components/namespace/List';
 import { NetworkPolicyDetails } from '../../components/networkpolicy/Details';
@@ -778,6 +782,34 @@ const defaultRoutes: { [routeName: string]: Route } = {
     name: 'Mutating Webhook Configuration',
     sidebar: 'mutatingWebhookConfigurations',
     component: () => <MutatingWebhookConfigurationDetails />,
+  },
+  mutatingAdmissionPolicies: {
+    path: '/mutatingadmissionpolicies',
+    exact: true,
+    name: 'Mutating Admission Policies',
+    sidebar: 'mutatingAdmissionPolicies',
+    component: () => <MutatingAdmissionPolicyList />,
+  },
+  mutatingAdmissionPolicy: {
+    path: '/mutatingadmissionpolicies/:name',
+    exact: true,
+    name: 'Mutating Admission Policy',
+    sidebar: 'mutatingAdmissionPolicies',
+    component: () => <MutatingAdmissionPolicyDetails />,
+  },
+  mutatingAdmissionPolicyBindings: {
+    path: '/mutatingadmissionpolicybindings',
+    exact: true,
+    name: 'Mutating Admission Policy Bindings',
+    sidebar: 'mutatingAdmissionPolicyBindings',
+    component: () => <MutatingAdmissionPolicyBindingList />,
+  },
+  mutatingAdmissionPolicyBinding: {
+    path: '/mutatingadmissionpolicybindings/:name',
+    exact: true,
+    name: 'Mutating Admission Policy Binding',
+    sidebar: 'mutatingAdmissionPolicyBindings',
+    component: () => <MutatingAdmissionPolicyBindingDetails />,
   },
   validatingWebhookConfigurations: {
     path: '/validatingwebhookconfigurations',


### PR DESCRIPTION
## Summary

This PR adds support for `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding` resources in Headlamp so users can view and create them from the UI instead of falling back to `kubectl`.

## Related Issue

Fixes #5542

## Changes

- Added Kubernetes resource classes for `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding`
- Added list and details pages for both resources under the Configuration section
- Wired the new resources into routing, the sidebar, and the resource map
- Reused the existing generic resource views so the behavior stays consistent with the rest of Headlamp
- Added a small regression test for the new resource classes

## Steps to Test

1. Open Headlamp and go to the Configuration section in the sidebar.
2. Verify that `Mutating Admission Policies` and `Mutating Admission Policy Bindings` are listed.
3. Open each page and confirm the list and details views load correctly.
4. If the cluster supports the API, create one of the resources and confirm it appears in the list.

## Screenshots

None required for this change.

## Notes for the Reviewer

This change follows the existing pattern already used for admission webhook resources, so it stays small and avoids introducing a separate code path. The new resource classes use the standard Kubernetes API version fallback order to handle clusters that expose the feature through older versions.