### PR TITLE
Fix unsafe token assertions in authentication

### DIFF
--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -613,10 +613,22 @@ func RefreshAndSetToken(params RefreshAndSetTokenParams) {
 		params.TelemetryHandler.RecordErrorCount(params.Ctx, attribute.String("error", "token_refresh_failure"))
 	} else if newToken != nil {
 		var newTokenString string
+
+		var ok bool
+
 		if params.OIDCUseAccessToken {
-			newTokenString = newToken.Extra("access_token").(string)
+			newTokenString, ok = newToken.Extra("access_token").(string)
 		} else {
-			newTokenString = newToken.Extra("id_token").(string)
+			newTokenString, ok = newToken.Extra("id_token").(string)
+		}
+
+		if !ok || newTokenString == "" {
+			logger.Log(logger.LevelError, map[string]string{"cluster": params.Cluster},
+				errors.New("refreshed token missing expected field"), "failed to extract token string")
+			params.TelemetryHandler.RecordError(params.Span,
+				errors.New("refreshed token missing expected field"), "Token extraction failed")
+
+			return
 		}
 
 		// Set refreshed token in cookie


### PR DESCRIPTION
## Summary

`RefreshAndSetToken()` in `pkg/auth/auth.go` uses bare type assertions on the return value of `oauth2.Token.Extra()`:

```go
newTokenString = newToken.Extra("access_token").(string) // panics if nil
newTokenString = newToken.Extra("id_token").(string)     // panics if nil
```

If the OIDC provider returns a refreshed token that is missing the expected `id_token` or `access_token` field, `Extra()` returns `nil` and the bare `.(string)` assertion **panics**, crashing the entire Headlamp server process.

## Changes

- Replaced bare type assertions with the safe comma-ok pattern
- Added early return with structured error logging (`logger.Log` + telemetry) when the token field is missing or not a string
- Prevents server crash on malformed OIDC provider responses

## Root Cause

`oauth2.Token.Extra()` returns `interface{}` which is `nil` when the key doesn't exist. A bare `.(string)` assertion on `nil` panics at runtime. This is the same pattern already fixed at line 153 in `CacheRefreshedToken` within the same file, making the existing code inconsistent.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Missing token field | Server panic | Logs error, returns gracefully |
| Empty token string | Sets empty cookie | Logs error, returns gracefully |
| Normal flow | Works | Works (no behavior change) |
