### PR TITLE
frontend: Fix multiple mobile UI issues

### DIFF
--- a/frontend/src/components/App/Settings/SettingsButton.test.tsx
+++ b/frontend/src/components/App/Settings/SettingsButton.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../../test';
+import SettingsButton from './SettingsButton';
+
+const mockHistoryPush = vi.fn();
+const { mockGetCluster } = vi.hoisted(() => ({ mockGetCluster: vi.fn<() => string | null>() }));
+
+vi.mock('react-router-dom', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useHistory: () => ({ push: mockHistoryPush }),
+}));
+
+vi.mock('../../../lib/cluster', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../lib/cluster')>()),
+  getCluster: () => mockGetCluster(),
+}));
+
+vi.mock('../../../lib/router/createRouteURL', () => ({
+  createRouteURL: (_route: string, params?: { cluster?: string }) =>
+    `/c/${params?.cluster ?? ''}/settings/cluster`,
+}));
+
+describe('SettingsButton', () => {
+  it('renders nothing when there is no active cluster', () => {
+    mockGetCluster.mockReturnValue(null);
+    const { container } = render(
+      <TestContext>
+        <SettingsButton />
+      </TestContext>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders an icon button when a cluster is active', () => {
+    mockGetCluster.mockReturnValue('my-cluster');
+    render(
+      <TestContext>
+        <SettingsButton />
+      </TestContext>
+    );
+    // ActionButton renders an <button> (IconButton); Settings is its accessible description
+    expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it('navigates to cluster settings on click', async () => {
+    mockGetCluster.mockReturnValue('my-cluster');
+    render(
+      <TestContext>
+        <SettingsButton />
+      </TestContext>
+    );
+    await userEvent.click(screen.getByRole('button', { name: /settings/i }));
+    expect(mockHistoryPush).toHaveBeenCalledWith('/c/my-cluster/settings/cluster');
+  });
+
+  it('calls onClickExtra after navigation', async () => {
+    mockGetCluster.mockReturnValue('my-cluster');
+    const onClickExtra = vi.fn();
+    render(
+      <TestContext>
+        <SettingsButton onClickExtra={onClickExtra} />
+      </TestContext>
+    );
+    await userEvent.click(screen.getByRole('button', { name: /settings/i }));
+    expect(onClickExtra).toHaveBeenCalledOnce();
+  });
+
+  it('does not have a nested interactive element (no role=button inside button)', () => {
+    mockGetCluster.mockReturnValue('my-cluster');
+    render(
+      <TestContext>
+        <SettingsButton />
+      </TestContext>
+    );
+    const button = screen.getByRole('button', { name: /settings/i });
+    // Verify there is no interactive descendant (no button nested inside the button)
+    expect(button.querySelector('[role="button"], button')).toBeNull();
+  });
+});

--- a/frontend/src/components/App/Settings/SettingsButton.tsx
+++ b/frontend/src/components/App/Settings/SettingsButton.tsx
@@ -20,6 +20,16 @@ import { getCluster } from '../../../lib/cluster';
 import { createRouteURL } from '../../../lib/router/createRouteURL';
 import ActionButton from '../../common/ActionButton';
 
+/** Pushes the cluster-settings route and optionally calls a post-navigation callback. */
+export function navigateToClusterSettings(
+  cluster: string,
+  history: ReturnType<typeof useHistory>,
+  onClickExtra?: () => void
+) {
+  history.push(createRouteURL('settingsCluster', { cluster }));
+  onClickExtra?.();
+}
+
 export default function SettingsButton(props: { onClickExtra?: () => void }) {
   const { onClickExtra } = props;
   const { t } = useTranslation(['glossary', 'translation']);
@@ -30,6 +40,10 @@ export default function SettingsButton(props: { onClickExtra?: () => void }) {
     return null;
   }
 
+  const handleClick = () => {
+    navigateToClusterSettings(clusterName, history, onClickExtra);
+  };
+
   return (
     <ActionButton
       icon="mdi:cog"
@@ -37,10 +51,7 @@ export default function SettingsButton(props: { onClickExtra?: () => void }) {
       iconButtonProps={{
         color: 'inherit',
       }}
-      onClick={() => {
-        history.push(createRouteURL('settingsCluster', { cluster: clusterName }));
-        onClickExtra && onClickExtra();
-      }}
+      onClick={handleClick}
     />
   );
 }

--- a/frontend/src/components/App/Settings/index.tsx
+++ b/frontend/src/components/App/Settings/index.tsx
@@ -15,9 +15,9 @@
  */
 
 import Settings from './Settings';
-import SettingsButton from './SettingsButton';
+import SettingsButton, { navigateToClusterSettings } from './SettingsButton';
 import SettingsCluster from './SettingsCluster';
 import SettingsClusters from './SettingsClusters';
 export * from './Settings';
 export default Settings;
-export { SettingsButton, SettingsClusters, SettingsCluster };
+export { SettingsButton, navigateToClusterSettings, SettingsClusters, SettingsCluster };

--- a/frontend/src/components/App/TopBar.test.tsx
+++ b/frontend/src/components/App/TopBar.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Icon } from '@iconify/react';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppBarActionsMenu } from './TopBar';
+
+// ── Mocks needed to prevent circular-dependency crashes when TopBar.tsx is ──
+// imported (it transitively loads k8s resource classes through lib/k8s and
+// several child components).
+
+vi.mock('../../lib/k8s', () => ({
+  useCluster: vi.fn(),
+  useClustersConf: vi.fn(),
+  useSelectedClusters: vi.fn(() => []),
+}));
+vi.mock('../../lib/k8s/api/v1/clusterApi', () => ({
+  getClusterUserInfo: vi.fn(),
+}));
+vi.mock('../../lib/auth', () => ({ logout: vi.fn() }));
+vi.mock('../../helpers/getProductInfo', () => ({
+  getProductName: vi.fn(() => 'Headlamp'),
+  getVersion: vi.fn(() => ({ VERSION: '0.0.0' })),
+}));
+vi.mock('../../lib/router/createRouteURL', () => ({ createRouteURL: vi.fn(() => '/') }));
+vi.mock('../../redux/hooks', () => ({ useTypedSelector: vi.fn(() => undefined) }));
+vi.mock('../../redux/uiSlice', () => ({ uiSlice: { actions: { setVersionDialogOpen: vi.fn() } } }));
+vi.mock('../cluster/Chooser', () => ({
+  ClusterTitle: () => null,
+  useClusterTitleVisible: vi.fn(() => false),
+}));
+vi.mock('../globalSearch/GlobalSearch', () => ({ GlobalSearch: () => null }));
+vi.mock('../Sidebar/HeadlampButton', () => ({ default: () => null }));
+vi.mock('../Sidebar/sidebarSlice', () => ({ setWhetherSidebarOpen: vi.fn() }));
+vi.mock('./AppLogo', () => ({ AppLogo: () => null }));
+vi.mock('../App/Settings', () => ({
+  navigateToClusterSettings: vi.fn(),
+  SettingsButton: () => null,
+}));
+vi.mock('@tanstack/react-query', () => ({ useQueries: vi.fn(() => []) }));
+vi.mock('react-redux', () => ({
+  useDispatch: vi.fn(() => vi.fn()),
+  useSelector: vi.fn(),
+}));
+vi.mock('react-router-dom', () => ({
+  useHistory: vi.fn(() => ({ push: vi.fn(), location: { pathname: '/' } })),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: vi.fn(() => ({ t: (k: string) => k })) }));
+vi.mock('@mui/material/useMediaQuery', () => ({ default: vi.fn(() => false) }));
+
+// ErrorBoundary uses a React class component — render it as a pass-through in tests.
+vi.mock('../common/ErrorBoundary', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('AppBarActionsMenu', () => {
+  it('passes a MenuItem element action through without double-wrapping', () => {
+    const action = {
+      id: 'test-action',
+      action: <MenuItem>direct item</MenuItem>,
+    };
+    render(<AppBarActionsMenu appBarActions={[action]} />);
+
+    // Exactly one menuitem, not two nested ones.
+    const items = screen.getAllByRole('menuitem');
+    expect(items).toHaveLength(1);
+
+    // The menuitem must not contain another menuitem or button inside it.
+    expect(items[0].querySelector('[role="menuitem"], [role="button"], button')).toBeNull();
+  });
+
+  it('wraps a non-MenuItem element action in a MenuItem', () => {
+    const action = {
+      id: 'test-action',
+      action: <span>element action</span>,
+    };
+    render(<AppBarActionsMenu appBarActions={[action]} />);
+
+    const item = screen.getByRole('menuitem');
+    expect(item).toHaveTextContent('element action');
+  });
+
+  it('wraps a function action in a MenuItem', () => {
+    const action = {
+      id: 'test-action',
+      action: () => <span>inner content</span>,
+    };
+    render(<AppBarActionsMenu appBarActions={[action]} />);
+
+    const item = screen.getByRole('menuitem');
+    expect(item).toHaveTextContent('inner content');
+  });
+
+  it('renders nothing for a null action', () => {
+    const action = { id: 'test-action', action: null };
+    const { container } = render(<AppBarActionsMenu appBarActions={[action]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a false action', () => {
+    const action = { id: 'test-action', action: false as unknown as null };
+    const { container } = render(<AppBarActionsMenu appBarActions={[action]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('USER mobile action: single menuitem with no nested interactive element', () => {
+    // This mirrors the USER action in PureTopBar's allAppBarActionsMobile.
+    // The old code used a Box role="button" inside the MenuItem — this test
+    // would have caught that regression.
+    const handleMenuClose = vi.fn();
+    const handleProfileMenuOpen = vi.fn();
+
+    const action = {
+      id: 'user-action',
+      action: (
+        <MenuItem
+          aria-controls="user-menu"
+          aria-haspopup="true"
+          onClick={event => {
+            handleMenuClose();
+            handleProfileMenuOpen(event);
+          }}
+        >
+          <ListItemIcon>
+            <Icon icon="mdi:account" />
+          </ListItemIcon>
+          <ListItemText>Account of current user</ListItemText>
+        </MenuItem>
+      ),
+    };
+
+    render(<AppBarActionsMenu appBarActions={[action]} />);
+
+    const items = screen.getAllByRole('menuitem');
+    expect(items).toHaveLength(1);
+    expect(items[0].querySelector('[role="button"], [role="menuitem"], button')).toBeNull();
+  });
+});

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -448,6 +448,24 @@ export const PureTopBar = memo(
           </MenuItem>
         ) : null,
       },
+      {
+        id: DefaultAppBarAction.VERSION,
+        action: (
+          <MenuItem
+            onClick={() => {
+              dispatch(uiSlice.actions.setVersionDialogOpen(true));
+              handleMobileMenuClose();
+            }}
+          >
+            <ListItemIcon>
+              <Icon icon="mdi:information-outline" />
+            </ListItemIcon>
+            <ListItemText>
+              {getProductName()} {getVersion()['VERSION']}
+            </ListItemText>
+          </MenuItem>
+        ),
+      },
     ];
     const renderMobileMenu = (
       <Menu

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -468,24 +468,6 @@ export const PureTopBar = memo(
           </MenuItem>
         ) : null,
       },
-      {
-        id: DefaultAppBarAction.VERSION,
-        action: (
-          <MenuItem
-            onClick={() => {
-              dispatch(uiSlice.actions.setVersionDialogOpen(true));
-              handleMobileMenuClose();
-            }}
-          >
-            <ListItemIcon>
-              <Icon icon="mdi:information-outline" />
-            </ListItemIcon>
-            <ListItemText>
-              {getProductName()} {getVersion()['VERSION']}
-            </ListItemText>
-          </MenuItem>
-        ),
-      },
     ];
     const renderMobileMenu = (
       <Menu

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -46,8 +46,8 @@ import {
 } from '../../redux/actionButtonsSlice';
 import { useTypedSelector } from '../../redux/hooks';
 import { uiSlice } from '../../redux/uiSlice';
-import { SettingsButton } from '../App/Settings';
-import { ClusterTitle } from '../cluster/Chooser';
+import { navigateToClusterSettings, SettingsButton } from '../App/Settings';
+import { ClusterTitle, useClusterTitleVisible } from '../cluster/Chooser';
 import ErrorBoundary from '../common/ErrorBoundary';
 import { GlobalSearch } from '../globalSearch/GlobalSearch';
 import HeadlampButton from '../Sidebar/HeadlampButton';
@@ -187,7 +187,7 @@ export interface PureTopBarProps {
   onToggleOpen: () => void;
 }
 
-function AppBarActionsMenu({
+export function AppBarActionsMenu({
   appBarActions,
 }: {
   appBarActions: Array<AppBarAction | AppBarActionType>;
@@ -197,12 +197,16 @@ function AppBarActionsMenu({
       appBarActions.map(action => {
         const Action = has(action, 'action') ? action.action : action;
         if (React.isValidElement(Action)) {
+          // If the action is already a MenuItem, pass it through directly to avoid nesting.
+          if ((Action as React.ReactElement).type === MenuItem) {
+            return <ErrorBoundary>{Action}</ErrorBoundary>;
+          }
           return (
             <ErrorBoundary>
               <MenuItem>{Action}</MenuItem>
             </ErrorBoundary>
           );
-        } else if (Action === null) {
+        } else if (Action === null || Action === false) {
           return null;
         } else if (typeof Action === 'function') {
           const ActionComponent = Action as React.FC;
@@ -231,7 +235,7 @@ function AppBarActions({
         const Action = has(action, 'action') ? action.action : action;
         if (React.isValidElement(Action)) {
           return <ErrorBoundary>{Action}</ErrorBoundary>;
-        } else if (Action === null) {
+        } else if (Action === null || Action === false) {
           return null;
         } else if (typeof Action === 'function') {
           const ActionComponent = Action as React.FC;
@@ -271,6 +275,7 @@ export const PureTopBar = memo(
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const [mobileMoreAnchorEl, setMobileMoreAnchorEl] = React.useState<null | HTMLElement>(null);
     const isClusterContext = !!cluster;
+    const isClusterTitleVisible = useClusterTitleVisible(cluster, clusters);
 
     const isMenuOpen = Boolean(anchorEl);
     const isMobileMenuOpen = Boolean(mobileMoreAnchorEl);
@@ -396,14 +401,14 @@ export const PureTopBar = memo(
     const allAppBarActionsMobile: AppBarAction[] = [
       {
         id: DefaultAppBarAction.CLUSTER,
-        action: isClusterContext && (
+        action: isClusterTitleVisible ? (
           <ClusterTitle
             cluster={cluster}
             clusters={clusters}
             selectedClusters={selectedClusters}
             onClick={() => handleMenuClose()}
           />
-        ),
+        ) : null,
       },
       ...appBarActions,
       {
@@ -412,25 +417,36 @@ export const PureTopBar = memo(
       },
       {
         id: DefaultAppBarAction.SETTINGS,
-        action: isClusterContext ? <SettingsButton onClickExtra={handleMenuClose} /> : null,
+        action: isClusterContext ? (
+          <MenuItem
+            onClick={() => {
+              navigateToClusterSettings(cluster!, history, handleMenuClose);
+            }}
+          >
+            <ListItemIcon>
+              <Icon icon="mdi:cog" />
+            </ListItemIcon>
+            <ListItemText>{t('translation|Settings')}</ListItemText>
+          </MenuItem>
+        ) : null,
       },
       {
         id: DefaultAppBarAction.USER,
-        action: showUserMenu && (
-          <IconButton
-            aria-label={t('Account of current user')}
+        action: showUserMenu ? (
+          <MenuItem
             aria-controls={userMenuId}
             aria-haspopup="true"
-            color="inherit"
             onClick={event => {
               handleMenuClose();
               handleProfileMenuOpen(event);
             }}
-            size="medium"
           >
-            <Icon icon="mdi:account" />
-          </IconButton>
-        ),
+            <ListItemIcon>
+              <Icon icon="mdi:account" />
+            </ListItemIcon>
+            <ListItemText>{t('Account of current user')}</ListItemText>
+          </MenuItem>
+        ) : null,
       },
     ];
     const renderMobileMenu = (
@@ -478,7 +494,7 @@ export const PureTopBar = memo(
       },
       {
         id: DefaultAppBarAction.USER,
-        action: showUserMenu && (
+        action: showUserMenu ? (
           <IconButton
             aria-label={t('Account of current user')}
             aria-controls={userMenuId}
@@ -489,7 +505,7 @@ export const PureTopBar = memo(
           >
             <Icon icon="mdi:account" />
           </IconButton>
-        ),
+        ) : null,
       },
     ];
 

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -187,6 +187,26 @@ export interface PureTopBarProps {
   onToggleOpen: () => void;
 }
 
+/**
+ * Wraps children in a MenuItem only if they render non-empty DOM content.
+ * Uses useLayoutEffect (fires before first paint) so the empty item is never
+ * visible to the user — it is suppressed in the same commit cycle.
+ * This handles plugin actions that are valid React elements or function
+ * components but conditionally render nothing in the mobile menu context.
+ */
+function NullableMenuItem({ children }: { children: React.ReactNode }) {
+  const ref = React.useRef<HTMLLIElement>(null);
+  const [show, setShow] = React.useState(true);
+
+  React.useLayoutEffect(() => {
+    if (ref.current && ref.current.innerHTML.trim() === '') {
+      setShow(false);
+    }
+  }, []);
+
+  return show ? <MenuItem ref={ref}>{children}</MenuItem> : null;
+}
+
 export function AppBarActionsMenu({
   appBarActions,
 }: {
@@ -203,7 +223,7 @@ export function AppBarActionsMenu({
           }
           return (
             <ErrorBoundary>
-              <MenuItem>{Action}</MenuItem>
+              <NullableMenuItem>{Action}</NullableMenuItem>
             </ErrorBoundary>
           );
         } else if (Action === null || Action === false) {
@@ -212,9 +232,9 @@ export function AppBarActionsMenu({
           const ActionComponent = Action as React.FC;
           return (
             <ErrorBoundary>
-              <MenuItem>
+              <NullableMenuItem>
                 <ActionComponent />
-              </MenuItem>
+              </NullableMenuItem>
             </ErrorBoundary>
           );
         }

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -130,6 +130,8 @@ function SidebarToggleButton() {
 
 const DefaultLinkArea = memo((props: { sidebarName: string; isOpen: boolean }) => {
   const { sidebarName, isOpen } = props;
+  const { isTemporary } = useSidebarInfo();
+  const dispatch = useDispatch();
 
   if (sidebarName === DefaultSidebars.HOME) {
     return (
@@ -150,7 +152,10 @@ const DefaultLinkArea = memo((props: { sidebarName: string; isOpen: boolean }) =
 
   return (
     <Box textAlign="center">
-      <CreateButton isNarrow={!isOpen} />
+      <CreateButton
+        isNarrow={!isOpen}
+        onClickExtra={isTemporary ? () => dispatch(setWhetherSidebarOpen(false)) : undefined}
+      />
       <Box
         display="flex"
         justifyContent="space-between"

--- a/frontend/src/components/Sidebar/VersionButton.tsx
+++ b/frontend/src/components/Sidebar/VersionButton.tsx
@@ -17,10 +17,8 @@
 import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
 import { styled, useTheme } from '@mui/system';
 import { useQuery } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
@@ -30,6 +28,7 @@ import semver from 'semver';
 import { getVersion, useCluster } from '../../lib/k8s';
 import { StringDict } from '../../lib/k8s/cluster';
 import { useTypedSelector } from '../../redux/hooks';
+import { Dialog } from '../common/Dialog';
 import { NameValueTable } from '../common/SimpleTable';
 
 const versionSnackbarHideTimeout = 5000; // ms
@@ -146,8 +145,7 @@ export default function VersionButton() {
           <Box>{clusterVersion.gitVersion}</Box>
         </Box>
       </Button>
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>{t('Kubernetes Version')}</DialogTitle>
+      <Dialog open={open} onClose={handleClose} title={t('Kubernetes Version')}>
         <DialogContent>
           <NameValueTable rows={getVersionRows()} />
         </DialogContent>

--- a/frontend/src/components/cluster/Chooser.test.tsx
+++ b/frontend/src/components/cluster/Chooser.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useClusterTitleVisible } from './Chooser';
+
+// Mutable object mutated per-test so that vi.mock's closure picks up changes.
+const mockState: {
+  plugins: { loaded: boolean };
+  ui: { clusterChooserButtonComponent: any };
+} = {
+  plugins: { loaded: false },
+  ui: { clusterChooserButtonComponent: undefined },
+};
+
+vi.mock('../../redux/hooks', () => ({
+  useTypedSelector: (selector: any) => selector(mockState),
+}));
+
+// Chooser.tsx transitively pulls in k8s resource classes which have a circular
+// dependency that breaks module initialisation in the test environment. Mock
+// the modules that trigger that chain so only useClusterTitleVisible is loaded.
+vi.mock('../../lib/k8s', () => ({ useClustersConf: vi.fn() }));
+vi.mock('../../lib/useShortcut', () => ({ useShortcut: vi.fn() }));
+vi.mock('../../helpers/recentClusters', () => ({
+  getRecentClusters: vi.fn(() => []),
+  setRecentCluster: vi.fn(),
+}));
+vi.mock('../../helpers/clusterAppearance', () => ({ getClusterAppearanceFromMeta: vi.fn() }));
+vi.mock('../../helpers/isElectron', () => ({ isElectron: vi.fn(() => false) }));
+vi.mock('../../lib/router/createRouteURL', () => ({ createRouteURL: vi.fn(() => '/') }));
+vi.mock('../common/ActionButton', () => ({ default: () => null }));
+vi.mock('../common/Dialog', () => ({ DialogTitle: () => null }));
+vi.mock('../common/ErrorBoundary', () => ({ default: ({ children }: any) => children }));
+vi.mock('../common/Loader', () => ({ default: () => null }));
+vi.mock('./ClusterChooser', () => ({ default: () => null }));
+vi.mock('./ClusterChooserPopup', () => ({ default: () => null }));
+vi.mock('../App/AppLogo', () => ({ AppLogo: () => null }));
+
+const TWO_CLUSTERS = { 'cluster-a': {} as any, 'cluster-b': {} as any };
+
+describe('useClusterTitleVisible', () => {
+  beforeEach(() => {
+    mockState.plugins.loaded = false;
+    mockState.ui.clusterChooserButtonComponent = undefined;
+  });
+
+  it('returns false when cluster is undefined', () => {
+    mockState.plugins.loaded = true;
+    const { result } = renderHook(() => useClusterTitleVisible(undefined, TWO_CLUSTERS));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when plugins are not yet loaded', () => {
+    // plugins.loaded defaults to false in beforeEach
+    const { result } = renderHook(() => useClusterTitleVisible('my-cluster', TWO_CLUSTERS));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when ChooserButton is explicitly null (hidden by a plugin)', () => {
+    mockState.plugins.loaded = true;
+    mockState.ui.clusterChooserButtonComponent = null;
+    const { result } = renderHook(() => useClusterTitleVisible('my-cluster', TWO_CLUSTERS));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when there is only one cluster and no custom ChooserButton', () => {
+    mockState.plugins.loaded = true;
+    // clusterChooserButtonComponent is undefined — no custom button
+    const { result } = renderHook(() =>
+      useClusterTitleVisible('my-cluster', { 'my-cluster': {} as any })
+    );
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when clusters is empty and no custom ChooserButton', () => {
+    mockState.plugins.loaded = true;
+    const { result } = renderHook(() => useClusterTitleVisible('my-cluster', {}));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when plugins are loaded and there are multiple clusters', () => {
+    mockState.plugins.loaded = true;
+    const { result } = renderHook(() => useClusterTitleVisible('my-cluster', TWO_CLUSTERS));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when plugins are loaded and a custom ChooserButton is set', () => {
+    mockState.plugins.loaded = true;
+    mockState.ui.clusterChooserButtonComponent = () => null; // custom component
+    const { result } = renderHook(() =>
+      useClusterTitleVisible('my-cluster', { 'my-cluster': {} as any })
+    );
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -66,26 +66,37 @@ export interface ClusterTitleProps {
   onClick?: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
+/**
+ * Returns true when ClusterTitle would render something for the given cluster/clusters.
+ * Use this to decide whether to include ClusterTitle in a menu so the caller can pass
+ * null as the action instead of mounting an empty wrapper.
+ */
+export function useClusterTitleVisible(
+  cluster?: string,
+  clusters?: { [clusterName: string]: Cluster }
+): boolean {
+  const arePluginsLoaded = useTypedSelector(state => state.plugins.loaded);
+  const ChooserButton = useTypedSelector(state => state.ui.clusterChooserButtonComponent);
+
+  if (!cluster) return false;
+  if (!arePluginsLoaded || _.isNull(ChooserButton)) return false;
+  if (!ChooserButton && Object.keys(clusters || {}).length <= 1) return false;
+  return true;
+}
+
 export function ClusterTitle(props: ClusterTitleProps) {
   const { cluster, clusters, selectedClusters, onClick } = props;
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const arePluginsLoaded = useTypedSelector(state => state.plugins.loaded);
+  // ChooserButton is still needed here to decide which component to render.
   const ChooserButton = useTypedSelector(state => state.ui.clusterChooserButtonComponent);
+  const isVisible = useClusterTitleVisible(cluster, clusters);
 
   useShortcut('CLUSTER_CHOOSER', () => {
     setAnchorEl(buttonRef.current);
   });
 
-  if (!cluster) {
-    return null;
-  }
-
-  if (!arePluginsLoaded || _.isNull(ChooserButton)) {
-    return null;
-  }
-
-  if (!ChooserButton && Object.keys(clusters || {}).length <= 1) {
+  if (!isVisible) {
     return null;
   }
 

--- a/frontend/src/components/common/Dialog.test.tsx
+++ b/frontend/src/components/common/Dialog.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for common/Dialog mobile-fullscreen behaviour.
+ *
+ * Policy (Dialog.tsx):
+ *   - On a mobile viewport (≤600 px) the dialog must open fullscreen.
+ *   - On a desktop viewport it must not.
+ *   - After the user presses the fullscreen toggle the choice is locked in,
+ *     regardless of the current viewport.
+ */
+
+import DialogContent from '@mui/material/DialogContent';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Dialog } from './Dialog';
+
+// ---------------------------------------------------------------------------
+// Mock useMediaQuery so tests control the "is mobile" signal without needing a
+// real browser viewport.
+// ---------------------------------------------------------------------------
+const mockUseMediaQuery = vi.fn<() => boolean>();
+vi.mock('@mui/material/useMediaQuery', () => ({
+  default: () => mockUseMediaQuery(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Helper: returns true if MUI rendered the dialog in fullscreen mode.
+// MUI adds MuiDialog-paperFullScreen to the Paper element when fullScreen={true}.
+function isFullscreen(): boolean {
+  return document.querySelector('.MuiDialog-paperFullScreen') !== null;
+}
+
+describe('Dialog — mobile fullscreen policy', () => {
+  it('opens fullscreen when the viewport is mobile (≤600 px)', () => {
+    mockUseMediaQuery.mockReturnValue(true); // isMobile = true
+
+    render(
+      <Dialog open title="Test">
+        <DialogContent>content</DialogContent>
+      </Dialog>
+    );
+
+    expect(isFullscreen()).toBe(true);
+  });
+
+  it('does not open fullscreen on a desktop viewport', () => {
+    mockUseMediaQuery.mockReturnValue(false); // isMobile = false
+
+    render(
+      <Dialog open title="Test">
+        <DialogContent>content</DialogContent>
+      </Dialog>
+    );
+
+    expect(isFullscreen()).toBe(false);
+  });
+
+  it('toggle button switches from fullscreen to windowed on mobile', () => {
+    mockUseMediaQuery.mockReturnValue(true); // isMobile = true
+
+    render(
+      <Dialog open title="Test" withFullScreen>
+        <DialogContent>content</DialogContent>
+      </Dialog>
+    );
+
+    expect(isFullscreen()).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: /toggle fullscreen/i }));
+
+    expect(isFullscreen()).toBe(false);
+  });
+
+  it('toggle button switches from windowed to fullscreen on desktop', () => {
+    mockUseMediaQuery.mockReturnValue(false); // isMobile = false
+
+    render(
+      <Dialog open title="Test" withFullScreen>
+        <DialogContent>content</DialogContent>
+      </Dialog>
+    );
+
+    expect(isFullscreen()).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: /toggle fullscreen/i }));
+
+    expect(isFullscreen()).toBe(true);
+  });
+
+  it('resets the user override after the dialog closes', () => {
+    mockUseMediaQuery.mockReturnValue(true);
+
+    const { rerender } = render(
+      <Dialog open title="Test" withFullScreen>
+        <DialogContent>content</DialogContent>
+      </Dialog>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /toggle fullscreen/i }));
+    expect(isFullscreen()).toBe(false);
+
+    rerender(
+      <Dialog open={false} title="Test" withFullScreen>
+        <DialogContent>content</DialogContent>
+      </Dialog>
+    );
+    rerender(
+      <Dialog open title="Test" withFullScreen>
+        <DialogContent>content</DialogContent>
+      </Dialog>
+    );
+
+    expect(isFullscreen()).toBe(true);
+  });
+});

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -18,7 +18,9 @@ import Box from '@mui/material/Box';
 import MuiDialog, { DialogProps as MuiDialogProps } from '@mui/material/Dialog';
 import MuiDialogTitle, { DialogTitleProps } from '@mui/material/DialogTitle';
 import Grid from '@mui/material/Grid';
+import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ActionButton from './ActionButton';
@@ -117,19 +119,25 @@ export function Dialog(props: DialogProps) {
     titleProps,
     ...other
   } = props;
-  const [fullScreen, setFullScreen] = React.useState(false);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  // null = user hasn't toggled; fall back to the reactive isMobile value.
+  const [userOverride, setUserOverride] = React.useState<boolean | null>(null);
+  const fullScreen = userOverride ?? isMobile;
   const { t } = useTranslation();
 
+  React.useEffect(() => {
+    if (!props.open) {
+      setUserOverride(null);
+    }
+  }, [props.open]);
+
   function handleFullScreen() {
-    setFullScreen(fs => {
-      const newFullScreenState = !fs;
-
-      if (!!onFullScreenToggled) {
-        onFullScreenToggled(newFullScreenState);
-      }
-
-      return newFullScreenState;
-    });
+    const newFullScreenState = !fullScreen;
+    setUserOverride(newFullScreenState);
+    if (onFullScreenToggled) {
+      onFullScreenToggled(newFullScreenState);
+    }
   }
 
   const generatedId = React.useId();
@@ -141,9 +149,9 @@ export function Dialog(props: DialogProps) {
       maxWidth="lg"
       scroll="paper"
       fullWidth
-      fullScreen={fullScreen}
       {...dialogAriaProps}
       {...other}
+      fullScreen={fullScreen}
     >
       {(!!title || withFullScreen) && (
         <DialogTitle

--- a/frontend/src/components/common/Resource/CreateButton.tsx
+++ b/frontend/src/components/common/Resource/CreateButton.tsx
@@ -220,13 +220,15 @@ function CreateActivityContent(props: { onClose: () => void }) {
 
 interface CreateButtonProps {
   isNarrow?: boolean;
+  onClickExtra?: () => void;
 }
 
 export default function CreateButton(props: CreateButtonProps) {
-  const { isNarrow } = props;
+  const { isNarrow, onClickExtra } = props;
   const { t } = useTranslation(['translation']);
 
   const openActivity = () => {
+    onClickExtra?.();
     const id = 'create-button';
     Activity.launch({
       id: id,

--- a/frontend/src/components/common/Resource/DeleteButton.test.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.test.tsx
@@ -138,7 +138,7 @@ describe('DeleteButton', () => {
     renderButton(makeNamespace({ name: 'kube-system' }));
     const dialog = await openDialog();
 
-    const confirmButton = within(dialog).getByLabelText('confirm-button');
+    const confirmButton = within(dialog).getByTestId('confirm-button');
     const input = within(dialog).getByLabelText('translation|Namespace name');
 
     expect(confirmButton).toBeDisabled();
@@ -162,7 +162,7 @@ describe('DeleteButton', () => {
     );
     const dialog = await openDialog();
 
-    const confirmButton = within(dialog).getByLabelText('confirm-button');
+    const confirmButton = within(dialog).getByTestId('confirm-button');
     const input = within(dialog).getByLabelText('translation|Namespace name');
 
     // The object's metadata.name should NOT unlock deletion.
@@ -186,7 +186,7 @@ describe('DeleteButton', () => {
     expect(within(dialog).queryByLabelText('translation|Namespace name')).not.toBeInTheDocument();
 
     // Confirm is enabled right away — no type-to-confirm step.
-    expect(within(dialog).getByLabelText('confirm-button')).toBeEnabled();
+    expect(within(dialog).getByTestId('confirm-button')).toBeEnabled();
   });
 
   it('stays in sync with the production protected namespace list', async () => {

--- a/frontend/src/components/common/Resource/DeleteMultipleButton.test.tsx
+++ b/frontend/src/components/common/Resource/DeleteMultipleButton.test.tsx
@@ -136,7 +136,7 @@ describe('DeleteMultipleButton', () => {
     ]);
     const dialog = await openDialog();
 
-    const confirmButton = within(dialog).getByLabelText('confirm-button');
+    const confirmButton = within(dialog).getByTestId('confirm-button');
     const input = within(dialog).getByLabelText('translation|Namespace name(s)');
 
     expect(confirmButton).toBeDisabled();
@@ -164,7 +164,7 @@ describe('DeleteMultipleButton', () => {
     ).not.toBeInTheDocument();
 
     // Confirm is enabled right away — no type-to-confirm step.
-    expect(within(dialog).getByLabelText('confirm-button')).toBeEnabled();
+    expect(within(dialog).getByTestId('confirm-button')).toBeEnabled();
   });
 
   it('stays in sync with the production protected namespace list', async () => {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -641,6 +641,7 @@ export default function EditorDialog(props: EditorDialogProps) {
           overflowY: 'hidden',
           display: 'flex',
           flexDirection: 'column',
+          px: { xs: 0, sm: 3 },
         }}
       >
         <Box py={1}>

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -79,7 +79,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-1gh0c7s-MuiDialogContent-root"
+          class="MuiDialogContent-root css-7r89gu-MuiDialogContent-root"
         >
           <div
             class="MuiBox-root css-1jpm9pd"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -79,7 +79,7 @@
           </div>
         </h2>
         <div
-          class="MuiDialogContent-root css-1gh0c7s-MuiDialogContent-root"
+          class="MuiDialogContent-root css-7r89gu-MuiDialogContent-root"
         >
           <div
             class="MuiBox-root css-1jpm9pd"

--- a/frontend/src/components/common/Terminal.tsx
+++ b/frontend/src/components/common/Terminal.tsx
@@ -23,6 +23,7 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as XTerminal } from '@xterm/xterm';
 import _ from 'lodash';
@@ -77,6 +78,7 @@ export default function Terminal(props: TerminalProps) {
   const { t } = useTranslation(['translation', 'glossary']);
   const muiTheme = useTheme();
   const xtermTheme = React.useMemo(() => getXtermTheme(muiTheme), [muiTheme]);
+  const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
 
   // @todo: Give the real exec type when we have it.
   function setupTerminal(containerRef: HTMLElement, xterm: XTerminal, fitAddon: FitAddon) {
@@ -437,6 +439,9 @@ export default function Terminal(props: TerminalProps) {
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+        ...(isMobile && {
+          padding: 0,
+        }),
         '& .xterm ': {
           height: '100vh', // So the terminal doesn't stay shrunk when shrinking vertically and maximizing again.
           '& .xterm-viewport': {
@@ -447,12 +452,12 @@ export default function Terminal(props: TerminalProps) {
           overflow: 'hidden',
           width: '100%',
           '& .terminal.xterm': {
-            padding: theme.spacing(1),
+            padding: isMobile ? 0 : theme.spacing(1),
           },
         },
       })}
     >
-      <Box>
+      <Box sx={isMobile ? { px: 1, pt: 1 } : undefined}>
         <FormControl sx={{ minWidth: '11rem' }}>
           <InputLabel shrink id="container-name-chooser-label">
             {t('glossary|Container')}

--- a/frontend/src/components/common/__snapshots__/Dialog.DialogAlreadyInFullScreen.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Dialog.DialogAlreadyInFullScreen.stories.storyshot
@@ -23,7 +23,7 @@
     >
       <div
         aria-labelledby=":mock-test-id:"
-        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthLg MuiDialog-paperFullWidth MuiDialog-paperFullScreen css-9gxng4-MuiPaper-root-MuiDialog-paper"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthLg MuiDialog-paperFullWidth css-kl791l-MuiPaper-root-MuiDialog-paper"
         role="dialog"
       >
         <h2

--- a/frontend/src/redux/actionButtonsSlice.ts
+++ b/frontend/src/redux/actionButtonsSlice.ts
@@ -63,6 +63,7 @@ export enum DefaultAppBarAction {
   SETTINGS = 'SETTINGS',
   USER = 'USER',
   GLOBAL_SEARCH = 'GLOBAL_SEARCH',
+  VERSION = 'VERSION',
 }
 
 type HeaderActionFuncType = (

--- a/frontend/src/redux/actionButtonsSlice.ts
+++ b/frontend/src/redux/actionButtonsSlice.ts
@@ -63,7 +63,6 @@ export enum DefaultAppBarAction {
   SETTINGS = 'SETTINGS',
   USER = 'USER',
   GLOBAL_SEARCH = 'GLOBAL_SEARCH',
-  VERSION = 'VERSION',
 }
 
 type HeaderActionFuncType = (


### PR DESCRIPTION
## Summary

Fixes mobile overflow-menu, dialog, terminal, editor, and temporary-sidebar behavior. The branch is rebased onto current `main`.

## Changes

- **Empty overflow entries:** `useClusterTitleVisible` is the shared source of truth for `ClusterTitle` and prevents the built-in cluster action from entering the mobile menu when it renders nothing. `NullableMenuItem` remains as a fallback for conditionally empty plugin actions.
- **Settings and Account semantics:** Both mobile actions render as a single MUI `MenuItem` with icon and label, avoiding nested interactive elements. Cluster settings navigation is shared through `navigateToClusterSettings`.
- **Mobile dialogs:** `common/Dialog` applies a responsive fullscreen policy while preserving the manual fullscreen toggle. `VersionButton` now uses the shared dialog; version information remains available from the Account menu.
- **Terminal and editor spacing:** Mobile terminal and editor dialogs remove unnecessary horizontal padding and use the available viewport width.
- **Temporary sidebar:** Creating a resource from the temporary mobile sidebar closes the sidebar before opening the activity.
- **Tests:** Adds focused coverage for chooser visibility, settings navigation, and mobile menu semantics, and refreshes the three dialog Storybook snapshots affected by the responsive policy.

## Steps to Test

1. Open Headlamp at a viewport width of 600 px or less.
2. Open the overflow menu and verify there is no empty item and Settings/Account each have one focusable menu item with icon and label.
3. Open the Account menu and select the version entry; verify the dialog opens fullscreen.
4. Open a YAML editor and a pod terminal; verify fullscreen layout without wasted horizontal padding.
5. From the temporary sidebar, select Create and verify the sidebar closes before the activity opens.

## Validation

- `CI=true make frontend-test` (2,059 tests, 643 Storybook cases)
- `make frontend-i18n-check`
- `make frontend-lint`
- `make frontend-tsc`
- `make frontend-build`

## Screenshots

All screenshots were captured at a 390x844 mobile viewport against a KWOK cluster.

### Mobile overflow menu

| Before | After |
|---|---|
| <img width="780" height="1688" alt="before-mobile-menu" src="https://github.com/user-attachments/assets/b29bb3ac-1328-49ca-8703-eabb9dd469eb" /> | <img width="780" height="1688" alt="after-mobile-menu" src="https://github.com/user-attachments/assets/0417f3e6-21ab-4f54-afea-0123664b45ef" /> |

### Terminal dialog

| Before | After |
|---|---|
| <img width="780" height="1688" alt="before-terminal" src="https://github.com/user-attachments/assets/f5d14c7b-ef55-4e39-a4f9-ad6ed027a6b2" /> | <img width="780" height="1688" alt="after-terminal" src="https://github.com/user-attachments/assets/42754076-c3c9-47fa-bc98-e0477ad8c81a" /> |

Assisted by Copilot.