### PR TITLE
app: verify-build: Add server cleanup check after app close

### DIFF
--- a/app/scripts/verify-build-linux.sh
+++ b/app/scripts/verify-build-linux.sh
@@ -113,6 +113,138 @@ if [ ! -z "$TARBALL" ]; then
     exit 1
   fi
   
+  # Step 4: Verify headlamp-server is cleaned up when app closes
+  echo "=== Verifying Server Cleanup After App Close ==="
+
+  # Record existing headlamp-server and headlamp PIDs to exclude them
+  EXISTING_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+  EXISTING_HEADLAMP_PIDS=$(pgrep -x headlamp 2>/dev/null || true)
+
+  # Start the app in the background (needs a virtual display on headless CI)
+  if command -v xvfb-run &>/dev/null; then
+    echo "Using xvfb-run to launch app with virtual display..."
+    xvfb-run --auto-servernum "$HEADLAMP_EXEC" > /dev/null 2>&1 &
+  else
+    echo "xvfb-run not available, launching app directly..."
+    "$HEADLAMP_EXEC" > /dev/null 2>&1 &
+  fi
+  WRAPPER_PID=$!
+  echo "Launcher started with PID: $WRAPPER_PID"
+
+  # Wait for headlamp-server to appear (up to 30 seconds)
+  echo "Waiting for headlamp-server to start..."
+  SERVER_PID=""
+  for i in $(seq 1 30); do
+    ALL_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+    for pid in $ALL_SERVER_PIDS; do
+      if [ -z "$EXISTING_SERVER_PIDS" ] || ! echo "$EXISTING_SERVER_PIDS" | grep -qw "$pid"; then
+        SERVER_PID="$pid"
+        break
+      fi
+    done
+    if [ -n "$SERVER_PID" ]; then
+      echo "headlamp-server started with PID: $SERVER_PID"
+      break
+    fi
+    sleep 1
+  done
+
+  if [ -z "$SERVER_PID" ]; then
+    echo "⚠ headlamp-server did not start within 30 seconds, skipping cleanup test"
+    # Kill the wrapper and any headlamp (Electron) processes we spawned
+    kill -TERM "$WRAPPER_PID" 2>/dev/null || true
+    ALL_HEADLAMP_PIDS=$(pgrep -x headlamp 2>/dev/null || true)
+    for pid in $ALL_HEADLAMP_PIDS; do
+      if [ -z "$EXISTING_HEADLAMP_PIDS" ] || ! echo "$EXISTING_HEADLAMP_PIDS" | grep -qw "$pid"; then
+        kill -TERM "$pid" 2>/dev/null || true
+      fi
+    done
+    for i in $(seq 1 10); do
+      if kill -0 "$WRAPPER_PID" 2>/dev/null; then sleep 1; else break; fi
+    done
+    kill -9 "$WRAPPER_PID" 2>/dev/null || true
+    for pid in $ALL_HEADLAMP_PIDS; do
+      if [ -z "$EXISTING_HEADLAMP_PIDS" ] || ! echo "$EXISTING_HEADLAMP_PIDS" | grep -qw "$pid"; then
+        kill -9 "$pid" 2>/dev/null || true
+      fi
+    done
+  else
+    # Find the actual headlamp (Electron) PID — when launched via xvfb-run,
+    # $WRAPPER_PID is the wrapper, not the Electron process. We need to SIGTERM
+    # the Electron process directly so its quit handler fires.
+    ELECTRON_PID=""
+    ALL_HEADLAMP_PIDS=$(pgrep -x headlamp 2>/dev/null || true)
+    for pid in $ALL_HEADLAMP_PIDS; do
+      if [ -z "$EXISTING_HEADLAMP_PIDS" ] || ! echo "$EXISTING_HEADLAMP_PIDS" | grep -qw "$pid"; then
+        ELECTRON_PID="$pid"
+        break
+      fi
+    done
+
+    if [ -z "$ELECTRON_PID" ]; then
+      echo "⚠ Could not find Electron PID, falling back to wrapper PID"
+      ELECTRON_PID="$WRAPPER_PID"
+    fi
+    echo "Sending SIGTERM to Electron app (PID: $ELECTRON_PID)..."
+    kill -TERM "$ELECTRON_PID" 2>/dev/null || true
+
+    # Bounded wait for the Electron app to exit (up to 15 seconds)
+    for i in $(seq 1 15); do
+      if kill -0 "$ELECTRON_PID" 2>/dev/null; then
+        sleep 1
+      else
+        break
+      fi
+    done
+    if kill -0 "$ELECTRON_PID" 2>/dev/null; then
+      echo "⚠ Electron app did not exit gracefully, force killing..."
+      kill -9 "$ELECTRON_PID" 2>/dev/null || true
+    fi
+    # Also clean up the wrapper process if it's still around
+    kill -TERM "$WRAPPER_PID" 2>/dev/null || true
+    for i in $(seq 1 10); do
+      if kill -0 "$WRAPPER_PID" 2>/dev/null; then sleep 1; else break; fi
+    done
+    kill -9 "$WRAPPER_PID" 2>/dev/null || true
+
+    # Wait for the server process to exit (up to 10 seconds)
+    echo "Waiting for headlamp-server to exit..."
+    for i in $(seq 1 10); do
+      REMAINING_SERVER_PIDS=""
+      ALL_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+      for pid in $ALL_SERVER_PIDS; do
+        if [ -z "$EXISTING_SERVER_PIDS" ] || ! echo "$EXISTING_SERVER_PIDS" | grep -qw "$pid"; then
+          REMAINING_SERVER_PIDS="$REMAINING_SERVER_PIDS $pid"
+        fi
+      done
+      if [ -z "$REMAINING_SERVER_PIDS" ]; then
+        break
+      fi
+      sleep 1
+    done
+
+    # Final check: are any new headlamp-server processes still running?
+    REMAINING_SERVER_PIDS=""
+    ALL_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+    for pid in $ALL_SERVER_PIDS; do
+      if [ -z "$EXISTING_SERVER_PIDS" ] || ! echo "$EXISTING_SERVER_PIDS" | grep -qw "$pid"; then
+        REMAINING_SERVER_PIDS="$REMAINING_SERVER_PIDS $pid"
+      fi
+    done
+
+    if [ -n "$REMAINING_SERVER_PIDS" ]; then
+      echo "✗ headlamp-server process(es) still running after app close: $REMAINING_SERVER_PIDS"
+      for pid in $REMAINING_SERVER_PIDS; do
+        kill -9 "$pid" 2>/dev/null || true
+      done
+      rm -rf "$EXTRACT_DIR"
+      rm -f "$OUTPUT_FILE"
+      exit 1
+    else
+      echo "✓ headlamp-server properly terminated after app close"
+    fi
+  fi
+
   # Cleanup
   rm -rf "$EXTRACT_DIR"
   rm -f "$OUTPUT_FILE"

