### PR TITLE
backend: Stop parseKubeConfig after invalid JSON

### DIFF
--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -165,6 +165,7 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 		logger.Log(logger.LevelError, nil, err, "decoding config")
 
 		http.Error(w, "Invalid JSON request body", http.StatusBadRequest)
+		return
 	}
 
 	kubeconfigs := kubeconfigReq.Kubeconfigs

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -110,6 +111,36 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStatelessClustersKubeConfig_InvalidJSON(t *testing.T) {
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "",
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	}
+	handler := createHeadlampHandler(context.Background(), &c)
+
+	token := uuid.New().String()
+	_ = os.Setenv("HEADLAMP_BACKEND_TOKEN", token)
+	defer func() { _ = os.Unsetenv("HEADLAMP_BACKEND_TOKEN") }()
+
+	req := httptest.NewRequest(http.MethodPost, "/parseKubeConfig", strings.NewReader("{"))
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", token)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Invalid JSON request body")
 }
 
 //nolint:funlen


### PR DESCRIPTION
## Summary

This PR fixes the `/parseKubeConfig` backend handler so it stops immediately after invalid JSON is received. Before this change, the handler logged the decode error and returned a 400, but then continued processing the request.

## Related Issue

Fixes #5627

## Changes

- Added an early return in `backend/cmd/stateless.go` after the JSON decode failure path
- Added a regression test in `backend/cmd/stateless_test.go` for malformed JSON input
- Kept the change scoped to the backend request handler and its direct test coverage

## Steps to Test

1. Run Headlamp with dynamic clusters enabled.
2. Send malformed JSON to `POST /parseKubeConfig`.
3. Confirm the response is `400 Bad Request` with `Invalid JSON request body`.
4. Verify the handler does not continue into kubeconfig parsing after the decode failure.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

This is a small backend-only fix. The change is intentionally limited to the error path in `parseKubeConfig` and a focused regression test.
