### PR TITLE
backend: headlamp: filter sensitive headers in external proxy

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -151,6 +151,11 @@ var maxProxyResponseSize int64 = 100 * 1024 * 1024
 //nolint:gochecknoglobals // allow test override
 var externalProxyTimeout = 30 * time.Second
 
+//nolint:gochecknoglobals // shared client preserves connection pooling for external proxy requests
+var externalProxyHTTPClient = &http.Client{
+	Transport: newExternalProxyTransport(),
+}
+
 const kubeConfigSource = "kubeconfig" // source for kubeconfig contexts
 
 const (
@@ -732,15 +737,14 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		// We may want to filter some headers, otherwise we could just use a shallow copy
 		proxyReq.Header = make(http.Header)
+		connectionHeaderTokens := externalProxyConnectionHeaderTokens(r.Header)
+
 		for h, val := range r.Header {
-			// Skip sensitive headers and internal routing headers
-			hLower := strings.ToLower(h)
-			if hLower == "authorization" ||
-				hLower == "cookie" ||
-				strings.HasPrefix(hLower, "x-headlamp-") ||
-				strings.HasPrefix(hLower, "x-headlamp_") ||
-				hLower == "proxy-to" ||
-				hLower == "forward-to" {
+			if shouldFilterExternalProxyRequestHeader(h) {
+				continue
+			}
+
+			if _, ok := connectionHeaderTokens[strings.ToLower(h)]; ok {
 				continue
 			}
 
@@ -753,9 +757,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		w.Header().Set("Pragma", "no-cache")
 		w.Header().Set("X-Accel-Expires", "0")
 
-		client := http.Client{}
-
-		resp, err := client.Do(proxyReq) //nolint:gosec
+		resp, err := externalProxyHTTPClient.Do(proxyReq) //nolint:gosec
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "making request")
 			http.Error(w, err.Error(), http.StatusBadGateway)
@@ -1374,6 +1376,62 @@ func isLoopbackAddr(addr string) bool {
 	ip := net.ParseIP(strings.Trim(addr, "[]"))
 
 	return ip != nil && ip.IsLoopback()
+}
+
+func shouldFilterExternalProxyRequestHeader(headerName string) bool {
+	hLower := strings.ToLower(headerName)
+
+	if hLower == "authorization" ||
+		hLower == "cookie" ||
+		hLower == "accept-encoding" ||
+		strings.HasPrefix(hLower, "x-headlamp-") ||
+		strings.HasPrefix(hLower, "x-headlamp_") {
+		return true
+	}
+
+	switch hLower {
+	case "connection",
+		"forward-to",
+		"keep-alive",
+		"proxy-connection",
+		"proxy-to",
+		"te",
+		"trailer",
+		"transfer-encoding",
+		"upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func externalProxyConnectionHeaderTokens(headers http.Header) map[string]struct{} {
+	tokens := map[string]struct{}{}
+
+	for _, headerValue := range headers.Values("Connection") {
+		for _, token := range strings.Split(headerValue, ",") {
+			token = strings.ToLower(strings.TrimSpace(token))
+			if token != "" {
+				tokens[token] = struct{}{}
+			}
+		}
+	}
+
+	return tokens
+}
+
+func newExternalProxyTransport() http.RoundTripper {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{
+			DisableCompression: true,
+		}
+	}
+
+	transport := defaultTransport.Clone()
+	transport.DisableCompression = true
+
+	return transport
 }
 
 // allowedHosts returns the set of normalized host values that are considered

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -733,6 +733,17 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		// We may want to filter some headers, otherwise we could just use a shallow copy
 		proxyReq.Header = make(http.Header)
 		for h, val := range r.Header {
+			// Skip sensitive headers and internal routing headers
+			hLower := strings.ToLower(h)
+			if hLower == "authorization" ||
+				hLower == "cookie" ||
+				strings.HasPrefix(hLower, "x-headlamp-") ||
+				strings.HasPrefix(hLower, "x-headlamp_") ||
+				hLower == "proxy-to" ||
+				hLower == "forward-to" {
+				continue
+			}
+
 			proxyReq.Header[h] = val
 		}
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -151,11 +151,36 @@ var maxProxyResponseSize int64 = 100 * 1024 * 1024
 //nolint:gochecknoglobals // allow test override
 var externalProxyTimeout = 30 * time.Second
 
+type proxyURLListContextKey struct{}
+
 //nolint:gochecknoglobals // shared client preserves connection pooling for external proxy requests
 var externalProxyHTTPClient = &http.Client{
 	Transport: newExternalProxyTransport(),
-	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+
+		proxyURLs, ok := req.Context().Value(proxyURLListContextKey{}).([]string)
+		if !ok || len(proxyURLs) == 0 {
+			// If not an external proxy request or no allowlist provided, do not follow redirects
+			return http.ErrUseLastResponse
+		}
+
+		isURLContainedInProxyURLs := false
+		for _, proxyURL := range proxyURLs {
+			g, err := glob.Compile(proxyURL)
+			if err == nil && g.Match(req.URL.String()) {
+				isURLContainedInProxyURLs = true
+				break
+			}
+		}
+
+		if !isURLContainedInProxyURLs {
+			return errors.New("redirect target not in allowlist")
+		}
+
+		return nil
 	},
 }
 
@@ -727,7 +752,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		proxyCtx, cancel := context.WithTimeout(r.Context(), externalProxyTimeout)
+		proxyCtx := context.WithValue(r.Context(), proxyURLListContextKey{}, config.ProxyURLs)
+		proxyCtx, cancel := context.WithTimeout(proxyCtx, externalProxyTimeout)
 		defer cancel()
 
 		proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, proxyURL, r.Body) //nolint:gosec
