### PR TITLE
frontend: DetailsViewSection.stories: Document why dispatch is excluded

### DIFF
--- a/frontend/src/components/DetailsViewSection/DetailsViewSection.stories.tsx
+++ b/frontend/src/components/DetailsViewSection/DetailsViewSection.stories.tsx
@@ -68,6 +68,10 @@ const Template: StoryFn<DetailsViewSectionProps> = args => {
         return null;
       })
     );
+    // `dispatch` is intentionally omitted from the deps array: the store is
+    // created inline in the decorator above, so `dispatch` changes identity
+    // on each decorator re-render. Listing it would re-fire this effect on
+    // every render and accumulate entries in `state.detailViews`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary

This PR documents the existing `react-hooks/exhaustive-deps` suppression in `frontend/src/components/DetailsViewSection/DetailsViewSection.stories.tsx` rather than removing it. The mount-effect in the `Template` references `dispatch` from `useDispatch()` but lists `[]` as deps. Adding `dispatch` to the deps array (the standard react-redux fix) is unsafe in this specific file, so the suppression has to stay; a comment now explains why.

## Related Issue

Fixes #5648 (sub-issue of umbrella #5183).

## Changes

- Kept the existing `// eslint-disable-next-line react-hooks/exhaustive-deps` directive.
- Added a four-line comment above it explaining that `dispatch` is intentionally omitted because the Storybook decorator creates a fresh store via `configureStore(...)` inline on every render, so `dispatch` changes identity each render and listing it in the deps would re-fire the effect (causing repeated `setDetailsView(...)` dispatches that push to `state.detailViews`).

### Iteration history

The first revision of this PR added `dispatch` to the deps array on the standard react-redux assumption that the value is stable. It isn't stable here because the decorator creates the store inline, so the deps array fix would have introduced a bug under repeated decorator renders. Reverted to the original deps with a documenting comment instead.

## Steps to Test

1. `cd frontend && npm install`
2. `npm run lint`: passes; the existing suppression continues to silence the rule on this hook.
3. `npm run tsc`: passes.

## Screenshots (if applicable)

N/A. No behaviour change.

## Notes for the Reviewer

- Single-file diff, +4 / -0 lines.
- DCO sign-off applied (`Signed-off-by:` in the commit).
- Force-pushed once on this PR to swap the deps-array fix for the documentation-only approach.
- Same pattern that landed on #5576 after maintainer feedback there.