### PR TITLE
docs: Update traefik middleware apiVersion

### DIFF
--- a/docs/installation/in-cluster/basic-auth.md
+++ b/docs/installation/in-cluster/basic-auth.md
@@ -142,7 +142,7 @@ by configuring their respective basic authentication middleware.
 
 For Traefik, you can use a similar approach with middleware:
 ```yaml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: headlamp-basic-auth


### PR DESCRIPTION
This change updates the Traefik Middleware apiVersion in the basic auth documentation from the deprecated `traefik.containo.us/v1alpha1` to the current `traefik.io/v1alpha1`.