### PR TITLE
fix(ClusterStatus): call registerClusterStatus callbacks as functions so null-check works

### DIFF
--- a/frontend/src/components/App/Home/ClusterStatus.test.tsx
+++ b/frontend/src/components/App/Home/ClusterStatus.test.tsx
@@ -103,6 +103,10 @@ describe('ClusterStatus — registerClusterStatus callback loop', () => {
   });
 
   it('skips a throwing callback and falls through to the next one', () => {
+    // The component logs the caught error via console.error; silence it here so the
+    // expected failure mode doesn't spam test output, and assert it was still logged.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
     const throwingCallback: ClusterStatusComponent = () => {
       throw new Error('hooks called outside component');
     };
@@ -118,6 +122,12 @@ describe('ClusterStatus — registerClusterStatus callback loop', () => {
     );
 
     expect(screen.getByTestId('recovery-status')).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[ClusterStatus] A registerClusterStatus callback threw.'),
+      expect.any(Error)
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('skips a callback that returns undefined and falls through to the next one', () => {

--- a/frontend/src/components/App/Home/ClusterStatus.test.tsx
+++ b/frontend/src/components/App/Home/ClusterStatus.test.tsx
@@ -64,6 +64,10 @@ function makeStore(clusterStatuses: ClusterStatusComponent[]) {
 
 const mockCluster = { name: 'test-cluster', server: 'https://k8s.example.com' } as any;
 
+// isConnected=true and error=null bypass the "Not connected" / "Connecting…" states
+// so the callback loop and the default active-status fallback are exercised directly.
+const connectedProps = { isConnected: true, onConnect: vi.fn(), error: null };
+
 describe('ClusterStatus — registerClusterStatus callback loop', () => {
   it('renders the first non-null callback result and skips null-returning callbacks', () => {
     const firstReturnsNull: ClusterStatusComponent = () => null;
@@ -73,26 +77,26 @@ describe('ClusterStatus — registerClusterStatus callback loop', () => {
 
     render(
       <Provider store={makeStore([firstReturnsNull, secondReturnsChip])}>
-        <ClusterStatus cluster={mockCluster} error={undefined} />
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
       </Provider>
     );
 
     expect(screen.getByTestId('custom-status')).toBeInTheDocument();
   });
 
-  it('falls through to the default status dots when all callbacks return null', () => {
+  it('falls through to the default status when all callbacks return null', () => {
     const alwaysNull: ClusterStatusComponent = () => null;
 
     render(
       <Provider store={makeStore([alwaysNull])}>
-        <ClusterStatus cluster={mockCluster} error={undefined} />
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
       </Provider>
     );
 
     // No custom chip rendered
     expect(screen.queryByTestId('custom-status')).not.toBeInTheDocument();
-    // Default unknown-state indicator is rendered (error === undefined → stateUnknown → '⋯')
-    expect(screen.getByText('⋯')).toBeInTheDocument();
+    // Default active-state label is rendered (isConnected + error === null → "Active")
+    expect(screen.getByText('translation|Active')).toBeInTheDocument();
   });
 
   it('skips a throwing callback and falls through to the next one', () => {
@@ -106,7 +110,7 @@ describe('ClusterStatus — registerClusterStatus callback loop', () => {
     // Should not throw; the error is caught and the loop continues
     render(
       <Provider store={makeStore([throwingCallback, recoveryCallback])}>
-        <ClusterStatus cluster={mockCluster} error={undefined} />
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
       </Provider>
     );
 
@@ -121,7 +125,7 @@ describe('ClusterStatus — registerClusterStatus callback loop', () => {
 
     render(
       <Provider store={makeStore([returnsUndefined, recoveryCallback])}>
-        <ClusterStatus cluster={mockCluster} error={undefined} />
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
       </Provider>
     );
 
@@ -134,7 +138,7 @@ describe('ClusterStatus — registerClusterStatus callback loop', () => {
 
     render(
       <Provider store={makeStore([firstReturnsChip, secondSpy])}>
-        <ClusterStatus cluster={mockCluster} error={undefined} />
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
       </Provider>
     );
 

--- a/frontend/src/components/App/Home/ClusterStatus.test.tsx
+++ b/frontend/src/components/App/Home/ClusterStatus.test.tsx
@@ -59,6 +59,9 @@ function makeStore(clusterStatuses: ClusterStatusComponent[]) {
         clusterStatuses,
       },
     },
+    // clusterStatuses holds functions, which aren't serializable; matches the app's
+    // own store config (redux/stores/store.tsx), which disables this check too.
+    middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
   });
 }
 

--- a/frontend/src/components/App/Home/ClusterStatus.test.tsx
+++ b/frontend/src/components/App/Home/ClusterStatus.test.tsx
@@ -113,11 +113,24 @@ describe('ClusterStatus — registerClusterStatus callback loop', () => {
     expect(screen.getByTestId('recovery-status')).toBeInTheDocument();
   });
 
+  it('skips a callback that returns undefined and falls through to the next one', () => {
+    const returnsUndefined: ClusterStatusComponent = () => undefined as any;
+    const recoveryCallback: ClusterStatusComponent = () => (
+      <span data-testid="recovery-status">Recovery</span>
+    );
+
+    render(
+      <Provider store={makeStore([returnsUndefined, recoveryCallback])}>
+        <ClusterStatus cluster={mockCluster} error={undefined} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('recovery-status')).toBeInTheDocument();
+  });
+
   it('uses only the first non-null callback; subsequent ones never run', () => {
     const secondSpy = vi.fn(() => <span data-testid="second">Second</span>);
-    const firstReturnsChip: ClusterStatusComponent = () => (
-      <span data-testid="first">First</span>
-    );
+    const firstReturnsChip: ClusterStatusComponent = () => <span data-testid="first">First</span>;
 
     render(
       <Provider store={makeStore([firstReturnsChip, secondSpy])}>

--- a/frontend/src/components/App/Home/ClusterStatus.test.tsx
+++ b/frontend/src/components/App/Home/ClusterStatus.test.tsx
@@ -19,7 +19,7 @@ import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { describe, expect, it, vi } from 'vitest';
 import clusterProviderReducer, {
-  ClusterStatusComponent,
+  type ClusterStatusComponent,
 } from '../../../redux/clusterProviderSlice';
 import { ClusterStatus } from './ClusterTable';
 

--- a/frontend/src/components/App/Home/ClusterStatus.test.tsx
+++ b/frontend/src/components/App/Home/ClusterStatus.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { describe, expect, it, vi } from 'vitest';
+import clusterProviderReducer, {
+  ClusterStatusComponent,
+} from '../../../redux/clusterProviderSlice';
+import { ClusterStatus } from './ClusterTable';
+
+vi.mock('react-i18next', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { changeLanguage: vi.fn() },
+    }),
+  };
+});
+
+vi.mock('@mui/material/styles', async importOriginal => {
+  const actual = await importOriginal<typeof import('@mui/material/styles')>();
+  return {
+    ...actual,
+    useTheme: () => ({
+      palette: {
+        home: { status: { error: '#f00', success: '#0f0', unknown: '#999' } },
+        common: { primary: '#00f' },
+      },
+      spacing: (n: number) => `${n * 8}px`,
+    }),
+  };
+});
+
+function makeStore(clusterStatuses: ClusterStatusComponent[]) {
+  return configureStore({
+    reducer: { clusterProvider: clusterProviderReducer },
+    preloadedState: {
+      clusterProvider: {
+        dialogs: [],
+        menuItems: [],
+        clusterProviders: [],
+        clusterStatuses,
+      },
+    },
+  });
+}
+
+const mockCluster = { name: 'test-cluster', server: 'https://k8s.example.com' } as any;
+
+describe('ClusterStatus — registerClusterStatus callback loop', () => {
+  it('renders the first non-null callback result and skips null-returning callbacks', () => {
+    const firstReturnsNull: ClusterStatusComponent = () => null;
+    const secondReturnsChip: ClusterStatusComponent = () => (
+      <span data-testid="custom-status">SSO Active</span>
+    );
+
+    render(
+      <Provider store={makeStore([firstReturnsNull, secondReturnsChip])}>
+        <ClusterStatus cluster={mockCluster} error={undefined} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('custom-status')).toBeInTheDocument();
+  });
+
+  it('falls through to the default status dots when all callbacks return null', () => {
+    const alwaysNull: ClusterStatusComponent = () => null;
+
+    render(
+      <Provider store={makeStore([alwaysNull])}>
+        <ClusterStatus cluster={mockCluster} error={undefined} />
+      </Provider>
+    );
+
+    // No custom chip rendered
+    expect(screen.queryByTestId('custom-status')).not.toBeInTheDocument();
+    // Default unknown-state indicator is rendered (error === undefined → stateUnknown → '⋯')
+    expect(screen.getByText('⋯')).toBeInTheDocument();
+  });
+
+  it('skips a throwing callback and falls through to the next one', () => {
+    const throwingCallback: ClusterStatusComponent = () => {
+      throw new Error('hooks called outside component');
+    };
+    const recoveryCallback: ClusterStatusComponent = () => (
+      <span data-testid="recovery-status">Recovery</span>
+    );
+
+    // Should not throw; the error is caught and the loop continues
+    render(
+      <Provider store={makeStore([throwingCallback, recoveryCallback])}>
+        <ClusterStatus cluster={mockCluster} error={undefined} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('recovery-status')).toBeInTheDocument();
+  });
+
+  it('uses only the first non-null callback; subsequent ones never run', () => {
+    const secondSpy = vi.fn(() => <span data-testid="second">Second</span>);
+    const firstReturnsChip: ClusterStatusComponent = () => (
+      <span data-testid="first">First</span>
+    );
+
+    render(
+      <Provider store={makeStore([firstReturnsChip, secondSpy])}>
+        <ClusterStatus cluster={mockCluster} error={undefined} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('first')).toBeInTheDocument();
+    expect(screen.queryByTestId('second')).not.toBeInTheDocument();
+    expect(secondSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/App/Home/ClusterStatus.test.tsx
+++ b/frontend/src/components/App/Home/ClusterStatus.test.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { describe, expect, it, vi } from 'vitest';
+import clusterProviderReducer, {
+  type ClusterStatusComponent,
+} from '../../../redux/clusterProviderSlice';
+import { ClusterStatus } from './ClusterTable';
+
+vi.mock('react-i18next', async importOriginal => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { changeLanguage: vi.fn() },
+    }),
+  };
+});
+
+vi.mock('@mui/material/styles', async importOriginal => {
+  const actual = await importOriginal<typeof import('@mui/material/styles')>();
+  return {
+    ...actual,
+    useTheme: () => ({
+      palette: {
+        home: { status: { error: '#f00', success: '#0f0', unknown: '#999' } },
+        common: { primary: '#00f' },
+      },
+      spacing: (n: number) => `${n * 8}px`,
+    }),
+  };
+});
+
+function makeStore(clusterStatuses: ClusterStatusComponent[]) {
+  return configureStore({
+    reducer: { clusterProvider: clusterProviderReducer },
+    preloadedState: {
+      clusterProvider: {
+        dialogs: [],
+        menuItems: [],
+        clusterProviders: [],
+        clusterStatuses,
+        clusterEmptyState: null,
+      },
+    },
+    // clusterStatuses holds functions, which aren't serializable; matches the app's
+    // own store config (redux/stores/store.tsx), which disables this check too.
+    middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+  });
+}
+
+const mockCluster = { name: 'test-cluster', server: 'https://k8s.example.com' } as any;
+
+// isConnected=true and error=null bypass the "Not connected" / "Connecting…" states
+// so the callback loop and the default active-status fallback are exercised directly.
+const connectedProps = { isConnected: true, onConnect: vi.fn(), error: null };
+
+describe('ClusterStatus — registerClusterStatus callback loop', () => {
+  it('renders the first non-null callback result and skips null-returning callbacks', () => {
+    const firstReturnsNull: ClusterStatusComponent = () => null;
+    const secondReturnsChip: ClusterStatusComponent = () => (
+      <span data-testid="custom-status">SSO Active</span>
+    );
+
+    render(
+      <Provider store={makeStore([firstReturnsNull, secondReturnsChip])}>
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('custom-status')).toBeInTheDocument();
+  });
+
+  it('falls through to the default status when all callbacks return null', () => {
+    const alwaysNull: ClusterStatusComponent = () => null;
+
+    render(
+      <Provider store={makeStore([alwaysNull])}>
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
+      </Provider>
+    );
+
+    // No custom chip rendered
+    expect(screen.queryByTestId('custom-status')).not.toBeInTheDocument();
+    // Default active-state label is rendered (isConnected + error === null → "Active")
+    expect(screen.getByText('translation|Active')).toBeInTheDocument();
+  });
+
+  it('skips a throwing callback and falls through to the next one', () => {
+    // The component logs the caught error via console.error; silence it here so the
+    // expected failure mode doesn't spam test output, and assert it was still logged.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const throwingCallback: ClusterStatusComponent = () => {
+      throw new Error('callback failed');
+    };
+    const recoveryCallback: ClusterStatusComponent = () => (
+      <span data-testid="recovery-status">Recovery</span>
+    );
+
+    // Should not throw; the error is caught and the loop continues
+    render(
+      <Provider store={makeStore([throwingCallback, recoveryCallback])}>
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('recovery-status')).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[ClusterStatus] A registerClusterStatus callback threw.'),
+      expect.any(Error)
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('skips a callback that returns undefined and falls through to the next one', () => {
+    const returnsUndefined: ClusterStatusComponent = () => undefined as any;
+    const recoveryCallback: ClusterStatusComponent = () => (
+      <span data-testid="recovery-status">Recovery</span>
+    );
+
+    render(
+      <Provider store={makeStore([returnsUndefined, recoveryCallback])}>
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('recovery-status')).toBeInTheDocument();
+  });
+
+  it('uses only the first non-null callback; subsequent ones never run', () => {
+    const secondSpy = vi.fn(() => <span data-testid="second">Second</span>);
+    const firstReturnsChip: ClusterStatusComponent = () => <span data-testid="first">First</span>;
+
+    render(
+      <Provider store={makeStore([firstReturnsChip, secondSpy])}>
+        <ClusterStatus cluster={mockCluster} {...connectedProps} />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('first')).toBeInTheDocument();
+    expect(screen.queryByTestId('second')).not.toBeInTheDocument();
+    expect(secondSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -83,11 +83,29 @@ export function ClusterStatus({
   const customStatuses = useTypedSelector(state => state.clusterProvider.clusterStatuses);
   const renderedCustomStatus = useMemo(() => {
     for (const Status of customStatuses) {
-      // Call as a function (not JSX) so the null-check below is meaningful.
-      // Using <Status ... /> creates a React element object which is always
-      // non-null, causing the loop to exit after the first registered callback
-      // regardless of what that callback renders. Callbacks must not use hooks.
-      const renderedStatus = Status({ cluster, error });
+      // Call as a plain function (not JSX) so the null-check below is meaningful.
+      // Using <Status ... /> would always return a non-null React element, causing
+      // the loop to exit after the first callback regardless of what it renders.
+      //
+      // Constraint: callbacks must not call React hooks. Stateful logic should live
+      // in an inner component that the callback returns, not in the callback itself.
+      // See: https://react.dev/reference/rules/rules-of-hooks
+      //
+      // A try/catch guards against callbacks that violate this constraint so that a
+      // misbehaving plugin does not crash the entire ClusterTable.
+      let renderedStatus: React.ReactElement | null;
+      try {
+        renderedStatus = Status({ cluster, error });
+      } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.error(
+            '[ClusterStatus] A registerClusterStatus callback threw. ' +
+              'Callbacks must not use React hooks — move hook calls into an inner component.',
+            e
+          );
+        }
+        continue;
+      }
       if (renderedStatus !== null) {
         return renderedStatus;
       }

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -93,7 +93,7 @@ export function ClusterStatus({
       //
       // A try/catch guards against callbacks that violate this constraint so that a
       // misbehaving plugin does not crash the entire ClusterTable.
-      let renderedStatus: React.ReactElement | null;
+      let renderedStatus: React.ReactElement | null | undefined;
       try {
         renderedStatus = Status({ cluster, error });
       } catch (e) {
@@ -106,7 +106,10 @@ export function ClusterStatus({
         }
         continue;
       }
-      if (renderedStatus !== null) {
+      // A plugin callback could mistakenly return undefined instead of null.
+      // Returning undefined from ClusterStatus itself is invalid for React, so
+      // treat it the same as null here.
+      if (renderedStatus !== null && renderedStatus !== undefined) {
         return renderedStatus;
       }
     }

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -65,7 +65,7 @@ import { getCustomClusterNames } from './customClusterNames';
  * @param {Object} props - The component props.
  * @param {ApiError|null} [props.error] - The error object if there is an error with the cluster.
  */
-function ClusterStatus({
+export function ClusterStatus({
   error,
   cluster,
   isConnected,
@@ -83,7 +83,11 @@ function ClusterStatus({
   const customStatuses = useTypedSelector(state => state.clusterProvider.clusterStatuses);
   const renderedCustomStatus = useMemo(() => {
     for (const Status of customStatuses) {
-      const renderedStatus = <Status cluster={cluster} error={error} />;
+      // Call as a function (not JSX) so the null-check below is meaningful.
+      // Using <Status ... /> creates a React element object which is always
+      // non-null, causing the loop to exit after the first registered callback
+      // regardless of what that callback renders. Callbacks must not use hooks.
+      const renderedStatus = Status({ cluster, error });
       if (renderedStatus !== null) {
         return renderedStatus;
       }

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -66,7 +66,7 @@ import RegisteredClusterEmptyState from './RegisteredClusterEmptyState';
  * @param {Object} props - The component props.
  * @param {ApiError|null} [props.error] - The error object if there is an error with the cluster.
  */
-function ClusterStatus({
+export function ClusterStatus({
   error,
   cluster,
   isConnected,
@@ -84,8 +84,34 @@ function ClusterStatus({
   const customStatuses = useTypedSelector(state => state.clusterProvider.clusterStatuses);
   const renderedCustomStatus = useMemo(() => {
     for (const Status of customStatuses) {
-      const renderedStatus = <Status cluster={cluster} error={error} />;
-      if (renderedStatus !== null) {
+      // Call as a plain function (not JSX) so the null-check below is meaningful.
+      // Using <Status ... /> would always return a non-null React element, causing
+      // the loop to exit after the first callback regardless of what it renders.
+      //
+      // Constraint: callbacks must not call React hooks. Stateful logic should live
+      // in an inner component that the callback returns, not in the callback itself.
+      // See: https://react.dev/reference/rules/rules-of-hooks
+      //
+      // A try/catch guards against callbacks that throw synchronously — whether from
+      // a hook-rules violation or any other runtime error — so a misbehaving plugin
+      // does not crash the entire ClusterTable.
+      let renderedStatus: React.ReactElement | null | undefined;
+      try {
+        renderedStatus = Status({ cluster, error });
+      } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.error(
+            '[ClusterStatus] A registerClusterStatus callback threw. ' +
+              'A common cause is calling React hooks in the callback — move hook calls into an inner component instead.',
+            e
+          );
+        }
+        continue;
+      }
+      // A plugin callback could mistakenly return undefined instead of null.
+      // Returning undefined from ClusterStatus itself is invalid for React, so
+      // treat it the same as null here.
+      if (renderedStatus !== null && renderedStatus !== undefined) {
         return renderedStatus;
       }
     }

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -948,22 +948,36 @@ export function registerClusterProviderMenuItem(item: MenuItemComponent) {
 }
 
 /**
- * Register a new cluster status component.
+ * Register a cluster status callback.
  *
- * @param item - The component to add to the cluster status.
- * Item is a function/component and its props are cluster and error.
+ * @param item - A render function that receives `{ cluster, error }` and returns
+ * a React element to display as the cluster's status, or `null` if this callback
+ * does not handle the given cluster.
+ *
+ * **Important:** Callbacks are invoked as plain functions (not as JSX components),
+ * so they **must not call React hooks**. If you need hooks or state, return an
+ * inner component from the callback:
  *
  * @example
  * ```tsx
  * import { registerClusterStatus } from '@kinvolk/headlamp-plugin/lib';
- * import { ClusterStatus } from './ClusterStatus';
+ *
+ * // ✅ Correct — outer callback is hook-free; stateful logic lives in the inner component.
  * registerClusterStatus(({ cluster, error }) => {
- *   if (!isElectron() || !isMinikube(cluster)) {
+ *   if (!isMyCluster(cluster)) {
  *     return null;
  *   }
- *   return <ClusterStatus cluster={cluster} error={error} />;
+ *   return <MyStatusInner cluster={cluster} error={error} />;
+ * });
+ *
+ * // ❌ Wrong — hooks in the outer callback can cause runtime Hook failures.
+ * registerClusterStatus(({ cluster, error }) => {
+ *   const [state, setState] = useState(null); // breaks rules of hooks
+ *   ...
  * });
  * ```
+ *
+ * @see https://react.dev/reference/rules/rules-of-hooks
  */
 export function registerClusterStatus(item: ClusterStatusComponent) {
   store.dispatch(addClusterStatus(item));

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -924,22 +924,36 @@ export function registerClusterProviderMenuItem(item: MenuItemComponent) {
 }
 
 /**
- * Register a new cluster status component.
+ * Register a cluster status callback.
  *
- * @param item - The component to add to the cluster status.
- * Item is a function/component and its props are cluster and error.
+ * @param item - A render function that receives `{ cluster, error }` and returns
+ * a React element to display as the cluster's status, or `null` if this callback
+ * does not handle the given cluster.
+ *
+ * **Important:** Callbacks are invoked as plain functions (not as JSX components),
+ * so they **must not call React hooks**. If you need hooks or state, return an
+ * inner component from the callback:
  *
  * @example
  * ```tsx
  * import { registerClusterStatus } from '@kinvolk/headlamp-plugin/lib';
- * import { ClusterStatus } from './ClusterStatus';
+ *
+ * // ✅ Correct — outer callback is hook-free; stateful logic lives in the inner component.
  * registerClusterStatus(({ cluster, error }) => {
- *   if (!isElectron() || !isMinikube(cluster)) {
+ *   if (!isMyCluster(cluster)) {
  *     return null;
  *   }
- *   return <ClusterStatus cluster={cluster} error={error} />;
+ *   return <MyStatusInner cluster={cluster} error={error} />;
+ * });
+ *
+ * // ❌ Wrong — hooks in the outer callback will throw at runtime.
+ * registerClusterStatus(({ cluster, error }) => {
+ *   const [state, setState] = useState(null); // breaks rules of hooks
+ *   ...
  * });
  * ```
+ *
+ * @see https://react.dev/reference/rules/rules-of-hooks
  */
 export function registerClusterStatus(item: ClusterStatusComponent) {
   store.dispatch(addClusterStatus(item));


### PR DESCRIPTION
## Summary

The `ClusterStatus` component in `ClusterTable.tsx` uses `<Status cluster={cluster} error={error} />` (JSX) to call each registered callback, then checks `if (renderedStatus !== null)`. A React JSX expression always returns a non-null React element object — so the null-check **always passes** and the loop exits after the very first registered callback. Subsequent callbacks registered via `registerClusterStatus()` never run.

**Before (buggy):**
```tsx
const renderedStatus = <Status cluster={cluster} error={error} />;
if (renderedStatus !== null) {   // always true — React element is never null
  return renderedStatus;
}
```

**After (fixed):**
```tsx
const renderedStatus = Status({ cluster, error });  // call as function → returns null or JSX
if (renderedStatus !== null) {
  return renderedStatus;
}
```

## Concrete example

The minikube plugin registers a `ClusterStatus` callback that returns `null` for every cluster that isn't a minikube cluster. With the bug, the loop exits after minikube's callback for every row, so every non-minikube cluster shows nothing in the Status column — and any subsequently-registered plugin's callback is completely ignored.

## Constraint on callbacks

Since callbacks are now called as plain functions inside `useMemo`, they **must not use React hooks**. Stateful logic should live in an inner component that the outer callback returns:

```tsx
// ✅ correct — outer callback is hook-free
registerClusterStatus(({ cluster, error }) => {
  if (!isMyCluster(cluster)) return null;
  return <MyStatusInner cluster={cluster} error={error} />;
});

// ❌ wrong — hooks in the outer callback will break
registerClusterStatus(({ cluster, error }) => {
  const [state, setState] = useState(null); // will throw
  ...
});
```

The existing type signature `ClusterStatusComponent = (props: ClusterStatusProps) => React.ReactElement | null` already documents this as a render function, not a component. This constraint is now accurately reflected in a code comment.

## Test plan

- [ ] Verify that with multiple `registerClusterStatus` callbacks registered, the first non-null return is shown (not always the first registered callback's result)
- [ ] Verify the minikube plugin still shows its chip for minikube clusters
- [ ] Verify non-minikube clusters fall through to the default status dots when no callback matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster status handling when custom status callbacks return no result or encounter errors.
  * The interface now continues checking available callbacks and falls back to the default active status when needed.
  * Invalid callbacks no longer prevent cluster status information from displaying.

* **Documentation**
  * Clarified callback behavior and provided guidance for safely using hooks within custom status renderers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->