### PR TITLE
frontend: Table: Add keyboard navigation (ArrowUp/ArrowDown)

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.Connecting.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.Connecting.stories.storyshot
@@ -498,8 +498,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -626,8 +627,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -752,8 +754,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -880,8 +883,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.Default.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.Default.stories.storyshot
@@ -498,8 +498,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -608,8 +609,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -716,8 +718,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -826,8 +829,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.NotConnected.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.NotConnected.stories.storyshot
@@ -498,8 +498,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -610,8 +611,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -722,8 +724,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -834,8 +837,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.UnhealthyControlPlane.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.UnhealthyControlPlane.stories.storyshot
@@ -498,8 +498,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/App/Home/__snapshots__/ClusterTable.WithErrors.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/ClusterTable.WithErrors.stories.storyshot
@@ -498,8 +498,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -608,8 +609,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -716,8 +718,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -826,8 +829,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -583,8 +583,9 @@
                   class="css-1obf64m"
                 >
                   <tr
-                    class="css-1ospngb"
+                    class="css-13druua"
                     data-selected="false"
+                    role="row"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -697,8 +698,9 @@
                     </td>
                   </tr>
                   <tr
-                    class="css-1ospngb"
+                    class="css-13druua"
                     data-selected="false"
+                    role="row"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -811,8 +813,9 @@
                     </td>
                   </tr>
                   <tr
-                    class="css-1ospngb"
+                    class="css-13druua"
                     data-selected="false"
+                    role="row"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -587,8 +587,9 @@
                     class="css-1obf64m"
                   >
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -699,8 +700,9 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -811,8 +813,9 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -387,8 +387,9 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -450,8 +451,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -515,8 +517,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -578,8 +581,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -643,8 +647,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.DefaultSaveEnable.stories.storyshot
@@ -391,8 +391,9 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -454,8 +455,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -519,8 +521,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -582,8 +585,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -647,8 +651,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -387,8 +387,9 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -450,8 +451,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -515,8 +517,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -578,8 +581,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -643,8 +647,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.EmptyHomepageItems.stories.storyshot
@@ -391,8 +391,9 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -454,8 +455,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -519,8 +521,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -582,8 +585,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -647,8 +651,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -387,8 +387,9 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -450,8 +451,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -515,8 +517,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -578,8 +581,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -643,8 +647,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.FewItems.stories.storyshot
@@ -391,8 +391,9 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -454,8 +455,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -519,8 +521,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -582,8 +585,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -647,8 +651,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -387,8 +387,9 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -450,8 +451,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -515,8 +517,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -578,8 +581,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -643,8 +647,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -706,8 +711,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -771,8 +777,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -834,8 +841,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -899,8 +907,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -962,8 +971,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1027,8 +1037,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1090,8 +1101,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1155,8 +1167,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1218,8 +1231,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1283,8 +1297,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.ManyItems.stories.storyshot
@@ -391,8 +391,9 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -454,8 +455,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -519,8 +521,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -582,8 +585,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -647,8 +651,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -710,8 +715,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -775,8 +781,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -838,8 +845,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -903,8 +911,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -966,8 +975,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1031,8 +1041,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1094,8 +1105,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1159,8 +1171,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1222,8 +1235,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1287,8 +1301,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
@@ -387,8 +387,9 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -450,8 +451,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -513,8 +515,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -576,8 +579,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
@@ -391,8 +391,9 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -454,8 +455,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -517,8 +519,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -580,8 +583,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -387,8 +387,9 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -450,8 +451,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -515,8 +517,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -578,8 +581,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -643,8 +647,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -706,8 +711,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -771,8 +777,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -834,8 +841,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -899,8 +907,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -962,8 +971,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1027,8 +1037,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1090,8 +1101,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1155,8 +1167,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1218,8 +1231,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1283,8 +1297,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MoreItems.stories.storyshot
@@ -391,8 +391,9 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -454,8 +455,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -519,8 +521,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -582,8 +585,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -647,8 +651,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -710,8 +715,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -775,8 +781,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -838,8 +845,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -903,8 +911,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -966,8 +975,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1031,8 +1041,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1094,8 +1105,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1159,8 +1171,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1222,8 +1235,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1287,8 +1301,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
@@ -387,8 +387,9 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -459,8 +460,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -533,8 +535,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -607,8 +610,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -679,8 +683,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -753,8 +758,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -816,8 +822,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -879,8 +886,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -942,8 +950,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1014,8 +1023,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1086,8 +1096,9 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
@@ -391,8 +391,9 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -463,8 +464,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -537,8 +539,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -611,8 +614,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -683,8 +687,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -757,8 +762,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -820,8 +826,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -883,8 +890,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -946,8 +954,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1018,8 +1027,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"
@@ -1090,8 +1100,9 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-16gecr3-MuiTableCell-root"

--- a/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
+++ b/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
@@ -509,8 +509,10 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="0"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-nch70x-MuiTableCell-root"

--- a/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
+++ b/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
@@ -513,8 +513,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-nch70x-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/ResourceTable.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.test.tsx
@@ -32,6 +32,13 @@ vi.mock('../../../lib/k8s', () => ({
   useSelectedClusters: vi.fn(() => ['test-cluster']),
 }));
 
