### PR TITLE
backend: kubeconfig: Stop treating empty path and missing file as load errors

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -473,11 +474,26 @@ type ContextLoadError struct {
 
 // LoadContextsFromFile loads contexts from a kubeconfig file.
 // It reads the kubeconfig file from the given path and loads the contexts from the file.
-// It returns an error if the file cannot be read.
+// An empty path or a file that does not exist is treated as a no-op and returns
+// (nil, nil, nil) rather than an error. Any other read failure is returned as an error.
 // It will return valid (contexts, ContextLoadErrors,nil) and errors if there are any errors in the file.
 func LoadContextsFromFile(kubeConfigPath string, source int) ([]Context, []ContextLoadError, error) {
+	// An empty path or a path that does not exist on disk is not an error
+	// condition for this loader: there is simply nothing to read. The
+	// in-cluster mode leaves KubeConfigPath empty, and the dynamic-cluster
+	// persistence file is absent on a fresh deployment until the user adds
+	// the first dynamic cluster. Treating both as ERRORs produced log
+	// spam reported in issues #4724 and #4401.
+	if kubeConfigPath == "" {
+		return nil, nil, nil
+	}
+
 	data, err := os.ReadFile(kubeConfigPath) //nolint:gosec
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil, nil
+		}
+
 		return nil, nil, fmt.Errorf("error reading kubeconfig file: %w", err)
 	}
 

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -77,11 +77,28 @@ func TestLoadAndStoreKubeConfigs(t *testing.T) {
 		require.Equal(t, "minikube", ctx.Name)
 	})
 
-	t.Run("invalid_file", func(t *testing.T) {
-		kubeConfigFile := "invalid_kubeconfig"
+	t.Run("missing_file", func(t *testing.T) {
+		// Regression for issues #4724 and #4401: a kubeconfig path that does
+		// not exist on disk (in-cluster dynamic-cluster persistence file,
+		// fresh deployments) used to surface as an ERROR. It should now be
+		// treated as "no contexts to load".
+		err := kubeconfig.LoadAndStoreKubeConfigs(
+			contextStore, "missing_kubeconfig", kubeconfig.KubeConfig, nil,
+		)
+		require.NoError(t, err)
+	})
 
-		err := kubeconfig.LoadAndStoreKubeConfigs(contextStore, kubeConfigFile, kubeconfig.KubeConfig, nil)
-		require.Error(t, err)
+	t.Run("empty_path", func(t *testing.T) {
+		// Regression for issues #4724 and #4401: in-cluster mode leaves
+		// KubeConfigPath empty; passing "" should not error.
+		store := kubeconfig.NewContextStore()
+
+		err := kubeconfig.LoadAndStoreKubeConfigs(store, "", kubeconfig.KubeConfig, nil)
+		require.NoError(t, err)
+
+		contexts, err := store.GetContexts()
+		require.NoError(t, err)
+		require.Empty(t, contexts)
 	})
 }
 
@@ -115,13 +132,22 @@ func TestLoadContextsFromKubeConfigFile(t *testing.T) {
 		require.Equal(t, 2, len(contexts), "Expected 2 contexts from valid file")
 	})
 
