### PR TITLE
backend: headlamp_test: Add negative test for unauthed callers

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1252,6 +1252,248 @@ func TestDeletePlugin(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+// TestRestrictedEndpointsRequireToken is the canary for the backend-token gate:
+// dropping checkHeadlampBackendToken from any listed route would fail here.
+// PUT /cluster/{name} (renameCluster) is omitted because it isn't gated yet.
+func TestRestrictedEndpointsRequireToken(t *testing.T) {
+	const validToken = "valid-token-for-test"
+
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", validToken)
+
+	kubeConfigBytes, err := os.ReadFile("./headlamp_testdata/kubeconfig")
+	require.NoError(t, err)
+
+	kubeConfigB64 := base64.StdEncoding.EncodeToString(kubeConfigBytes)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   interface{}
+	}{
+		{
+			name:   "POST /cluster (addCluster)",
+			method: http.MethodPost,
+			path:   "/cluster",
+			body:   ClusterReq{KubeConfig: &kubeConfigB64},
+		},
+		{
+			name:   "DELETE /cluster/{name} (deleteCluster)",
+			method: http.MethodDelete,
+			path:   "/cluster/" + minikubeName,
+			body:   nil,
+		},
+		{
+			name:   "DELETE /plugins/{name} (deletePlugin)",
+			method: http.MethodDelete,
+			path:   "/plugins/test-plugin",
+			body:   nil,
+		},
+		{
+			name:   "GET /clusters/{name}/helm/releases (handleClusterHelm)",
+			method: http.MethodGet,
+			path:   "/clusters/" + minikubeName + "/helm/releases",
+			body:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRouteRequiresBackendToken(t, tc.method, tc.path, tc.body, validToken)
+		})
+	}
+}
+
+// newRestrictedEndpointsHandler builds a handler with a fresh plugin tree and
+// kubeconfig store so the mutating valid-token subtest can't leak state.
+func newRestrictedEndpointsHandler(t *testing.T) http.Handler {
+	t.Helper()
+
+	pluginRoot := t.TempDir()
+
+	userPluginDir := filepath.Join(pluginRoot, "user-plugins")
+	require.NoError(t, os.Mkdir(userPluginDir, 0o750))
+
+	devPluginDir := filepath.Join(pluginRoot, "plugins")
+	require.NoError(t, os.Mkdir(devPluginDir, 0o750))
+
+	pluginDir := filepath.Join(devPluginDir, "test-plugin")
+	require.NoError(t, os.Mkdir(pluginDir, 0o750))
+
+	f, err := os.Create(filepath.Join(pluginDir, "main.js")) //nolint:gosec
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "./headlamp_testdata/kubeconfig",
+				EnableDynamicClusters: true,
+				EnableHelm:            true,
+				PluginDir:             devPluginDir,
+				UserPluginDir:         userPluginDir,
+				KubeConfigStore:       kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	return createHeadlampHandler(context.Background(), &c)
+}
+
+// assertRouteRequiresBackendToken runs the three auth variants (missing,
+// wrong, valid) against a single route. The valid case only asserts the
+// gate did not fire; the route's actual response is out of scope.
+func assertRouteRequiresBackendToken(t *testing.T, method, path string, body interface{}, validToken string) {
+	t.Helper()
+
+	variants := []struct {
+		name        string
+		setHeader   bool
+		headerValue string
+		rejected    bool
+	}{
+		{name: "missing token header", setHeader: false, rejected: true},
+		{name: "wrong token value", setHeader: true, headerValue: "not-the-token", rejected: true},
+		{name: "valid token", setHeader: true, headerValue: validToken, rejected: false},
+	}
+
+	for _, av := range variants {
+		t.Run(av.name, func(t *testing.T) {
+			handler := newRestrictedEndpointsHandler(t)
+
+			req, err := makeJSONReq(method, path, body)
+			require.NoError(t, err)
+
+			if av.setHeader {
+				req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", av.headerValue)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if av.rejected {
+				assert.Equal(t, http.StatusForbidden, rr.Code,
+					"%s %s with %s must be rejected by the backend-token gate",
+					method, path, av.name)
+			} else {
+				assert.NotEqual(t, http.StatusForbidden, rr.Code,
+					"%s %s with a valid token must NOT be rejected by the backend-token gate",
+					method, path)
+				assert.NotEqual(t, http.StatusUnauthorized, rr.Code,
+					"%s %s with a valid token must NOT be rejected by the backend-token gate",
+					method, path)
+			}
+		})
+	}
+}
+
+// TestRestrictedEndpointsRejectEmptyEnvToken makes sure an empty env var doesn't
+// turn into a bypass when the client also sends an empty header.
+func TestRestrictedEndpointsRejectEmptyEnvToken(t *testing.T) {
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", "")
+
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "./headlamp_testdata/kubeconfig",
+				EnableDynamicClusters: true,
+				PluginDir:             t.TempDir(),
+				UserPluginDir:         t.TempDir(),
+				KubeConfigStore:       kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+	handler := createHeadlampHandler(context.Background(), &c)
+
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/cluster"},
+		{http.MethodDelete, "/cluster/" + minikubeName},
+		{http.MethodDelete, "/plugins/test-plugin"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			for _, headerValue := range []string{"" /* matches empty env */, "anything"} {
+				req, err := makeJSONReq(route.method, route.path, nil)
+				require.NoError(t, err)
+
+				req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", headerValue)
+
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				assert.Equal(t, http.StatusForbidden, rr.Code,
+					"empty HEADLAMP_BACKEND_TOKEN env must reject all callers (header=%q)", headerValue)
+			}
+		})
+	}
+}
+
+// TestRestrictedEndpointsBypassedInCluster checks the other half of the gate:
+// when UseInCluster is true it must never fire, since there's no desktop app
+// to hand a token to. A non-empty env var is set to make sure that doesn't
+// accidentally re-enable rejection.
+func TestRestrictedEndpointsBypassedInCluster(t *testing.T) {
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", "some-token")
+
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          true,
+				KubeConfigPath:        "./headlamp_testdata/kubeconfig",
+				EnableDynamicClusters: true,
+				EnableHelm:            true,
+				PluginDir:             t.TempDir(),
+				UserPluginDir:         t.TempDir(),
+				KubeConfigStore:       kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+	handler := createHeadlampHandler(context.Background(), &c)
+
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/cluster"},
+		{http.MethodDelete, "/cluster/" + minikubeName},
+		{http.MethodDelete, "/plugins/test-plugin"},
+		{http.MethodGet, "/clusters/" + minikubeName + "/helm/releases"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			req, err := makeJSONReq(route.method, route.path, nil)
+			require.NoError(t, err)
+			// No X-HEADLAMP_BACKEND-TOKEN header on purpose.
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.NotEqual(t, http.StatusForbidden, rr.Code,
+				"%s %s must not be rejected by the backend-token gate when UseInCluster=true",
+				route.method, route.path)
+			assert.NotEqual(t, http.StatusUnauthorized, rr.Code,
+				"%s %s must not be rejected by the backend-token gate when UseInCluster=true",
+				route.method, route.path)
+		})
+	}
+}
+
 func TestHandleClusterAPI_XForwardedHost(t *testing.T) {
 	// Create a new server for testing
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

The backend's mutating/proxy endpoints (`/cluster`, `/plugins/{name}`, `/clusters/{name}/helm/...`) are gated by the `X-HEADLAMP_BACKEND-TOKEN` header, which must match the `HEADLAMP_BACKEND_TOKEN` env var set by the desktop app. Until now there was no negative test proving the gate actually rejects unauthenticated callers a regression that removed `checkHeadlampBackendToken` from any of those handlers would have shipped green. The gate also has a deliberate carve-out (`UseInCluster == true` skips the check entirely), and that was equally untested.

This PR adds three focused tests in `backend/cmd/headlamp_test.go` that pin the gate's behavior on both sides.

## Changes

Added in `backend/cmd/headlamp_test.go`:

- **`TestRestrictedEndpointsRequireToken`** — table-driven over the four currently-gated routes:
  - `POST /cluster`
  - `DELETE /cluster/{name}`
  - `DELETE /plugins/{name}`
  - `GET /clusters/{name}/helm/...` (Helm proxy)

  For each route it runs three subtests:
  - missing `X-HEADLAMP_BACKEND-TOKEN` header → expects `403 Forbidden`
  - wrong token value → expects `403 Forbidden`
  - correct token → expects status to NOT be `401`/`403` (we only pin the auth gate, not the response body)

Each subtest builds a fresh handler with its own `t.TempDir()` so the "valid token" subtest, which actually mutates state, can't bleed into the others. Env var is set with `t.Setenv` so it's restored automatically. The test handler sets `EnableHelm: true` so the Helm route is actually registered (otherwise the generic `/clusters/{name}/...` proxy catches the path and the test would observe proxy-layer status codes instead of the auth gate).

- **`TestRestrictedEndpointsRejectEmptyEnvToken`** — pins a second property of `checkHeadlampBackendToken`: when `HEADLAMP_BACKEND_TOKEN` is empty, every request must be rejected, including one with an empty header. Without this, clearing the env var would silently disable the gate.

- **`TestRestrictedEndpointsBypassedInCluster`**  — pins the other half of the gate. With `UseInCluster: true` and a non-empty `HEADLAMP_BACKEND_TOKEN` env var, requests with **no** `X-HEADLAMP_BACKEND-TOKEN` header must not be rejected on any of the four gated routes. A regression that made the gate apply in-cluster would break every in-cluster install; this test makes that a CI failure instead of a deployment incident.

## Steps to Test

1. `cd backend && go test -count=1 -run 'TestRestrictedEndpoints' ./cmd/...` all three tests should pass.
3. Full backend suite: `npm run backend:test`.

## Notes for the Reviewer

- **Scope is intentionally tight.** No production code is changed; this is purely test coverage of behavior that already exists.
- **`PUT /cluster/{name}` (`renameCluster`) is deliberately excluded from the table.** While writing these tests I noticed `renameCluster` does not call `checkHeadlampBackendToken`, unlike its `addCluster`/`deleteCluster` siblings so it's currently reachable without the backend token. Adding it to this table would assert behavior that does not exist and fail CI. The omission is documented in a one-line comment on `TestRestrictedEndpointsRequireToken`.
- The expected rejection status is `403 Forbidden` (not `401`) because that's what `checkHeadlampBackendToken` returns via `http.Error`. The "valid token" and in-cluster branches assert `!= 403 && != 401`, so they stay robust to handlers returning `200`/`201`/`400`/`404`/`5xx` depending on body and cluster state.