+const { mockHistoryPush } = vi.hoisted(() => ({ mockHistoryPush: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<any>('react-router-dom');
+  return { ...actual, useHistory: () => ({ push: mockHistoryPush }) };
+});
+
 // Capture the props passed to Table using a hoisted holder object
 const { lastTablePropsHolder } = vi.hoisted(() => ({
   lastTablePropsHolder: { current: null as any },
@@ -225,5 +232,120 @@ describe('ResourceTable Column Visibility', () => {
     );
 
     expect(lastTablePropsHolder.current.enableFacetedValues).toBe(true);
+  });
+});
+
+describe('ResourceTable row activation', () => {
+  const columns = [{ id: 'name', label: 'Name', getValue: (item: any) => item.metadata.name }];
+
+  const makeRow = (link: string | undefined) => ({
+    ...mockData[0],
+    getDetailsLink: () => link,
+  });
+
+  const keyEvent = (mods: Partial<React.KeyboardEvent> = {}) =>
+    ({ ctrlKey: false, metaKey: false, shiftKey: false, ...mods } as React.KeyboardEvent);
+
+  let windowOpen: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    lastTablePropsHolder.current = null;
+    mockHistoryPush.mockClear();
+    windowOpen = vi.fn(() => null);
+    vi.stubGlobal('open', windowOpen);
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const renderTable = (props: any) =>
+    render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <ResourceTable {...props} />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+  it('routes in-app for a relative details link', () => {
+    renderTable({ id: 'activation', columns, data: mockData });
+
+    lastTablePropsHolder.current.onRowOpen(makeRow('/c/test/pods/ns/mypod1'), keyEvent());
+
+    expect(mockHistoryPush).toHaveBeenCalledWith('/c/test/pods/ns/mypod1');
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it('opens a new tab when a modifier key is held', () => {
+    renderTable({ id: 'activation', columns, data: mockData });
+
+    lastTablePropsHolder.current.onRowOpen(
+      makeRow('/c/test/pods/ns/mypod1'),
+      keyEvent({ metaKey: true })
+    );
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      '/c/test/pods/ns/mypod1',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(mockHistoryPush).not.toHaveBeenCalled();
+  });
+
+  it('opens a new tab for an absolute link rather than pushing a broken route', () => {
+    renderTable({ id: 'activation', columns, data: mockData });
+
+    lastTablePropsHolder.current.onRowOpen(makeRow('https://example.com/thing'), keyEvent());
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      'https://example.com/thing',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(mockHistoryPush).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the row has no details link', () => {
+    renderTable({ id: 'activation', columns, data: mockData });
+
+    lastTablePropsHolder.current.onRowOpen(makeRow(undefined), keyEvent());
+
+    expect(mockHistoryPush).not.toHaveBeenCalled();
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it('prefers a caller supplied onRowOpen over the default routing', () => {
+    const onRowOpen = vi.fn();
+    renderTable({ id: 'activation', columns, data: mockData, onRowOpen });
+
+    const row = makeRow('/c/test/pods/ns/mypod1');
+    lastTablePropsHolder.current.onRowOpen(row, keyEvent());
+
+    expect(onRowOpen).toHaveBeenCalledWith(row, expect.anything());
+    expect(mockHistoryPush).not.toHaveBeenCalled();
+  });
+
+  it('disables keyboard activation entirely with disableRowOpen', () => {
+    renderTable({ id: 'activation', columns, data: mockData, disableRowOpen: true });
+
+    expect(lastTablePropsHolder.current.onRowOpen).toBeUndefined();
   });
 });

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -39,6 +39,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 import { loadTableSettings, storeTableSettings } from '../../../helpers/tableSettings';
 import { useSelectedClusters } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
@@ -162,6 +163,16 @@ export interface ResourceTableProps<RowItem> {
   errors?: ApiError[] | null;
   /** State of the Table (page, rows per page) is reflected in the url */
   reflectInURL?: string | boolean;
+  /** Disable row activation via keyboard (Enter key).
+   * When false or not provided, Enter uses `onRowOpen` if provided,
+   * otherwise it navigates to the row's detail page via `getDetailsLink()`.
+   */
+  disableRowOpen?: boolean;
+  /**
+   * Called when a row is activated via keyboard (Enter key).
+   * When not provided, Enter navigates to the row's detail page via `getDetailsLink()`.
+   */
+  onRowOpen?: (row: KubeObject, event: React.KeyboardEvent) => void;
 }
 
 export interface ResourceTableFromResourceClassProps<KubeClass extends KubeObjectClass>
@@ -315,9 +326,12 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
     enableRowActions = false,
     enableRowSelection = false,
     errors,
+    onRowOpen,
+    disableRowOpen,
   } = props;
   const { t } = useTranslation(['glossary', 'translation']);
   const theme = useTheme();
+  const history = useHistory();
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
   const clusters = useSelectedClusters();
   const tableProcessors = useTypedSelector(state => state.resourceTable.tableColumnsProcessors);
@@ -719,6 +733,21 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
         globalFilterFn="kubeObjectSearch"
         filterFunction={filterFunc}
         getRowId={item => item?.metadata?.uid}
+        onRowOpen={
+          disableRowOpen
+            ? undefined
+            : onRowOpen
+            ? (row: RowItem, event: React.KeyboardEvent) => onRowOpen(row, event)
+            : (row: RowItem, event: React.KeyboardEvent) => {
+                const link = row.getDetailsLink?.();
+                if (!link) return;
+                if (event.ctrlKey || event.metaKey || event.shiftKey) {
+                  window.open(link, '_blank', 'noopener,noreferrer');
+                } else {
+                  history.push(link);
+                }
+              }
+        }
       />
     </>
   );

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -163,7 +163,9 @@ export interface ResourceTableProps<RowItem> {
   errors?: ApiError[] | null;
   /** State of the Table (page, rows per page) is reflected in the url */
   reflectInURL?: string | boolean;
-  /** Disable row activation via keyboard (Enter key).
+  /**
+   * Disables all keyboard navigation on the table: ArrowUp/ArrowDown row focus,
+   * Enter-to-open, tabIndex on rows, focus highlight styling, and the blur handler.
    * When false or not provided, Enter uses `onRowOpen` if provided,
    * otherwise it navigates to the row's detail page via `getDetailsLink()`.
    */

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -40,6 +40,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 import { loadTableSettings, storeTableSettings } from '../../../helpers/tableSettings';
 import { useSelectedClusters } from '../../../lib/k8s';
 import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
@@ -173,6 +174,22 @@ export interface ResourceTableProps<RowItem> {
   errors?: ApiError[] | null;
   /** State of the Table (page, rows per page) is reflected in the url */
   reflectInURL?: string | boolean;
+  /**
+   * Disables all keyboard navigation on the table: ArrowUp/ArrowDown row focus,
+   * Enter-to-open, tabIndex on rows, focus highlight styling, and the blur handler.
+   * When false or not provided, Enter uses `onRowOpen` if provided,
+   * otherwise it navigates to the row's detail page via `getDetailsLink()`.
+   */
+  disableRowOpen?: boolean;
+  /**
+   * Called when a row is activated via keyboard (Enter key).
+   * When not provided, Enter navigates to the row's detail page via `getDetailsLink()`.
+   */
+  onRowOpen?: (row: KubeObject, event: React.KeyboardEvent) => void;
+  /**
+   * Accessible name for the table, announced when a row receives keyboard focus.
+   */
+  ariaLabel?: string;
 }
 
 export interface ResourceTableFromResourceClassProps<KubeClass extends KubeObjectClass>
@@ -225,6 +242,7 @@ function TableFromResourceClass<KubeClass extends KubeObjectClass>(
     <ResourceTableContent
       errors={errors}
       id={id || `headlamp-${resourceClass.pluralName}`}
+      ariaLabel={props.ariaLabel ?? resourceClass.className}
       {...otherProps}
       data={throttledItems}
     />
@@ -330,9 +348,13 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
     enableRowActions = false,
     enableRowSelection = false,
     errors,
+    onRowOpen,
+    disableRowOpen,
+    ariaLabel,
   } = props;
   const { t } = useTranslation(['glossary', 'translation']);
   const theme = useTheme();
+  const history = useHistory();
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
   const clusters = useSelectedClusters();
   const tableProcessors = useTypedSelector(state => state.resourceTable.tableColumnsProcessors);
@@ -758,6 +780,23 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
         globalFilterFn="kubeObjectSearch"
         filterFunction={filterFunc}
         getRowId={getResourceRowId}
+        onRowOpen={
+          disableRowOpen
+            ? undefined
+            : onRowOpen
+            ? (row: RowItem, event: React.KeyboardEvent) => onRowOpen(row, event)
+            : (row: RowItem, event: React.KeyboardEvent) => {
+                const link = row.getDetailsLink?.();
+                if (!link) return;
+                const isInAppRoute = link.startsWith('/');
+                if (!isInAppRoute || event.ctrlKey || event.metaKey || event.shiftKey) {
+                  window.open(link, '_blank', 'noopener,noreferrer');
+                } else {
+                  history.push(link);
+                }
+              }
+        }
+        ariaLabel={ariaLabel}
       />
     </>
   );

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -409,8 +409,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -490,8 +492,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -571,8 +575,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -652,8 +658,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -733,8 +741,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -413,8 +413,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -494,8 +496,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -575,8 +579,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -656,8 +662,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -737,8 +745,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -375,8 +375,10 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="0"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -200,6 +200,7 @@
         </div>
       </div>
       <table
+        aria-label="Pod"
         class="MuiTable-root css-ygfd7h-MuiTable-root"
       >
         <thead
@@ -379,8 +380,10 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="0"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -310,8 +310,10 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="0"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -346,8 +348,10 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="-1"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -382,8 +386,10 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="-1"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -418,8 +424,10 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="-1"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -135,6 +135,7 @@
         </div>
       </div>
       <table
+        aria-label="Pod"
         class="MuiTable-root css-ygfd7h-MuiTable-root"
       >
         <thead
@@ -314,8 +315,10 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="0"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -350,8 +353,10 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="-1"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -386,8 +391,10 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="-1"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -422,8 +429,10 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="-1"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -255,8 +255,10 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="0"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -281,8 +283,10 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="-1"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -307,8 +311,10 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="-1"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -333,8 +339,10 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
+          tabindex="-1"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -135,6 +135,7 @@
         </div>
       </div>
       <table
+        aria-label="Pod"
         class="MuiTable-root css-1jnbgrs-MuiTable-root"
       >
         <thead
@@ -259,8 +260,10 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="0"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -285,8 +288,10 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="-1"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -311,8 +316,10 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="-1"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
@@ -337,8 +344,10 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
+            tabindex="-1"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/common/Table/Table.test.tsx
+++ b/frontend/src/components/common/Table/Table.test.tsx
@@ -16,6 +16,7 @@
 
 import { ThemeProvider } from '@mui/material/styles';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../../lib/themes';
 import Table, { TableProps } from './Table';
@@ -86,6 +87,7 @@ vi.mock('material-react-table', () => ({
     const rows = options.data.map((item: Record<string, unknown>, index: number) => {
       const row: any = {
         id: String(index),
+        original: item,
         getCanSelect: () => true,
         getIsSelected: () => false,
       };
@@ -443,5 +445,95 @@ describe('Table states and options', () => {
     renderTable({ columns: [{ accessorKey: 'selected', header: 'Selection' }] });
 
     expect(tableMocks.setColumnVisibility).toHaveBeenCalledOnce();
+  });
+});
+
+describe('Table keyboard navigation', () => {
+  beforeEach(() => {
+    tableMocks.forceNoRows = false;
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  function renderRows(props: Partial<TableProps<TestRow>> = {}) {
+    return render(
+      <ThemeProvider theme={theme}>
+        <Table
+          columns={[{ accessorKey: 'selected', header: 'Selection' }]}
+          data={[{ selected: false }, { selected: false }, { selected: false }]}
+          {...props}
+        />
+      </ThemeProvider>
+    );
+  }
+
+  it('ignores Enter raised by a control inside a cell', async () => {
+    const onRowOpen = vi.fn();
+    renderRows({ onRowOpen });
+
+    // Focus the row first so a row-level Enter would otherwise activate it, then move into a
+    // control in one of its cells. Enter there belongs to the control, not to the row.
+    const row = screen.getAllByRole('row')[1];
+    act(() => row.focus());
+
+    const checkbox = screen.getAllByRole('checkbox')[0];
+    act(() => checkbox.focus());
+    await userEvent.keyboard('{Enter}');
+
+    expect(onRowOpen).not.toHaveBeenCalled();
+  });
+
+  it('opens the row when Enter is pressed on the row itself', async () => {
+    const onRowOpen = vi.fn();
+    renderRows({ onRowOpen });
+
+    const row = screen.getAllByRole('row')[1];
+    act(() => row.focus());
+    await userEvent.keyboard('{Enter}');
+
+    expect(onRowOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds the focused row when the user tabs into the table', async () => {
+    const onRowOpen = vi.fn();
+    renderRows({ onRowOpen });
+
+    const rows = screen.getAllByRole('row').slice(1);
+    act(() => rows[0].focus());
+
+    expect(rows[0]).toHaveAttribute('data-focused', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(rows[1]).toHaveAttribute('data-focused', 'true');
+    expect(rows[0]).not.toHaveAttribute('data-focused');
+  });
+
+  it('scrolls a cell of the focused row, since the row itself has no layout box', async () => {
+    const scrolled: string[] = [];
+    Element.prototype.scrollIntoView = vi.fn(function (this: Element) {
+      scrolled.push(this.tagName);
+    });
+
+    renderRows({ onRowOpen: vi.fn() });
+
+    const rows = screen.getAllByRole('row').slice(1);
+    act(() => rows[0].focus());
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+    // StyledRow is display:contents, so scrolling the TR would be a no-op.
+    expect(scrolled).not.toContain('TR');
+    expect(scrolled).toContain('TD');
+  });
+
+  it('leaves rows untouched when keyboard navigation is not enabled', () => {
+    renderRows();
+
+    const row = screen.getAllByRole('row')[1];
+
+    expect(row).not.toHaveAttribute('tabindex');
   });
 });

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -528,10 +528,12 @@ export default function Table<RowItem extends Record<string, any>>({
 
   const handleRowClickCombined = useCallback(
     (e: React.MouseEvent, rowIndex: number) => {
-      onKeyboardRowClick(rowIndex);
+      if (onRowOpen) {
+        onKeyboardRowClick(rowIndex);
+      }
       handleRowClick(e, rowIndex);
     },
-    [onKeyboardRowClick, handleRowClick]
+    [onRowOpen, onKeyboardRowClick, handleRowClick]
   );
 
   const emptyMsg = emptyMessage || t('No data to be shown.');

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -47,9 +47,10 @@ import { MRT_Localization_KO } from 'material-react-table/locales/ko';
 import { MRT_Localization_PT } from 'material-react-table/locales/pt';
 import { MRT_Localization_ZH_HANS } from 'material-react-table/locales/zh-Hans';
 import { MRT_Localization_ZH_HANT } from 'material-react-table/locales/zh-Hant';
-import { memo, ReactNode, useEffect, useMemo, useState } from 'react';
+import { memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTablesRowsPerPage, setTablesRowsPerPage } from '../../../helpers/tablesRowsPerPage';
+import { useKeyboardNavigation } from '../../../lib/useKeyboardNavigation';
 import { useShortcut } from '../../../lib/useShortcut';
 import { useURLState } from '../../../lib/util';
 import { useSettings } from '../../App/Settings/hook';
@@ -124,6 +125,13 @@ export type TableProps<RowItem extends Record<string, any>> = Omit<
    */
   loading?: boolean;
   renderRowSelectionToolbar?: (props: { table: MRT_TableInstance<RowItem> }) => ReactNode;
+  /**
+   * Called when a row is activated via keyboard (Enter key).
+   * Receives the row's original data item.
+   * When provided, arrow-key navigation and Enter-to-open are enabled on the table.
+   * The keyboard event is passed so callers can inspect modifier keys (Ctrl/Cmd/Shift).
+   */
+  onRowOpen?: (row: RowItem, event: React.KeyboardEvent) => void;
 };
 
 // Use a zero-indexed "useURLState" hook, so pages are shown in the URL as 1-indexed
@@ -176,6 +184,14 @@ const StyledRow = styled('tr')(({ theme }) => ({
   '&[data-selected=true]': {
     background: alpha(theme.palette.primary.main, 0.2),
   },
+  '&[data-focused=true] td': {
+    background: alpha(theme.palette.primary.main, 0.12),
+    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.5)}`,
+    borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.5)}`,
+  },
+  '&[data-focused=true] td:first-of-type': {
+    borderLeft: `3px solid ${theme.palette.primary.main}`,
+  },
 }));
 const StyledBody = styled('tbody')({ display: 'contents' });
 
@@ -192,6 +208,7 @@ export default function Table<RowItem extends Record<string, any>>({
   filterFunction,
   errorMessage,
   loading,
+  onRowOpen,
   ...tableProps
 }: TableProps<RowItem>) {
   const shouldReflectInURL = reflectInURL !== undefined && reflectInURL !== false;
@@ -452,45 +469,70 @@ export default function Table<RowItem extends Record<string, any>>({
   const rows = useMRT_Rows(table);
   const rowIds = useMemo(() => rows.map(r => r.id), [rows]);
 
+  const {
+    focusedRowIndex,
+    onKeyDown: onTableKeyDown,
+    onRowClick: onKeyboardRowClick,
+    clearFocus,
+  } = useKeyboardNavigation({
+    rowCount: rows.length,
+    enabled: !!onRowOpen,
+    onRowOpen: (index, event) => {
+      const row = rows[index]?.original;
+      if (row) onRowOpen?.(row, event);
+    },
+  });
+
   // Handle shift+click range selection
-  const handleRowClick = (e: React.MouseEvent, clickedIndex: number) => {
-    if (!table || !table.getRowModel) {
-      return;
-    }
-
-    const target = e.target as HTMLElement | null;
-    const shouldHandle =
-      !!target &&
-      !!target.closest('input[type="checkbox"]') &&
-      !target.closest('.MuiSwitch-root, [role="switch"]') &&
-      !target.closest('[role="dialog"]');
-
-    if (!shouldHandle) {
-      return;
-    }
-
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (e.shiftKey && lastSelectedRowIndex !== null) {
-      const start = Math.min(lastSelectedRowIndex, clickedIndex);
-      const end = Math.max(lastSelectedRowIndex, clickedIndex);
-
-      const newSelected: Record<string, boolean> = {};
-      for (let i = start; i <= end; i++) {
-        const rowId = rowIds[i];
-        if (rowId) {
-          newSelected[rowId] = true;
-        }
+  const handleRowClick = useCallback(
+    (e: React.MouseEvent, clickedIndex: number) => {
+      if (!table || !table.getRowModel) {
+        return;
       }
 
-      table.setRowSelection(prev => ({ ...prev, ...newSelected }));
-    } else {
-      const rowId = rowIds[clickedIndex];
-      table.setRowSelection(prev => ({ ...prev, [rowId]: !prev[rowId] }));
-      setLastSelectedRowIndex(clickedIndex);
-    }
-  };
+      const target = e.target as HTMLElement | null;
+      const shouldHandle =
+        !!target &&
+        !!target.closest('input[type="checkbox"]') &&
+        !target.closest('.MuiSwitch-root, [role="switch"]') &&
+        !target.closest('[role="dialog"]');
+
+      if (!shouldHandle) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.shiftKey && lastSelectedRowIndex !== null) {
+        const start = Math.min(lastSelectedRowIndex, clickedIndex);
+        const end = Math.max(lastSelectedRowIndex, clickedIndex);
+
+        const newSelected: Record<string, boolean> = {};
+        for (let i = start; i <= end; i++) {
+          const rowId = rowIds[i];
+          if (rowId) {
+            newSelected[rowId] = true;
+          }
+        }
+
+        table.setRowSelection(prev => ({ ...prev, ...newSelected }));
+      } else {
+        const rowId = rowIds[clickedIndex];
+        table.setRowSelection(prev => ({ ...prev, [rowId]: !prev[rowId] }));
+        setLastSelectedRowIndex(clickedIndex);
+      }
+    },
+    [lastSelectedRowIndex, rowIds, table]
+  );
+
+  const handleRowClickCombined = useCallback(
+    (e: React.MouseEvent, rowIndex: number) => {
+      onKeyboardRowClick(rowIndex);
+      handleRowClick(e, rowIndex);
+    },
+    [onKeyboardRowClick, handleRowClick]
+  );
 
   const emptyMsg = emptyMessage || t('No data to be shown.');
   const isEmpty = !tableProps.data?.length && !loading;
@@ -562,7 +604,12 @@ export default function Table<RowItem extends Record<string, any>>({
                 cells={row.getVisibleCells() as MRT_Cell<Record<string, any>, unknown>[]}
                 table={table as MRT_TableInstance<Record<string, any>>}
                 isSelected={row.getIsSelected()}
-                onRowClick={handleRowClick}
+                isFocused={focusedRowIndex === index}
+                isInitialTabStop={!!onRowOpen && focusedRowIndex === -1 && index === 0}
+                keyboardEnabled={!!onRowOpen}
+                onKeyDown={onTableKeyDown}
+                onBlur={clearFocus}
+                onRowClick={handleRowClickCombined}
               />
             ))}
           </StyledBody>
@@ -614,21 +661,72 @@ const MemoHeadCell = memo(
     a.filterValue === b.filterValue
 );
 
-const Row = memo(
-  <RowItem extends Record<string, any>>({
-    cells,
-    table,
-    isSelected,
-    onRowClick,
-    rowIndex,
-  }: {
-    table: MRT_TableInstance<RowItem>;
-    cells: MRT_Cell<RowItem, unknown>[];
-    isSelected: boolean;
-    onRowClick?: (e: React.MouseEvent, rowIndex: number) => void;
-    rowIndex: number;
-  }) => (
-    <StyledRow data-selected={isSelected} onClickCapture={e => onRowClick?.(e, rowIndex)}>
+const Row = memo(function Row<RowItem extends Record<string, any>>({
+  cells,
+  table,
+  isSelected,
+  isFocused,
+  isInitialTabStop,
+  onRowClick,
+  onKeyDown,
+  onBlur,
+  rowIndex,
+  keyboardEnabled,
+}: {
+  table: MRT_TableInstance<RowItem>;
+  cells: MRT_Cell<RowItem, unknown>[];
+  isSelected: boolean;
+  isFocused?: boolean;
+  isInitialTabStop?: boolean;
+  onRowClick?: (e: React.MouseEvent, rowIndex: number) => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onBlur?: () => void;
+  rowIndex: number;
+  keyboardEnabled?: boolean;
+}) {
+  const rowRef = useRef<HTMLTableRowElement>(null);
+
+  const handleBlur = useCallback(
+    (e: React.FocusEvent) => {
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        onBlur?.();
+      }
+    },
+    [onBlur]
+  );
+
+  const handleClickCapture = useCallback(
+    (e: React.MouseEvent) => onRowClick?.(e, rowIndex),
+    [onRowClick, rowIndex]
+  );
+
+  useEffect(() => {
+    if (!keyboardEnabled || !isFocused || !rowRef.current) {
+      return;
+    }
+    const activeElement = document.activeElement;
+    if (activeElement && rowRef.current.contains(activeElement)) {
+      return;
+    }
+    const tableElement = rowRef.current.closest('table');
+    if (activeElement && tableElement && !tableElement.contains(activeElement)) {
+      return;
+    }
+    rowRef.current.focus({ preventScroll: true });
+  }, [isFocused, keyboardEnabled]);
+
+  return (
+    <StyledRow
+      ref={rowRef}
+      role="row"
+      data-selected={isSelected}
+      data-focused={isFocused || undefined}
+      aria-selected={isSelected || undefined}
+      tabIndex={keyboardEnabled ? (isFocused || isInitialTabStop ? 0 : -1) : undefined}
+      onKeyDown={keyboardEnabled ? onKeyDown : undefined}
+      onBlur={keyboardEnabled ? handleBlur : undefined}
+      onClickCapture={handleClickCapture}
+    >
       {cells.map(cell => (
         <MemoCell
           cell={cell as MRT_Cell<Record<string, any>, unknown>}
@@ -639,8 +737,8 @@ const Row = memo(
         />
       ))}
     </StyledRow>
-  )
-);
+  );
+});
 
 const MemoCell = memo(
   <RowItem extends Record<string, any>>({

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -40,9 +40,10 @@ import {
   useMaterialReactTable,
   useMRT_Rows,
 } from 'material-react-table';
-import { memo, ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTablesRowsPerPage, setTablesRowsPerPage } from '../../../helpers/tablesRowsPerPage';
+import { useKeyboardNavigation } from '../../../lib/useKeyboardNavigation';
 import { useShortcut } from '../../../lib/useShortcut';
 import { useURLState } from '../../../lib/util';
 import { useSettings } from '../../App/Settings/hook';
@@ -126,6 +127,17 @@ export type TableProps<RowItem extends Record<string, any>> = Omit<
    */
   loading?: boolean;
   renderRowSelectionToolbar?: (props: { table: MRT_TableInstance<RowItem> }) => ReactNode;
+  /**
+   * Called when a row is activated via keyboard (Enter key).
+   * Receives the row's original data item.
+   * When provided, arrow-key navigation and Enter-to-open are enabled on the table.
+   * The keyboard event is passed so callers can inspect modifier keys (Ctrl/Cmd/Shift).
+   */
+  onRowOpen?: (row: RowItem, event: React.KeyboardEvent) => void;
+  /**
+   * Accessible name for the table, announced when a row receives keyboard focus.
+   */
+  ariaLabel?: string;
 };
 
 // Use a zero-indexed "useURLState" hook, so pages are shown in the URL as 1-indexed
@@ -164,6 +176,14 @@ const StyledRow = styled('tr')(({ theme }) => ({
   display: 'contents',
   '&[data-selected=true]': {
     background: alpha(theme.palette.primary.main, 0.2),
+  },
+  '&[data-focused=true] td': {
+    background: alpha(theme.palette.primary.main, 0.12),
+    borderTop: `1px solid ${alpha(theme.palette.primary.main, 0.5)}`,
+    borderBottom: `1px solid ${alpha(theme.palette.primary.main, 0.5)}`,
+  },
+  '&[data-focused=true] td:first-of-type': {
+    borderLeft: `3px solid ${theme.palette.primary.main}`,
   },
 }));
 const StyledBody = styled('tbody')({ display: 'contents' });
@@ -210,6 +230,8 @@ export default function Table<RowItem extends Record<string, any>>({
   filterFunction,
   errorMessage,
   loading,
+  onRowOpen,
+  ariaLabel,
   ...tableProps
 }: TableProps<RowItem>) {
   const shouldReflectInURL = reflectInURL !== undefined && reflectInURL !== false;
@@ -564,45 +586,72 @@ export default function Table<RowItem extends Record<string, any>>({
   const rows = useMRT_Rows(table);
   const rowIds = useMemo(() => rows.map(r => r.id), [rows]);
 
+  const {
+    focusedRowIndex,
+    onKeyDown: onTableKeyDown,
+    onRowClick: onKeyboardRowClick,
+    clearFocus,
+  } = useKeyboardNavigation({
+    rowCount: rows.length,
+    enabled: !!onRowOpen,
+    onRowOpen: (index, event) => {
+      const row = rows[index]?.original;
+      if (row) onRowOpen?.(row, event);
+    },
+  });
+
   // Handle shift+click range selection
-  const handleRowClick = (e: React.MouseEvent, clickedIndex: number) => {
-    if (!table || !table.getRowModel || tableProps.enableRowSelection === false) {
-      return;
-    }
-
-    const target = e.target as HTMLElement | null;
-    const shouldHandle =
-      !!target &&
-      !!target.closest('input[type="checkbox"]') &&
-      !target.closest('.MuiSwitch-root, [role="switch"]') &&
-      !target.closest('[role="dialog"]');
-
-    if (!shouldHandle) {
-      return;
-    }
-
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (e.shiftKey && lastSelectedRowIndex !== null) {
-      const start = Math.min(lastSelectedRowIndex, clickedIndex);
-      const end = Math.max(lastSelectedRowIndex, clickedIndex);
-
-      const newSelected: Record<string, boolean> = {};
-      for (let i = start; i <= end; i++) {
-        const rowId = rowIds[i];
-        if (rowId) {
-          newSelected[rowId] = true;
-        }
+  const handleRowClick = useCallback(
+    (e: React.MouseEvent, clickedIndex: number) => {
+      if (!table || !table.getRowModel || tableProps.enableRowSelection === false) {
+        return;
       }
 
-      table.setRowSelection(prev => ({ ...prev, ...newSelected }));
-    } else {
-      const rowId = rowIds[clickedIndex];
-      table.setRowSelection(prev => ({ ...prev, [rowId]: !prev[rowId] }));
-      setLastSelectedRowIndex(clickedIndex);
-    }
-  };
+      const target = e.target as HTMLElement | null;
+      const shouldHandle =
+        !!target &&
+        !!target.closest('input[type="checkbox"]') &&
+        !target.closest('.MuiSwitch-root, [role="switch"]') &&
+        !target.closest('[role="dialog"]');
+
+      if (!shouldHandle) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.shiftKey && lastSelectedRowIndex !== null) {
+        const start = Math.min(lastSelectedRowIndex, clickedIndex);
+        const end = Math.max(lastSelectedRowIndex, clickedIndex);
+
+        const newSelected: Record<string, boolean> = {};
+        for (let i = start; i <= end; i++) {
+          const rowId = rowIds[i];
+          if (rowId) {
+            newSelected[rowId] = true;
+          }
+        }
+
+        table.setRowSelection(prev => ({ ...prev, ...newSelected }));
+      } else {
+        const rowId = rowIds[clickedIndex];
+        table.setRowSelection(prev => ({ ...prev, [rowId]: !prev[rowId] }));
+        setLastSelectedRowIndex(clickedIndex);
+      }
+    },
+    [lastSelectedRowIndex, rowIds, table, tableProps.enableRowSelection]
+  );
+
+  const handleRowClickCombined = useCallback(
+    (e: React.MouseEvent, rowIndex: number) => {
+      if (onRowOpen) {
+        onKeyboardRowClick(rowIndex);
+      }
+      handleRowClick(e, rowIndex);
+    },
+    [onRowOpen, onKeyboardRowClick, handleRowClick]
+  );
 
   const emptyMsg = emptyMessage || t('No data to be shown.');
   const isEmpty = !tableProps.data?.length && !loading;
@@ -639,6 +688,7 @@ export default function Table<RowItem extends Record<string, any>>({
       <>
         {(tableProps.enableTopToolbar ?? true) && <MRT_TopToolbar table={table} />}
         <MuiTable
+          aria-label={ariaLabel}
           sx={{
             display: 'grid',
             border: '1px solid',
@@ -674,7 +724,13 @@ export default function Table<RowItem extends Record<string, any>>({
                 cells={row.getVisibleCells() as MRT_Cell<Record<string, any>, unknown>[]}
                 table={table as MRT_TableInstance<Record<string, any>>}
                 isSelected={row.getIsSelected()}
-                onRowClick={handleRowClick}
+                isFocused={focusedRowIndex === index}
+                isInitialTabStop={!!onRowOpen && focusedRowIndex === -1 && index === 0}
+                keyboardEnabled={!!onRowOpen}
+                onKeyDown={onTableKeyDown}
+                onBlur={clearFocus}
+                onRowClick={handleRowClickCombined}
+                onRowFocus={onKeyboardRowClick}
               />
             ))}
           </StyledBody>
@@ -726,21 +782,103 @@ const MemoHeadCell = memo(
     a.filterValue === b.filterValue
 );
 
-const Row = memo(
-  <RowItem extends Record<string, any>>({
-    cells,
-    table,
-    isSelected,
-    onRowClick,
-    rowIndex,
-  }: {
-    table: MRT_TableInstance<RowItem>;
-    cells: MRT_Cell<RowItem, unknown>[];
-    isSelected: boolean;
-    onRowClick?: (e: React.MouseEvent, rowIndex: number) => void;
-    rowIndex: number;
-  }) => (
-    <StyledRow data-selected={isSelected} onClickCapture={e => onRowClick?.(e, rowIndex)}>
+const Row = memo(function Row<RowItem extends Record<string, any>>({
+  cells,
+  table,
+  isSelected,
+  isFocused,
+  isInitialTabStop,
+  onRowClick,
+  onRowFocus,
+  onKeyDown,
+  onBlur,
+  rowIndex,
+  keyboardEnabled,
+}: {
+  table: MRT_TableInstance<RowItem>;
+  cells: MRT_Cell<RowItem, unknown>[];
+  isSelected: boolean;
+  isFocused?: boolean;
+  isInitialTabStop?: boolean;
+  onRowClick?: (e: React.MouseEvent, rowIndex: number) => void;
+  onRowFocus?: (rowIndex: number) => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onBlur?: () => void;
+  rowIndex: number;
+  keyboardEnabled?: boolean;
+}) {
+  const rowRef = useRef<HTMLTableRowElement>(null);
+
+  const handleBlur = useCallback(
+    (e: React.FocusEvent) => {
+      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        onBlur?.();
+      }
+    },
+    [onBlur]
+  );
+
+  const handleClickCapture = useCallback(
+    (e: React.MouseEvent) => onRowClick?.(e, rowIndex),
+    [onRowClick, rowIndex]
+  );
+
+  // Controls inside a cell handle their own keys. Without this guard, Enter on a checkbox or
+  // an action button would be prevented here and would also activate the row.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.target !== e.currentTarget) {
+        return;
+      }
+      onKeyDown?.(e);
+    },
+    [onKeyDown]
+  );
+
+  // Tabbing into the roving tab stop has to seed the focused index, or the row shows no
+  // highlight, Enter does nothing, and the first ArrowDown lands on row 0 instead of moving.
+  const handleFocus = useCallback(
+    (e: React.FocusEvent) => {
+      if (e.target !== e.currentTarget) {
+        return;
+      }
+      onRowFocus?.(rowIndex);
+    },
+    [onRowFocus, rowIndex]
+  );
+
+  useEffect(() => {
+    if (!keyboardEnabled || !isFocused || !rowRef.current) {
+      return;
+    }
+    const activeElement = document.activeElement;
+    if (activeElement && rowRef.current.contains(activeElement)) {
+      return;
+    }
+    const tableElement = rowRef.current.closest('table');
+    if (activeElement && tableElement && !tableElement.contains(activeElement)) {
+      return;
+    }
+    rowRef.current.focus({ preventScroll: true });
+
+    // StyledRow is display:contents, so the <tr> has no layout box and scrolling it does
+    // nothing. Its cells are the grid items that actually occupy space, so scroll one of those.
+    rowRef.current.firstElementChild?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [isFocused, keyboardEnabled]);
+
+  return (
+    <StyledRow
+      ref={rowRef}
+      role="row"
+      data-selected={isSelected}
+      data-focused={isFocused || undefined}
+      aria-selected={isSelected || undefined}
+      tabIndex={keyboardEnabled ? (isFocused || isInitialTabStop ? 0 : -1) : undefined}
+      onKeyDown={keyboardEnabled ? handleKeyDown : undefined}
+      onFocus={keyboardEnabled ? handleFocus : undefined}
+      onBlur={keyboardEnabled ? handleBlur : undefined}
+      onClickCapture={handleClickCapture}
+    >
       {cells.map(cell => (
         <MemoCell
           cell={cell as MRT_Cell<Record<string, any>, unknown>}
@@ -751,8 +889,8 @@ const Row = memo(
         />
       ))}
     </StyledRow>
-  )
-);
+  );
+});
 
 const MemoCell = memo(
   <RowItem extends Record<string, any>>({

--- a/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
@@ -365,8 +365,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -390,8 +391,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -415,8 +417,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Datum.stories.storyshot
@@ -369,8 +369,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -394,8 +395,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -419,8 +421,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
@@ -420,8 +420,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -450,8 +451,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -480,8 +482,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.Getter.stories.storyshot
@@ -424,8 +424,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -454,8 +455,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -484,8 +486,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
@@ -474,8 +474,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -497,8 +498,9 @@
           />
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -522,8 +524,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -547,8 +550,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.LabelSearch.stories.storyshot
@@ -478,8 +478,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -501,8 +502,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -526,8 +528,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -551,8 +554,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
@@ -474,8 +474,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -497,8 +498,9 @@
           />
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -522,8 +524,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -547,8 +550,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NameSearch.stories.storyshot
@@ -478,8 +478,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -501,8 +502,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -526,8 +528,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -551,8 +554,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
@@ -474,8 +474,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -497,8 +498,9 @@
           />
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -522,8 +524,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -547,8 +550,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSearch.stories.storyshot
@@ -478,8 +478,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -501,8 +502,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -526,8 +528,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -551,8 +554,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
@@ -512,8 +512,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -535,8 +536,9 @@
           />
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NamespaceSelect.stories.storyshot
@@ -516,8 +516,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -539,8 +540,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
@@ -474,8 +474,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -497,8 +498,9 @@
           />
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -522,8 +524,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -547,8 +550,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NotFoundMessage.stories.storyshot
@@ -478,8 +478,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -501,8 +502,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -526,8 +528,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -551,8 +554,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
@@ -419,8 +419,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -439,8 +440,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -459,8 +461,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -479,8 +482,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.NumberSearch.stories.storyshot
@@ -423,8 +423,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -443,8 +444,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -463,8 +465,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -483,8 +486,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
@@ -327,8 +327,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -347,8 +348,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -367,8 +369,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -387,8 +390,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -407,8 +411,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURL.stories.storyshot
@@ -331,8 +331,9 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -351,8 +352,9 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -371,8 +373,9 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -391,8 +394,9 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -411,8 +415,9 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
@@ -327,8 +327,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -345,8 +346,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -363,8 +365,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -381,8 +384,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -399,8 +403,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.ReflectInURLWithPrefix.stories.storyshot
@@ -331,8 +331,9 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -349,8 +350,9 @@
               />
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -367,8 +369,9 @@
               />
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -385,8 +388,9 @@
               />
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -403,8 +407,9 @@
               />
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
@@ -474,8 +474,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -497,8 +498,9 @@
           />
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -522,8 +524,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -547,8 +550,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.UIDSearch.stories.storyshot
@@ -478,8 +478,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -501,8 +502,9 @@
             />
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -526,8 +528,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -551,8 +554,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
@@ -255,8 +255,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -270,8 +271,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -285,8 +287,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -300,8 +303,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithFilterMultiSelect.stories.storyshot
@@ -259,8 +259,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -274,8 +275,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -289,8 +291,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -304,8 +307,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithGlobalFilter.stories.storyshot
@@ -5,7 +5,9 @@
       aria-live="polite"
       class="MuiBox-root css-ty8jgw"
       role="status"
-    />
+    >
+      No results found
+    </div>
     <div
       class="MuiBox-root css-1ipmh7v"
     >

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
@@ -365,8 +365,9 @@
         class="css-1obf64m"
       >
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -390,8 +391,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -415,8 +417,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -440,8 +443,9 @@
           </td>
         </tr>
         <tr
-          class="css-1ospngb"
+          class="css-13druua"
           data-selected="false"
+          role="row"
         >
           <td
             class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
+++ b/frontend/src/components/common/Table/__snapshots__/Table.WithSorting.stories.storyshot
@@ -369,8 +369,9 @@
           class="css-1obf64m"
         >
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -394,8 +395,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -419,8 +421,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"
@@ -444,8 +447,9 @@
             </td>
           </tr>
           <tr
-            class="css-1ospngb"
+            class="css-13druua"
             data-selected="false"
+            role="row"
           >
             <td
               class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1574zbf-MuiTableCell-root"

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -565,8 +565,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -651,8 +653,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="ConfigMap"
             class="MuiTable-root css-xsr5nr-MuiTable-root"
           >
             <thead
@@ -569,8 +570,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -655,8 +658,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -741,8 +746,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -827,8 +834,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -1064,8 +1064,10 @@
                   class="css-1obf64m"
                 >
                   <tr
-                    class="css-1ospngb"
+                    class="css-13druua"
                     data-selected="false"
+                    role="row"
+                    tabindex="0"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1150,8 +1152,10 @@
                     </td>
                   </tr>
                   <tr
-                    class="css-1ospngb"
+                    class="css-13druua"
                     data-selected="false"
+                    role="row"
+                    tabindex="-1"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -755,6 +755,7 @@
                   </div>
                 </div>
                 <table
+                  aria-label="MyCustomResource"
                   class="MuiTable-root css-aypfj2-MuiTable-root"
                 >
                   <thead
@@ -1062,8 +1063,10 @@
                     class="css-1obf64m"
                   >
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="0"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1148,8 +1151,10 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="-1"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -574,8 +574,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -578,8 +578,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -575,8 +575,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -661,8 +663,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -272,6 +272,7 @@
             </div>
           </div>
           <table
+            aria-label="MyCustomResource"
             class="MuiTable-root css-aypfj2-MuiTable-root"
           >
             <thead
@@ -579,8 +580,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -665,8 +668,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -840,8 +840,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -967,8 +969,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1094,8 +1098,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1221,8 +1227,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1348,8 +1356,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="CronJob"
             class="MuiTable-root css-10si4eq-MuiTable-root"
           >
             <thead
@@ -844,8 +845,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -971,8 +974,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1098,8 +1103,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1225,8 +1232,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1352,8 +1361,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -898,8 +898,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -265,6 +265,7 @@
               </div>
             </div>
             <table
+              aria-label="DaemonSet"
               class="MuiTable-root css-7biw9r-MuiTable-root"
             >
               <thead
@@ -902,8 +903,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/daemonset/__snapshots__/List.LongName.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.LongName.stories.storyshot
@@ -265,6 +265,7 @@
               </div>
             </div>
             <table
+              aria-label="DaemonSet"
               class="MuiTable-root css-7biw9r-MuiTable-root"
             >
               <thead
@@ -902,8 +903,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -788,8 +788,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -916,8 +918,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -265,6 +265,7 @@
               </div>
             </div>
             <table
+              aria-label="Deployment"
               class="MuiTable-root css-heugea-MuiTable-root"
             >
               <thead
@@ -792,8 +793,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -918,8 +921,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -675,8 +675,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="EndpointSlice"
             class="MuiTable-root css-1twug3x-MuiTable-root"
           >
             <thead
@@ -679,8 +680,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -565,8 +565,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="Endpoint"
             class="MuiTable-root css-1pn9zsq-MuiTable-root"
           >
             <thead
@@ -569,8 +570,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -620,8 +620,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="BackendTLSPolicy"
             class="MuiTable-root css-1cl9dip-MuiTable-root"
           >
             <thead
@@ -624,8 +625,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -620,8 +620,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="XBackendTrafficPolicy"
             class="MuiTable-root css-1cl9dip-MuiTable-root"
           >
             <thead
@@ -624,8 +625,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -476,8 +476,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="GatewayClass"
             class="MuiTable-root css-1ah2k8q-MuiTable-root"
           >
             <thead
@@ -480,8 +481,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteDetails.Basic.stories.storyshot
@@ -249,6 +249,12 @@ api.example.com"
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 MuiGrid-grid-md-12 css-1cbfx75-MuiGrid-root"
                 >
                   <div
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="MuiBox-root css-ty8jgw"
+                    role="status"
+                  />
+                  <div
                     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
                     tabindex="0"
                   >
@@ -326,6 +332,12 @@ api.example.com"
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 MuiGrid-grid-md-12 css-1cbfx75-MuiGrid-root"
                 >
+                  <div
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="MuiBox-root css-ty8jgw"
+                    role="status"
+                  />
                   <div
                     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
                     tabindex="0"
@@ -428,6 +440,12 @@ api.example.com"
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 MuiGrid-grid-md-12 css-v9t693-MuiGrid-root"
                 >
                   <div
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="MuiBox-root css-ty8jgw"
+                    role="status"
+                  />
+                  <div
                     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
                     tabindex="0"
                   >
@@ -476,6 +494,12 @@ api.example.com"
                 <dd
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 MuiGrid-grid-md-12 css-v9t693-MuiGrid-root"
                 >
+                  <div
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="MuiBox-root css-ty8jgw"
+                    role="status"
+                  />
                   <div
                     class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-1sjkwtf-MuiPaper-root-MuiTableContainer-root"
                     tabindex="0"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -510,8 +510,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="GRPCRoute"
             class="MuiTable-root css-1ca5o47-MuiTable-root"
           >
             <thead
@@ -514,8 +515,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="Gateway"
             class="MuiTable-root css-13kw56n-MuiTable-root"
           >
             <thead
@@ -679,8 +680,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -675,8 +675,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="Gateway"
             class="MuiTable-root css-13kw56n-MuiTable-root"
           >
             <thead
@@ -679,8 +680,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -620,8 +620,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -717,8 +719,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="HTTPRoute"
             class="MuiTable-root css-1cl9dip-MuiTable-root"
           >
             <thead
@@ -624,8 +625,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -721,8 +724,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -620,8 +620,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="ReferenceGrant"
             class="MuiTable-root css-1cl9dip-MuiTable-root"
           >
             <thead
@@ -624,8 +625,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/TCPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/TCPRouteList.Items.stories.storyshot
@@ -250,6 +250,7 @@
             </div>
           </div>
           <table
+            aria-label="TCPRoute"
             class="MuiTable-root css-1ef1unc-MuiTable-root"
           >
             <thead
@@ -484,8 +485,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/gateway/__snapshots__/UDPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/UDPRouteList.Items.stories.storyshot
@@ -250,6 +250,7 @@
             </div>
           </div>
           <table
+            aria-label="UDPRoute"
             class="MuiTable-root css-1ef1unc-MuiTable-root"
           >
             <thead
@@ -484,8 +485,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -785,8 +785,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="HorizontalPodAutoscaler"
             class="MuiTable-root css-1qlqnwc-MuiTable-root"
           >
             <thead
@@ -789,8 +790,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -531,8 +531,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -613,8 +615,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="IngressClass"
             class="MuiTable-root css-iyjoyr-MuiTable-root"
           >
             <thead
@@ -535,8 +536,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -617,8 +620,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -675,8 +675,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -782,8 +784,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="Ingress"
             class="MuiTable-root css-13kw56n-MuiTable-root"
           >
             <thead
@@ -679,8 +680,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -786,8 +789,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -785,8 +785,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -913,8 +915,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1041,8 +1045,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1169,8 +1175,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -789,8 +789,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -917,8 +919,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1045,8 +1049,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1173,8 +1179,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
+++ b/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
@@ -128,6 +128,12 @@
         class="MuiBox-root css-1txv3mw"
       >
         <div
+          aria-atomic="true"
+          aria-live="polite"
+          class="MuiBox-root css-ty8jgw"
+          role="status"
+        />
+        <div
           class="MuiBox-root css-1ipmh7v"
         >
           <div
@@ -559,8 +565,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -645,8 +653,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -731,8 +741,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -817,8 +829,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
+++ b/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="JobSet"
             class="MuiTable-root css-xsr5nr-MuiTable-root"
           >
             <thead
@@ -569,8 +570,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -655,8 +658,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -741,8 +746,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -827,8 +834,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.Items.stories.storyshot
+++ b/frontend/src/components/leaderworkerset/__snapshots__/LeaderWorkerSetList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="LeaderWorkerSet"
             class="MuiTable-root css-pp14pd-MuiTable-root"
           >
             <thead
@@ -679,8 +680,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -775,8 +778,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -871,8 +876,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -967,8 +974,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -565,8 +565,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="Lease"
             class="MuiTable-root css-1rgvv0h-MuiTable-root"
           >
             <thead
@@ -569,8 +570,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -510,8 +510,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -514,8 +514,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -476,8 +476,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="Namespace"
             class="MuiTable-root css-126y9uq-MuiTable-root"
           >
             <thead
@@ -480,8 +481,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -620,8 +620,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -715,8 +717,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="NetworkPolicy"
             class="MuiTable-root css-c9uaau-MuiTable-root"
           >
             <thead
@@ -624,8 +625,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -719,8 +722,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/node/__snapshots__/List.NoNodePools.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.NoNodePools.stories.storyshot
@@ -176,6 +176,7 @@
               </div>
             </div>
             <table
+              aria-label="Node"
               class="MuiTable-root css-1drzxj3-MuiTable-root"
             >
               <thead
@@ -813,8 +814,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -934,8 +937,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -809,8 +809,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -926,8 +928,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -176,6 +176,7 @@
               </div>
             </div>
             <table
+              aria-label="Node"
               class="MuiTable-root css-r4i8ha-MuiTable-root"
             >
               <thead
@@ -868,8 +869,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -994,8 +997,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -895,8 +895,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1031,8 +1033,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1185,8 +1189,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1321,8 +1327,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1457,8 +1465,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1593,8 +1603,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1729,8 +1741,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1865,8 +1879,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -899,8 +899,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1060,8 +1062,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1214,8 +1218,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1375,8 +1381,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1536,8 +1544,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1697,8 +1707,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1858,8 +1870,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -2019,8 +2033,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -675,8 +675,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="PodDisruptionBudget"
             class="MuiTable-root css-pp14pd-MuiTable-root"
           >
             <thead
@@ -679,8 +680,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/podGroup/__snapshots__/List.PodGroups.stories.storyshot
+++ b/frontend/src/components/podGroup/__snapshots__/List.PodGroups.stories.storyshot
@@ -253,6 +253,7 @@
               </div>
             </div>
             <table
+              aria-label="PodGroup"
               class="MuiTable-root css-1m6v9bx-MuiTable-root"
             >
               <thead
@@ -725,8 +726,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -830,8 +833,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -476,8 +476,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="PriorityClass"
             class="MuiTable-root css-14pvwot-MuiTable-root"
           >
             <thead
@@ -480,8 +481,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -843,8 +843,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -988,8 +990,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -265,6 +265,7 @@
               </div>
             </div>
             <table
+              aria-label="ReplicaSet"
               class="MuiTable-root css-155ms3a-MuiTable-root"
             >
               <thead
@@ -847,8 +848,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -992,8 +995,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -620,8 +620,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -624,8 +624,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/role/__snapshots__/BindingList.RoleBindings.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/BindingList.RoleBindings.stories.storyshot
@@ -691,8 +691,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -801,8 +803,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/role/__snapshots__/List.Roles.stories.storyshot
+++ b/frontend/src/components/role/__snapshots__/List.Roles.stories.storyshot
@@ -471,8 +471,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -550,8 +552,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -421,8 +421,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="RuntimeClass"
             class="MuiTable-root css-1fjavuh-MuiTable-root"
           >
             <thead
@@ -425,8 +426,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/schedulingWorkload/__snapshots__/List.Workloads.stories.storyshot
+++ b/frontend/src/components/schedulingWorkload/__snapshots__/List.Workloads.stories.storyshot
@@ -253,6 +253,7 @@
               </div>
             </div>
             <table
+              aria-label="Workload"
               class="MuiTable-root css-1cl9dip-MuiTable-root"
             >
               <thead
@@ -615,8 +616,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -706,8 +709,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -651,8 +651,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -742,8 +744,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -655,8 +655,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -746,8 +748,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -785,8 +785,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="Service"
             class="MuiTable-root css-brrsef-MuiTable-root"
           >
             <thead
@@ -789,8 +790,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -840,8 +840,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="Service"
             class="MuiTable-root css-19ac5os-MuiTable-root"
           >
             <thead
@@ -844,8 +845,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/serviceaccount/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/List.Items.stories.storyshot
@@ -265,6 +265,7 @@
               </div>
             </div>
             <table
+              aria-label="ServiceAccount"
               class="MuiTable-root css-xsr5nr-MuiTable-root"
             >
               <thead
@@ -572,8 +573,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -658,8 +661,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -744,8 +749,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -730,8 +730,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -843,8 +845,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="StatefulSet"
             class="MuiTable-root css-fh34cz-MuiTable-root"
           >
             <thead
@@ -734,8 +735,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -847,8 +850,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -730,8 +730,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="StatefulSet"
             class="MuiTable-root css-fh34cz-MuiTable-root"
           >
             <thead
@@ -734,8 +735,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -730,8 +730,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="StatefulSet"
             class="MuiTable-root css-fh34cz-MuiTable-root"
           >
             <thead
@@ -734,8 +735,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -840,8 +840,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -975,8 +977,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1101,8 +1105,10 @@
               </td>
             </tr>
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="-1"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="PersistentVolumeClaim"
             class="MuiTable-root css-kmiwto-MuiTable-root"
           >
             <thead
@@ -844,8 +845,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -979,8 +982,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1105,8 +1110,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -641,8 +641,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="StorageClass"
             class="MuiTable-root css-t7kba7-MuiTable-root"
           >
             <thead
@@ -645,8 +646,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -739,8 +742,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -833,8 +838,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/storage/__snapshots__/VolumeAttributesClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeAttributesClassList.Items.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="VolumeAttributesClass"
             class="MuiTable-root css-1fjavuh-MuiTable-root"
           >
             <thead
@@ -425,8 +426,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -641,8 +641,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -173,6 +173,7 @@
             </div>
           </div>
           <table
+            aria-label="StorageClass"
             class="MuiTable-root css-t7kba7-MuiTable-root"
           >
             <thead
@@ -645,8 +646,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -675,8 +675,10 @@
             class="css-1obf64m"
           >
             <tr
-              class="css-1ospngb"
+              class="css-13druua"
               data-selected="false"
+              role="row"
+              tabindex="0"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -262,6 +262,7 @@
             </div>
           </div>
           <table
+            aria-label="VerticalPodAutoscaler"
             class="MuiTable-root css-13kw56n-MuiTable-root"
           >
             <thead
@@ -679,8 +680,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -424,8 +424,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -500,8 +502,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -576,8 +580,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -652,8 +658,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -728,8 +736,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -804,8 +814,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -176,6 +176,7 @@
               </div>
             </div>
             <table
+              aria-label="MutatingWebhookConfiguration"
               class="MuiTable-root css-mh2h9q-MuiTable-root"
             >
               <thead
@@ -428,8 +429,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -504,8 +507,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -580,8 +585,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -656,8 +663,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -732,8 +741,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -808,8 +819,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -424,8 +424,10 @@
               class="css-1obf64m"
             >
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="0"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -500,8 +502,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -576,8 +580,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -652,8 +658,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -728,8 +736,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -804,8 +814,10 @@
                 </td>
               </tr>
               <tr
-                class="css-1ospngb"
+                class="css-13druua"
                 data-selected="false"
+                role="row"
+                tabindex="-1"
               >
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -176,6 +176,7 @@
               </div>
             </div>
             <table
+              aria-label="ValidatingWebhookConfiguration"
               class="MuiTable-root css-mh2h9q-MuiTable-root"
             >
               <thead
@@ -428,8 +429,10 @@
                 class="css-1obf64m"
               >
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="0"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -504,8 +507,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -580,8 +585,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -656,8 +663,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -732,8 +741,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -808,8 +819,10 @@
                   </td>
                 </tr>
                 <tr
-                  class="css-1ospngb"
+                  class="css-13druua"
                   data-selected="false"
+                  role="row"
+                  tabindex="-1"
                 >
                   <td
                     class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1630,8 +1630,10 @@
                     class="css-1obf64m"
                   >
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="0"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1721,8 +1723,10 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="-1"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1812,8 +1816,10 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="-1"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1903,8 +1909,10 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="-1"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1994,8 +2002,10 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="-1"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -2085,8 +2095,10 @@
                       </td>
                     </tr>
                     <tr
-                      class="css-1ospngb"
+                      class="css-13druua"
                       data-selected="false"
+                      role="row"
+                      tabindex="-1"
                     >
                       <td
                         class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1814,8 +1814,10 @@
                       class="css-1obf64m"
                     >
                       <tr
-                        class="css-1ospngb"
+                        class="css-13druua"
                         data-selected="false"
+                        role="row"
+                        tabindex="0"
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1905,8 +1907,10 @@
                         </td>
                       </tr>
                       <tr
-                        class="css-1ospngb"
+                        class="css-13druua"
                         data-selected="false"
+                        role="row"
+                        tabindex="-1"
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -1996,8 +2000,10 @@
                         </td>
                       </tr>
                       <tr
-                        class="css-1ospngb"
+                        class="css-13druua"
                         data-selected="false"
+                        role="row"
+                        tabindex="-1"
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -2087,8 +2093,10 @@
                         </td>
                       </tr>
                       <tr
-                        class="css-1ospngb"
+                        class="css-13druua"
                         data-selected="false"
+                        role="row"
+                        tabindex="-1"
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -2178,8 +2186,10 @@
                         </td>
                       </tr>
                       <tr
-                        class="css-1ospngb"
+                        class="css-13druua"
                         data-selected="false"
+                        role="row"
+                        tabindex="-1"
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
@@ -2269,8 +2279,10 @@
                         </td>
                       </tr>
                       <tr
-                        class="css-1ospngb"
+                        class="css-13druua"
                         data-selected="false"
+                        role="row"
+                        tabindex="-1"
                       >
                         <td
                           class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"

--- a/frontend/src/lib/useKeyboardNavigation.test.ts
+++ b/frontend/src/lib/useKeyboardNavigation.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useKeyboardNavigation } from './useKeyboardNavigation';
+
+function makeKeyEvent(key: string): React.KeyboardEvent {
+  return {
+    key,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as React.KeyboardEvent;
+}
+
+describe('useKeyboardNavigation', () => {
+  it('starts with no row focused', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('moves focus to first row on ArrowDown when no row is focused', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(0);
+  });
+
+  it('moves focus down by one on ArrowDown', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(2));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(3);
+  });
+
+  it('moves focus up by one on ArrowUp', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(3));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowUp')));
+    expect(result.current.focusedRowIndex).toBe(2);
+  });
+
+  it('does not move focus below last row', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 3, enabled: true }));
+    act(() => result.current.onRowClick(2));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(2);
+  });
+
+  it('does not move focus above first row', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 3, enabled: true }));
+    act(() => result.current.onRowClick(0));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowUp')));
+    expect(result.current.focusedRowIndex).toBe(0);
+  });
+
+  it('calls onRowOpen with the focused index and keyboard event on Enter', () => {
+    const onRowOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useKeyboardNavigation({ rowCount: 5, enabled: true, onRowOpen })
+    );
+    act(() => result.current.onRowClick(2));
+    const event = makeKeyEvent('Enter');
+    act(() => result.current.onKeyDown(event));
+    expect(onRowOpen).toHaveBeenCalledWith(2, event);
+    expect(onRowOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onRowOpen when no row is focused', () => {
+    const onRowOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useKeyboardNavigation({ rowCount: 5, enabled: true, onRowOpen })
+    );
+    act(() => result.current.onKeyDown(makeKeyEvent('Enter')));
+    expect(onRowOpen).not.toHaveBeenCalled();
+  });
+
+  it('clears focus when clearFocus is called', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(3));
+    expect(result.current.focusedRowIndex).toBe(3);
+    act(() => result.current.clearFocus());
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('tracks focus when onRowClick is called', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(4));
+    expect(result.current.focusedRowIndex).toBe(4);
+  });
+
+  it('does not navigate when enabled is false', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: false }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('does not navigate when rowCount is 0', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 0, enabled: true }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('moves to last row on ArrowUp when no row is focused', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 4, enabled: true }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowUp')));
+    expect(result.current.focusedRowIndex).toBe(3);
+  });
+
+  it('ignores unrelated keys', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(2));
+    act(() => result.current.onKeyDown(makeKeyEvent('Tab')));
+    expect(result.current.focusedRowIndex).toBe(2);
+  });
+
+  it('calls preventDefault on ArrowDown', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    const event = makeKeyEvent('ArrowDown');
+    act(() => result.current.onKeyDown(event));
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on ArrowUp', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    const event = makeKeyEvent('ArrowUp');
+    act(() => result.current.onKeyDown(event));
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on Enter', () => {
+    const { result } = renderHook(() =>
+      useKeyboardNavigation({ rowCount: 5, enabled: true, onRowOpen: vi.fn() })
+    );
+    act(() => result.current.onRowClick(1));
+    const event = makeKeyEvent('Enter');
+    act(() => result.current.onKeyDown(event));
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('clears focus when rowCount changes (e.g. filter or pagination)', () => {
+    let rowCount = 5;
+    const { result, rerender } = renderHook(() =>
+      useKeyboardNavigation({ rowCount, enabled: true })
+    );
+    act(() => result.current.onRowClick(3));
+    expect(result.current.focusedRowIndex).toBe(3);
+    rowCount = 2;
+    rerender();
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+});

--- a/frontend/src/lib/useKeyboardNavigation.test.ts
+++ b/frontend/src/lib/useKeyboardNavigation.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useKeyboardNavigation } from './useKeyboardNavigation';
+
+function makeKeyEvent(key: string): React.KeyboardEvent {
+  return {
+    key,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as React.KeyboardEvent;
+}
+
+describe('useKeyboardNavigation', () => {
+  it('starts with no row focused', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('moves focus to first row on ArrowDown when no row is focused', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(0);
+  });
+
+  it('moves focus down by one on ArrowDown', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(2));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(3);
+  });
+
+  it('moves focus up by one on ArrowUp', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(3));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowUp')));
+    expect(result.current.focusedRowIndex).toBe(2);
+  });
+
+  it('does not move focus below last row', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 3, enabled: true }));
+    act(() => result.current.onRowClick(2));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(2);
+  });
+
+  it('does not move focus above first row', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 3, enabled: true }));
+    act(() => result.current.onRowClick(0));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowUp')));
+    expect(result.current.focusedRowIndex).toBe(0);
+  });
+
+  it('calls onRowOpen with the focused index and keyboard event on Enter', () => {
+    const onRowOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useKeyboardNavigation({ rowCount: 5, enabled: true, onRowOpen })
+    );
+    act(() => result.current.onRowClick(2));
+    const event = makeKeyEvent('Enter');
+    act(() => result.current.onKeyDown(event));
+    expect(onRowOpen).toHaveBeenCalledWith(2, event);
+    expect(onRowOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onRowOpen when no row is focused', () => {
+    const onRowOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useKeyboardNavigation({ rowCount: 5, enabled: true, onRowOpen })
+    );
+    act(() => result.current.onKeyDown(makeKeyEvent('Enter')));
+    expect(onRowOpen).not.toHaveBeenCalled();
+  });
+
+  it('clears focus when clearFocus is called', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(3));
+    expect(result.current.focusedRowIndex).toBe(3);
+    act(() => result.current.clearFocus());
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('tracks focus when onRowClick is called', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(4));
+    expect(result.current.focusedRowIndex).toBe(4);
+  });
+
+  it('does not navigate when enabled is false', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: false }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('does not navigate when rowCount is 0', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 0, enabled: true }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('moves to last row on ArrowUp when no row is focused', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 4, enabled: true }));
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowUp')));
+    expect(result.current.focusedRowIndex).toBe(3);
+  });
+
+  it('ignores unrelated keys', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    act(() => result.current.onRowClick(2));
+    act(() => result.current.onKeyDown(makeKeyEvent('Tab')));
+    expect(result.current.focusedRowIndex).toBe(2);
+  });
+
+  it('calls preventDefault on ArrowDown', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    const event = makeKeyEvent('ArrowDown');
+    act(() => result.current.onKeyDown(event));
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on ArrowUp', () => {
+    const { result } = renderHook(() => useKeyboardNavigation({ rowCount: 5, enabled: true }));
+    const event = makeKeyEvent('ArrowUp');
+    act(() => result.current.onKeyDown(event));
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on Enter', () => {
+    const { result } = renderHook(() =>
+      useKeyboardNavigation({ rowCount: 5, enabled: true, onRowOpen: vi.fn() })
+    );
+    act(() => result.current.onRowClick(1));
+    const event = makeKeyEvent('Enter');
+    act(() => result.current.onKeyDown(event));
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('clears focus when rowCount changes (e.g. filter or pagination)', () => {
+    let rowCount = 5;
+    const { result, rerender } = renderHook(() =>
+      useKeyboardNavigation({ rowCount, enabled: true })
+    );
+    act(() => result.current.onRowClick(3));
+    expect(result.current.focusedRowIndex).toBe(3);
+    rowCount = 2;
+    rerender();
+    expect(result.current.focusedRowIndex).toBe(-1);
+  });
+
+  it('navigates again after rowCount shrinks past the focused row', () => {
+    let rowCount = 8;
+    const { result, rerender } = renderHook(() =>
+      useKeyboardNavigation({ rowCount, enabled: true })
+    );
+    act(() => result.current.onRowClick(7));
+    rowCount = 3;
+    rerender();
+
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowDown')));
+
+    expect(result.current.focusedRowIndex).toBe(0);
+  });
+
+  it('opens the row the user sees after rowCount shrinks', () => {
+    const onRowOpen = vi.fn();
+    let rowCount = 8;
+    const { result, rerender } = renderHook(() =>
+      useKeyboardNavigation({ rowCount, enabled: true, onRowOpen })
+    );
+    act(() => result.current.onRowClick(7));
+    rowCount = 3;
+    rerender();
+
+    act(() => result.current.onKeyDown(makeKeyEvent('Enter')));
+    expect(onRowOpen).not.toHaveBeenCalled();
+
+    act(() => result.current.onKeyDown(makeKeyEvent('ArrowUp')));
+    act(() => result.current.onKeyDown(makeKeyEvent('Enter')));
+
+    expect(onRowOpen).toHaveBeenCalledWith(2, expect.anything());
+  });
+});

