### PR TITLE
backend: externalproxy: Fix glob panic and pre-compile patterns

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -77,6 +77,7 @@ import (
 
 type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
+	CompiledProxyURLs []glob.Glob
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -603,8 +604,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		isURLContainedInProxyURLs := false
 
-		for _, proxyURL := range config.ProxyURLs {
-			g := glob.MustCompile(proxyURL)
+		for _, g := range config.CompiledProxyURLs {
 			if g.Match(url.String()) {
 				isURLContainedInProxyURLs = true
 				break

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -77,6 +77,7 @@ import (
 
 type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
+	proxyURLMu        sync.Mutex
 	compiledProxyURLs []glob.Glob
 }
 
@@ -96,16 +97,23 @@ func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
 }
 
 func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
+	c.proxyURLMu.Lock()
+
 	if c.compiledProxyURLs == nil && len(c.ProxyURLs) > 0 {
 		compiledProxyURLs, err := compileProxyURLPatterns(c.ProxyURLs)
 		if err != nil {
+			c.proxyURLMu.Unlock()
+
 			return false, err
 		}
 
 		c.compiledProxyURLs = compiledProxyURLs
 	}
 
-	for _, g := range c.compiledProxyURLs {
+	compiledProxyURLs := c.compiledProxyURLs
+	c.proxyURLMu.Unlock()
+
+	for _, g := range compiledProxyURLs {
 		if g.Match(proxyURL) {
 			return true, nil
 		}

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -77,7 +77,41 @@ import (
 
 type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
-	CompiledProxyURLs []glob.Glob
+	compiledProxyURLs []glob.Glob
+}
+
+func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
+	compiledProxyURLs := make([]glob.Glob, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		g, err := glob.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
+		}
+
+		compiledProxyURLs = append(compiledProxyURLs, g)
+	}
+
+	return compiledProxyURLs, nil
+}
+
+func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
+	if c.compiledProxyURLs == nil && len(c.ProxyURLs) > 0 {
+		compiledProxyURLs, err := compileProxyURLPatterns(c.ProxyURLs)
+		if err != nil {
+			return false, err
+		}
+
+		c.compiledProxyURLs = compiledProxyURLs
+	}
+
+	for _, g := range c.compiledProxyURLs {
+		if g.Match(proxyURL) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -602,13 +636,12 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		isURLContainedInProxyURLs := false
+		isURLContainedInProxyURLs, err := config.proxyURLAllowed(url.String())
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL}, err, "compiling proxy URL patterns")
+			http.Error(w, "failed to compile proxy URL patterns", http.StatusInternalServerError)
 
-		for _, g := range config.CompiledProxyURLs {
-			if g.Match(url.String()) {
-				isURLContainedInProxyURLs = true
-				break
-			}
+			return
 		}
 
 		if !isURLContainedInProxyURLs {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -38,7 +38,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gobwas/glob"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
@@ -430,7 +429,6 @@ func TestExternalProxy(t *testing.T) {
 					},
 					Cache: cache,
 				},
-				CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 			}),
 			useForwardedHeaders: true,
 		},
@@ -457,7 +455,6 @@ func TestExternalProxy(t *testing.T) {
 					},
 					Cache: cache,
 				},
-				CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 			}),
 			useProxyURL: true,
 		},
@@ -503,6 +500,29 @@ func TestExternalProxy(t *testing.T) {
 	}
 }
 
+func TestCompileProxyURLPatternsInvalidPattern(t *testing.T) {
+	_, err := compileProxyURLPatterns([]string{"["})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "compiling proxy URL pattern")
+}
+
+func TestProxyURLAllowedCompilesConfiguredProxyURLs(t *testing.T) {
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				ProxyURLs: []string{"https://example.com/*"},
+			},
+		},
+	}
+
+	allowed, err := config.proxyURLAllowed("https://example.com/api")
+
+	require.NoError(t, err)
+	assert.True(t, allowed)
+	assert.NotEmpty(t, config.compiledProxyURLs)
+}
+
 func TestExternalProxyForwarding(t *testing.T) {
 	// Create a new server for testing that returns a specific status and content type
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -530,7 +550,6 @@ func TestExternalProxyForwarding(t *testing.T) {
 			},
 			Cache: cache,
 		},
-		CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
@@ -576,7 +595,6 @@ func TestExternalProxyTimeout(t *testing.T) {
 			},
 			Cache: cache,
 		},
-		CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -38,6 +38,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gobwas/glob"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
@@ -429,6 +430,7 @@ func TestExternalProxy(t *testing.T) {
 					},
 					Cache: cache,
 				},
+				CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 			}),
 			useForwardedHeaders: true,
 		},
@@ -455,6 +457,7 @@ func TestExternalProxy(t *testing.T) {
 					},
 					Cache: cache,
 				},
+				CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 			}),
 			useProxyURL: true,
 		},
@@ -527,6 +530,7 @@ func TestExternalProxyForwarding(t *testing.T) {
 			},
 			Cache: cache,
 		},
+		CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
@@ -572,6 +576,7 @@ func TestExternalProxyTimeout(t *testing.T) {
 			},
 			Cache: cache,
 		},
