### PR TITLE
backend: Require kubeconfigs in parseKubeConfig

### DIFF
--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -170,6 +170,11 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 	}
 
 	kubeconfigs := kubeconfigReq.Kubeconfigs
+	if len(kubeconfigs) == 0 {
+		http.Error(w, "kubeconfigs is required", http.StatusBadRequest)
+
+		return
+	}
 
 	contexts, setupErrors := parseClusterFromKubeConfig(kubeconfigs)
 	if len(setupErrors) > 0 {

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -150,6 +150,62 @@ func TestParseKubeConfigInvalidJSONReturnsBadRequest(t *testing.T) {
 	assert.NotContains(t, resp.Body.String(), "clusters")
 }
 
+func TestParseKubeConfigRequiresKubeconfigs(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]interface{}
+	}{
+		{
+			name: "missing kubeconfigs",
+			body: map[string]interface{}{},
+		},
+		{
+			name: "singular kubeconfig",
+			body: map[string]interface{}{
+				"kubeconfig": "bad-or-empty-value",
+			},
+		},
+		{
+			name: "empty kubeconfigs",
+			body: map[string]interface{}{
+				"kubeconfigs": []string{},
+			},
+		},
+		{
+			name: "null kubeconfigs",
+			body: map[string]interface{}{
+				"kubeconfigs": nil,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := cache.New[interface{}]()
+			kubeConfigStore := kubeconfig.NewContextStore()
+			c := HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:          false,
+						KubeConfigPath:        "",
+						EnableDynamicClusters: true,
+						KubeConfigStore:       kubeConfigStore,
+					},
+					Cache: cache,
+				},
+			}
+			handler := createHeadlampHandler(context.Background(), &c)
+
+			resp, err := getResponseFromRestrictedEndpoint(handler, "POST", "/parseKubeConfig", tc.body)
+			require.NoError(t, err)
+
+			assert.Equal(t, http.StatusBadRequest, resp.Code)
+			assert.Equal(t, "kubeconfigs is required\n", resp.Body.String())
+			assert.NotContains(t, resp.Body.String(), "clusters")
+		})
+	}
+}
+
 //nolint:funlen
 func TestStatelessClusterApiRequest(t *testing.T) {
 	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")


### PR DESCRIPTION
  ## Summary

  This PR fixes backend validation for POST /parseKubeConfig. The endpoint now returns 400 Bad Request when the request body does not include at least one kubeconfigs entry.

  ## Related Issue

  Fixes #5658

  ## Changes

  - Added validation for missing, empty, or null kubeconfigs in parseKubeConfig.
  - Added regression tests for malformed payloads that previously returned success.
  - Kept existing behavior unchanged for valid kubeconfig requests and malformed JSON.

  ## Steps to Test

  1. Run cd backend && go test ./cmd.
  2. Run npm run backend:lint.
  3. Send a request without kubeconfigs:

     curl -i -X POST http://localhost:4466/parseKubeConfig \
       -H "Content-Type: application/json" \
       -d '{"kubeconfig":"bad-or-empty-value"}'

  4. Verify the endpoint returns 400 Bad Request with kubeconfigs is required.

  ## Screenshots (if applicable)

  Not applicable. This is a backend validation change.

  ## Notes for the Reviewer

  This is intentionally limited to validating the request body before kubeconfig parsing. It does not change the parsing behavior for valid kubeconfigs payloads.