### PR TITLE
backend: Skip DaemonSet pods during drain

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2924,8 +2924,7 @@ func (c *HeadlampConfig) drainNodePods(
 			return
 		}
 
-		// ignore daemonsets
-		if pod.Labels["kubernetes.io/created-by"] == "daemonset-controller" {
+		if isDaemonSetPod(pod) {
 			continue
 		}
 
@@ -2950,6 +2949,27 @@ func (c *HeadlampConfig) drainNodePods(
 	} else {
 		_ = c.Cache.SetWithTTL(ctx, cacheKey, "success", cacheItemTTL)
 	}
+}
+
+// isDaemonSetPod reports whether pod should be treated as managed by a DaemonSet.
+// It supports both the legacy daemonset-controller label and modern owner references.
+func isDaemonSetPod(pod corev1.Pod) bool {
+	if pod.Labels["kubernetes.io/created-by"] == "daemonset-controller" {
+		return true
+	}
+
+	// Prefer the controller owner reference (matches kubectl drain behavior).
+	if controller := v1.GetControllerOf(&pod); controller != nil && controller.Kind == "DaemonSet" {
+		return true
+	}
+
+	for _, owner := range pod.OwnerReferences {
+		if owner.Kind == "DaemonSet" {
+			return true
+		}
+	}
+
+	return false
 }
 
 /*

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -59,6 +59,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -925,7 +926,14 @@ func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod-daemonset",
 			Namespace: "default",
-			Labels:    map[string]string{"kubernetes.io/created-by": "daemonset-controller"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "DaemonSet",
+					Name:       "node-agent",
+					Controller: ptr.To(true),
+				},
+			},
 		},
 		Spec: corev1.PodSpec{
 			NodeName: "test-node",
@@ -991,6 +999,7 @@ func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
 	assert.True(t, strings.HasPrefix(status, "error:"),
 		"expected error status, got: %s", status)
 	assert.Contains(t, status, "failed to delete")
+	assert.ElementsMatch(t, []string{"pod-ok", "pod-fail"}, deletedPodNames(fakeClient.Actions()))
 }
 
 func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
@@ -1052,6 +1061,28 @@ func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "success", status)
+
+	assert.ElementsMatch(t, []string{"pod-1"}, deletedPodNames(fakeClient.Actions()))
+}
+
+// deletedPodNames returns the pod names from delete actions recorded by the fake client.
+func deletedPodNames(actions []k8stesting.Action) []string {
+	deletedPods := []string{}
+
+	for _, action := range actions {
+		if action.GetVerb() != "delete" || action.GetResource().Resource != "pods" {
+			continue
+		}
+
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		if !ok {
+			continue
+		}
+
+		deletedPods = append(deletedPods, deleteAction.GetName())
+	}
+
+	return deletedPods
 }
 
 func TestHandleNodeDrainUsesRequestedClusterCookieForCustomNamedContext(t *testing.T) { //nolint:funlen


### PR DESCRIPTION
## Summary

This PR fixes backend node drain behavior so DaemonSet-owned pods are skipped even when they do not have the legacy `kubernetes.io/created-by=daemonset-controller` label.

## Related Issue

Fixes #5687

## Changes

- Added DaemonSet pod detection using pod owner references.
- Kept the existing legacy label check for compatibility.
- Updated drain-node tests to verify DaemonSet-owned pods are not deleted.

## Steps to Test

1. Run `cd backend && go test ./cmd -run 'TestDrainNodePodDeletionFailure|TestDrainNodeAllPodsDeletedSuccessfully'`.
2. Run `cd backend && go test ./cmd`.
3. Run `npm run backend:lint`.

## Screenshots (if applicable)

Not applicable. This is a backend node drain change.

## Notes for the Reviewer

The change is limited to the backend drain loop. It does not change how regular pods are deleted during drain; it only avoids deleting pods owned by DaemonSets.
