### PR TITLE
backend: helm: Fail when repo lock is not acquired

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -40,7 +40,10 @@ const (
 	defaultNewConfigFolderMode os.FileMode = os.FileMode(0o770)
 )
 
-var errRepositoryNotFound = errors.New("repository not found")
+var (
+	errRepositoryNotFound        = errors.New("repository not found")
+	errRepositoryLockNotAcquired = errors.New("repository lock not acquired")
+)
 
 // add repository.
 type AddUpdateRepoRequest struct {
@@ -94,6 +97,18 @@ func lockRepositoryFile(lockCtx context.Context, repositoryConfig string) (bool,
 	return locked, fileLock, err
 }
 
+func ensureRepositoryFileLocked(locked bool, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if !locked {
+		return errRepositoryLockNotAcquired
+	}
+
+	return nil
+}
+
 const timeoutForLock = 30 * time.Second
 
 // Adds a repository with name, url to the helm config. Returns error if there is one.
@@ -108,19 +123,17 @@ func addRepository(name string, url string, settings *cli.EnvSettings) error {
 	defer cancel()
 
 	locked, fileLock, err := lockRepositoryFile(lockCtx, settings.RepositoryConfig)
-	if err == nil && locked {
-		defer func() {
-			err := fileLock.Unlock()
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
-			}
-		}()
-	}
-
-	if err != nil {
+	if err = ensureRepositoryFileLocked(locked, err); err != nil {
 		logger.Log(logger.LevelError, nil, err, "locking repository config file")
 		return err
 	}
+
+	defer func() {
+		err := fileLock.Unlock()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
+		}
+	}()
 
 	// read repo file
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
@@ -288,19 +301,17 @@ func RemoveRepository(name string, settings *cli.EnvSettings) error {
 	defer cancel()
 
 	locked, fileLock, err := lockRepositoryFile(lockCtx, settings.RepositoryConfig)
-	if err == nil && locked {
-		defer func() {
-			err := fileLock.Unlock()
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
-			}
-		}()
-	}
-
-	if err != nil {
+	if err = ensureRepositoryFileLocked(locked, err); err != nil {
 		logger.Log(logger.LevelError, nil, err, "locking repository config file")
 		return err
 	}
+
+	defer func() {
+		err := fileLock.Unlock()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
+		}
+	}()
 
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
 	if err != nil {
@@ -358,19 +369,17 @@ func UpdateRepository(name, url string, settings *cli.EnvSettings) error {
 	defer cancel()
 
 	locked, fileLock, err := lockRepositoryFile(lockCtx, settings.RepositoryConfig)
-	if err == nil && locked {
-		defer func() {
-			err := fileLock.Unlock()
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
-			}
-		}()
-	}
-
-	if err != nil {
+	if err = ensureRepositoryFileLocked(locked, err); err != nil {
 		logger.Log(logger.LevelError, nil, err, "locking repository config file")
 		return err
 	}
+
+	defer func() {
+		err := fileLock.Unlock()
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "unlocking repository config file")
+		}
+	}()
 
 	repoFile, err := repo.LoadFile(settings.RepositoryConfig)
 	if err != nil {

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -18,6 +18,7 @@ package helm
 
 import (
 	"errors"
+	"io/fs"
 	"path/filepath"
 	"testing"
 
@@ -41,4 +42,26 @@ func TestRemoveRepositoryReturnsNotFoundError(t *testing.T) {
 	err := RemoveRepository("missing", settings)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errRepositoryNotFound))
+}
+
+func TestEnsureRepositoryFileLocked(t *testing.T) {
+	t.Run("locked", func(t *testing.T) {
+		assert.NoError(t, ensureRepositoryFileLocked(true, nil))
+	})
+
+	t.Run("lock_error", func(t *testing.T) {
+		lockErr := fs.ErrPermission
+
+		err := ensureRepositoryFileLocked(false, lockErr)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, lockErr))
+	})
+
+	t.Run("not_locked_without_error", func(t *testing.T) {
+		err := ensureRepositoryFileLocked(false, nil)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, errRepositoryLockNotAcquired))
+	})
 }


### PR DESCRIPTION
## Summary

  This PR fixes a backend Helm repository locking bug by making repository add, remove, and update operations fail closed when the repository file lock is not acquired.

  Previously, these paths only checked err from lockRepositoryFile(). If locked was false and err was nil, the code could continue into repository file reads and writes without holding the lock.

  ## Related Issue

  Fixes #5634

  ## Changes

  - Added an explicit errRepositoryLockNotAcquired error for unsuccessful lock acquisition.
  - Added a small helper to validate both locked and err from lockRepositoryFile().
  - Updated Helm repository add, remove, and update paths to stop before reading or writing when the lock is not confirmed.
  - Added regression coverage for the locked == false && err == nil case.

  ## Steps to Test

  1. Run cd backend && go test -v ./pkg/helm.
  2. Run npm run backend:lint.
  3. Confirm Helm repository tests pass and lint reports 0 issues.

  ## Screenshots (if applicable)

  Not applicable. This is a backend-only change.

  ## Notes for the Reviewer

  This keeps the existing lock/unlock flow intact and only adds the missing fail-closed check after lock acquisition.