--- a/frontend/src/lib/useKeyboardNavigation.ts
+++ b/frontend/src/lib/useKeyboardNavigation.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useState } from 'react';
+
+export interface UseKeyboardNavigationOptions {
+  /**
+   * Total number of rows currently visible in the table.
+   */
+  rowCount: number;
+  /**
+   * Called when the user presses Enter on a focused row.
+   * Receives the zero-based index and the originating keyboard event so callers
+   * can inspect modifier keys (Ctrl/Cmd/Shift) for e.g. open-in-new-tab.
+   */
+  onRowOpen?: (rowIndex: number, event: React.KeyboardEvent) => void;
+  /**
+   * When true, keyboard navigation is active.
+   * @default true
+   */
+  enabled?: boolean;
+}
+
+export interface UseKeyboardNavigationResult {
+  /**
+   * The zero-based index of the currently keyboard-focused row, or -1 when none.
+   */
+  focusedRowIndex: number;
+  /**
+   * Attach to the table container's onKeyDown to handle arrow keys and Enter.
+   */
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  /**
+   * Call this to clear focused row (e.g. on table blur).
+   */
+  clearFocus: () => void;
+  /**
+   * Call this when a row is clicked so keyboard focus tracks mouse clicks too.
+   */
+  onRowClick: (rowIndex: number) => void;
+}
+
+/**
+ * Adds arrow-key and Enter keyboard navigation to a table.
+ *
+ * Navigation is scoped: it only activates when the table container has focus,
+ * so it does not interfere with other inputs on the page.
+ *
+ * - ArrowDown / ArrowUp move the focused row highlight.
+ * - Enter opens the focused row via `onRowOpen`.
+ *
+ * @example
+ * ```tsx
+ * const { focusedRowIndex, onKeyDown, clearFocus, onRowClick } = useKeyboardNavigation({
+ *   rowCount: rows.length,
+ *   onRowOpen: index => history.push(`/details/${rows[index].name}`),
+ * });
+ * // attach onKeyDown and onBlur to the table wrapper, pass focusedRowIndex to rows
+ * ```
+ */
+export function useKeyboardNavigation({
+  rowCount,
+  onRowOpen,
+  enabled = true,
+}: UseKeyboardNavigationOptions): UseKeyboardNavigationResult {
+  const [focusedRowIndex, setFocusedRowIndex] = useState<number>(-1);
+
+  // Clamp during render: if rowCount shrinks (filter/pagination), reset focus
+  // without needing a setState-in-effect.
+  const effectiveFocusedRowIndex = focusedRowIndex >= rowCount ? -1 : focusedRowIndex;
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!enabled || rowCount === 0) return;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next =
+          effectiveFocusedRowIndex === -1
+            ? 0
+            : Math.min(effectiveFocusedRowIndex + 1, rowCount - 1);
+        setFocusedRowIndex(next);
+        return;
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const next =
+          effectiveFocusedRowIndex === -1
+            ? rowCount - 1
+            : Math.max(effectiveFocusedRowIndex - 1, 0);
+        setFocusedRowIndex(next);
+        return;
+      }
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (effectiveFocusedRowIndex !== -1 && onRowOpen) {
+          onRowOpen(effectiveFocusedRowIndex, e);
+        }
+        return;
+      }
+    },
+    [enabled, rowCount, effectiveFocusedRowIndex, onRowOpen]
+  );
+
+  const clearFocus = useCallback(() => setFocusedRowIndex(-1), []);
+
+  const onRowClick = useCallback((rowIndex: number) => {
+    setFocusedRowIndex(rowIndex);
+  }, []);
+
+  return { focusedRowIndex: effectiveFocusedRowIndex, onKeyDown, clearFocus, onRowClick };
+}