--- a/app/scripts/verify-build-mac.sh
+++ b/app/scripts/verify-build-mac.sh
@@ -181,4 +181,180 @@ else
 fi
 
 echo ""
+echo "=== Verifying Server Cleanup After App Close ==="
+
+# Function to test server cleanup
+test_server_cleanup() {
+  local APP_BUNDLE="$1"
+
+  if [ ! -d "$APP_BUNDLE" ]; then
+    echo "✗ Cannot test server cleanup: app bundle not found at $APP_BUNDLE"
+    return 1
+  fi
+
+  # Record existing PIDs to exclude them
+  local EXISTING_SERVER_PIDS
+  local EXISTING_APP_PIDS
+  local ELECTRON_PID
+  local SERVER_PID
+  local ALL_SERVER_PIDS
+  local ALL_APP_PIDS
+  local REMAINING_SERVER_PIDS
+
+  EXISTING_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+  EXISTING_APP_PIDS=$(pgrep -x Headlamp 2>/dev/null || true)
+
+  # Launch the app using macOS 'open' command so it properly registers with
+  # WindowServer and Electron's 'ready' event fires (direct binary execution
+  # skips this registration on CI runners).
+  # --disable-gpu avoids GPU initialization failures on headless macOS CI runners.
+  echo "Launching app for server cleanup test (via open, GPU disabled for CI)..."
+  open "$APP_BUNDLE" --args --disable-gpu
+
+  # Wait for the Headlamp process to appear (up to 15 seconds)
+  ELECTRON_PID=""
+  for i in $(seq 1 15); do
+    ALL_APP_PIDS=$(pgrep -x Headlamp 2>/dev/null || true)
+    for pid in $ALL_APP_PIDS; do
+      if [ -z "$EXISTING_APP_PIDS" ] || ! echo "$EXISTING_APP_PIDS" | grep -qw "$pid"; then
+        ELECTRON_PID="$pid"
+        break
+      fi
+    done
+    if [ -n "$ELECTRON_PID" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  if [ -z "$ELECTRON_PID" ]; then
+    echo "⚠ Headlamp process did not appear within 15 seconds, skipping cleanup test"
+    return 0
+  fi
+  echo "Electron app started with PID: $ELECTRON_PID"
+
+  # Wait for headlamp-server to appear (up to 30 seconds)
+  echo "Waiting for headlamp-server to start..."
+  SERVER_PID=""
+  for i in $(seq 1 30); do
+    ALL_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+    for pid in $ALL_SERVER_PIDS; do
+      if [ -z "$EXISTING_SERVER_PIDS" ] || ! echo "$EXISTING_SERVER_PIDS" | grep -qw "$pid"; then
+        SERVER_PID="$pid"
+        break
+      fi
+    done
+    if [ -n "$SERVER_PID" ]; then
+      echo "headlamp-server started with PID: $SERVER_PID"
+      break
+    fi
+    sleep 1
+  done
+
+  if [ -z "$SERVER_PID" ]; then
+    echo "⚠ headlamp-server did not start within 30 seconds, skipping cleanup test"
+    kill -TERM "$ELECTRON_PID" 2>/dev/null || true
+    # Bounded wait for process to exit (up to 10 seconds)
+    for i in $(seq 1 10); do
+      if kill -0 "$ELECTRON_PID" 2>/dev/null; then sleep 1; else break; fi
+    done
+    kill -9 "$ELECTRON_PID" 2>/dev/null || true
+    return 0
+  fi
+
+  # Gracefully close the Electron app (SIGTERM triggers the quit handler)
+  echo "Sending SIGTERM to Electron app (PID: $ELECTRON_PID)..."
+  kill -TERM "$ELECTRON_PID" 2>/dev/null || true
+
+  # Bounded wait for the Electron app to exit (up to 15 seconds)
+  for i in $(seq 1 15); do
+    if kill -0 "$ELECTRON_PID" 2>/dev/null; then
+      sleep 1
+    else
+      break
+    fi
+  done
+  if kill -0 "$ELECTRON_PID" 2>/dev/null; then
+    echo "⚠ Electron app did not exit gracefully, force killing..."
+    kill -9 "$ELECTRON_PID" 2>/dev/null || true
+  fi
+
+  # Wait for all new server processes to exit (up to 10 seconds)
+  echo "Waiting for headlamp-server to exit..."
+  for i in $(seq 1 10); do
+    REMAINING_SERVER_PIDS=""
+    ALL_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+    for pid in $ALL_SERVER_PIDS; do
+      if [ -z "$EXISTING_SERVER_PIDS" ] || ! echo "$EXISTING_SERVER_PIDS" | grep -qw "$pid"; then
+        REMAINING_SERVER_PIDS="$REMAINING_SERVER_PIDS $pid"
+      fi
+    done
+    if [ -z "$REMAINING_SERVER_PIDS" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  # Final check: are any new headlamp-server processes still running?
+  REMAINING_SERVER_PIDS=""
+  ALL_SERVER_PIDS=$(pgrep -f headlamp-server 2>/dev/null || true)
+  for pid in $ALL_SERVER_PIDS; do
+    if [ -z "$EXISTING_SERVER_PIDS" ] || ! echo "$EXISTING_SERVER_PIDS" | grep -qw "$pid"; then
+      REMAINING_SERVER_PIDS="$REMAINING_SERVER_PIDS $pid"
+    fi
+  done
+
+  if [ -n "$REMAINING_SERVER_PIDS" ]; then
+    echo "✗ headlamp-server process(es) still running after app close: $REMAINING_SERVER_PIDS"
+    for pid in $REMAINING_SERVER_PIDS; do
+      kill -9 "$pid" 2>/dev/null || true
+    done
+    return 1
+  else
+    echo "✓ headlamp-server properly terminated after app close"
+    return 0
+  fi
+}
+
+# Test server cleanup using the app bundle found earlier.
+# Prefer native architecture build: on arm64 runners, dist/mac contains the x64
+# build (via Rosetta) and dist/mac-arm64 contains the native arm64 build.
+ARCH=$(uname -m)
+MAC_DIR=""
+if [ "$ARCH" = "arm64" ] && [ -d "$DIST_DIR/mac-arm64" ]; then
+  MAC_DIR="$DIST_DIR/mac-arm64"
+elif [ -d "$DIST_DIR/mac" ]; then
+  MAC_DIR="$DIST_DIR/mac"
+fi
+
+if [ -n "$MAC_DIR" ]; then
+  APP_BUNDLE=$(find "$MAC_DIR" -name "*.app" -type d | head -n 1)
+  if [ -n "$APP_BUNDLE" ]; then
+    test_server_cleanup "$APP_BUNDLE" || exit 1
+  fi
+else
+  # DMG was already unmounted; re-mount to test server cleanup
+  DMG_FILE=$(ls "$DIST_DIR"/*.dmg | head -n 1)
+  if [ ! -z "$DMG_FILE" ]; then
+    MOUNT_POINT=$(mktemp -d -t headlamp-dmg-cleanup)
+    if hdiutil attach "$DMG_FILE" -mountpoint "$MOUNT_POINT" > /dev/null 2>&1; then
+      APP_BUNDLE=$(find "$MOUNT_POINT" -name "*.app" -type d | head -n 1)
+      if [ -n "$APP_BUNDLE" ]; then
+        if ! test_server_cleanup "$APP_BUNDLE"; then
+          hdiutil detach "$MOUNT_POINT" > /dev/null 2>&1
+          rm -rf "$MOUNT_POINT" || true
+          exit 1
+        fi
+      else
+        echo "⚠ App bundle not found in re-mounted DMG, skipping server cleanup test"
+      fi
+      hdiutil detach "$MOUNT_POINT" > /dev/null 2>&1
+    else
+      echo "⚠ Failed to re-mount DMG for server cleanup test, skipping"
+    fi
+    rm -rf "$MOUNT_POINT" || true
+  fi
+fi
+
+echo ""
 echo "✓ All Mac verification checks passed"

--- a/app/scripts/verify-build-windows.ps1
+++ b/app/scripts/verify-build-windows.ps1
@@ -205,5 +205,81 @@ if ($appPath -and (Test-Path $appPath)) {
 }
 
 Write-Host ""
+Write-Host "=== Verifying Server Cleanup After App Close ===" -ForegroundColor Cyan
+
+# Record existing headlamp-server PIDs to exclude them
+$existingServerPIDs = @(Get-Process -Name "headlamp-server" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Id)
+
+# Start the app in background
+Write-Host "Launching app for server cleanup test..."
+$appProcess = Start-Process -FilePath $appPath -PassThru -ErrorAction Stop
+Write-Host "Electron app started with PID: $($appProcess.Id)"
+
+# Wait for headlamp-server to appear (up to 30 seconds)
+Write-Host "Waiting for headlamp-server to start..."
+$serverPID = $null
+for ($i = 1; $i -le 30; $i++) {
+  $allServerProcs = @(Get-Process -Name "headlamp-server" -ErrorAction SilentlyContinue)
+  foreach ($proc in $allServerProcs) {
+    if ($existingServerPIDs -notcontains $proc.Id) {
+      $serverPID = $proc.Id
+      break
+    }
+  }
+  if ($null -ne $serverPID) {
+    Write-Host "headlamp-server started with PID: $serverPID"
+    break
+  }
+  Start-Sleep -Seconds 1
+}
+
+if ($null -eq $serverPID) {
+  Write-Host "WARNING: headlamp-server did not start within 30 seconds, skipping cleanup test" -ForegroundColor Yellow
+  Stop-Process -Id $appProcess.Id -Force -ErrorAction SilentlyContinue
+} else {
+  # Gracefully close the Electron app (CloseMainWindow sends WM_CLOSE)
+  Write-Host "Closing Electron app (PID: $($appProcess.Id))..."
+  try {
+    $appProcess.CloseMainWindow() | Out-Null
+  } catch {
+    # Ignore if window is not available
+  }
+  # Wait for the app to exit gracefully (up to 10 seconds)
+  $appExited = $false
+  try {
+    $appExited = $appProcess.WaitForExit(10000)
+  } catch {
+    # Ignore if already exited
+  }
+  if (-not $appExited) {
+    Write-Host "App did not exit gracefully, forcing termination..."
+    Stop-Process -Id $appProcess.Id -Force -ErrorAction SilentlyContinue
+  }
+
+  # Wait for all new server processes to exit (up to 10 seconds)
+  Write-Host "Waiting for headlamp-server to exit..."
+  for ($i = 1; $i -le 10; $i++) {
+    $remainingServers = @(Get-Process -Name "headlamp-server" -ErrorAction SilentlyContinue | Where-Object { $existingServerPIDs -notcontains $_.Id })
+    if ($remainingServers.Count -eq 0) {
+      break
+    }
+    Start-Sleep -Seconds 1
+  }
+
+  # Final check: are any new headlamp-server processes still running?
+  $remainingServers = @(Get-Process -Name "headlamp-server" -ErrorAction SilentlyContinue | Where-Object { $existingServerPIDs -notcontains $_.Id })
+  if ($remainingServers.Count -gt 0) {
+    $remainingPIDs = ($remainingServers | Select-Object -ExpandProperty Id) -join ", "
+    Write-Host "[FAIL] headlamp-server process(es) still running after app close: $remainingPIDs" -ForegroundColor Red
+    foreach ($proc in $remainingServers) {
+      Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+    }
+    exit 1
+  } else {
+    Write-Host "[PASS] headlamp-server properly terminated after app close" -ForegroundColor Green
+  }
+}
+
+Write-Host ""
 Write-Host "[PASS] All Windows verification checks passed" -ForegroundColor Green
 


### PR DESCRIPTION
## Summary


Verify that headlamp-server is properly terminated when the Electron app
closes, on Linux, macOS, and Windows.

Each script starts the app, waits for headlamp-server to appear, sends
SIGTERM (or equivalent on Windows) to the Electron process, then checks
that no headlamp-server processes remain after the app exits. The test
is skipped with a warning if the server does not start within 30 seconds.

No changes to `app/electron/main.ts` are included. The verification scripts validate the existing server cleanup behavior. Tested that each test works by commenting out the quitServerProcess code and seeing the test fail.

## Related Issue

There was a regression last release, and several other times as well.

## Steps to Test

1. Build the app for any platform (`make app-linux`, `make app-mac`, or `make app-win`)
2. Run the corresponding verify script (`npm run app:verify-build-linux`, etc.)
3. Observe the new "Verifying Server Cleanup After App Close" section in output
4. The verify script should **pass** on all three platforms, confirming that `headlamp-server` is properly terminated when the app exits

Test script catches problems?
- You can comment out `Uncommented app.on('quit', quitServerProcess)` to make sure it quits.

In CI? Yes, these verify tests are already running in CI for each platform, this addition tests they quit headlamp-server properly in CI.