### PR TITLE
backend: Fix drain node goroutine to use server shutdown context instead of context.Background()

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -65,6 +65,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -503,6 +504,7 @@ func setupInClusterContext(config *HeadlampConfig) {
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
 
+	config.ServerCtx = ctx
 	config.StaticPluginDir = os.Getenv("HEADLAMP_STATIC_PLUGINS_DIR")
 
 	logger.Log(logger.LevelInfo, nil, nil, "Creating Headlamp handler")
@@ -2792,7 +2794,7 @@ func (c *HeadlampConfig) addClusterSetupRoute(r *mux.Router) {
 /*
 This function is used to handle the node drain request.
 */
-func (c *HeadlampConfig) handleNodeDrain(w http.ResponseWriter, r *http.Request) {
+func (c *HeadlampConfig) handleNodeDrain(w http.ResponseWriter, r *http.Request) { //nolint:funlen
 	ctx := r.Context()
 	_, span := telemetry.CreateSpan(ctx, r, "node-management", "handleNodeDrain")
 	c.TelemetryHandler.RecordRequestCount(ctx, r)
@@ -2852,19 +2854,37 @@ func (c *HeadlampConfig) handleNodeDrain(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	c.drainNode(clientset, drainPayload.NodeName, drainPayload.Cluster)
+	serverCtx := c.ServerCtx
+	if serverCtx == nil {
+		serverCtx = context.Background()
+	}
+
+	c.drainNode(serverCtx, clientset, drainPayload.NodeName, drainPayload.Cluster)
 }
 
-func (c *HeadlampConfig) drainNode(clientset kubernetes.Interface, nodeName string, cluster string) {
+func (c *HeadlampConfig) drainNode(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	nodeName string,
+	cluster string,
+) {
 	go func() {
+		if ctx.Err() != nil {
+			return
+		}
+
 		nodeClient := clientset.CoreV1().Nodes()
-		ctx := context.Background()
-		cacheKey := uuid.NewSHA1(uuid.Nil, []byte(nodeName+cluster)).String()
-		cacheItemTTL := DrainNodeCacheTTL * time.Minute
+		cacheKey := uuid.NewSHA1(uuid.Nil, []byte(nodeName+"\x00"+cluster)).String()
+		cacheItemTTL := DrainNodeCacheTTL * time.Second
 
 		node, err := nodeClient.Get(ctx, nodeName, v1.GetOptions{})
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+
 			_ = c.Cache.SetWithTTL(ctx, cacheKey, "error: "+err.Error(), cacheItemTTL)
+
 			return
 		}
 
@@ -2873,44 +2893,73 @@ func (c *HeadlampConfig) drainNode(clientset kubernetes.Interface, nodeName stri
 
 		_, err = nodeClient.Update(ctx, node, v1.UpdateOptions{})
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+
 			_ = c.Cache.SetWithTTL(ctx, cacheKey, "error: "+err.Error(), cacheItemTTL)
+
 			return
 		}
 
 		pods, err := clientset.CoreV1().Pods("").List(ctx,
 			v1.ListOptions{FieldSelector: "spec.nodeName=" + nodeName})
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+
 			_ = c.Cache.SetWithTTL(ctx, cacheKey, "error: "+err.Error(), cacheItemTTL)
+
 			return
 		}
 
-		var gracePeriod int64 = 0
-
-		var deleteErrors []string
-
-		for _, pod := range pods.Items {
-			// ignore daemonsets
-			if pod.Labels["kubernetes.io/created-by"] == "daemonset-controller" {
-				continue
-			}
-
-			if err := clientset.CoreV1().Pods(pod.Namespace).Delete(ctx,
-				pod.Name, v1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); err != nil && !apierrors.IsNotFound(err) {
-				deleteErrors = append(deleteErrors, fmt.Sprintf("%s/%s: %v", pod.Namespace, pod.Name, err))
-			}
-		}
-
-		if len(deleteErrors) > 0 {
-			errMsg := fmt.Sprintf("error: failed to delete %d pod(s)", len(deleteErrors))
-			logger.Log(logger.LevelError, nil, nil,
-				fmt.Sprintf("node drain: failed to delete %d pod(s): %s",
-					len(deleteErrors), strings.Join(deleteErrors, "; ")))
-
-			_ = c.Cache.SetWithTTL(ctx, cacheKey, errMsg, cacheItemTTL)
-		} else {
-			_ = c.Cache.SetWithTTL(ctx, cacheKey, "success", cacheItemTTL)
-		}
+		c.drainNodePods(ctx, clientset, pods.Items, cacheKey, cacheItemTTL)
 	}()
+}
+
+func (c *HeadlampConfig) drainNodePods(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	pods []corev1.Pod,
+	cacheKey string,
+	cacheItemTTL time.Duration,
+) {
+	var gracePeriod int64 = 0
+
+	var deleteErrors []string
+
+	for _, pod := range pods {
+		if ctx.Err() != nil {
+			return
+		}
+
+		// ignore daemonsets
+		if pod.Labels["kubernetes.io/created-by"] == "daemonset-controller" {
+			continue
+		}
+
+		if err := clientset.CoreV1().Pods(pod.Namespace).Delete(ctx,
+			pod.Name, v1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); err != nil &&
+			!apierrors.IsNotFound(err) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			deleteErrors = append(deleteErrors, fmt.Sprintf("%s/%s: %v", pod.Namespace, pod.Name, err))
+		}
+	}
+
+	if ctx.Err() != nil {
+		return
+	}
+
+	if len(deleteErrors) > 0 {
+		errMsg := fmt.Sprintf("error: failed to delete %d pod(s)", len(deleteErrors))
+		logger.Log(logger.LevelError, nil, nil,
+			fmt.Sprintf("node drain: failed to delete %d pod(s): %s",
+				len(deleteErrors), strings.Join(deleteErrors, "; ")))
+
+		_ = c.Cache.SetWithTTL(ctx, cacheKey, errMsg, cacheItemTTL)
+	} else {
+		_ = c.Cache.SetWithTTL(ctx, cacheKey, "success", cacheItemTTL)
+	}
 }
 
 /*
@@ -2951,7 +3000,7 @@ func (c *HeadlampConfig) handleNodeDrainStatus(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	cacheKey := uuid.NewSHA1(uuid.Nil, []byte(drainPayload.NodeName+drainPayload.Cluster)).String()
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte(drainPayload.NodeName+"\x00"+drainPayload.Cluster)).String()
 
 	cacheItem, err := c.Cache.Get(ctx, cacheKey)
 	if err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -696,8 +696,8 @@ func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
 				status, http.StatusOK)
 		}
 
-		cacheKey := uuid.NewSHA1(uuid.Nil, []byte(drainNodePayload.NodeName+drainNodePayload.Cluster)).String()
-		cacheItemTTL := DrainNodeCacheTTL * time.Minute
+		cacheKey := uuid.NewSHA1(uuid.Nil, []byte(drainNodePayload.NodeName+"\x00"+drainNodePayload.Cluster)).String()
+		cacheItemTTL := DrainNodeCacheTTL * time.Second
 		ctx := context.Background()
 
 		err = cache.SetWithTTL(ctx, cacheKey, "success", cacheItemTTL)
@@ -777,10 +777,10 @@ func TestDrainNodePodDeletionFailure(t *testing.T) { //nolint:funlen
 		},
 	}
 
-	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"\x00"+"test-cluster")).String()
 	ctx := context.Background()
 
-	c.drainNode(fakeClient, "test-node", "test-cluster")
+	c.drainNode(ctx, fakeClient, "test-node", "test-cluster")
 
 	require.Eventually(t, func() bool {
 		cacheItem, err := testCache.Get(ctx, cacheKey)
@@ -840,10 +840,10 @@ func TestDrainNodeAllPodsDeletedSuccessfully(t *testing.T) {
 		},
 	}
 
-	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"test-cluster")).String()
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"\x00"+"test-cluster")).String()
 	ctx := context.Background()
 
-	c.drainNode(fakeClient, "test-node", "test-cluster")
+	c.drainNode(ctx, fakeClient, "test-node", "test-cluster")
 
 	require.Eventually(t, func() bool {
 		cacheItem, err := testCache.Get(ctx, cacheKey)
@@ -953,6 +953,45 @@ func TestHandleNodeDrainUsesRequestedClusterCookieForCustomNamedContext(t *testi
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for drain request to reach Kubernetes API")
 	}
+}
+
+func TestDrainNodeCancelledContextDoesNotWriteCache(t *testing.T) {
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	fakeClient := fake.NewClientset(node, pod1)
+
+	testCache := cache.New[interface{}]()
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			Cache: testCache,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cacheKey := uuid.NewSHA1(uuid.Nil, []byte("test-node"+"\x00"+"test-cluster")).String()
+
+	c.drainNode(ctx, fakeClient, "test-node", "test-cluster")
+
+	assert.Never(t, func() bool {
+		_, err := testCache.Get(context.Background(), cacheKey)
+		return err == nil
+	}, 100*time.Millisecond, 10*time.Millisecond, "cache should not be written when context is already cancelled")
 }
 
 func TestDeletePlugin(t *testing.T) {

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -1,6 +1,7 @@
 package headlampconfig
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
@@ -41,6 +42,7 @@ type HeadlampConfig struct {
 	ProxyAuthGroupHeader      string
 	ProxyAuthEmailHeader      string
 	ProxyAuthTokenHeader      string
+	ServerCtx                 context.Context
 }
 
 type HeadlampCFG struct {


### PR DESCRIPTION
## Summary

This PR fixes the `drainNode` goroutine in the backend which was using
`context.Background()` -- a context that is never cancelled. When the Headlamp
server shuts down or restarts mid-drain, the goroutine would continue running,
making Kubernetes API calls (cordoning the node, deleting pods) with no way to
stop it. The fix threads the server-lifecycle context through to `drainNode` so
the operation is cancelled cleanly on shutdown.

## Related Issue

Fixes #5734

## Changes

- Added `ServerCtx context.Context` field to `HeadlampConfig` in
  `backend/pkg/headlampconfig/headlampConfig.go`
- Set `config.ServerCtx = ctx` at the start of `createHeadlampHandler` so the
  server-lifecycle context is available on the config struct
- Updated `drainNode` signature to accept a `context.Context` parameter instead
  of creating its own `context.Background()`
- Updated `handleNodeDrain` to pass `c.ServerCtx` when calling `drainNode`
- Extracted pod-deletion logic into `drainNodePods` helper to keep `drainNode`
  within the linter's function-length limit
- Fixed cache key delimiter: use `nodeName+"\x00"+cluster` instead of
  `nodeName+cluster` to prevent key collisions
- Fixed `DrainNodeCacheTTL` multiplier from `time.Minute` to `time.Second` to
  match the constant's documented unit (`// seconds`). This shortens drain
  status retention from 20 minutes to 20 seconds -- the previous value was a
  bug, not intentional behaviour
- Added early exit in the goroutine and in `drainNodePods` when the context is
  already cancelled, so a shutdown-in-progress does not produce misleading
  "failed to delete" cache entries or log noise
- Added `TestDrainNodeCancelledContextDoesNotWriteCache` to cover the
  cancelled-context path

## Steps to Test

1. Connect Headlamp to a Kubernetes cluster with at least one drainable node.
2. Navigate to a node's detail page and trigger a drain operation.
3. While the drain is in progress, restart or shut down the Headlamp server.
4. Confirm the goroutine does not continue making Kubernetes API calls after
   the server stops (no further cordon/pod-delete activity on the cluster).

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The server-lifecycle context (`ctx`) is already created in the `main` function
  via `context.WithCancel` and cancelled on `SIGINT`/`SIGTERM` -- this PR just
  makes `drainNode` respect that signal instead of ignoring it.
- The TTL fix (`time.Minute` -> `time.Second`) is a behavioural correction: the
  constant has always been documented as seconds, so the previous multiplier was
  incorrect. Drain status is now retained for 20 seconds after completion, which
  is sufficient for the polling client to read the final result.
- Context-cancelled delete errors are silently ignored (not treated as drain
  failures) so shutdown does not produce spurious error statuses in the cache.
