### PR TITLE
frontend: optimize recent cluster lookup with Map-based lookup

### DIFF
--- a/frontend/src/components/App/Home/RecentClusters.tsx
+++ b/frontend/src/components/App/Home/RecentClusters.tsx
@@ -86,12 +86,17 @@ export default function RecentClusters(props: RecentClustersProps) {
 
   let recentClusters: Cluster[] = [];
 
-  // If we have more than the maximum number of recent clusters allowed, we show the most
-  // recent ones. Otherwise, just show the clusters in the order they are received.
+  const clustersByName = React.useMemo(() => {
+    if (clusters.length <= maxRecentClusters) {
+      return new Map<string, Cluster>();
+    }
+    return new Map<string, Cluster>(clusters.map(cluster => [cluster.name, cluster] as const));
+  }, [clusters]);
+
   if (clusters.length > maxRecentClusters) {
     // Get clusters matching the recent cluster names, if they exist still.
     recentClusters = recentClusterNames
-      .map(name => clusters.find(cluster => cluster.name === name))
+      .map(name => clustersByName.get(name))
       .filter(item => !!item) as Cluster[];
     // See whether we need to fill with new clusters (when the recent clusters were less than the
     // maximum/wanted).

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -191,12 +191,17 @@ function ClusterList(props: ClusterListProps) {
 
   let recentClusters: Cluster[] = [];
 
-  // If we have more than the maximum number of recent clusters allowed, we show the most
-  // recent ones. Otherwise, just show the clusters in the order they are received.
+  const clustersByName = React.useMemo(() => {
+    if (clusters.length <= maxRecentClusters) {
+      return new Map<string, Cluster>();
+    }
+    return new Map<string, Cluster>(clusters.map(cluster => [cluster.name, cluster] as const));
+  }, [clusters]);
+
   if (clusters.length > maxRecentClusters) {
     // Get clusters matching the recent cluster names, if they exist still.
     recentClusters = recentClusterNames
-      .map(name => clusters.find(cluster => cluster.name === name))
+      .map(name => clustersByName.get(name))
       .filter(item => !!item) as Cluster[];
     // See whether we need to fill with new clusters (when the recent clusters were less than the
     // maximum/wanted).


### PR DESCRIPTION
## What
Optimized the recent cluster lookup logic by replacing nested array iterations ($O(N \cdot M)$) with a Map-based lookup ($O(N + M)$).

## Why
In environments with a large number of clusters, the current nested `.find()` inside `.map()` can lead to performance degradation during re-renders. Using a `Map` and `React.useMemo` ensures the lookup table is built once per cluster list update and provides constant-time lookups.

## Changes
- Added `clustersByName` Map using `useMemo` in `Chooser.tsx` and `RecentClusters.tsx`.
- - Replaced `clusters.find()` with `clustersByName.get()`.
## Testing
Verified that recent clusters are still correctly identified and filtered.