+		CompiledProxyURLs: []glob.Glob{glob.MustCompile(proxyURL.String())},
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/cli/browser"
+	"github.com/gobwas/glob"
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
@@ -98,7 +99,12 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		WatchPluginsChanges:    conf.WatchPluginsChanges,
 		KubeConfigStore:        kubeConfigStore,
 		BaseURL:                conf.BaseURL,
-		ProxyURLs:              strings.Split(conf.ProxyURLs, ","),
+		ProxyURLs: func() []string {
+			if conf.ProxyURLs == "" {
+				return []string{}
+			}
+			return strings.Split(conf.ProxyURLs, ",")
+		}(),
 		TLSCertPath:            conf.TLSCertPath,
 		TLSKeyPath:             conf.TLSKeyPath,
 		SessionTTL:             conf.SessionTTL,
@@ -167,8 +173,20 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 	cfg.ProxyAuthEmailHeader = conf.ProxyAuthEmailHeader
 	cfg.ProxyAuthTokenHeader = conf.ProxyAuthTokenHeader
 
+	compiledProxyURLs := make([]glob.Glob, 0, len(cfg.ProxyURLs))
+	for _, pattern := range cfg.ProxyURLs {
+		g, err := glob.Compile(pattern)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"pattern": pattern},
+				err, "failed to compile proxy URL pattern")
+			os.Exit(1)
+		}
+		compiledProxyURLs = append(compiledProxyURLs, g)
+	}
+
 	return &HeadlampConfig{
-		HeadlampConfig: cfg,
+		HeadlampConfig:    cfg,
+		CompiledProxyURLs: compiledProxyURLs,
 	}
 }
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/cli/browser"
-	"github.com/gobwas/glob"
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
@@ -174,21 +173,15 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 	cfg.ProxyAuthEmailHeader = conf.ProxyAuthEmailHeader
 	cfg.ProxyAuthTokenHeader = conf.ProxyAuthTokenHeader
 
-	compiledProxyURLs := make([]glob.Glob, 0, len(cfg.ProxyURLs))
-	for _, pattern := range cfg.ProxyURLs {
-		g, err := glob.Compile(pattern)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"pattern": pattern},
-				err, "failed to compile proxy URL pattern")
-			os.Exit(1)
-		}
-
-		compiledProxyURLs = append(compiledProxyURLs, g)
+	compiledProxyURLs, err := compileProxyURLPatterns(cfg.ProxyURLs)
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "failed to compile proxy URL patterns")
+		os.Exit(1)
 	}
 
 	return &HeadlampConfig{
 		HeadlampConfig:    cfg,
-		CompiledProxyURLs: compiledProxyURLs,
+		compiledProxyURLs: compiledProxyURLs,
 	}
 }
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -103,16 +103,17 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 			if conf.ProxyURLs == "" {
 				return []string{}
 			}
+
 			return strings.Split(conf.ProxyURLs, ",")
 		}(),
-		TLSCertPath:            conf.TLSCertPath,
-		TLSKeyPath:             conf.TLSKeyPath,
-		SessionTTL:             conf.SessionTTL,
-		PodDebugImage:          conf.PodDebugImage,
-		OidcUseCookie:          conf.OidcUseCookie,
-		DefaultLightTheme:      conf.DefaultLightTheme,
-		DefaultDarkTheme:       conf.DefaultDarkTheme,
-		ForceTheme:             conf.ForceTheme,
+		TLSCertPath:       conf.TLSCertPath,
+		TLSKeyPath:        conf.TLSKeyPath,
+		SessionTTL:        conf.SessionTTL,
+		PodDebugImage:     conf.PodDebugImage,
+		OidcUseCookie:     conf.OidcUseCookie,
+		DefaultLightTheme: conf.DefaultLightTheme,
+		DefaultDarkTheme:  conf.DefaultDarkTheme,
+		ForceTheme:        conf.ForceTheme,
 	}
 }
 
@@ -181,6 +182,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 				err, "failed to compile proxy URL pattern")
 			os.Exit(1)
 		}
+
 		compiledProxyURLs = append(compiledProxyURLs, g)
 	}
 


### PR DESCRIPTION
## Description

This change fixes a bug where an invalid `/externalproxy` URL glob pattern could crash the Headlamp backend. It also improves request handling by compiling allowed proxy URL patterns once and reusing the compiled patterns during external proxy validation.

## Changes

- **Centralized proxy URL glob compilation:** Added a shared helper for compiling configured proxy URL patterns so startup, request handling, and tests use the same path.
- **Safer external proxy validation:** `/externalproxy` now validates requests through a helper that can compile configured `ProxyURLs` when needed, preventing configs with only `ProxyURLs` populated from silently denying all proxy requests.
- **Startup validation:** Invalid proxy URL glob patterns are detected during config creation and logged with a clear error before startup exits.
- **Improved performance:** Valid proxy URL patterns are precompiled and stored for reuse instead of being reprocessed on every request.
- **Updated tests:** Added coverage for invalid glob pattern compilation and for configs that provide `ProxyURLs` without manually precompiled patterns.
