### PR TITLE
backend: config: Replace os.Exit with error return

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -107,6 +107,19 @@ func getResponseFromRestrictedEndpoint(handler http.Handler, method, url string,
 	return rr, nil
 }
 
+// getDefaultKubeConfigPathForTest is a test helper that wraps config.GetDefaultKubeConfigPath
+// and fails the test immediately if retrieving the default path returns an error.
+func getDefaultKubeConfigPathForTest(t *testing.T) string {
+	t.Helper()
+
+	path, err := config.GetDefaultKubeConfigPath()
+	if err != nil {
+		t.Fatalf("failed to get default kubeconfig path: %v", err)
+	}
+
+	return path
+}
+
 func TestGetConfigIncludesDefaultPodDebugImage(t *testing.T) {
 	c := &HeadlampConfig{
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
@@ -585,7 +598,7 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 				HeadlampConfig: &headlampconfig.HeadlampConfig{
 					HeadlampCFG: &headlampconfig.HeadlampCFG{
 						UseInCluster:    false,
-						KubeConfigPath:  config.GetDefaultKubeConfigPath(),
+						KubeConfigPath:  getDefaultKubeConfigPathForTest(t),
 						KubeConfigStore: kubeConfigStore,
 					},
 					Cache:            cache,
@@ -819,7 +832,7 @@ func TestDeletePlugin(t *testing.T) {
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:    false,
-				KubeConfigPath:  config.GetDefaultKubeConfigPath(),
+				KubeConfigPath:  getDefaultKubeConfigPathForTest(t),
 				PluginDir:       devPluginDir,
 				UserPluginDir:   userPluginDir,
 				KubeConfigStore: kubeConfigStore,
@@ -874,7 +887,7 @@ func TestHandleClusterAPI_XForwardedHost(t *testing.T) {
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:    false,
-				KubeConfigPath:  config.GetDefaultKubeConfigPath(),
+				KubeConfigPath:  getDefaultKubeConfigPathForTest(t),
 				KubeConfigStore: kubeConfigStore,
 			},
 			Cache:            cache,
@@ -2041,7 +2054,12 @@ func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 
 	kubeConfigPath := os.Getenv("KUBECONFIG")
 	if kubeConfigPath == "" {
-		kubeConfigPath = config.GetDefaultKubeConfigPath()
+		var err error
+
+		kubeConfigPath, err = config.GetDefaultKubeConfigPath()
+		if err != nil {
+			t.Fatalf("failed to get default kubeconfig path: %v", err)
+		}
 	}
 
 	// KUBECONFIG may be a list of files separated by os.PathListSeparator.

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -245,22 +245,29 @@ func patchWatchPluginsChanges(config *Config, explicitFlags map[string]bool) {
 }
 
 // setKubeConfigPath sets the kubeconfig path if not set, using env or default.
-func setKubeConfigPath(config *Config) {
+func setKubeConfigPath(config *Config) error {
 	// If a specific path was set, use it. Otherwise, determine default.
 	if config.KubeConfigPath != "" {
-		return
+		return nil
 	}
 
 	if config.InCluster {
-		return
+		return nil
 	}
 
 	kubeConfigEnv := os.Getenv("KUBECONFIG")
 	if kubeConfigEnv != "" {
 		config.KubeConfigPath = kubeConfigEnv
 	} else {
-		config.KubeConfigPath = GetDefaultKubeConfigPath()
+		defaultPath, err := GetDefaultKubeConfigPath()
+		if err != nil {
+			return fmt.Errorf("getting default kubeconfig path: %w", err)
+		}
+
+		config.KubeConfigPath = defaultPath
 	}
+
+	return nil
 }
 
 // ApplyMeDefaults trims and applies defaults to the JMESPath expressions used for the /me endpoint.
@@ -345,7 +352,11 @@ func Parse(args []string) (*Config, error) {
 
 	// 7. Post-process: patch plugin flag and kubeconfig path.
 	patchWatchPluginsChanges(&config, explicitFlags)
-	setKubeConfigPath(&config)
+
+	if err := setKubeConfigPath(&config); err != nil {
+		return nil, err
+	}
+
 	setMeDefaults(&config)
 
 	// 8. Validate flags that depend on build-time behaviour.
@@ -580,14 +591,11 @@ func defaultUserPluginDir() string {
 	return userPluginsConfigDir
 }
 
-func GetDefaultKubeConfigPath() string {
-	user, err := user.Current()
+func GetDefaultKubeConfigPath() (string, error) {
+	currentUser, err := user.Current()
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "getting current user")
-		os.Exit(1)
+		return "", fmt.Errorf("getting current user for kubeconfig path: %w", err)
 	}
 
-	homeDirectory := user.HomeDir
-
-	return filepath.Join(homeDirectory, ".kube", "config")
+	return filepath.Join(currentUser.HomeDir, ".kube", "config"), nil
 }

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -329,11 +329,12 @@ func TestContext(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	kubeConfigFile := config.GetDefaultKubeConfigPath()
+	kubeConfigFile, err := config.GetDefaultKubeConfigPath()
+	require.NoError(t, err)
 
 	configStore := kubeconfig.NewContextStore()
 
-	err := kubeconfig.LoadAndStoreKubeConfigs(configStore, kubeConfigFile, kubeconfig.KubeConfig, nil)
+	err = kubeconfig.LoadAndStoreKubeConfigs(configStore, kubeConfigFile, kubeconfig.KubeConfig, nil)
 	if err != nil {
 		t.Skipf("Skipping test: failed to load default kubeconfig: %v", err)
 	}


### PR DESCRIPTION
## Summary

`GetDefaultKubeConfigPath()` in `pkg/config/config.go` was calling `os.Exit(1)` when
`user.Current()` failed. This is a Go anti-pattern in library packages - it makes the
function untestable, skips deferred cleanup, and removes control from the caller.

This PR changes the function signature from `string` to `(string, error)` and updates
all callers to handle the error gracefully.

## Changes

- **`pkg/config/config.go`**: Changed `GetDefaultKubeConfigPath()` to return `(string, error)` instead of calling `os.Exit(1)`. Updated internal caller `setKubeConfigPath` to log and return on error.
- **`cmd/headlamp_test.go`**: Added `getDefaultKubeConfigPathForTest(t)` helper and updated 4 call sites.
- **`pkg/kubeconfig/kubeconfig_test.go`**: Updated 1 call site to handle the new error return.

## Steps to Test

1. `cd backend`
2. `go vet ./pkg/config/... ./cmd/... ./pkg/kubeconfig/...`
3. `go test ./pkg/config/... ./cmd/... ./pkg/kubeconfig/... -v`
4. All tests pass with zero failures.
