### PR TITLE
frontend: ShowHideLabel: Fix react-hooks/exhaustive-deps — add maxChars to useMemo deps

### DIFF
--- a/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
+++ b/frontend/src/components/common/ShowHideLabel/ShowHideLabel.tsx
@@ -46,8 +46,7 @@ export default function ShowHideLabel(props: ShowHideLabelProps) {
     }
 
     return [children.substr(0, maxChars), children.length > maxChars];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [children, expanded]);
+  }, [children, expanded, maxChars]);
 
   if (!children) {
     return null;


### PR DESCRIPTION
## Summary
Add missing `maxChars` dependency to `useMemo` in `ShowHideLabel.tsx` 
and remove the eslint suppression comment.

Part of #5183