### PR TITLE
backend: Fix port-forward cache key collisions

### DIFF
--- a/backend/pkg/portforward/export_test.go
+++ b/backend/pkg/portforward/export_test.go
@@ -27,7 +27,7 @@ func StorePortForwardForTest(c cache.Cache[interface{}], clusterName, userID str
 		Pod:        "test-pod",
 		Namespace:  "default",
 		Cluster:    clusterName,
-		cacheKey:   clusterName + userID,
+		cacheKey:   portforwardClusterKey(clusterName, userID),
 		Port:       "8080",
 		TargetPort: "80",
 		Status:     RUNNING,

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -55,6 +55,7 @@ const (
 const (
 	PodAvailabilityCheckTimer   = 5 // seconds
 	PortForwardReadinessTimeout = 30 * time.Second
+	portforwardClusterKeySep    = "\x00"
 )
 
 var inFlightPortForwards sync.Map
@@ -99,6 +100,14 @@ type portForward struct {
 	TargetPort       string `json:"targetPort"`
 	Status           string `json:"status"`
 	Error            string `json:"error"`
+}
+
+func portforwardClusterKey(clusterName, userID string) string {
+	if userID == "" {
+		return clusterName
+	}
+
+	return clusterName + portforwardClusterKeySep + userID
 }
 
 // setStatusAndSnapshot updates the Status and Error fields and returns a
@@ -157,6 +166,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 	userID := r.Header.Get("X-HEADLAMP-USER-ID")
 	requestClusterName := mux.Vars(r)["clusterName"]
 	clusterName := requestClusterName
+	cacheKey := portforwardClusterKey(requestClusterName, userID)
 
 	if userID != "" {
 		clusterName += userID
@@ -165,7 +175,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 	// Ensure we don't orphan an existing port-forward by overwriting its cache entry.
 	// This check happens before any resource allocation or blocking code so duplicates short-circuit
 	// deterministically and avoid unnecessary listener churn.
-	if existingPF, err := getPortForwardByID(cache, clusterName, p.ID); err == nil && existingPF.Status == RUNNING {
+	if existingPF, err := getPortForwardByID(cache, cacheKey, p.ID); err == nil && existingPF.Status == RUNNING {
 		//nolint:goconst
 		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
 			nil, "portforward ID already exists")
@@ -175,7 +185,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 	}
 
 	// Reject duplicates before any resource-consuming work (port alloc, kubeconfig lookup).
-	inFlightKey := strings.Join([]string{requestClusterName, userID, p.ID}, "\x00")
+	inFlightKey := strings.Join([]string{requestClusterName, userID, p.ID}, portforwardClusterKeySep)
 	if _, loaded := inFlightPortForwards.LoadOrStore(inFlightKey, struct{}{}); loaded {
 		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
 			nil, "portforward ID is already starting")
@@ -220,7 +230,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		token, _ = auth.GetTokenFromCookie(r, requestClusterName)
 	}
 
-	err = startPortForward(kContext, cache, p, token, clusterName, requestClusterName)
+	err = startPortForward(kContext, cache, p, token, cacheKey, requestClusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "starting portforward")
 
@@ -621,7 +631,7 @@ func runAndMonitorPortForward(
 // startPortForward starts a port forward. This is the internal function that was refactored.
 // It sets up Kubernetes clients, initializes the port forwarder, and manages its lifecycle.
 func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{}],
-	p portForwardRequest, token string, clusterName string, requestClusterName string,
+	p portForwardRequest, token string, cacheKey string, requestClusterName string,
 ) error {
 	clientset, rConf, err := getKubeClientAndConfig(kContext, token)
 	if err != nil {
@@ -658,7 +668,7 @@ func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{
 		closeChan:        stopChan,
 		Pod:              p.Pod,
 		Cluster:          requestClusterName,
-		cacheKey:         clusterName,
+		cacheKey:         cacheKey,
 		Namespace:        p.Namespace,
 		Service:          p.Service,
 		ServiceNamespace: p.ServiceNamespace,
@@ -721,10 +731,7 @@ func StopOrDeletePortForward(cache cache.Cache[interface{}], w http.ResponseWrit
 
 	userID := r.Header.Get("X-HEADLAMP-USER-ID")
 	clusterName := mux.Vars(r)["clusterName"]
-
-	if userID != "" {
-		clusterName += userID
-	}
+	clusterName = portforwardClusterKey(clusterName, userID)
 
 	err = stopOrDeletePortForward(cache, clusterName, p.ID, p.StopOrDelete)
 	if err == nil {
@@ -750,11 +757,7 @@ func GetPortForwards(cache cache.Cache[interface{}], w http.ResponseWriter, r *h
 	}
 
 	userID := r.Header.Get("X-HEADLAMP-USER-ID")
-	clusterName := cluster
-
-	if userID != "" {
-		clusterName = cluster + userID
-	}
+	clusterName := portforwardClusterKey(cluster, userID)
 
 	ports := getPortForwardList(cache, clusterName)
 
@@ -787,11 +790,7 @@ func GetPortForwardByID(cache cache.Cache[interface{}], w http.ResponseWriter, r
 	}
 
 	userID := r.Header.Get("X-HEADLAMP-USER-ID")
-	clusterName := cluster
-
-	if userID != "" {
-		clusterName = cluster + userID
-	}
+	clusterName := portforwardClusterKey(cluster, userID)
 
 	p, err := getPortForwardByID(cache, clusterName, id)
 	if err != nil {

--- a/backend/pkg/portforward/handler_test.go
+++ b/backend/pkg/portforward/handler_test.go
@@ -214,14 +214,6 @@ func TestStartPortForward(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(stopRespBody), "stopped")
 
-	cacheKey := "PORT_FORWARD_" + minikubeName + id
-	chState, err := ch.Get(context.Background(), cacheKey)
-	require.NoError(t, err, "failed to get port-forward state from cache with key %s", cacheKey)
-
-	chData, err := json.Marshal(chState)
-	require.NoError(t, err)
-	assert.Contains(t, string(chData), "Stopped")
-
 	listReq := &http.Request{
 		Header: make(http.Header),
 	}
@@ -326,10 +318,11 @@ func TestStartPortForward(t *testing.T) {
 	require.Contains(t, string(deleteRespBody), "stopped")
 
 	require.Eventually(t, func() bool {
-		_, err := ch.Get(context.Background(), cacheKey)
-		return err != nil
-	}, 3*time.Second, 50*time.Millisecond,
-		"port-forward with key %s should be deleted from cache", cacheKey)
+		getAfterDeleteResp := httptest.NewRecorder()
+		portforward.GetPortForwardByID(ch, getAfterDeleteResp, getReq)
+
+		return getAfterDeleteResp.Code == http.StatusNotFound
+	}, 3*time.Second, 50*time.Millisecond, "port-forward should be deleted from cache")
 }
 
 // TestGetPortForwardsClusterNameNotExposingUserID verifies that when a dynamic

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -106,16 +106,21 @@ func TestPortforwardKeyGenerator(t *testing.T) {
 		p    portForward
 		want string
 	}{
-		{"only_cluster_id", portForward{ID: "id", Cluster: "cluster"}, "PORT_FORWARD_clusterid"},
-		{"only_service", portForward{Cluster: "cluster", Service: "service"}, "PORT_FORWARD_clusterservice"},
-		{"only_pod", portForward{Cluster: "cluster", Pod: "pod"}, "PORT_FORWARD_clusterpod"},
-		{"service_and_pod", portForward{Cluster: "cluster", Service: "service", Pod: "pod"}, "PORT_FORWARD_clusterservice"},
-		{"id_and_service", portForward{Cluster: "cluster", ID: "id", Service: "service"}, "PORT_FORWARD_clusterid"},
-		{"id_and_pod", portForward{Cluster: "cluster", ID: "id", Pod: "pod"}, "PORT_FORWARD_clusterid"},
+		{"only_cluster_id", portForward{ID: "id", Cluster: "cluster"}, "PORT_FORWARD_cluster:id"},
+		{"only_service", portForward{Cluster: "cluster", Service: "service"}, "PORT_FORWARD_cluster:service"},
+		{"only_pod", portForward{Cluster: "cluster", Pod: "pod"}, "PORT_FORWARD_cluster:pod"},
+		{"service_and_pod", portForward{Cluster: "cluster", Service: "service", Pod: "pod"}, "PORT_FORWARD_cluster:service"},
+		{"id_and_service", portForward{Cluster: "cluster", ID: "id", Service: "service"}, "PORT_FORWARD_cluster:id"},
+		{"id_and_pod", portForward{Cluster: "cluster", ID: "id", Pod: "pod"}, "PORT_FORWARD_cluster:id"},
 		{
 			"id_and_service_and_pod",
 			portForward{Cluster: "cluster", ID: "id", Service: "service", Pod: "pod"},
-			"PORT_FORWARD_clusterid",
+			"PORT_FORWARD_cluster:id",
+		},
+		{
+			"delimiter_chars",
+			portForward{Cluster: "foo:bar", ID: "baz:qux"},
+			"PORT_FORWARD_foo%3Abar:baz%3Aqux",
 		},
 	}
 
@@ -126,6 +131,15 @@ func TestPortforwardKeyGenerator(t *testing.T) {
 			assert.Equal(t, tt.want, key)
 		})
 	}
+}
+
+func TestPortforwardClusterKey(t *testing.T) {
+	assert.Equal(t, "cluster", portforwardClusterKey("cluster", ""))
+	assert.Equal(t, "cluster\x00user", portforwardClusterKey("cluster", "user"))
+	assert.NotEqual(t,
+		portforwardClusterKey("foo", "bar/baz"),
+		portforwardClusterKey("foo/bar", "baz"),
+	)
 }
 
 // TestPortforwardStore tests portforwardstore function.
@@ -214,6 +228,53 @@ func TestGetPortForwardList(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []portForward{p3}, pfList)
+}
+
+func TestGetPortForwardList_ClusterPrefixCollision(t *testing.T) {
+	tests := []struct {
+		name    string
+		first   portForward
+		second  portForward
+		cluster string
+		want    []portForward
+	}{
+		{
+			name:    "similar_names",
+			first:   portForward{ID: "id1", Cluster: "foo"},
+			second:  portForward{ID: "id2", Cluster: "foobar"},
+			cluster: "foo",
+			want:    []portForward{{ID: "id1", Cluster: "foo"}},
+		},
+		{
+			name:    "delimiter_in_cluster_name",
+			first:   portForward{ID: "id1", Cluster: "foo"},
+			second:  portForward{ID: "id2", Cluster: "foo:bar"},
+			cluster: "foo",
+			want:    []portForward{{ID: "id1", Cluster: "foo"}},
+		},
+		{
+			name:    "delimiter_in_id",
+			first:   portForward{ID: "bar:baz", Cluster: "foo"},
+			second:  portForward{ID: "baz", Cluster: "foo:bar"},
+			cluster: "foo",
+			want:    []portForward{{ID: "bar:baz", Cluster: "foo"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := cache.New[interface{}]()
+
+			err := cache.Set(context.Background(), portforwardKeyGenerator(tt.first), tt.first)
+			require.NoError(t, err)
+
+			err = cache.Set(context.Background(), portforwardKeyGenerator(tt.second), tt.second)
+			require.NoError(t, err)
+
+			pfList := getPortForwardList(cache, tt.cluster)
+			assert.ElementsMatch(t, tt.want, pfList)
+		})
+	}
 }
 
 // Test portForwardRequest.Validate() function.
@@ -508,8 +569,29 @@ func TestGetPortForwardList_UserIDKeyIsolation(t *testing.T) {
 	assert.Equal(t, "pf-1", result[0].ID)
 
 	// Query with a user-specific key — should NOT find the entry.
-	resultWithUser := getPortForwardList(c, "clusteruser123")
+	resultWithUser := getPortForwardList(c, portforwardClusterKey("cluster", "user123"))
 	assert.Empty(t, resultWithUser, "user-specific key must not return entries stored under base cluster key")
+}
+
+func TestGetPortForwardList_UserIDCollision(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	userPF := portForward{
+		ID:       "pf-user",
+		cacheKey: portforwardClusterKey("foo", "bar"),
+		Cluster:  "foo",
+		Status:   RUNNING,
+	}
+	clusterPF := portForward{ID: "pf-cluster", Cluster: "foobar", Status: RUNNING}
+
+	portforwardstore(c, userPF)
+	portforwardstore(c, clusterPF)
+
+	userResult := getPortForwardList(c, portforwardClusterKey("foo", "bar"))
+	assert.ElementsMatch(t, []portForward{userPF}, userResult)
+
+	clusterResult := getPortForwardList(c, "foobar")
+	assert.ElementsMatch(t, []portForward{clusterPF}, clusterResult)
 }
 
 // TestGetPortForwardByID_UserIDKeyIsolation verifies that getPortForwardByID
@@ -527,7 +609,7 @@ func TestGetPortForwardByID_UserIDKeyIsolation(t *testing.T) {
 	assert.Equal(t, "pf-2", found.ID)
 
 	// Lookup with a user-specific key — should fail.
-	_, err = getPortForwardByID(c, "clusteruser456", "pf-2")
+	_, err = getPortForwardByID(c, portforwardClusterKey("cluster", "user456"), "pf-2")
 	assert.Error(t, err, "user-specific key must not find entries stored under base cluster key")
 }
 
@@ -616,8 +698,42 @@ func TestGetPortForwardByIDHandler_UserIDKeyIsolation(t *testing.T) {
 		"user-specific lookup must not find entries under base cluster key")
 }
 
+func TestGetPortForwardByIDHandler_UserIDKeepsRouteCluster(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	pf := portForward{
+		ID:        "pf-user",
+		cacheKey:  portforwardClusterKey("cluster", "user999"),
+		Cluster:   "cluster",
+		Pod:       "redis",
+		Namespace: "cache",
+		Status:    RUNNING,
+	}
+	portforwardstore(c, pf)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward?id=pf-user", nil)
+	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
+	r.URL = &url.URL{RawQuery: "id=pf-user"}
+	r.Header.Set("X-HEADLAMP-USER-ID", "user999")
+
+	GetPortForwardByID(c, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var payload map[string]string
+
+	err := json.NewDecoder(res.Body).Decode(&payload)
+	require.NoError(t, err)
+	assert.Equal(t, "cluster", payload["cluster"])
+}
+
 // TestStopOrDeletePortForwardHandler_UserIDKeyIsolation verifies that
-// StopOrDeletePortForward uses cluster+userID as the cache key.
+// StopOrDeletePortForward uses the user-scoped cluster cache key.
 func TestStopOrDeletePortForwardHandler_UserIDKeyIsolation(t *testing.T) {
 	c := cache.New[interface{}]()
 

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -19,6 +19,7 @@ package portforward
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
@@ -27,29 +28,32 @@ import (
 
 const storeKeyPrefix = "PORT_FORWARD_"
 
+func portforwardCacheKeyPrefix(cluster string) string {
+	return storeKeyPrefix + url.QueryEscape(cluster) + ":"
+}
+
 // portforwardKeyGenerator generates a unique key
 // based on the cluster name, id,service name, and pod name.
 func portforwardKeyGenerator(p portForward) string {
-	clusterKey := p.cacheKey
-	if clusterKey == "" {
+	cluster := p.cacheKey
+	if cluster == "" {
 		// Fallback for entries created before the cacheKey field existed
 		// (cacheKey unset), where the cache key was derived from Cluster.
-		clusterKey = p.Cluster
+		cluster = p.Cluster
 	}
 
-	if p.ID != "" {
-		return storeKeyPrefix + clusterKey + p.ID
+	key := portforwardCacheKeyPrefix(cluster)
+
+	switch {
+	case p.ID != "":
+		return key + url.QueryEscape(p.ID)
+	case p.Service != "":
+		return key + url.QueryEscape(p.Service)
+	case p.Pod != "":
+		return key + url.QueryEscape(p.Pod)
+	default:
+		return key
 	}
-
-	key := storeKeyPrefix + clusterKey
-
-	if p.Service != "" {
-		key += p.Service
-	} else if p.Pod != "" {
-		key += p.Pod
-	}
-
-	return key
 }
 
 // portforwardstore stores a port forward in the cache.
@@ -99,7 +103,7 @@ func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id 
 // getPortForwardList returns a list of port forwards by its cluster name.
 func getPortForwardList(cache cache.Cache[interface{}], cluster string) []portForward {
 	portforwards, err := cache.GetAll(context.Background(), func(key string) bool {
-		return strings.HasPrefix(key, storeKeyPrefix+cluster)
+		return strings.HasPrefix(key, portforwardCacheKeyPrefix(cluster))
 	})
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
@@ -118,7 +122,10 @@ func getPortForwardList(cache cache.Cache[interface{}], cluster string) []portFo
 
 // getPortForwardByID returns a port forward by its cluster name and id.
 func getPortForwardByID(cache cache.Cache[interface{}], cluster string, id string) (portForward, error) {
-	cacheValue, err := cache.Get(context.Background(), storeKeyPrefix+cluster+id)
+	cacheValue, err := cache.Get(context.Background(), portforwardKeyGenerator(portForward{
+		cacheKey: cluster,
+		ID:       id,
+	}))
 	if err != nil {
 		return portForward{}, fmt.Errorf("failed to get portforward from cache: %w", err)
 	}


### PR DESCRIPTION
## Summary

  This PR fixes a backend port-forward cache-key collision in Headlamp. Port-forward entries now use separator-safe cache keys, so clusters with similar
  names no longer overlap when entries are listed, looked up, or deleted.

  ## Related Issue

  Fixes #5625

  ## Changes

  - Updated port-forward cache key generation to use a safer, delimiter-based format
  - Made cluster matching in port-forward listing exact instead of relying on a raw prefix
  - Reused the same key generator for ID lookups to keep cache access consistent
  - Added a regression test for the `foo` vs `foobar` cluster-name collision case

  ## Steps to Test

  1. Start Headlamp with the backend running.
  2. Create or simulate two clusters with similar names, such as `foo` and `foobar`.
  3. Create a port-forward entry for one of the clusters.
  4. List or stop port-forward entries and confirm that only the matching cluster’s entries are affected.
  5. Run the backend port-forward tests and confirm they pass.

  ## Screenshots

  Not applicable for this backend-only change.

  ## Notes for the Reviewer

  This is a focused backend fix. The change stays within the existing port-forward cache logic and adds a regression test for the collision scenario
  described in the issue.