### PR TITLE
frontend: router: Handle missing route params gracefully in createRouteURL

### DIFF
--- a/frontend/src/lib/router/createRouteURL.test.ts
+++ b/frontend/src/lib/router/createRouteURL.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRouteURL } from './createRouteURL';
+
+vi.mock('./getRoute', () => ({
+  getRoute: vi.fn((name?: string) => {
+    if (name === 'pluginParameterizedRoute') {
+      return { path: '/plugin/:namespace/:name', useClusterURL: false };
+    }
+    if (name === 'pluginSimpleRoute') {
+      return { path: '/plugin', useClusterURL: false };
+    }
+    return undefined;
+  }),
+}));
+
+vi.mock('./getRoutePath', () => ({
+  getRoutePath: vi.fn((route: { path: string }) => route.path),
+}));
+
+vi.mock('./getRouteUseClusterURL', () => ({
+  getRouteUseClusterURL: vi.fn((route: { useClusterURL?: boolean }) => !!route.useClusterURL),
+}));
+
+describe('createRouteURL', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty string when no route name is provided', () => {
+    expect(createRouteURL()).toBe('');
+  });
+
+  it('returns an empty string when the route name is unknown', () => {
+    expect(createRouteURL('does-not-exist')).toBe('');
+  });
+
+  it('returns the generated URL when all required params are provided', () => {
+    expect(createRouteURL('pluginParameterizedRoute', { namespace: 'default', name: 'foo' })).toBe(
+      '/plugin/default/foo'
+    );
+  });
+
+  it('returns the URL as-is for non-parameterized routes', () => {
+    expect(createRouteURL('pluginSimpleRoute')).toBe('/plugin');
+  });
+
+  it('returns an empty string instead of throwing when required params are missing (#4863)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => createRouteURL('pluginParameterizedRoute')).not.toThrow();
+    expect(createRouteURL('pluginParameterizedRoute')).toBe('');
+
+    expect(warnSpy).toHaveBeenCalled();
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('pluginParameterizedRoute');
+    expect(message).toContain('/plugin/:namespace/:name');
+  });
+});

--- a/frontend/src/lib/router/createRouteURL.tsx
+++ b/frontend/src/lib/router/createRouteURL.tsx
@@ -99,5 +99,14 @@ export function createRouteURL(routeName?: string, params: RouteURLProps = {}) {
   }
 
   const url = getRoutePath(route);
-  return generatePath(url, fullParams);
+  try {
+    // generatePath throws when required params are missing (e.g. plugin :namespace routes during init).
+    return generatePath(url, fullParams);
+  } catch (err) {
+    console.warn(
+      `[createRouteURL] Failed to generate URL for route "${routeName}" with path "${url}":`,
+      err
+    );
+    return '';
+  }
 }


### PR DESCRIPTION
## Summary

`createRouteURL` calls `generatePath(url, fullParams)` from `react-router` without guarding against missing required params. When a plugin registers a detail route with `:namespace` / `:name` placeholders and the dashboard iterates registered routes during initialization without concrete param values, `generatePath` throws `TypeError: Expected \"namespace\" to be defined` and the entire dashboard view crashes.

This PR wraps the `generatePath` call in a try/catch and returns an empty string on failure, matching the existing `!route` and missing-cluster early-return behaviour higher up in the same function. A `console.warn` keeps the diagnostic visible to plugin developers.

## Related Issue

Fixes #4863.

## Changes

- `frontend/src/lib/router/createRouteURL.tsx`: wrapped `generatePath(url, fullParams)` in a try/catch. On failure, logs a warning with the route name + path + error and returns `''`.
- `frontend/src/lib/router/createRouteURL.test.ts`: new suite covering the missing-name and unknown-route cases, the happy path for parameterized and non-parameterized routes, and the new missing-required-params behaviour. Five tests, all passing.

### Why this approach

The minimum-disruption fix. The function already has two existing fallbacks that return early without crashing (`!route` returns `''` at line 76; missing cluster returns `'/'` at line 83). Adding a third for the missing-param case is symmetric with that behaviour and avoids any change to the success path. Plugin developers still see the warning so they can fix their route registration if they want a proper URL, but their plugin won't take down the dashboard.

A more ambitious fix would expose a plugin-side API for routing owner references / unknown-namespace routes (the original reporter raised this as a follow-up question). That's worth a separate design discussion and is out of scope for this defensive fix.

## Steps to Test

1. `cd frontend && npm install`
2. `npm run lint`: passes.
3. `npm run tsc`: passes.
4. `npx vitest run src/lib/router/createRouteURL.test.ts`: all 5 tests pass.
5. Manual repro: in a plugin, call `registerRoute({ path: '/myplugin/:namespace/:name', ... })`, build the plugin, install it, and load the dashboard. Before this PR the dashboard crashes on initialization with the `TypeError`; after, the dashboard renders normally and a `console.warn` appears in DevTools.

## Screenshots (if applicable)

N/A. The bug is a crash; the fix prevents it.

## Notes for the Reviewer

- Two files: a six-line production change and a new ~70-line test file.
- DCO sign-off applied (`Signed-off-by:` in the commit).
- A prior PR (#2383) attempted a similar graceful fix but was auto-closed by the K8s stale-bot in August 2025 after 120 days of inactivity, not on merit. This PR revives the direction with a smaller surface and tests.
- A concurrent PR (#5391) refactors `createRouteURL` to remove the `settingsCluster` hardcode. The two PRs touch the same file but different lines; rebasing either onto the other is straightforward.