### PR TITLE
backend: OIDC: Return error on state generation failure

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -80,6 +80,7 @@ type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
 	proxyURLMu        sync.Mutex
 	compiledProxyURLs []glob.Glob
+	oidcStateReader   io.Reader
 }
 
 func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
@@ -963,14 +964,12 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		// state should be unique per request, cryptographically secure random, url safe
-		state, err := func() (string, error) {
-			b := make([]byte, 32)
-			if _, err := rand.Read(b); err != nil {
-				return "", fmt.Errorf("generating OIDC state: %w", err)
-			}
+		stateReader := config.oidcStateReader
+		if stateReader == nil {
+			stateReader = rand.Reader
+		}
 
-			return base64.RawURLEncoding.EncodeToString(b), nil
-		}()
+		state, err := generateOidcState(stateReader)
 		if err != nil {
 			logger.Log(logger.LevelError, map[string]string{logFieldCluster: cluster}, err, "failed to generate OIDC state")
 			http.Error(w, "failed to generate OIDC state", http.StatusInternalServerError)
@@ -1261,6 +1260,16 @@ func isLoopbackAddr(addr string) bool {
 	ip := net.ParseIP(strings.Trim(addr, "[]"))
 
 	return ip != nil && ip.IsLoopback()
+}
+
+func generateOidcState(reader io.Reader) (string, error) {
+	b := make([]byte, 32)
+
+	if _, err := io.ReadFull(reader, b); err != nil {
+		return "", fmt.Errorf("generating OIDC state: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 // allowedHosts returns the set of normalized host values that are considered

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -2157,6 +2158,127 @@ func TestOidcStateMapEviction(t *testing.T) {
 
 	assert.False(t, stalePresent, "stale OIDC state entry should have been evicted")
 	assert.True(t, freshPresent, "fresh OIDC state entry should still be present")
+}
+
+func TestGenerateOidcState(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		stateBytes := make([]byte, 32)
+		for i := range stateBytes {
+			stateBytes[i] = byte(i)
+		}
+
+		state, err := generateOidcState(bytes.NewReader(stateBytes))
+		require.NoError(t, err)
+		assert.Equal(t, "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8", state)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		state, err := generateOidcState(errReader{err: errors.New("rand failure")})
+
+		require.Error(t, err)
+		assert.Empty(t, state)
+	})
+
+	t.Run("short read", func(t *testing.T) {
+		// bytes.NewReader with fewer than 32 bytes triggers the short-read path.
+		state, err := generateOidcState(bytes.NewReader(make([]byte, 31)))
+
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		assert.Empty(t, state)
+	})
+}
+
+func TestOIDCHandlerReturnsInternalServerErrorWhenStateGenerationFails(t *testing.T) {
+	var oidcProvider *httptest.Server
+
+	oidcProvider = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"issuer":                                oidcProvider.URL,
+				"authorization_endpoint":                oidcProvider.URL + "/auth",
+				"token_endpoint":                        oidcProvider.URL + "/token",
+				"jwks_uri":                              oidcProvider.URL + "/keys",
+				"id_token_signing_alg_values_supported": []string{"RS256"},
+			})
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(oidcProvider.Close)
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	err := kubeConfigStore.AddContext(&kubeconfig.Context{
+		Name: "test-cluster",
+		OidcConf: &kubeconfig.OidcConfig{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+			IdpIssuerURL: oidcProvider.URL,
+		},
+	})
+	require.NoError(t, err)
+
+	cfg := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+		oidcStateReader: errReader{err: errors.New("rand failure")},
+	}
+
+	handler := createHeadlampHandler(context.Background(), cfg)
+	rr, err := getResponse(handler, http.MethodGet, "/oidc?cluster=test-cluster", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "failed to generate OIDC state")
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestOIDCTokenRefreshMiddleware(t *testing.T) {
+	kubeConfigStore := kubeconfig.NewContextStore()
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeConfigStore},
+			Cache:            cache.New[interface{}](),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := config.OIDCTokenRefreshMiddleware(handler)
+
+	// Test case: non-cluster request
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/non-cluster", nil)
+	rec := httptest.NewRecorder()
+	middleware.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Test case: cluster request without token
+	req = httptest.NewRequestWithContext(context.Background(), "GET", "/clusters/test-cluster", nil)
+	rec = httptest.NewRecorder()
+	middleware.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestStartHeadlampServer(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR refactors OIDC state generation so the random source can be injected in tests while preserving the existing handler behavior of returning `500 Internal Server Error` when state generation fails.

## Related Issue

Related to #5630

## Changes

- Added `generateOidcState` to generate a 32-byte raw URL-safe base64 state value.
- Added an injectable OIDC state reader on `HeadlampConfig` for deterministic failure-path tests.
- Added regression tests for state encoding, short reads, reader failures, and the `/oidc` handler 500 response.

## Steps to Test

1. Run `cd backend && go test ./...`.
2. Confirm `backend/cmd` tests pass, including `TestGenerateOidcState` and `TestOIDCHandlerReturnsInternalServerErrorWhenStateGenerationFails`.
3. Confirm `gofmt -d backend/cmd/headlamp_test.go` produces no output.

## Screenshots

Not applicable.

## Notes for the Reviewer

This is intentionally limited to testability and regression coverage for OIDC state generation. The handler already returned an HTTP 500 on state generation failure; this PR makes that path injectable and covered by tests.
