### PR TITLE
frontend: DaemonSet Details: Add missing LogsButton action

### DIFF
--- a/frontend/src/components/daemonset/Details.tsx
+++ b/frontend/src/components/daemonset/Details.tsx
@@ -20,6 +20,7 @@ import DaemonSet from '../../lib/k8s/daemonSet';
 import {
   ContainersSection,
   DetailsGrid,
+  LogsButton,
   MetadataDictGrid,
   OwnedPodsSection,
   RevisionHistorySection,
@@ -103,6 +104,10 @@ export default function DaemonSetDetails(props: {
       actions={item => {
         if (!item) return [];
         return [
+          {
+            id: 'headlamp.daemonset-logs',
+            action: <LogsButton key="logs" item={item} />,
+          },
           {
             id: 'headlamp.daemonset-rollback',
             action: <RollbackButton key="rollback" item={item} />,


### PR DESCRIPTION
## Summary

Add missing Logs action to the DaemonSet detail page to align with other workload resources.

## Related Issue

Fixes #5628

## Changes

* Import `LogsButton` from `../common/Resource`
* Add `headlamp.daemonset-logs` action to DaemonSet `DetailsGrid`

## How to Test

1. Navigate to Workloads → DaemonSets
2. Open any DaemonSet
3. Verify a Logs action is available alongside Rollback

## Notes

`DaemonSet` is already included in `LOGGABLE_WORKLOAD_KINDS` in `LogsButton.tsx`; this change wires it up in the UI, consistent with StatefulSet and Deployment.
