### PR TITLE
refactor: rename stopOrDelete parameter for better readability

### DIFF
--- a/frontend/src/components/common/Resource/PortForward.tsx
+++ b/frontend/src/components/common/Resource/PortForward.tsx
@@ -315,7 +315,7 @@ function PortForwardContent(props: PortForwardProps) {
       return;
     }
     setLoading(true);
-    stopOrDeletePortForward(cluster, portForward.id, true)
+    stopOrDeletePortForward(cluster, portForward.id, true /* justStop */)
       .then(() => {
         portForward.status = PORT_FORWARD_STOP_STATUS;
         setPortForward(portForward);
@@ -335,7 +335,7 @@ function PortForwardContent(props: PortForwardProps) {
       return;
     }
     setLoading(true);
-    stopOrDeletePortForward(cluster, id, false).finally(() => {
+    stopOrDeletePortForward(cluster, id, false /* justStop */).finally(() => {
       setLoading(false);
       const portforwardInStorage = localStorage.getItem(PORT_FORWARDS_STORAGE_KEY);
       const parsedPortForwards = JSON.parse(portforwardInStorage || '[]');

--- a/frontend/src/components/portforward/index.tsx
+++ b/frontend/src/components/portforward/index.tsx
@@ -199,7 +199,7 @@ export default function PortForwardingList() {
     if (option === PortForwardAction.Stop) {
       setPortForwardInActionSafely({ ...portforward, loading: true });
       // stop portforward
-      stopOrDeletePortForward(cluster, id, true).finally(() => {
+      stopOrDeletePortForward(cluster, id, true /* justStop */).finally(() => {
         setPortForwardInActionSafely(null);
         // Always refresh the backend-backed port-forward list so localStorage
         // stays in sync even if the component unmounts before the request settles.
@@ -209,7 +209,7 @@ export default function PortForwardingList() {
     if (option === PortForwardAction.Delete) {
       setPortForwardInActionSafely({ ...portforward, loading: true });
       // delete portforward
-      stopOrDeletePortForward(cluster, id, false).finally(() => {
+      stopOrDeletePortForward(cluster, id, false /* justStop */).finally(() => {
         setPortForwardInActionSafely(null);
 
         // remove portforward from storage too

--- a/frontend/src/lib/k8s/api/v1/portForward.ts
+++ b/frontend/src/lib/k8s/api/v1/portForward.ts
@@ -122,13 +122,12 @@ export async function startPortForward(
   });
 }
 
-// @todo: stopOrDelete true is confusing, rename this param to justStop?
 /**
  * Stops or deletes a portforward with the specified details.
  *
  * @param cluster - The cluster to portforward for.
  * @param id - The id to portforward for.
- * @param stopOrDelete - Whether to stop or delete the portforward. True for stop, false for delete.
+ * @param justStop - Whether to just stop the portforward (true) or delete it entirely (false).
  *
  * @returns The response from the API.
  * @throws {Error} if the request fails.
@@ -136,7 +135,7 @@ export async function startPortForward(
 export async function stopOrDeletePortForward(
   cluster: string,
   id: string,
-  stopOrDelete: boolean = true
+  justStop: boolean = true
 ): Promise<string> {
   const kubeconfig = await findKubeconfigByClusterName(cluster);
   const headers = new Headers(addBackstageAuthHeaders(JSON_HEADERS));
@@ -151,7 +150,7 @@ export async function stopOrDeletePortForward(
     headers: headers,
     body: JSON.stringify({
       id,
-      stopOrDelete,
+      stopOrDelete: justStop,
     }),
     cluster,
   }).then(async response => {


### PR DESCRIPTION
This PR improves readability in the port forwarding API by renaming the confusing stopOrDelete parameter to justStop.

Changes Made
Renamed stopOrDelete → justStop
Updated all related call sites and references
Kept existing functionality unchanged

Testing
Verified the project builds successfully
Confirmed port forwarding behavior works as expected

#5691 