### PR TITLE
fix: Replace clearInterval with clearTimeout in KubeObjectNode hover-expand effect

### DIFF
--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -182,7 +182,7 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
     }
 
     const id = setTimeout(() => setIsExpanded(true), EXPAND_DELAY);
-    return () => clearInterval(id);
+    return () => clearTimeout(id);
   }, [isHovered]);
 
   const icon = kubeObject ? (


### PR DESCRIPTION
Fixes the cleanup function in the hover-expand useEffect in KubeObjectNode.tsx. The timeout was created with setTimeout but cleaned up with clearInterval, which does nothing on a timeout ID. This meant the expand would still fire even after the user moved their mouse away.

Changed `clearInterval(id)` to `clearTimeout(id)`

Closes #5711