### PR TITLE
backend: config: Validate options and env override

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"flag"
@@ -22,6 +23,7 @@ import (
 const (
 	defaultPort       = 4466
 	defaultSessionTTL = 86400 // 24 hours in seconds
+	maxPort           = 65535
 	osWindows         = "windows"
 )
 
@@ -96,6 +98,18 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
+	if c.Port == 0 || c.Port > maxPort {
+		return fmt.Errorf("port must be between 1 and %d", maxPort)
+	}
+
+	if !isValidLogLevel(c.LogLevel) {
+		return errors.New("log-level must be one of debug, info, warn, or error")
+	}
+
+	if err := validateTLSPaths(c.TLSCertPath, c.TLSKeyPath); err != nil {
+		return err
+	}
+
 	if !c.InCluster && !c.OidcUseCookie && (c.OidcClientID != "" || c.OidcClientSecret != "" || c.OidcIdpIssuerURL != "" ||
 		c.OidcValidatorClientID != "" || c.OidcValidatorIdpIssuerURL != "") {
 		return errors.New("oidc-client-id, oidc-client-secret, oidc-idp-issuer-url, " +
@@ -151,6 +165,31 @@ func (c *Config) Validate() error {
 			(c.OTLPEndpoint == nil || *c.OTLPEndpoint == "") {
 			return errors.New("otlp-endpoint must be configured when use-otlp-http is enabled")
 		}
+	}
+
+	return nil
+}
+
+func isValidLogLevel(logLevel string) bool {
+	switch strings.ToLower(strings.TrimSpace(logLevel)) {
+	case "debug", "info", "warn", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateTLSPaths(certPath, keyPath string) error {
+	if certPath == "" && keyPath == "" {
+		return nil
+	}
+
+	if certPath == "" || keyPath == "" {
+		return errors.New("tls-cert-path and tls-key-path must be configured together")
+	}
+
+	if _, err := tls.LoadX509KeyPair(certPath, keyPath); err != nil {
+		return fmt.Errorf("invalid tls certificate or key path: %w", err)
 	}
 
 	return nil

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -98,15 +98,7 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if c.Port == 0 || c.Port > maxPort {
-		return fmt.Errorf("port must be between 1 and %d", maxPort)
-	}
-
-	if !isValidLogLevel(c.LogLevel) {
-		return errors.New("log-level must be one of debug, info, warn, or error")
-	}
-
-	if err := validateTLSPaths(c.TLSCertPath, c.TLSKeyPath); err != nil {
+	if err := c.validateOptionValues(); err != nil {
 		return err
 	}
 
@@ -168,6 +160,18 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *Config) validateOptionValues() error {
+	if c.Port == 0 || c.Port > maxPort {
+		return fmt.Errorf("port must be between 1 and %d", maxPort)
+	}
+
+	if !isValidLogLevel(c.LogLevel) {
+		return errors.New("log-level must be one of debug, info, warn, or error")
+	}
+
+	return validateTLSPaths(c.TLSCertPath, c.TLSKeyPath)
 }
 
 func isValidLogLevel(logLevel string) bool {
@@ -383,6 +387,7 @@ func Parse(args []string) (*Config, error) {
 	if err := loadConfigFromEnv(k); err != nil {
 		return nil, err
 	}
+
 	watchPluginsChangesEnvSet := hasWatchPluginsChangesEnv()
 
 	// 5. Reload explicitly-set flags to override env values.

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -172,7 +172,7 @@ func (c *Config) Validate() error {
 
 func isValidLogLevel(logLevel string) bool {
 	switch strings.ToLower(strings.TrimSpace(logLevel)) {
-	case "debug", "info", "warn", "error":
+	case "", "debug", "info", "warn", "error":
 		return true
 	default:
 		return false
@@ -236,6 +236,11 @@ func recordExplicitFlags(f *flag.FlagSet) map[string]bool {
 	return explicitFlags
 }
 
+func hasWatchPluginsChangesEnv() bool {
+	_, ok := os.LookupEnv("HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES")
+	return ok
+}
+
 // loadConfigFromEnv loads config values from environment variables into koanf.
 func loadConfigFromEnv(k *koanf.Koanf) error {
 	err := k.Load(env.Provider("HEADLAMP_CONFIG_", ".", func(s string) string {
@@ -276,9 +281,9 @@ func unmarshalConfig(k *koanf.Koanf, config *Config) error {
 	return nil
 }
 
-// patchWatchPluginsChanges disables plugin watching if running in-cluster and user didn't set the flag.
-func patchWatchPluginsChanges(config *Config, explicitFlags map[string]bool) {
-	if config.InCluster && !explicitFlags["watch-plugins-changes"] {
+// patchWatchPluginsChanges disables plugin watching if running in-cluster and the user didn't set the option.
+func patchWatchPluginsChanges(config *Config, explicitFlags map[string]bool, hasEnvOverride bool) {
+	if config.InCluster && !explicitFlags["watch-plugins-changes"] && !hasEnvOverride {
 		config.WatchPluginsChanges = false
 	}
 }
@@ -378,6 +383,7 @@ func Parse(args []string) (*Config, error) {
 	if err := loadConfigFromEnv(k); err != nil {
 		return nil, err
 	}
+	watchPluginsChangesEnvSet := hasWatchPluginsChangesEnv()
 
 	// 5. Reload explicitly-set flags to override env values.
 	if err := reloadExplicitFlags(k, f, explicitFlags); err != nil {
@@ -390,7 +396,7 @@ func Parse(args []string) (*Config, error) {
 	}
 
 	// 7. Post-process: patch plugin flag and kubeconfig path.
-	patchWatchPluginsChanges(&config, explicitFlags)
+	patchWatchPluginsChanges(&config, explicitFlags, watchPluginsChangesEnvSet)
 
 	if err := setKubeConfigPath(&config); err != nil {
 		return nil, err

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -186,6 +186,16 @@ var ParseWithEnvTests = []struct {
 			assert.Equal(t, "X-Env-Token-Header", conf.ProxyAuthTokenHeader)
 		},
 	},
+	{
+		name: "watch_plugins_changes_from_env_in_cluster",
+		args: []string{"go run ./cmd", "--in-cluster"},
+		env: map[string]string{
+			"HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES": "true",
+		},
+		verify: func(t *testing.T, conf *config.Config) {
+			assert.Equal(t, true, conf.WatchPluginsChanges)
+		},
+	},
 }
 
 func TestParseWithEnv(t *testing.T) {
@@ -478,6 +488,22 @@ func TestOIDCTLSEnvironmentVariables(t *testing.T) {
 	}
 }
 
+func TestWatchPluginsChangesInClusterDefaults(t *testing.T) {
+	require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES"))
+
+	conf, err := config.Parse([]string{"go run ./cmd", "--in-cluster"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+	assert.Equal(t, false, conf.WatchPluginsChanges)
+}
+
+func TestWatchPluginsChangesInClusterFlagOverride(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd", "--in-cluster", "--watch-plugins-changes=true"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+	assert.Equal(t, true, conf.WatchPluginsChanges)
+}
+
 var applyMeDefaultsTests = []struct {
 	name             string
 	usernamePath     string
@@ -673,6 +699,16 @@ func TestValidateLogLevel(t *testing.T) {
 		{
 			name:        "log_level_error",
 			args:        []string{"go run ./cmd", "--log-level=error"},
+			expectError: false,
+		},
+		{
+			name:        "log_level_empty",
+			args:        []string{"go run ./cmd", "--log-level="},
+			expectError: false,
+		},
+		{
+			name:        "log_level_whitespace",
+			args:        []string{"go run ./cmd", "--log-level= \t"},
 			expectError: false,
 		},
 		{

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -617,6 +617,133 @@ func TestValidateSessionTTL(t *testing.T) {
 	}
 }
 
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "port_zero",
+			args:          []string{"go run ./cmd", "--port=0"},
+			expectError:   true,
+			errorContains: "port must be between 1 and 65535",
+		},
+		{
+			name:          "port_above_max",
+			args:          []string{"go run ./cmd", "--port=65536"},
+			expectError:   true,
+			errorContains: "port must be between 1 and 65535",
+		},
+		{
+			name:        "port_max",
+			args:        []string{"go run ./cmd", "--port=65535"},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+			}
+		})
+	}
+}
+
+func TestValidateLogLevel(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "log_level_debug",
+			args:        []string{"go run ./cmd", "--log-level=debug"},
+			expectError: false,
+		},
+		{
+			name:        "log_level_error",
+			args:        []string{"go run ./cmd", "--log-level=error"},
+			expectError: false,
+		},
+		{
+			name:          "log_level_invalid",
+			args:          []string{"go run ./cmd", "--log-level=verbose"},
+			expectError:   true,
+			errorContains: "log-level must be one of debug, info, warn, or error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+			}
+		})
+	}
+}
+
+func TestValidateTLSPaths(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "tls_cert_without_key",
+			args:          []string{"go run ./cmd", "--tls-cert-path=/tmp/tls.crt"},
+			expectError:   true,
+			errorContains: "tls-cert-path and tls-key-path must be configured together",
+		},
+		{
+			name:          "tls_key_without_cert",
+			args:          []string{"go run ./cmd", "--tls-key-path=/tmp/tls.key"},
+			expectError:   true,
+			errorContains: "tls-cert-path and tls-key-path must be configured together",
+		},
+		{
+			name: "tls_invalid_pair",
+			args: []string{
+				"go run ./cmd",
+				"--tls-cert-path=" + filepath.Join(getTestDataPath(), "valid_ca.pem"),
+				"--tls-key-path=" + filepath.Join(getTestDataPath(), "invalid_ca.pem"),
+			},
+			expectError:   true,
+			errorContains: "invalid tls certificate or key path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := config.Parse(tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, conf)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conf)
+			}
+		})
+	}
+}
+
 var validateTracingTests = []struct {
 	name          string
 	args          []string


### PR DESCRIPTION
## Summary

This PR fixes backend config validation and in-cluster plugin watching configuration handling. It rejects invalid server config earlier and preserves an explicit environment override for plugin watching in in-cluster deployments.

## Related Issue

Fixes #5596
Fixes #5590

## Changes

- Validate backend config port values, log-level values, and serving TLS certificate/key paths.
- Preserve HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES when Headlamp runs in in-cluster mode.
- Add backend config regression tests for invalid config values and plugin-watch override behavior.

## Steps to Test

1. Run go test ./pkg/config from the backend directory.
2. Run git diff --check from the repository root.
3. Verify invalid config values return validation errors and HEADLAMP_CONFIG_WATCH_PLUGINS_CHANGES=true remains true with --in-cluster.

## Screenshots (if applicable)

Not applicable; backend config changes only.

## Notes for the Reviewer

The branch uses two atomic commits, one for #5596 and one for #5590, following the contribution docs.