@@ -808,6 +834,14 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		if resp.ContentLength > maxProxyResponseSize {
 			logger.Log(logger.LevelError, nil, nil, "proxy response exceeded maximum allowed size (Content-Length)")
 			http.Error(w, "response too large", http.StatusBadGateway)
+
+			return
+		}
+
+		// Prevent redirects without Location from being returned or breaking the proxy
+		if resp.StatusCode >= 300 && resp.StatusCode <= 399 && resp.StatusCode != http.StatusNotModified {
+			logger.Log(logger.LevelError, nil, nil, fmt.Sprintf("proxy response is a redirect (status %d), which is not supported", resp.StatusCode))
+			http.Error(w, "redirects are not supported by the external proxy", http.StatusBadGateway)
 
 			return
 		}

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -844,7 +844,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		if resp.StatusCode >= 300 && resp.StatusCode <= 399 && resp.StatusCode != http.StatusNotModified {
 			logger.Log(logger.LevelError, nil, nil,
 				fmt.Sprintf("proxy response returned an unexpected or unfollowed redirect (status %d)", resp.StatusCode))
-			http.Error(w, "external proxy request failed due to an unexpected or unfollowed redirect response", http.StatusBadGateway)
+			http.Error(w, "external proxy request failed: unexpected redirect", http.StatusBadGateway)
 
 			return
 		}

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -168,6 +168,7 @@ var externalProxyHTTPClient = &http.Client{
 		}
 
 		isURLContainedInProxyURLs := false
