### PR TITLE
frontend: Event: Put hooks back into the class for compatibility

### DIFF
--- a/frontend/src/lib/k8s/event.ts
+++ b/frontend/src/lib/k8s/event.ts
@@ -47,6 +47,9 @@ class Event extends KubeObject<KubeEvent> {
 
   static isNamespaced = true;
 
+  static useListForClusters = useEventListForClusters;
+  static useWarningList = useEventWarningList;
+
   // Max number of events to fetch from the API
   private static maxEventsLimit = 2000;
 


### PR DESCRIPTION
Places hook back as static methods that were moved recently, addresses #5652


