### PR TITLE
backend: helm: Fix repository lock retry timing

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -92,7 +92,7 @@ func lockRepositoryFile(lockCtx context.Context, repositoryConfig string) (bool,
 
 	fileLock := flock.New(lockPath)
 
-	locked, err := fileLock.TryLockContext(lockCtx, time.Second)
+	locked, err := fileLock.TryLockContext(lockCtx, lockRetryDelay)
 
 	return locked, fileLock, err
 }
@@ -109,7 +109,10 @@ func ensureRepositoryFileLocked(locked bool, err error) error {
 	return nil
 }
 
-const timeoutForLock = 30 * time.Second
+const (
+	timeoutForLock = 30 * time.Second
+	lockRetryDelay = 100 * time.Millisecond
+)
 
 // Adds a repository with name, url to the helm config. Returns error if there is one.
 func addRepository(name string, url string, settings *cli.EnvSettings) error {

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package helm
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/cli"
@@ -64,4 +67,43 @@ func TestEnsureRepositoryFileLocked(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, errRepositoryLockNotAcquired))
 	})
+}
+
+func TestLockRepositoryFileRetriesBeforeContextDeadline(t *testing.T) {
+	settings := cli.New()
+	tempDir := t.TempDir()
+	settings.RepositoryConfig = filepath.Join(tempDir, "repositories.yaml")
+
+	lockPath := filepath.Join(tempDir, "repositories.lock")
+	holder := flock.New(lockPath)
+
+	locked, err := holder.TryLock()
+	require.NoError(t, err)
+	require.True(t, locked)
+
+	t.Cleanup(func() {
+		_ = holder.Unlock()
+	})
+
+	unlocked := make(chan struct{})
+
+	go func() {
+		time.Sleep(2 * lockRetryDelay)
+
+		_ = holder.Unlock()
+
+		close(unlocked)
+	}()
+
+	lockCtx, cancel := context.WithTimeout(context.Background(), time.Second-lockRetryDelay)
+	defer cancel()
+
+	locked, fileLock, err := lockRepositoryFile(lockCtx, settings.RepositoryConfig)
+	require.NoError(t, err)
+	require.True(t, locked)
+	require.NotNil(t, fileLock)
+
+	defer func() { _ = fileLock.Unlock() }()
+
+	<-unlocked
 }


### PR DESCRIPTION
## Summary

This PR fixes Helm repository locking in Headlamp so the retry behavior is explicit and consistent. The lock helper now uses a dedicated retry delay constant instead of a hardcoded value, and the change is covered by a regression test.

## Related Issue

Fixes #5629

## Changes

- Updated `backend/pkg/helm/repository.go` to use an explicit retry delay for `TryLockContext`
- Kept the overall wait window controlled by the existing lock timeout context
- Added a regression test in `backend/pkg/helm/repository_internal_test.go` to verify the lock helper retries after the lock is released

## Steps to Test

1. Run the Helm backend tests.
2. Trigger concurrent Helm repository operations or hold the repository lock briefly.
3. Confirm the helper retries and succeeds once the lock is released.

## Screenshots

Not applicable.

## Notes for the Reviewer

This is a backend-only change in the Helm repository helper. The patch is intentionally small and keeps the lock timing behavior explicit.
