### PR TITLE
frontend: PortForwardContent: Clean up localStorage on start failure

### DIFF
--- a/frontend/src/components/common/Resource/PortForward.tsx
+++ b/frontend/src/components/common/Resource/PortForward.tsx
@@ -289,6 +289,16 @@ function PortForwardContent(props: PortForwardProps) {
         setError(error?.message ?? 'An unexpected error occurred.');
         setLoading(false);
         setPortForward(null);
+
+        if (portForward?.id) {
+          const portForwardsInStorage = localStorage.getItem(PORT_FORWARDS_STORAGE_KEY);
+          const parsedPortForwards = JSON.parse(portForwardsInStorage || '[]');
+          const index = parsedPortForwards.findIndex((pf: any) => pf.id === portForward.id);
+          if (index !== -1) {
+            parsedPortForwards.splice(index, 1);
+            localStorage.setItem(PORT_FORWARDS_STORAGE_KEY, JSON.stringify(parsedPortForwards));
+          }
+        }
       });
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a localStorage leak in `PortForwardContent` where a failed port-forward restart left a zombie "Stopped" entry in localStorage, causing it to incorrectly reappear on page refresh.

## Related Issue

Fixes #5659

## Changes

- Fixed `.catch()` block in `startPortForwardWithSelection` in `PortForward.tsx` to remove the failed entry from `PORT_FORWARDS_STORAGE_KEY` when a restart fails and `portForward.id` exists

## Steps to Test

1. Open Headlamp in the Electron desktop app and navigate to any running Pod
2. Start a port-forward, then stop it so it appears in the "Stopped" state
3. Ensure the restart will fail (e.g. delete the target pod or occupy the local port)
4. Click the **Start port forward** button to attempt a restart
5. Observe the UI shows an error and hides the component
6. Refresh the page — the zombie "Stopped" entry should **not** reappear

## Notes for the Reviewer

- The fix only runs when `portForward.id` exists (i.e. restarting an existing stopped entry), so a brand-new port-forward failure is unaffected
- Port forwarding is Electron-only and cannot be reproduced in browser mode