--- a/frontend/src/lib/useKeyboardNavigation.ts
+++ b/frontend/src/lib/useKeyboardNavigation.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useState } from 'react';
+
+export interface UseKeyboardNavigationOptions {
+  /**
+   * Total number of rows currently visible in the table.
+   */
+  rowCount: number;
+  /**
+   * Called when the user presses Enter on a focused row.
+   * Receives the zero-based index and the originating keyboard event so callers
+   * can inspect modifier keys (Ctrl/Cmd/Shift) for e.g. open-in-new-tab.
+   */
+  onRowOpen?: (rowIndex: number, event: React.KeyboardEvent) => void;
+  /**
+   * When true, keyboard navigation is active.
+   * @default true
+   */
+  enabled?: boolean;
+}
+
+export interface UseKeyboardNavigationResult {
+  /**
+   * The zero-based index of the currently keyboard-focused row, or -1 when none.
+   */
+  focusedRowIndex: number;
+  /**
+   * Attach to the table container's onKeyDown to handle arrow keys and Enter.
+   */
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  /**
+   * Call this to clear focused row (e.g. on table blur).
+   */
+  clearFocus: () => void;
+  /**
+   * Call this when a row is clicked so keyboard focus tracks mouse clicks too.
+   */
+  onRowClick: (rowIndex: number) => void;
+}
+
+/**
+ * Adds arrow-key and Enter keyboard navigation to a table.
+ *
+ * Navigation is scoped: it only activates when the table container has focus,
+ * so it does not interfere with other inputs on the page.
+ *
+ * - ArrowDown / ArrowUp move the focused row highlight.
+ * - Enter opens the focused row via `onRowOpen`.
+ *
+ * @example
+ * ```tsx
+ * const { focusedRowIndex, onKeyDown, clearFocus, onRowClick } = useKeyboardNavigation({
+ *   rowCount: rows.length,
+ *   onRowOpen: index => history.push(`/details/${rows[index].name}`),
+ * });
+ * // attach onKeyDown and onBlur to the table wrapper, pass focusedRowIndex to rows
+ * ```
+ */
+export function useKeyboardNavigation({
+  rowCount,
+  onRowOpen,
+  enabled = true,
+}: UseKeyboardNavigationOptions): UseKeyboardNavigationResult {
+  const [focusedRowIndex, setFocusedRowIndex] = useState<number>(-1);
+
+  // Clamp during render: if rowCount shrinks (filter/pagination), reset focus
+  // without needing a setState-in-effect.
+  const effectiveFocusedRowIndex = focusedRowIndex >= rowCount ? -1 : focusedRowIndex;
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!enabled || rowCount === 0) return;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setFocusedRowIndex(prev => {
+          if (prev === -1) return 0;
+          return prev + 1 < rowCount ? prev + 1 : prev;
+        });
+        return;
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setFocusedRowIndex(prev => {
+          if (prev === -1) return rowCount - 1;
+          return prev - 1 >= 0 ? prev - 1 : prev;
+        });
+        return;
+      }
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (effectiveFocusedRowIndex !== -1 && onRowOpen) {
+          onRowOpen(effectiveFocusedRowIndex, e);
+        }
+        return;
+      }
+    },
+    [enabled, rowCount, effectiveFocusedRowIndex, onRowOpen]
+  );
+
+  const clearFocus = useCallback(() => setFocusedRowIndex(-1), []);
+
+  const onRowClick = useCallback((rowIndex: number) => {
+    setFocusedRowIndex(rowIndex);
+  }, []);
+
+  return { focusedRowIndex: effectiveFocusedRowIndex, onKeyDown, clearFocus, onRowClick };
+}