+
 		for _, proxyURL := range proxyURLs {
 			g, err := glob.Compile(proxyURL)
 			if err == nil && g.Match(req.URL.String()) {
@@ -753,6 +754,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		proxyCtx := context.WithValue(r.Context(), proxyURLListContextKey{}, config.ProxyURLs)
+
 		proxyCtx, cancel := context.WithTimeout(proxyCtx, externalProxyTimeout)
 		defer cancel()
 
@@ -840,7 +842,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		// Prevent redirects without Location from being returned or breaking the proxy
 		if resp.StatusCode >= 300 && resp.StatusCode <= 399 && resp.StatusCode != http.StatusNotModified {
-			logger.Log(logger.LevelError, nil, nil, fmt.Sprintf("proxy response is a redirect (status %d), which is not supported", resp.StatusCode))
+			logger.Log(logger.LevelError, nil, nil,
+				fmt.Sprintf("proxy response is a redirect (status %d), which is not supported", resp.StatusCode))
 			http.Error(w, "redirects are not supported by the external proxy", http.StatusBadGateway)
 
 			return

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -153,32 +153,50 @@ var externalProxyTimeout = 30 * time.Second
 
 type proxyURLListContextKey struct{}
 
+type proxyURLAllowlistEntry struct {
+	pattern string
+	matcher glob.Glob
+}
+
+func compileProxyURLAllowlist(proxyURLs []string) []proxyURLAllowlistEntry {
+	allowlist := make([]proxyURLAllowlistEntry, 0, len(proxyURLs))
+
+	for _, proxyURL := range proxyURLs {
+		allowlist = append(allowlist, proxyURLAllowlistEntry{
+			pattern: proxyURL,
+			matcher: glob.MustCompile(proxyURL),
+		})
+	}
+
+	return allowlist
+}
+
+func matchProxyURLAllowlist(proxyURL string, allowlist []proxyURLAllowlistEntry) (string, bool) {
+	for _, entry := range allowlist {
+		if entry.matcher.Match(proxyURL) {
+			return entry.pattern, true
+		}
+	}
+
+	return "", false
+}
+
 //nolint:gochecknoglobals // shared client preserves connection pooling for external proxy requests
 var externalProxyHTTPClient = &http.Client{
 	Transport: newExternalProxyTransport(),
 	CheckRedirect: func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
+			return fmt.Errorf("stopped after 10 redirects while requesting %q", req.URL.Redacted())
 		}
 
-		proxyURLs, ok := req.Context().Value(proxyURLListContextKey{}).([]string)
-		if !ok || len(proxyURLs) == 0 {
+		proxyURLAllowlist, ok := req.Context().Value(proxyURLListContextKey{}).([]proxyURLAllowlistEntry)
+		if !ok || len(proxyURLAllowlist) == 0 {
 			// If not an external proxy request or no allowlist provided, do not follow redirects
 			return http.ErrUseLastResponse
 		}
 
-		isURLContainedInProxyURLs := false
-
-		for _, proxyURL := range proxyURLs {
-			g, err := glob.Compile(proxyURL)
-			if err == nil && g.Match(req.URL.String()) {
-				isURLContainedInProxyURLs = true
-				break
-			}
-		}
-
-		if !isURLContainedInProxyURLs {
-			return errors.New("redirect target not in allowlist")
+		if _, ok := matchProxyURLAllowlist(req.URL.String(), proxyURLAllowlist); !ok {
+			return fmt.Errorf("redirect target %q not in allowlist", req.URL.Redacted())
 		}
 
 		return nil
@@ -585,6 +603,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	logger.Log(logger.LevelInfo, nil, nil, "Dynamic clusters support: "+fmt.Sprint(config.EnableDynamicClusters))
 	logger.Log(logger.LevelInfo, nil, nil, "Helm support: "+fmt.Sprint(config.EnableHelm))
 	logger.Log(logger.LevelInfo, nil, nil, "Proxy URLs: "+fmt.Sprint(config.ProxyURLs))
+	proxyURLAllowlist := compileProxyURLAllowlist(config.ProxyURLs)
 	logger.Log(logger.LevelInfo, nil, nil, "TLS certificate path: "+config.TLSCertPath)
 	logger.Log(logger.LevelInfo, nil, nil, "TLS key path: "+config.TLSKeyPath)
 	logger.Log(logger.LevelInfo, nil, nil, "me Username Paths: "+config.MeUsernamePaths)
@@ -729,7 +748,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		url, err := url.Parse(proxyURL)
+		targetURL, err := url.Parse(proxyURL)
 		if err != nil {
 			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL},
 				err, "The provided proxy URL is invalid")
@@ -738,22 +757,15 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		isURLContainedInProxyURLs, err := config.proxyURLAllowed(url.String())
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL}, err, "compiling proxy URL patterns")
-			http.Error(w, "failed to compile proxy URL patterns", http.StatusInternalServerError)
-
-			return
-		}
-
-		if !isURLContainedInProxyURLs {
-			logger.Log(logger.LevelError, nil, err, "no allowed proxy url match, request denied")
+		if _, ok := matchProxyURLAllowlist(targetURL.String(), proxyURLAllowlist); !ok {
+			logger.Log(logger.LevelError, map[string]string{"proxyURL": targetURL.Redacted()},
+				err, "no allowed proxy url match, request denied")
 			http.Error(w, "no allowed proxy url match, request denied ", http.StatusBadRequest)
 
 			return
 		}
 
-		proxyCtx := context.WithValue(r.Context(), proxyURLListContextKey{}, config.ProxyURLs)
+		proxyCtx := context.WithValue(r.Context(), proxyURLListContextKey{}, proxyURLAllowlist)
 
 		proxyCtx, cancel := context.WithTimeout(proxyCtx, externalProxyTimeout)
 		defer cancel()

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -83,6 +83,11 @@ type HeadlampConfig struct {
 	compiledProxyURLs []proxyURLAllowlistEntry
 }
 
+type proxyURLAllowlistEntry struct {
+	pattern string
+	matcher glob.Glob
+}
+
 func compileProxyURLPatterns(patterns []string) ([]proxyURLAllowlistEntry, error) {
 	compiledProxyURLs := make([]proxyURLAllowlistEntry, 0, len(patterns))
 
@@ -118,9 +123,19 @@ func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
 	compiledProxyURLs := c.compiledProxyURLs
 	c.proxyURLMu.Unlock()
 
-	_, allowed := matchProxyURLAllowlist(proxyURL, compiledProxyURLs)
+	allowed := matchProxyURLAllowlist(proxyURL, compiledProxyURLs)
 
 	return allowed, nil
+}
+
+func matchProxyURLAllowlist(proxyURL string, allowlist []proxyURLAllowlistEntry) bool {
+	for _, entry := range allowlist {
+		if entry.matcher.Match(proxyURL) {
+			return true
+		}
+	}
+
+	return false
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -152,34 +167,6 @@ var externalProxyTimeout = 30 * time.Second
 
 type proxyURLListContextKey struct{}
 
-type proxyURLAllowlistEntry struct {
-	pattern string
-	matcher glob.Glob
-}
-
-func compileProxyURLAllowlist(proxyURLs []string) []proxyURLAllowlistEntry {
-	allowlist := make([]proxyURLAllowlistEntry, 0, len(proxyURLs))
-
-	for _, proxyURL := range proxyURLs {
-		allowlist = append(allowlist, proxyURLAllowlistEntry{
-			pattern: proxyURL,
-			matcher: glob.MustCompile(proxyURL),
-		})
-	}
-
-	return allowlist
-}
-
-func matchProxyURLAllowlist(proxyURL string, allowlist []proxyURLAllowlistEntry) (string, bool) {
-	for _, entry := range allowlist {
-		if entry.matcher.Match(proxyURL) {
-			return entry.pattern, true
-		}
-	}
-
-	return "", false
-}
-
 //nolint:gochecknoglobals // shared client preserves connection pooling for external proxy requests
 var externalProxyHTTPClient = &http.Client{
 	Transport: newExternalProxyTransport(),
@@ -194,7 +181,7 @@ var externalProxyHTTPClient = &http.Client{
 			return http.ErrUseLastResponse
 		}
 
-		if _, ok := matchProxyURLAllowlist(req.URL.String(), proxyURLAllowlist); !ok {
+		if !matchProxyURLAllowlist(req.URL.String(), proxyURLAllowlist) {
 			return fmt.Errorf("redirect target %q not in allowlist", req.URL.Redacted())
 		}
 
@@ -602,7 +589,9 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	logger.Log(logger.LevelInfo, nil, nil, "Dynamic clusters support: "+fmt.Sprint(config.EnableDynamicClusters))
 	logger.Log(logger.LevelInfo, nil, nil, "Helm support: "+fmt.Sprint(config.EnableHelm))
 	logger.Log(logger.LevelInfo, nil, nil, "Proxy URLs: "+fmt.Sprint(config.ProxyURLs))
+
 	config.proxyURLMu.Lock()
+
 	proxyURLAllowlist := config.compiledProxyURLs
 	if proxyURLAllowlist == nil {
 		var err error
@@ -611,11 +600,13 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		if err != nil {
 			logger.Log(logger.LevelError, nil, nil,
 				"Invalid ProxyURLs configuration; disabling /externalproxy: "+err.Error())
+
 			proxyURLAllowlist = []proxyURLAllowlistEntry{}
 		}
 
 		config.compiledProxyURLs = proxyURLAllowlist
 	}
+
 	config.proxyURLMu.Unlock()
 	logger.Log(logger.LevelInfo, nil, nil, "TLS certificate path: "+config.TLSCertPath)
 	logger.Log(logger.LevelInfo, nil, nil, "TLS key path: "+config.TLSKeyPath)
@@ -770,7 +761,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		if _, ok := matchProxyURLAllowlist(targetURL.String(), proxyURLAllowlist); !ok {
+		if !matchProxyURLAllowlist(targetURL.String(), proxyURLAllowlist) {
 			denyErr := errors.New("no allowed proxy url match, request denied")
 			logger.Log(logger.LevelError, map[string]string{"proxyURL": targetURL.Redacted()},
 				denyErr, "no allowed proxy url match, request denied")

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -791,7 +791,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		resp, err := externalProxyHTTPClient.Do(proxyReq) //nolint:gosec
 		if err != nil {
 			logger.Log(logger.LevelError, nil, err, "making request")
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			http.Error(w, "external proxy request failed", http.StatusBadGateway)
 
 			return
 		}
@@ -840,11 +840,11 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			return
 		}
 
-		// Prevent redirects without Location from being returned or breaking the proxy
+		// Prevent unexpected or unfollowed redirects from being returned or breaking the proxy.
 		if resp.StatusCode >= 300 && resp.StatusCode <= 399 && resp.StatusCode != http.StatusNotModified {
 			logger.Log(logger.LevelError, nil, nil,
-				fmt.Sprintf("proxy response is a redirect (status %d), which is not supported", resp.StatusCode))
-			http.Error(w, "redirects are not supported by the external proxy", http.StatusBadGateway)
+				fmt.Sprintf("proxy response returned an unexpected or unfollowed redirect (status %d)", resp.StatusCode))
+			http.Error(w, "external proxy request failed due to an unexpected or unfollowed redirect response", http.StatusBadGateway)
 
 			return
 		}

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -80,11 +80,11 @@ import (
 type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
 	proxyURLMu        sync.Mutex
-	compiledProxyURLs []glob.Glob
+	compiledProxyURLs []proxyURLAllowlistEntry
 }
 
-func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
-	compiledProxyURLs := make([]glob.Glob, 0, len(patterns))
+func compileProxyURLPatterns(patterns []string) ([]proxyURLAllowlistEntry, error) {
+	compiledProxyURLs := make([]proxyURLAllowlistEntry, 0, len(patterns))
 
 	for _, pattern := range patterns {
 		g, err := glob.Compile(pattern)
@@ -92,7 +92,10 @@ func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
 			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
 		}
 
-		compiledProxyURLs = append(compiledProxyURLs, g)
+		compiledProxyURLs = append(compiledProxyURLs, proxyURLAllowlistEntry{
+			pattern: pattern,
+			matcher: g,
+		})
 	}
 
 	return compiledProxyURLs, nil
@@ -115,13 +118,9 @@ func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
 	compiledProxyURLs := c.compiledProxyURLs
 	c.proxyURLMu.Unlock()
 
-	for _, g := range compiledProxyURLs {
-		if g.Match(proxyURL) {
-			return true, nil
-		}
-	}
+	_, allowed := matchProxyURLAllowlist(proxyURL, compiledProxyURLs)
 
-	return false, nil
+	return allowed, nil
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -603,7 +602,21 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	logger.Log(logger.LevelInfo, nil, nil, "Dynamic clusters support: "+fmt.Sprint(config.EnableDynamicClusters))
 	logger.Log(logger.LevelInfo, nil, nil, "Helm support: "+fmt.Sprint(config.EnableHelm))
 	logger.Log(logger.LevelInfo, nil, nil, "Proxy URLs: "+fmt.Sprint(config.ProxyURLs))
-	proxyURLAllowlist := compileProxyURLAllowlist(config.ProxyURLs)
+	config.proxyURLMu.Lock()
+	proxyURLAllowlist := config.compiledProxyURLs
+	if proxyURLAllowlist == nil {
+		var err error
+
+		proxyURLAllowlist, err = compileProxyURLPatterns(config.ProxyURLs)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, nil,
+				"Invalid ProxyURLs configuration; disabling /externalproxy: "+err.Error())
+			proxyURLAllowlist = []proxyURLAllowlistEntry{}
+		}
+
+		config.compiledProxyURLs = proxyURLAllowlist
+	}
+	config.proxyURLMu.Unlock()
 	logger.Log(logger.LevelInfo, nil, nil, "TLS certificate path: "+config.TLSCertPath)
 	logger.Log(logger.LevelInfo, nil, nil, "TLS key path: "+config.TLSKeyPath)
 	logger.Log(logger.LevelInfo, nil, nil, "me Username Paths: "+config.MeUsernamePaths)
@@ -758,9 +771,10 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		if _, ok := matchProxyURLAllowlist(targetURL.String(), proxyURLAllowlist); !ok {
+			denyErr := errors.New("no allowed proxy url match, request denied")
 			logger.Log(logger.LevelError, map[string]string{"proxyURL": targetURL.Redacted()},
-				err, "no allowed proxy url match, request denied")
-			http.Error(w, "no allowed proxy url match, request denied ", http.StatusBadRequest)
+				denyErr, "no allowed proxy url match, request denied")
+			http.Error(w, "no allowed proxy url match, request denied", http.StatusBadRequest)
 
 			return
 		}

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -154,6 +154,9 @@ var externalProxyTimeout = 30 * time.Second
 //nolint:gochecknoglobals // shared client preserves connection pooling for external proxy requests
 var externalProxyHTTPClient = &http.Client{
 	Transport: newExternalProxyTransport(),
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
 }
 
 const kubeConfigSource = "kubeconfig" // source for kubeconfig contexts
@@ -1384,6 +1387,7 @@ func shouldFilterExternalProxyRequestHeader(headerName string) bool {
 	if hLower == "authorization" ||
 		hLower == "cookie" ||
 		hLower == "accept-encoding" ||
+		hLower == "proxy-authorization" ||
 		strings.HasPrefix(hLower, "x-headlamp-") ||
 		strings.HasPrefix(hLower, "x-headlamp_") {
 		return true

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3742,7 +3742,9 @@ func TestExternalProxyRedirectErrorIncludesTargetURL(t *testing.T) {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, redirectTarget, nil)
 	require.NoError(t, err)
 
-	proxyURLAllowlist := compileProxyURLAllowlist([]string{"https://allowed.example.com/*"})
+	proxyURLAllowlist, err := compileProxyURLPatterns([]string{"https://allowed.example.com/*"})
+	require.NoError(t, err)
+
 	req = req.WithContext(context.WithValue(req.Context(), proxyURLListContextKey{}, proxyURLAllowlist))
 
 	err = externalProxyHTTPClient.CheckRedirect(req, []*http.Request{{}})

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3629,6 +3629,17 @@ func TestExternalProxyHeaderFiltering(t *testing.T) {
 	// Test an underscore-style X-HEADLAMP_* variant defensively as well.
 	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", "sensitive-underscore-token")
 
+	// Set transport/protocol headers that should not be forwarded.
+	req.Header.Set("Accept-Encoding", "br, zstd")
+	req.Header.Set("Connection", "Upgrade, X-Connection-Only")
+	req.Header.Set("Keep-Alive", "timeout=5")
+	req.Header.Set("Proxy-Connection", "keep-alive")
+	req.Header.Set("TE", "trailers")
+	req.Header.Set("Trailer", "Expires")
+	req.Header.Set("Transfer-Encoding", "chunked")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("X-Connection-Only", "drop-me")
+
 	// Set a non-sensitive header that should be preserved
 	req.Header.Set("X-Custom-Preserve", "preserve-me")
 
@@ -3644,4 +3655,15 @@ func TestExternalProxyHeaderFiltering(t *testing.T) {
 	assertHeadersEmpty(t, receivedHeaders, "X-HEADLAMP_BACKEND-TOKEN")
 	assertHeaderPrefixAbsent(t, receivedHeaders, "X-HEADLAMP_")
 	assertHeadersEmpty(t, receivedHeaders, "proxy-to", "Forward-to")
+	assertHeadersEmpty(t, receivedHeaders,
+		"Accept-Encoding",
+		"Connection",
+		"Keep-Alive",
+		"Proxy-Connection",
+		"TE",
+		"Trailer",
+		"Transfer-Encoding",
+		"Upgrade",
+		"X-Connection-Only",
+	)
 }

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3719,6 +3719,38 @@ func TestExternalProxyDoesNotFollowRedirects(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestExternalProxyInvalidProxyURLGlobPanics(t *testing.T) {
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	require.Panics(t, func() {
+		createHeadlampHandler(context.Background(), &HeadlampConfig{
+			HeadlampConfig: &headlampconfig.HeadlampConfig{
+				HeadlampCFG: &headlampconfig.HeadlampCFG{
+					UseInCluster:    false,
+					ProxyURLs:       []string{"["},
+					KubeConfigStore: kubeConfigStore,
+				},
+				Cache: cache,
+			},
+		})
+	})
+}
+
+func TestExternalProxyRedirectErrorIncludesTargetURL(t *testing.T) {
+	redirectTarget := "https://redirect.example.com/disallowed"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, redirectTarget, nil)
+	require.NoError(t, err)
+
+	proxyURLAllowlist := compileProxyURLAllowlist([]string{"https://allowed.example.com/*"})
+	req = req.WithContext(context.WithValue(req.Context(), proxyURLListContextKey{}, proxyURLAllowlist))
+
+	err = externalProxyHTTPClient.CheckRedirect(req, []*http.Request{{}})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), redirectTarget)
+}
+
 func TestExternalProxyFollowsAllowedRedirects(t *testing.T) {
 	var mu sync.Mutex
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3711,9 +3711,65 @@ func TestExternalProxyDoesNotFollowRedirects(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Body.String(), "redirect target not in allowlist")
 
 	mu.Lock()
 	assert.False(t, disallowedTargetHit, "external proxy should not follow redirect to a disallowed target")
+	mu.Unlock()
+}
+
+func TestExternalProxyFollowsAllowedRedirects(t *testing.T) {
+	var mu sync.Mutex
+
+	allowedTargetHit := false
+
+	allowedTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		allowedTargetHit = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer allowedTarget.Close()
+
+	proxyTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, allowedTarget.URL, http.StatusFound)
+	}))
+	defer proxyTarget.Close()
+
+	proxyURL, err := url.Parse(proxyTarget.URL)
+	require.NoError(t, err)
+
+	allowedURL, err := url.Parse(allowedTarget.URL)
+	require.NoError(t, err)
+
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{proxyURL.String(), allowedURL.String()},
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("proxy-to", proxyURL.String())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "OK", rr.Body.String())
+
+	mu.Lock()
+	assert.True(t, allowedTargetHit, "external proxy should follow redirect to an allowed target")
 	mu.Unlock()
 }

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3719,11 +3719,11 @@ func TestExternalProxyDoesNotFollowRedirects(t *testing.T) {
 	mu.Unlock()
 }
 
