### PR TITLE
frontend: job: Restore ?view=logs deep-link and fix misleading test

### DIFF
--- a/frontend/src/components/job/Details.test.tsx
+++ b/frontend/src/components/job/Details.test.tsx
@@ -128,7 +128,7 @@ describe('JobDetails', () => {
     expect(statusField.hide).toBe(true);
   });
 
-  it('resets owned pods state when navigating to a different Job', () => {
+  it('provides onResourceUpdate to DetailsGrid for tracking workload changes', () => {
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-job' }}>
         <JobDetails />
@@ -137,5 +137,12 @@ describe('JobDetails', () => {
 
     const props = mockDetailsGrid.mock.calls[0][0];
     expect(props.onResourceUpdate).toBeDefined();
+
+    // Should not throw when called with a resource
+    expect(() => props.onResourceUpdate(fakeJob)).not.toThrow();
+    // Should not throw when called with a different UID (triggers state reset)
+    expect(() =>
+      props.onResourceUpdate({ ...fakeJob, metadata: { ...fakeJob.metadata, uid: 'new-uid' } })
+    ).not.toThrow();
   });
 });

--- a/frontend/src/components/job/Details.tsx
+++ b/frontend/src/components/job/Details.tsx
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { ApiError } from '../../lib/k8s/api/v2/ApiError';
 import Job from '../../lib/k8s/job';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import Pod from '../../lib/k8s/pod';
 import { formatDuration } from '../../lib/util';
+import { useEventCallback } from '../../redux/headlampEventSlice';
 import {
   ConditionsSection,
   ContainersSection,
   DetailsGrid,
+  launchWorkloadLogs,
   LogsButton,
   MetadataDictGrid,
   OwnedPodsSection,
@@ -48,6 +50,24 @@ export default function JobDetails(props: { name?: string; namespace?: string; c
     },
     []
   );
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const autoLaunchView = queryParams.get('view');
+
+  const dispatchHeadlampEvent = useEventCallback();
+  const lastAutoLaunchedLogs = React.useRef<string | null>(null);
+  const [workloadItem, setWorkloadItem] = useState<Job | null>(null);
+
+  React.useEffect(() => {
+    if (autoLaunchView !== 'logs') {
+      lastAutoLaunchedLogs.current = null;
+      return;
+    }
+    if (workloadItem && lastAutoLaunchedLogs.current !== workloadItem.metadata.uid) {
+      lastAutoLaunchedLogs.current = workloadItem.metadata.uid;
+      launchWorkloadLogs(workloadItem, dispatchHeadlampEvent);
+    }
+  }, [workloadItem, autoLaunchView, dispatchHeadlampEvent]);
 
   return (
     <DetailsGrid
@@ -57,6 +77,7 @@ export default function JobDetails(props: { name?: string; namespace?: string; c
       cluster={cluster}
       withEvents
       onResourceUpdate={item => {
+        setWorkloadItem(item);
         setOwnedPods(prev =>
           prev.workloadUid === item?.metadata?.uid
             ? prev


### PR DESCRIPTION
## Summary

Restores `?view=logs` deep-link behavior for Job details, which was dropped when #5664 replaced `WorkloadDetails` with `JobDetails`. Also fixes a misleading test assertion.

## Related Issue

Fixes #5725

## Changes

- Ported `useLocation`/`launchWorkloadLogs` deep-link logic from `WorkloadDetails` into `JobDetails`
- Added `setWorkloadItem` in `onResourceUpdate` to track the current Job for auto-launch
- Renamed and tightened the `onResourceUpdate` test to accurately reflect what it validates

## Steps to Test

1. Navigate to Workloads → Jobs → click any Job — confirm detail page loads normally
2. Navigate directly to `/jobs/<namespace>/<job-name>?view=logs`
3. Verify logs view auto-launches on page load

## Notes for the Reviewer

- Direct port from `WorkloadDetails` — same pattern, same imports, no new logic invented
- No i18n or translation changes