### PR TITLE
backend: Return error when repository lock is not acquired

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -108,19 +108,21 @@ func addRepository(name string, url string, settings *cli.EnvSettings) error {
 	defer cancel()
 
 	locked, fileLock, err := lockRepositoryFile(lockCtx, settings.RepositoryConfig)
-	if err == nil && locked {
-		defer func() {
-			err := fileLock.Unlock()
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
-			}
-		}()
-	}
-
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "locking repository config file")
 		return err
 	}
+
+	if !locked {
+		return errors.New("failed to acquire repository lock")
+	}
+
+	defer func() {
+		err := fileLock.Unlock()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
+		}
+	}()
 
 	// read repo file
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
@@ -288,19 +290,21 @@ func RemoveRepository(name string, settings *cli.EnvSettings) error {
 	defer cancel()
 
 	locked, fileLock, err := lockRepositoryFile(lockCtx, settings.RepositoryConfig)
-	if err == nil && locked {
-		defer func() {
-			err := fileLock.Unlock()
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
-			}
-		}()
-	}
-
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "locking repository config file")
 		return err
 	}
+
+	if !locked {
+		return errors.New("failed to acquire repository lock")
+	}
+
+	defer func() {
+		err := fileLock.Unlock()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
+		}
+	}()
 
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
 	if err != nil {
@@ -358,20 +362,21 @@ func UpdateRepository(name, url string, settings *cli.EnvSettings) error {
 	defer cancel()
 
 	locked, fileLock, err := lockRepositoryFile(lockCtx, settings.RepositoryConfig)
-	if err == nil && locked {
-		defer func() {
-			err := fileLock.Unlock()
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
-			}
-		}()
-	}
-
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "locking repository config file")
 		return err
 	}
 
+	if !locked {
+		return errors.New("failed to acquire repository lock")
+	}
+
+	defer func() {
+		err := fileLock.Unlock()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
+		}
+	}()
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "reading repo file")


### PR DESCRIPTION
## Summary
This PR fixes a concurrency bug in the Helm repository helpers where a failed 
lock acquisition could go undetected, allowing unsafe reads and writes to the 
repository config file.

## Related Issue
Fixes #5634

## Changes
- Fixed lock check logic in `addRepository`, `RemoveRepository`, and 
  `UpdateRepository` in `backend/pkg/helm/repository.go`
- All three functions now explicitly check `!locked` after `lockRepositoryFile` 
  returns, and return an error immediately if the lock was not acquired
- Moved the `defer fileLock.Unlock()` to only run after both guards pass, 
  so we never try to unlock a lock we don't own

## Steps to Test
1. Run `go build ./pkg/helm/...` from the `backend/` directory — should 
   produce no output (clean build)
2. Trigger two concurrent Helm repository operations (e.g., two simultaneous 
   AddRepo calls)
3. The operation that loses the lock race should now return 
   `"failed to acquire repository lock"` instead of silently proceeding
4. Check logs — no unlocking errors should appear from a lock that was 
   never held

## Screenshots (if applicable)
N/A — this is a backend-only logic fix with no UI impact

## Notes for the Reviewer
- The bug was subtle: `lockRepositoryFile` returns three values (`locked`, 
  `fileLock`, `err`), but the original code only branched on `err`. If 
  `locked == false` and `err == nil`, the code would silently fall through 
  and proceed without the lock. This PR closes that gap in all three callers.
- The fix pattern is now consistent across all three functions — check `err`, 
  then check `!locked`, then set up the defer. Same order everywhere.