### PR TITLE
backend: auth: Fix panic in OIDC state generation

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -777,14 +777,20 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		// state should be unique per request, cryptographically secure random, url safe
-		state := func() string {
+		state, err := func() (string, error) {
 			b := make([]byte, 32)
 			if _, err := rand.Read(b); err != nil {
-				panic(err)
+				return "", fmt.Errorf("generating OIDC state: %w", err)
 			}
 
-			return base64.RawURLEncoding.EncodeToString(b)
+			return base64.RawURLEncoding.EncodeToString(b), nil
 		}()
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"cluster": cluster}, err, "failed to generate OIDC state")
+			http.Error(w, "failed to generate OIDC state", http.StatusInternalServerError)
+
+			return
+		}
 
 		entry := &OauthConfig{
 			Config:   oauthConfig,


### PR DESCRIPTION
## Summary

The OIDC login handler used `panic()` when `rand.Read` failed during state generation. This crash would bring down the entire server process instead of returning a proper HTTP error to the client.

This PR replaces the `panic` with graceful error handling - logs the error and returns `500 Internal Server Error` to the client.


## Changes

- Converted the anonymous `state` closure from returning `string` to `(string, error)`
- Replaced `panic(err)` with `return "", fmt.Errorf("generating OIDC state: %w", err)`
- Added post-call error check: logs via `logger.Log` and responds with `http.Error(..., http.StatusInternalServerError)` before returning

## Root Cause

`crypto/rand.Read` can fail in low-entropy or OS-level error scenarios. The previous code panicked on this path, which is unsafe in a long-running HTTP server.

