### PR TITLE
helm: Simplify oidc-scopes conditional with externalSecret

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -308,7 +308,8 @@ spec:
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            {{- if $oidc.externalSecret.hasScopes }}
+            {{- if or (ne $oidc.scopes "") (ne $scopes "") }}
+            # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
             {{- end }}
             {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}

--- a/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
+++ b/charts/headlamp/tests/expected_templates/ingress-multi-backend.yaml
@@ -126,10 +126,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
 ---

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret-with-scopes.yaml
@@ -110,6 +110,7 @@ spec:
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
+            # Check if scopes are non empty either from env or oidc.config
             - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
@@ -119,9 +120,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp-volume.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-custom-tmp.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
@@ -138,10 +138,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
@@ -138,10 +138,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem.yaml
@@ -123,10 +123,22 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}
           volumeMounts:

--- a/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
+++ b/charts/headlamp/tests/expected_templates/service-extra-ports.yaml
@@ -132,9 +132,21 @@ spec:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: "/"
               port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             {}

--- a/charts/headlamp/tests/test_cases/oidc-external-secret-with-scopes.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-external-secret-with-scopes.yaml
@@ -1,11 +1,10 @@
-# This is a test case for OIDC external secret with hasScopes enabled.
-# When hasScopes is true, the -oidc-scopes argument is included so that
-# the OIDC_SCOPES key from the external secret is passed to Headlamp.
+# This is a test case for OIDC external secret with scopes configured.
+# When oidc.scopes is set, the -oidc-scopes arg should be included.
 config:
   oidc:
+    scopes: "openid profile email"
     secret:
       create: false
     externalSecret:
       enabled: true
       name: oidc
-      hasScopes: true

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -233,10 +233,6 @@
                 "enabled": {
                   "type": "boolean",
                   "description": "Enable the external secret"
-                },
-                "hasScopes": {
-                  "type": "boolean",
-                  "description": "Set to true if the external secret contains an OIDC_SCOPES key"
                 }
               }
             }

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -104,10 +104,6 @@ config:
     externalSecret:
       enabled: false
       name: ""
-      # -- Set to true if your external secret contains an OIDC_SCOPES key.
-      # When false (default), the -oidc-scopes argument is omitted so that
-      # a missing key does not produce an empty or unresolved argument.
-      hasScopes: false
 
     # -- URL to fetch additional user info for the /me endpoint.
     # For oauth2proxy /oauth2/userinfo can be used. Empty and it will not be used.


### PR DESCRIPTION
This replaces the `hasScopes` parameter introduced in #5573 with a simpler conditional that reuses the existing `$oidc.scopes`/`$scopes` values check, consistent with how all other optional OIDC args are handled in the same template.

The `hasScopes` field is removed from `values.yaml` and the schema since it's no longer needed -- scopes are included when explicitly configured via `oidc.scopes` or the `OIDC_SCOPES` env var.

Fixes: #5744, supercedes from #5573