-	t.Run("invalid_file", func(t *testing.T) {
-		kubeConfigFile := "invalid_kubeconfig"
+	t.Run("missing_file", func(t *testing.T) {
+		// Regression for issues #4724 and #4401. See TestLoadAndStoreKubeConfigs.
+		contexts, contextErrors, err := kubeconfig.LoadContextsFromFile(
+			"missing_kubeconfig", kubeconfig.KubeConfig,
+		)
+		require.NoError(t, err, "missing file is not an error condition")
+		require.Empty(t, contextErrors)
+		require.Empty(t, contexts)
+	})
 
-		contexts, contextErrors, err := kubeconfig.LoadContextsFromFile(kubeConfigFile, kubeconfig.KubeConfig)
-		require.Error(t, err, "Expected error for invalid file")
-		require.Empty(t, contextErrors, "Expected no context errors for invalid file")
-		require.Empty(t, contexts, "Expected no contexts from invalid file")
+	t.Run("empty_path", func(t *testing.T) {
+		// Regression for issues #4724 and #4401: in-cluster mode passes "".
+		contexts, contextErrors, err := kubeconfig.LoadContextsFromFile("", kubeconfig.KubeConfig)
+		require.NoError(t, err)
+		require.Empty(t, contextErrors)
+		require.Empty(t, contexts)
 	})
 
 	t.Run("autherror", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Two long-standing issues report the same root cause: a default in-cluster Headlamp deployment writes two `ERROR` lines to its pod log on every startup, even when nothing is wrong.

```
{"level":"error","source":".../backend/cmd/headlamp.go","line":496,
 "error":"error loading kubeconfig files: error reading kubeconfig file: open : no such file or directory",
 "message":"loading kubeconfig"}
{"level":"error","source":".../backend/cmd/headlamp.go","line":516,
 "error":"error loading kubeconfig files: error reading kubeconfig file: open /home/headlamp/.config/Headlamp/kubeconfigs/config: no such file or directory",
 "message":"loading dynamic kubeconfig"}
```

The first line comes from `LoadAndStoreKubeConfigs(store, "", ...)` because in-cluster mode leaves `KubeConfigPath` empty (the service account token is the actual credential). The second comes from `LoadAndStoreKubeConfigs(store, ~/.config/Headlamp/kubeconfigs/config, ...)`: this file is owned by Headlamp itself and is absent on a fresh pod until the user adds the first dynamic cluster. Both situations are normal but were both treated as `ERROR`.

## Related Issues

Issue: https://github.com/kubernetes-sigs/headlamp/issues/4724
Issue: https://github.com/kubernetes-sigs/headlamp/issues/4401

## Changes

- `backend/pkg/kubeconfig/kubeconfig.go::LoadContextsFromFile`
  - If the path is empty, return `(nil, nil, nil)`. There is nothing to read.
  - If `os.ReadFile` fails with `errors.Is(err, fs.ErrNotExist)`, return `(nil, nil, nil)`. The file simply isn't there.
  - All other read errors (permission denied, malformed file, etc.) keep their existing behavior.
  - Bonus: switch the existing wrap from `fmt.Errorf("...: %v", err)` to `... %w`, so callers can use `errors.Is` on the chain.
- `backend/pkg/kubeconfig/kubeconfig_test.go`
  - Rename the existing `invalid_file` subtests in `TestLoadAndStoreKubeConfigs` and `TestLoadContextsFromKubeConfigFile` to `missing_file`, and flip their assertion to `NoError`. The old name was misleading because the test was passing a path to a file that does not exist on disk, not a malformed kubeconfig.
  - Add a new `empty_path` subtest to each of the two test groups, covering the in-cluster scenario directly.

The fix cascades through every caller: `createHeadlampHandler` at the two startup load sites (`cmd/headlamp.go:522` and `:541`), and the two reload paths in `pkg/kubeconfig/watcher.go`. None of those call sites needed to change.

## Steps to Test

1. `cd backend && go test ./pkg/kubeconfig/ -run 'TestLoadAndStoreKubeConfigs|TestLoadContextsFromKubeConfigFile' -v`. All subtests pass, including the new `missing_file` and `empty_path` cases.
2. Revert only `kubeconfig.go` and rerun: both `missing_file` and `empty_path` subtests fail with exactly the error from the reporters, demonstrating the regression test catches the bug.
3. `cd backend && go test ./pkg/kubeconfig/... ./cmd/... -race`. Clean.
4. `cd backend && go build ./... && go vet ./pkg/kubeconfig/ ./cmd/`. Clean.

I also ran the full backend suite. One race finding in `pkg/telemetry/TestResponseWriterHijack_SucceedsWithUnderlyingHijacker` exists on `main` independent of this change (`git stash && go test ./pkg/telemetry/...` still fails) and is out of scope here.

## Notes for the Reviewer

- This intentionally trades off "loud about every missing kubeconfig" for "quiet about the common, expected cases". A user who passes `--kubeconfig=/typo/path` will no longer see an `ERROR` line for that typo, only the (already existing) absence of contexts in the UI. If you'd prefer an `INFO`-level "skipping nonexistent kubeconfig path: ..." log at the call sites in `createHeadlampHandler`, I'm happy to add it.
- The `%v` → `%w` swap is harmless on its own (the message string is identical) and gives callers an `errors.Is`/`errors.As` foothold if they ever need to distinguish error kinds in the future.