### PR TITLE
frontend: NamespacesAutocomplete: Fix react-hooks/exhaustive-deps — add missing deps to useDefaultNamespaceFallback

### DIFF
--- a/frontend/src/components/common/NamespacesAutocomplete.tsx
+++ b/frontend/src/components/common/NamespacesAutocomplete.tsx
@@ -259,8 +259,8 @@ const useDefaultNamespaceFallback = (
         dispatch(setNamespaceFilter([defaultNamespaceFromKubeconfig]));
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespacesList, isNamespaceError, currentCluster]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- dispatch is stable (Redux guarantee); selectedNamespaces omitted to avoid re-triggering fallback when user clears the filter
+  }, [namespacesList, isNamespaceError, currentCluster, allClustersConfigs]);
 };
 
 function NamespacesFromClusterAutocomplete(


### PR DESCRIPTION
Add `allClustersConfigs` as a genuine missing dependency to the 
useEffect in `useDefaultNamespaceFallback` hook.

`selectedNamespaces` and `dispatch` are intentionally kept out of 
the dependency array — adding `selectedNamespaces` causes infinite 
re-renders when the user clears the namespace filter, and `dispatch` 
is stable across renders (Redux guarantee). The eslint suppression 
is kept with an inline comment explaining this.

Part of #5183