### PR TITLE
frontend: Notifications: add missing dispatch dep to useEffect

### DIFF
--- a/frontend/src/components/App/Notifications/Notifications.tsx
+++ b/frontend/src/components/App/Notifications/Notifications.tsx
@@ -213,8 +213,7 @@ export default function Notifications() {
       // we are here means the events list changed and we have now new set of events, so we will notify the store about it
       dispatch(setNotifications(notificationsToShow.concat(currentNotifications)));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [warnings, notifications]);
+  }, [warnings, notifications, dispatch]);
 
   const [areAllNotificationsInDeleteState, areThereUnseenNotifications, filteredNotifications] =
     useMemo(() => {


### PR DESCRIPTION
`dispatch` was used inside the effect but left out of the deps array with an eslint-disable comment. Since `dispatch` from `useDispatch()` is stable adding it has no behavior change.

Part of #5183