--- a/frontend/src/lib/useKeyboardNavigation.ts
+++ b/frontend/src/lib/useKeyboardNavigation.ts
@@ -88,19 +88,21 @@ export function useKeyboardNavigation({
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setFocusedRowIndex(prev => {
-          if (prev === -1) return 0;
-          return prev + 1 < rowCount ? prev + 1 : prev;
-        });
+        const next =
+          effectiveFocusedRowIndex === -1
+            ? 0
+            : Math.min(effectiveFocusedRowIndex + 1, rowCount - 1);
+        setFocusedRowIndex(next);
         return;
       }
 
       if (e.key === 'ArrowUp') {
         e.preventDefault();
-        setFocusedRowIndex(prev => {
-          if (prev === -1) return rowCount - 1;
-          return prev - 1 >= 0 ? prev - 1 : prev;
-        });
+        const next =
+          effectiveFocusedRowIndex === -1
+            ? rowCount - 1
+            : Math.max(effectiveFocusedRowIndex - 1, 0);
+        setFocusedRowIndex(next);
         return;
       }
 


### PR DESCRIPTION
## Summary

Allow users to navigate table rows with ArrowUp/ArrowDown. Focus tracks mouse clicks and is cleared on table blur.

Adds a `useKeyboardNavigation` hook that manages focused-row state and handles arrow key and Enter events scoped to the table element, so navigation does not interfere with other inputs on the page.

## Related Issue

Closes #5727

## Changes

- Added `src/lib/useKeyboardNavigation.ts` — hook managing focused row index with ArrowUp, ArrowDown, and Enter handling. The stored index is clamped during render, so a filter or page change that shrinks the row count cannot leave focus pointing past the end or make the arrow keys inert.
- Added `src/lib/useKeyboardNavigation.test.ts` — 20 unit tests covering navigation, boundary conditions, Enter-to-open, disabled state, recovery after the row count shrinks, and preventDefault calls
- Updated `src/components/common/Table/Table.tsx` — new `onRowOpen` prop; when provided, table rows get a roving `tabIndex`, keyboard handler, and focus highlight styling (blue left border + light background). Rows carry `role="row"` and `aria-selected`, and the table takes an optional `ariaLabel` so screen readers can name the region a row belongs to.
- Updated `src/components/common/Resource/ResourceTable.tsx` — exposes `onRowOpen` with default behaviour of navigating to the resource detail page; pass `disableRowOpen` to opt out. `ariaLabel` defaults to the resource class name.

## Steps to Test

1. Start Headlamp and open any resource list (e.g. Pods, Deployments)
2. Click anywhere inside the table to focus it
3. Press ArrowDown / ArrowUp — a blue highlight should move between rows
4. Press Enter on a focused row — should navigate to that resource's detail page
5. Hold Ctrl/Cmd/Shift and press Enter — should open the detail page in a new tab
6. Click a row with the mouse — keyboard focus should follow the click
7. Click outside the table — focus highlight should clear
8. Interact with the search input or filter fields — arrow keys should not trigger row navigation while those inputs are focused
9. Filter the list down so fewer rows remain than the row you had focused, then press ArrowDown — navigation should resume from the top rather than doing nothing

## Screenshots

https://github.com/user-attachments/assets/06cf282d-6a52-4b1f-83df-638d0509103a

## Notes for the Reviewer

- Navigation is scoped to the table element via `onKeyDown` (not a global hotkey), so it only activates when the table itself has focus
- The focus target is the `<tr>` itself, held by a per-row ref, and is focused with `preventScroll: true`. Focus is only moved when the previous focus was already inside the same table, so a click elsewhere on the page cannot be stolen and the scroll position is not yanked
- Only one row is ever in the tab order: the focused row, or the first row when nothing is focused
- Enter falls back to `row.getDetailsLink()`. The result is only handed to the router when it is an in-app path; anything else is opened in a new tab rather than pushed onto the history stack as a broken route
- To disable keyboard navigation on a `ResourceTable`, pass `disableRowOpen`. Omitting `onRowOpen` does not disable it — it falls back to navigating to `row.getDetailsLink()`
- Key handling is done entirely via the scoped `onKeyDown` on the table element; no changes to `shortcutsSlice.ts` are included in this PR
