### PR TITLE
backend: Tests: Add regression test for ApplyMeDefaults trimming

### DIFF
--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -560,6 +560,20 @@ func TestApplyMeDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyMeDefaults_TrimsWhitespace(t *testing.T) {
+	gotUsername, gotEmail, gotGroups, gotUserInfo := config.ApplyMeDefaults(
+		"  user.name  ",
+		"  user.email  ",
+		"  user.groups  ",
+		"  /oauth2/userinfo  ",
+	)
+
+	assert.Equal(t, "user.name", gotUsername)
+	assert.Equal(t, "user.email", gotEmail)
+	assert.Equal(t, "user.groups", gotGroups)
+	assert.Equal(t, "/oauth2/userinfo", gotUserInfo)
+}
+
 func TestValidateSessionTTL(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary
Adds one small regression test for `ApplyMeDefaults` to confirm it trims surrounding whitespace and returns the expected values.

## Related Issue
NA  

## Changes
- Added `TestApplyMeDefaults_TrimsWhitespace` in `config_test.go`

## Steps to Test
`cd backend`
`go test ./pkg/config -run TestApplyMeDefaults_TrimsWhitespace -v`
