### PR TITLE
frontend: RouteSwitcher.stories: Add route to useEffect deps

### DIFF
--- a/frontend/src/components/App/RouteSwitcher.stories.tsx
+++ b/frontend/src/components/App/RouteSwitcher.stories.tsx
@@ -35,8 +35,7 @@ const Template: StoryFn<{ route: Route }> = args => {
 
   React.useEffect(() => {
     store.dispatch(setRoute(route));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [route]);
 
   return (
     <TestContext store={store} urlPrefix={route.path}>


### PR DESCRIPTION
## Summary

This PR clears the `react-hooks/exhaustive-deps` suppression in `frontend/src/components/App/RouteSwitcher.stories.tsx` by adding the missing `route` to the `useEffect` deps array. The story-arg `route` is now properly tracked, so changing the arg in Storybook controls re-dispatches the new route into the redux store rather than leaving the originally mounted route in place.

## Related Issue

Fixes #5666 (sub-issue of umbrella #5183).

## Changes

- Added `[route]` to the deps array of the mount-effect in the stories `Template`.
- Removed the `// eslint-disable-next-line react-hooks/exhaustive-deps` directive.

### Why this is also a tiny behaviour fix

`route` comes from the story args destructure (`const { route } = args;`). With `[]` as deps the effect only fired on mount; subsequent arg changes did not re-dispatch the route, so the rendered `RouteSwitcher` continued to show the route the story originally mounted with. With `[route]` the effect re-fires when the arg changes and the store updates correctly. `store` itself is a module-level import (stable) so eslint accepts it being omitted from the deps array.

## Steps to Test

1. `cd frontend && npm install`
2. `npm run lint`: the file lints cleanly; no `react-hooks/exhaustive-deps` violation surfaces.
3. `npm run tsc`: passes.
4. Visual smoke: `npm run storybook`, navigate to **routes/RouteSwitcher**, change the `route` arg in Storybook controls and observe that the rendered route updates.

## Screenshots (if applicable)

N/A. No visual regression.

## Notes for the Reviewer

- Single-file diff, +1 / -2 lines.
- DCO sign-off applied (`Signed-off-by:` in the commit).
- Listed as an unchecked `exhaustive-deps` bullet in umbrella issue #5183.