-func TestExternalProxyInvalidProxyURLGlobPanics(t *testing.T) {
+func TestExternalProxyInvalidProxyURLGlobDoesNotPanic(t *testing.T) {
 	cache := cache.New[interface{}]()
 	kubeConfigStore := kubeconfig.NewContextStore()
 
-	require.Panics(t, func() {
+	require.NotPanics(t, func() {
 		createHeadlampHandler(context.Background(), &HeadlampConfig{
 			HeadlampConfig: &headlampconfig.HeadlampConfig{
 				HeadlampCFG: &headlampconfig.HeadlampCFG{

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -788,7 +788,7 @@ func TestExternalProxyTimeout(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "context deadline exceeded")
+	assert.Contains(t, rr.Body.String(), "external proxy request failed")
 }
 
 func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
@@ -3712,7 +3712,7 @@ func TestExternalProxyDoesNotFollowRedirects(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "redirect target not in allowlist")
+	assert.Contains(t, rr.Body.String(), "external proxy request failed")
 
 	mu.Lock()
 	assert.False(t, disallowedTargetHit, "external proxy should not follow redirect to a disallowed target")

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3623,6 +3623,7 @@ func TestExternalProxyHeaderFiltering(t *testing.T) {
 	// Set sensitive headers that should be filtered
 	req.Header.Set("Authorization", "Bearer sensitive-token")
 	req.Header.Set("Cookie", "session=sensitive-cookie")
+	req.Header.Set("Proxy-Authorization", "Basic sensitive-proxy-token")
 	// Test hyphenated X-Headlamp-* headers
 	req.Header.Set("X-Headlamp-Backend-Token", "sensitive-backend-token")
 	req.Header.Set("X-Headlamp-Custom", "sensitive-custom-header")
@@ -3650,7 +3651,7 @@ func TestExternalProxyHeaderFiltering(t *testing.T) {
 
 	receivedHeaders := receivedHeadersSnapshot()
 	assert.Equal(t, "preserve-me", receivedHeaders.Get("X-Custom-Preserve"), "Non-sensitive header should be preserved")
-	assertHeadersEmpty(t, receivedHeaders, "Authorization", "Cookie")
+	assertHeadersEmpty(t, receivedHeaders, "Authorization", "Cookie", "Proxy-Authorization")
 	assertHeaderPrefixAbsent(t, receivedHeaders, "X-HEADLAMP-")
 	assertHeadersEmpty(t, receivedHeaders, "X-HEADLAMP_BACKEND-TOKEN")
 	assertHeaderPrefixAbsent(t, receivedHeaders, "X-HEADLAMP_")
@@ -3666,4 +3667,53 @@ func TestExternalProxyHeaderFiltering(t *testing.T) {
 		"Upgrade",
 		"X-Connection-Only",
 	)
+}
+
+func TestExternalProxyDoesNotFollowRedirects(t *testing.T) {
+	var mu sync.Mutex
+
+	disallowedTargetHit := false
+
+	disallowedTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		disallowedTargetHit = true
+		mu.Unlock()
+	}))
+	defer disallowedTarget.Close()
+
+	proxyTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, disallowedTarget.URL, http.StatusFound)
+	}))
+	defer proxyTarget.Close()
+
+	proxyURL, err := url.Parse(proxyTarget.URL)
+	require.NoError(t, err)
+
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{proxyURL.String()},
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("proxy-to", proxyURL.String())
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+
+	mu.Lock()
+	assert.False(t, disallowedTargetHit, "external proxy should not follow redirect to a disallowed target")
+	mu.Unlock()
 }

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3541,3 +3541,107 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func assertHeadersEmpty(t *testing.T, headers http.Header, headerNames ...string) {
+	t.Helper()
+
+	for _, headerName := range headerNames {
+		assert.Empty(t, headers.Get(headerName), "%s header should be filtered", headerName)
+	}
+}
+
+func assertHeaderPrefixAbsent(t *testing.T, headers http.Header, prefix string) {
+	t.Helper()
+
+	for h := range headers {
+		if strings.HasPrefix(strings.ToUpper(h), prefix) {
+			t.Errorf("Header %s should have been filtered", h)
+		}
+	}
+}
+
+func newExternalProxyHeaderFilteringHandler(
+	t *testing.T,
+) (http.Handler, *url.URL, *httptest.Server, func() http.Header) {
+	t.Helper()
+
+	var mu sync.Mutex
+
+	var receivedHeaders http.Header
+
+	proxyTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		receivedHeaders = r.Header.Clone()
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+
+	proxyURL, err := url.Parse(proxyTarget.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:    false,
+				ProxyURLs:       []string{proxyURL.String()},
+				KubeConfigStore: kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	}
+
+	receivedHeadersSnapshot := func() http.Header {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return receivedHeaders.Clone()
+	}
+
+	return createHeadlampHandler(context.Background(), c), proxyURL, proxyTarget, receivedHeadersSnapshot
+}
+
+func TestExternalProxyHeaderFiltering(t *testing.T) {
+	handler, proxyURL, proxyTarget, receivedHeadersSnapshot := newExternalProxyHeaderFilteringHandler(t)
+	defer proxyTarget.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the proxy-to header (internal routing header that should be filtered)
+	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("Forward-to", "/some/path")
+
+	// Set sensitive headers that should be filtered
+	req.Header.Set("Authorization", "Bearer sensitive-token")
+	req.Header.Set("Cookie", "session=sensitive-cookie")
+	// Test hyphenated X-Headlamp-* headers
+	req.Header.Set("X-Headlamp-Backend-Token", "sensitive-backend-token")
+	req.Header.Set("X-Headlamp-Custom", "sensitive-custom-header")
+	// Test an underscore-style X-HEADLAMP_* variant defensively as well.
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", "sensitive-underscore-token")
+
+	// Set a non-sensitive header that should be preserved
+	req.Header.Set("X-Custom-Preserve", "preserve-me")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	receivedHeaders := receivedHeadersSnapshot()
+	assert.Equal(t, "preserve-me", receivedHeaders.Get("X-Custom-Preserve"), "Non-sensitive header should be preserved")
+	assertHeadersEmpty(t, receivedHeaders, "Authorization", "Cookie")
+	assertHeaderPrefixAbsent(t, receivedHeaders, "X-HEADLAMP-")
+	assertHeadersEmpty(t, receivedHeaders, "X-HEADLAMP_BACKEND-TOKEN")
+	assertHeaderPrefixAbsent(t, receivedHeaders, "X-HEADLAMP_")
+	assertHeadersEmpty(t, receivedHeaders, "proxy-to", "Forward-to")
+}


### PR DESCRIPTION
### Description
Headlamp's external proxy previously forwarded all incoming headers from the user's browser directly to external services (like ArtifactHub) and mishandled HTTP redirects by dropping their `Location` headers. This posed a security risk (leaking sensitive credentials) and broke functionality for targets utilizing HTTP→HTTPS redirects.

I have fixed these issues by implementing a comprehensive header filtering mechanism and an allowlist-enforced redirect follower.

### Changes Made
**`backend/cmd/headlamp.go`**:
- **Comprehensive Header Filtering**: Updated the `/externalproxy` handler to explicitly sanitize incoming headers before forwarding the request. It now strictly removes:
  - **Security credentials**: `Authorization`, `Proxy-Authorization`, and `Cookie`.
  - **Internal headers**: Any header starting with `X-HEADLAMP-`, `proxy-to`, and `Forward-to`.
  - **Protocol hop-by-hop & connection headers**: `Connection`, `Upgrade`, `Transfer-Encoding`, `Keep-Alive`, `Proxy-Connection`, `TE`, `Trailer`, `Accept-Encoding`, as well as any dynamic header explicitly listed in the incoming `Connection` header.
- **Secure Redirects**: Updated the shared HTTP client to securely follow `3xx` redirects **only** if the new redirect target matches the configured `ProxyURLs` allowlist. Un-followable `3xx` responses are explicitly rejected (returning a 502 Bad Gateway) to prevent returning broken redirects to the frontend.

**`backend/cmd/headlamp_test.go`**:
- Added `TestExternalProxyHeaderFiltering` to confirm that sensitive and hop-by-hop headers are removed while normal headers are successfully passed through.
- Updated `TestExternalProxyDoesNotFollowRedirects` to verify that disallowed redirects are explicitly blocked.
- Added `TestExternalProxyFollowsAllowedRedirects` to ensure valid allowlist redirects are transparently followed.

### How to Test
Run the following commands to verify the comprehensive header filtering and the new redirect handling logic:

```bash
cd backend
go test -v ./cmd -run TestExternalProxyHeaderFiltering
go test -v ./cmd -run TestExternalProxyDoesNotFollowRedirects
go test -v ./cmd -run TestExternalProxyFollowsAllowedRedirects
