### PR TITLE
backend: oidc-callback: Stop logging unrelated outer-scope error on missing state

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -846,7 +846,9 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		state := r.URL.Query().Get("state")
 
 		if state == "" {
-			logger.Log(logger.LevelError, nil, err, "invalid request state is empty")
+			// nil err: the closure-local err is declared below, so any err
+			// here would leak from createHeadlampHandler's outer scope.
+			logger.Log(logger.LevelError, nil, nil, "invalid request state is empty")
 			http.Error(w, "invalid request state is empty", http.StatusBadRequest)
 
 			return

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -843,12 +843,15 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		config.handleNodeDrainStatus).Methods("GET").Queries("cluster", "{cluster}", "nodeName", "{node}")
 
 	r.HandleFunc("/oidc-callback", func(w http.ResponseWriter, r *http.Request) {
+		// Shadow createHeadlampHandler's outer-scope err so any log call in
+		// this handler is guaranteed to reference this closure's err and
+		// never the startup kubeconfig-load error. See issue #4839.
+		var err error
+
 		state := r.URL.Query().Get("state")
 
 		if state == "" {
-			// nil err: the closure-local err is declared below, so any err
-			// here would leak from createHeadlampHandler's outer scope.
-			logger.Log(logger.LevelError, nil, nil, "invalid request state is empty")
+			logger.Log(logger.LevelError, nil, err, "invalid request state is empty")
 			http.Error(w, "invalid request state is empty", http.StatusBadRequest)
 
 			return
@@ -870,8 +873,6 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		var oauth2Token *oauth2.Token
-
-		var err error
 
 		// Exchange authorization code for token, with or without PKCE
 		if config.OidcUsePKCE && oauthConfig.CodeVerifier != "" {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -851,7 +851,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		state := r.URL.Query().Get("state")
 
 		if state == "" {
-			logger.Log(logger.LevelError, nil, err, "invalid request state is empty")
+			logger.Log(logger.LevelError, nil, nil, "invalid request state is empty")
 			http.Error(w, "invalid request state is empty", http.StatusBadRequest)
 
 			return

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -35,6 +35,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -44,6 +45,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1405,6 +1407,80 @@ func TestGetOidcCallbackURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Regression test for #4839: /oidc-callback's missing-state log must not
+// carry the outer-scope kubeconfig-load err from createHeadlampHandler.
+func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
+	type logCall struct {
+		level uint
+		msg   string
+		err   interface{}
+	}
+
+	var (
+		logMu    sync.Mutex
+		logCalls []logCall
+	)
+
+	originalLogFunc := logger.SetLogFunc(func(level uint, _ map[string]string, err interface{}, msg string) {
+		logMu.Lock()
+		defer logMu.Unlock()
+
+		logCalls = append(logCalls, logCall{level: level, msg: msg, err: err})
+	})
+	defer logger.SetLogFunc(originalLogFunc)
+
+	scratch := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cfg := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster: false,
+				// Guaranteed-missing kubeconfig so the startup load fails and
+				// seeds the outer-scope err the callback closure would leak.
+				KubeConfigPath:  filepath.Join(scratch, "missing-kubeconfig"),
+				KubeConfigStore: kubeconfig.NewContextStore(),
+				PluginDir:       scratch,
+				UserPluginDir:   scratch,
+				StaticPluginDir: scratch,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	handler := createHeadlampHandler(ctx, cfg)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/oidc-callback", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code,
+		"empty state should still produce a 400 response")
+
+	logMu.Lock()
+	captured := append([]logCall(nil), logCalls...)
+	logMu.Unlock()
+
+	var stateLog *logCall
+
+	for i := range captured {
+		if captured[i].msg == "invalid request state is empty" {
+			stateLog = &captured[i]
+			break
+		}
+	}
+
+	require.NotNil(t, stateLog, "expected a log entry for the missing-state branch")
+	assert.Nil(t, stateLog.err,
+		"missing-state log must not carry a stale error from the outer createHeadlampHandler scope")
 }
 
 func TestOIDCTokenRefreshMiddleware(t *testing.T) {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1435,6 +1435,10 @@ func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
 
 	scratch := t.TempDir()
 
+	// createHeadlampHandler overwrites config.StaticPluginDir from this env
+	// var, so set it deterministically rather than relying on the caller.
+	t.Setenv("HEADLAMP_STATIC_PLUGINS_DIR", scratch)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -1448,7 +1452,6 @@ func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
 				KubeConfigStore: kubeconfig.NewContextStore(),
 				PluginDir:       scratch,
 				UserPluginDir:   scratch,
-				StaticPluginDir: scratch,
 			},
 			Cache:            cache.New[interface{}](),
 			TelemetryConfig:  GetDefaultTestTelemetryConfig(),

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1411,6 +1411,8 @@ func TestGetOidcCallbackURL(t *testing.T) {
 
 // Regression test for #4839: /oidc-callback's missing-state log must not
 // carry the outer-scope kubeconfig-load err from createHeadlampHandler.
+//
+//nolint:funlen
 func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
 	type logCall struct {
 		level uint
@@ -1466,7 +1468,9 @@ func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
 		"empty state should still produce a 400 response")
 
 	logMu.Lock()
+
 	captured := append([]logCall(nil), logCalls...)
+
 	logMu.Unlock()
 
 	var stateLog *logCall


### PR DESCRIPTION
## Summary

The `/oidc-callback` handler in `backend/cmd/headlamp.go` logged a stray `err` variable when the OIDC `state` query parameter was missing. The variable was not declared in the handler closure: it resolved to the outer-scope `err` returned by the kubeconfig load that runs once at server startup inside `createHeadlampHandler`.

The practical effect is that every malformed callback request surfaced whatever happened at boot, attached to an unrelated 400 response. For example, a typical in-cluster pod without a local kubeconfig logs this on every empty-state callback:

```
error loading kubeconfig files: error reading kubeconfig file:
open /home/headlamp/.config/Headlamp/kubeconfigs/config: no such file or directory
```

That is the exact misleading line reported in the issue.

## Related Issue

Fixes https://github.com/kubernetes-sigs/headlamp/issues/4839

## Changes

- `backend/cmd/headlamp.go`: pass `nil` to `logger.Log` on the missing-state branch (instead of the captured outer-scope `err`). Added a short comment explaining the scoping trap so the capture is not reintroduced.
- `backend/cmd/headlamp_test.go`: new regression test `TestOidcCallbackEmptyStateDoesNotLogStaleError`. Hooks the logger via `logger.SetLogFunc`, runs `createHeadlampHandler` with a deliberately broken `KubeConfigPath` so the kubeconfig load returns a known error into the captured outer-scope `err`, fires `GET /oidc-callback` with no `state`, then asserts:
  - The response is `400 Bad Request` (unchanged behavior).
  - The captured log entry for `invalid request state is empty` carries a `nil` error value (not the stale kubeconfig load error).

## Steps to Test

1. `cd backend && go test ./cmd/ -run TestOidcCallbackEmptyStateDoesNotLogStaleError -v`. Passes.
2. Reverting only `headlamp.go` (keeping the test) reproduces the bug: the test fails with `Expected nil, but got: &errors.errorString{s:"error loading kubeconfig files: error reading kubeconfig file: open .../kubeconfigs/config: no such file or directory"}`. That is exactly the misleading log the reporter described.
3. `cd backend && go test ./cmd/... -race`. All existing `cmd/` tests still pass.
4. `cd backend && go build ./... && go vet ./cmd/...`. Clean.

## Notes for the Reviewer

- This is a minimal correctness fix. The behavior of the endpoint (`400 Bad Request` on missing `state`) is unchanged. Only the log line argument changes.
- There is a sibling logger misuse at the type-assertion branch a few lines below (`logger.Log(... , nil, err, ...)` when the oauth2 token has no expected token field). At that point the closure's local `err` is always `nil`, so the call is misleading-but-harmless rather than a real outer-scope leak. I left it untouched to keep this PR scoped to the issue. Happy to clean it up in a follow-up.
- The regression test uses `logger.SetLogFunc`, which the logger package already exposes for tests (see `backend/pkg/logger/logger_test.go`). No new test helpers were added.