### PR TITLE
backend: Stop parsing invalid kubeconfig JSON

### DIFF
--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -165,6 +165,8 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 		logger.Log(logger.LevelError, nil, err, "decoding config")
 
 		http.Error(w, "Invalid JSON request body", http.StatusBadRequest)
+
+		return
 	}
 
 	kubeconfigs := kubeconfigReq.Kubeconfigs

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -131,6 +131,7 @@ func TestParseKubeConfigInvalidJSONReturnsBadRequest(t *testing.T) {
 
 	token := uuid.New().String()
 	require.NoError(t, os.Setenv("HEADLAMP_BACKEND_TOKEN", token))
+
 	defer func() { _ = os.Unsetenv("HEADLAMP_BACKEND_TOKEN") }()
 
 	req := httptest.NewRequestWithContext(

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -110,6 +111,42 @@ func TestStatelessClustersKubeConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseKubeConfigInvalidJSONReturnsBadRequest(t *testing.T) {
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "",
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	}
+	handler := createHeadlampHandler(context.Background(), &c)
+
+	token := uuid.New().String()
+	require.NoError(t, os.Setenv("HEADLAMP_BACKEND_TOKEN", token))
+	defer func() { _ = os.Unsetenv("HEADLAMP_BACKEND_TOKEN") }()
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/parseKubeConfig",
+		strings.NewReader("{"),
+	)
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", token)
+
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, "Invalid JSON request body\n", resp.Body.String())
+	assert.NotContains(t, resp.Body.String(), "clusters")
 }
 
 //nolint:funlen


### PR DESCRIPTION
## Summary

This PR fixes the /parseKubeConfig handler so malformed JSON requests stop immediately after the decode error. Without the early return, the handler writes a 400 response and then continues with the zero-value request payload.

## Related Issue

Fixes #5598
Related #5627

## Changes

- Return immediately after /parseKubeConfig fails to decode the JSON request body.
- Add a regression test that posts malformed JSON and verifies only the bad request response is returned.

## Steps to Test

1. Run go test ./cmd -run TestParseKubeConfigInvalidJSONReturnsBadRequest -count=1 from the backend directory.
2. Run go test ./cmd -run TestStatelessClustersKubeConfig -count=1 from the backend directory.
3. Run git diff --check from the repository root.

## Screenshots (if applicable)

Not applicable; backend handler change only.

## Notes for the Reviewer

Issue #5627 reports the same behavior as #5598, so this PR targets the older existing issue and references the newer duplicate.