### PR TITLE
frontend: Add node pool support

### DIFF
--- a/frontend/src/components/node/Details.tsx
+++ b/frontend/src/components/node/Details.tsx
@@ -348,6 +348,7 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
         extraInfo={item => {
           if (!item) return [];
           const roles = item.getRoles();
+          const nodePool = item.getNodePool();
           // The keys of interest are reported by the API in kebab-case.
           const reportedKeys = ['cpu', 'memory', 'pods', 'ephemeral-storage'];
           const pickResources = (res: { [key: string]: string } = {}) =>
@@ -372,6 +373,11 @@ export default function NodeDetails(props: { name?: string; cluster?: string }) 
             {
               name: t('translation|Conditions'),
               value: <NodeConditionsLabel node={item} />,
+            },
+            {
+              name: t('Node Pool'),
+              value: nodePool,
+              hide: !nodePool,
             },
             {
               name: t('Pod CIDR'),

--- a/frontend/src/components/node/List.stories.tsx
+++ b/frontend/src/components/node/List.stories.tsx
@@ -19,7 +19,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { TestContext } from '../../test';
 import List from './List';
-import { NODE_DUMMY_DATA } from './storyHelper';
+import { NODE_DUMMY_DATA, NODE_DUMMY_DATA_NO_POOLS } from './storyHelper';
 
 export default {
   title: 'node/List',
@@ -61,3 +61,38 @@ const Template: StoryFn = () => {
 };
 
 export const Nodes = Template.bind({});
+
+export const NoNodePools: StoryFn = () => (
+  <Container maxWidth="xl">
+    <List />
+  </Container>
+);
+NoNodePools.parameters = {
+  msw: {
+    handlers: {
+      base: null,
+      story: [
+        http.get('http://localhost:4466/api/v1/nodes', () =>
+          HttpResponse.json({
+            kind: 'NodeList',
+            apiVersion: 'v1',
+            metadata: {},
+            items: NODE_DUMMY_DATA_NO_POOLS,
+          })
+        ),
+        http.post(
+          'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
+          () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+        ),
+        http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
+          HttpResponse.json({
+            apiVersion: 'metrics.k8s.io/v1beta1',
+            kind: 'NodeMetricsList',
+            metadata: {},
+            items: [],
+          })
+        ),
+      ],
+    },
+  },
+};

--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import Node from '../../lib/k8s/node';
 import { getResourceMetrics } from '../../lib/util';
@@ -26,9 +27,15 @@ import { formatTaint, NodeTaintsLabel } from './utils';
 
 export default function NodeList() {
   const [nodeMetrics, metricsError] = Node.useMetrics();
+  const { items } = Node.useList();
   const { t } = useTranslation(['glossary', 'translation']);
 
   const noMetrics = metricsError?.status === 404;
+
+  const hasNodePools = useMemo(() => {
+    if (!items || items.length === 0) return false;
+    return items.some(node => node.getNodePool() !== '');
+  }, [items]);
 
   return (
     <>
@@ -105,6 +112,17 @@ export default function NodeList() {
                 .join(',');
             },
           },
+          ...(hasNodePools
+            ? [
+                {
+                  id: 'nodePool',
+                  label: t('Node Pool'),
+                  gridTemplate: 'minmax(150px, .5fr)',
+                  getValue: (node: Node) => node.getNodePool(),
+                  filterVariant: 'multi-select' as const,
+                },
+              ]
+            : []),
           {
             id: 'internalIP',
             label: t('translation|Internal IP'),

--- a/frontend/src/components/node/__snapshots__/List.NoNodePools.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.NoNodePools.stories.storyshot
@@ -172,7 +172,7 @@
             </div>
           </div>
           <table
-            class="MuiTable-root css-r4i8ha-MuiTable-root"
+            class="MuiTable-root css-1drzxj3-MuiTable-root"
           >
             <thead
               class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
@@ -561,61 +561,6 @@
                 </th>
                 <th
                   aria-sort="none"
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2288ty-MuiTableCell-root"
-                  colspan="1"
-                  data-can-sort="true"
-                  data-index="-1"
-                  scope="col"
-                >
-                  <div
-                    class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
-                  >
-                    <div
-                      class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
-                    >
-                      <div
-                        class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
-                      >
-                        Node Pool
-                      </div>
-                      <span
-                        aria-label="Sort by Node Pool ascending"
-                        class="MuiBadge-root css-1c32n2y-MuiBadge-root"
-                        data-mui-internal-clone-element="true"
-                      >
-                        <span
-                          aria-label="Sort by Node Pool ascending"
-                          class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
-                          role="button"
-                          tabindex="0"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                            data-testid="SyncAltIcon"
-                            focusable="false"
-                            style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
-                        >
-                          0
-                        </span>
-                      </span>
-                    </div>
-                    <div
-                      class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
-                    />
-                  </div>
-                </th>
-                <th
-                  aria-sort="none"
                   class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1lfzwg-MuiTableCell-root"
                   colspan="1"
                   data-can-sort="true"
@@ -943,11 +888,6 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ibx802-MuiTableCell-root"
                 />
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-l7wb3v-MuiTableCell-root"
-                >
-                  default-pool
-                </td>
-                <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-kxj8ha-MuiTableCell-root"
                 />
                 <td
@@ -1063,9 +1003,6 @@
                 </td>
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ibx802-MuiTableCell-root"
-                />
-                <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-l7wb3v-MuiTableCell-root"
                 />
                 <td
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-kxj8ha-MuiTableCell-root"

--- a/frontend/src/components/node/storyHelper.ts
+++ b/frontend/src/components/node/storyHelper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { KubeNode } from '../../lib/k8s/node';
+import { KubeNode, NODE_POOL_LABEL_KEYS } from '../../lib/k8s/node';
 
 const creationTimestamp = new Date('2022-01-01').toISOString();
 
@@ -27,7 +27,9 @@ export const NODE_DUMMY_DATA: KubeNode[] = [
       namespace: 'default',
       creationTimestamp,
       uid: '123',
-      labels: {},
+      labels: {
+        'cloud.google.com/gke-nodepool': 'default-pool',
+      },
     },
     spec: {
       podCIDR: '',
@@ -89,3 +91,19 @@ export const NODE_DUMMY_DATA: KubeNode[] = [
     status: {},
   },
 ];
+
+/**
+ * Node data where no node has a node pool label.
+ * Used to verify the "Node Pool" column is hidden when no pool labels exist.
+ */
+export const NODE_DUMMY_DATA_NO_POOLS: KubeNode[] = NODE_DUMMY_DATA.map(node => ({
+  ...node,
+  metadata: {
+    ...node.metadata,
+    labels: Object.fromEntries(
+      Object.entries(node.metadata.labels ?? {}).filter(
+        ([key]) => !(NODE_POOL_LABEL_KEYS as readonly string[]).includes(key)
+      )
+    ),
+  },
+}));

--- a/frontend/src/components/resourceMap/sources/definitions/sources.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/sources.tsx
@@ -42,6 +42,7 @@ import { Lease } from '../../../../lib/k8s/lease';
 import { LimitRange } from '../../../../lib/k8s/limitRange';
 import MutatingWebhookConfiguration from '../../../../lib/k8s/mutatingWebhookConfiguration';
 import NetworkPolicy from '../../../../lib/k8s/networkpolicy';
+import Node from '../../../../lib/k8s/node';
 import PersistentVolumeClaim from '../../../../lib/k8s/persistentVolumeClaim';
 import Pod from '../../../../lib/k8s/pod';
 import PDB from '../../../../lib/k8s/podDisruptionBudget';
@@ -192,6 +193,15 @@ export function useGetAllSources(): GraphSource[] {
           />
         ),
         sources: [makeKubeSource(PersistentVolumeClaim)],
+      },
+      {
+        id: 'cluster',
+        label: 'Cluster',
+        icon: (
+          <Icon icon="mdi:server" width="100%" height="100%" color={getKindGroupColor('other')} />
+        ),
+        isEnabledByDefault: false,
+        sources: [makeKubeSource(Node)],
       },
       {
         id: 'network',

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "إلغاء العزل",
   "Cordon": "عزل",
   "Drain": "تفريغ",
+  "Node Pool": "",
   "Pod CIDR": "نطاق Pod CIDR",
   "Capacity": "السعة",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Planungssperre aufheben",
   "Cordon": "Planungssperre setzen",
   "Drain": "Entleeren",
+  "Node Pool": "",
   "Pod CIDR": "CIDR des Pods",
   "Capacity": "Kapazität",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Uncordon",
   "Cordon": "Cordon",
   "Drain": "Drain",
+  "Node Pool": "Node Pool",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "Capacity",
   "Allocatable": "Allocatable",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Desbloquear",
   "Cordon": "Bloquear",
   "Drain": "Drenar",
+  "Node Pool": "",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "Capacidad",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Débloquer",
   "Cordon": "Bloquer",
   "Drain": "Vider",
+  "Node Pool": "",
   "Pod CIDR": "CIDR du pod",
   "Capacity": "Capacité",
   "Allocatable": "Allouable",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Uncordon",
   "Cordon": "Cordon",
   "Drain": "Drain",
+  "Node Pool": "",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "Capacity",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "अनकॉर्डन",
   "Cordon": "कॉर्डन",
   "Drain": "ड्रेन",
+  "Node Pool": "",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "क्षमता",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Abilita",
   "Cordon": "Disabilita",
   "Drain": "Svuota",
+  "Node Pool": "",
   "Pod CIDR": "CIDR del Pod",
   "Capacity": "Capacità",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "封鎖解除",
   "Cordon": "封鎖",
   "Drain": "排出",
+  "Node Pool": "",
   "Pod CIDR": "ポッド CIDR",
   "Capacity": "容量",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Uncordon",
   "Cordon": "Cordon",
   "Drain": "Drain",
+  "Node Pool": "",
   "Pod CIDR": "파드 CIDR",
   "Capacity": "용량",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Desbloquear",
   "Cordon": "Bloquear",
   "Drain": "Drenar",
+  "Node Pool": "",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "Capacidade",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "Снять cordon",
   "Cordon": "Установить cordon",
   "Drain": "Дренировать",
+  "Node Pool": "",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "Ёмкость",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "அன்கார்டன்",
   "Cordon": "கார்டன்",
   "Drain": "ட்ரெயின்",
+  "Node Pool": "",
   "Pod CIDR": "பாட் சிஐடிஆர்",
   "Capacity": "கொள்ளளவு",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "انکارڈن",
   "Cordon": "کارڈن",
   "Drain": "ڈرین",
+  "Node Pool": "",
   "Pod CIDR": "پوڈ CIDR",
   "Capacity": "صلاحیت",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "解除封鎖",
   "Cordon": "封鎖",
   "Drain": "驅逐",
+  "Node Pool": "",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "容量",
   "Allocatable": "",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -142,6 +142,7 @@
   "Uncordon": "解除封锁",
   "Cordon": "封锁",
   "Drain": "驱逐",
+  "Node Pool": "",
   "Pod CIDR": "Pod CIDR",
   "Capacity": "容量",
   "Allocatable": "",

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -142,6 +142,22 @@ class Node extends KubeObject<KubeNode> {
       .filter(key => key.startsWith(rolePrefix))
       .map(key => key.slice(rolePrefix.length));
   }
+
+  /**
+   * Returns the node pool name from well-known cloud provider labels.
+   * Supports GKE, AKS, EKS, kOps, and Cluster API.
+   */
+  getNodePool(): string {
+    const labels = this.metadata.labels ?? {};
+    return (
+      labels['cloud.google.com/gke-nodepool'] ??
+      labels['kubernetes.azure.com/agentpool'] ??
+      labels['eks.amazonaws.com/nodegroup'] ??
+      labels['kops.k8s.io/instancegroup'] ??
+      labels['cluster.x-k8s.io/deployment-name'] ??
+      ''
+    );
+  }
 }
 
 export default Node;

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -63,6 +63,18 @@ export interface KubeNode extends KubeObjectInterface {
   };
 }
 
+/**
+ * The exact label keys checked by {@link Node.getNodePool}.
+ * Export this so test helpers and stories can strip them without drifting.
+ */
+export const NODE_POOL_LABEL_KEYS = [
+  'cloud.google.com/gke-nodepool',
+  'kubernetes.azure.com/agentpool',
+  'eks.amazonaws.com/nodegroup',
+  'kops.k8s.io/instancegroup',
+  'cluster.x-k8s.io/deployment-name',
+] as const;
+
 class Node extends KubeObject<KubeNode> {
   static kind = 'Node';
   static apiName = 'nodes';
@@ -149,14 +161,12 @@ class Node extends KubeObject<KubeNode> {
    */
   getNodePool(): string {
     const labels = this.metadata.labels ?? {};
-    return (
-      labels['cloud.google.com/gke-nodepool'] ??
-      labels['kubernetes.azure.com/agentpool'] ??
-      labels['eks.amazonaws.com/nodegroup'] ??
-      labels['kops.k8s.io/instancegroup'] ??
-      labels['cluster.x-k8s.io/deployment-name'] ??
-      ''
-    );
+    for (const key of NODE_POOL_LABEL_KEYS) {
+      if (labels[key] !== undefined) {
+        return labels[key];
+      }
+    }
+    return '';
   }
 }
 

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -464,6 +464,13 @@
       "default": [Function],
     },
     "node": {
+      "NODE_POOL_LABEL_KEYS": [
+        "cloud.google.com/gke-nodepool",
+        "kubernetes.azure.com/agentpool",
+        "eks.amazonaws.com/nodegroup",
+        "kops.k8s.io/instancegroup",
+        "cluster.x-k8s.io/deployment-name",
+      ],
       "default": [Function],
     },
     "persistentVolume": {


### PR DESCRIPTION
## Summary

Adds node pool awareness across the UI by extracting pool names from well-known cloud provider labels (GKE, AKS, EKS, kOps, Cluster API) and surfacing them in the node list, details view, and resource map. The Node Pool column auto-shows when any node has a pool label and is hidden otherwise.

This is a widely used but emergent defacto standard... there's no Kubernetes standard for this.

## Related Issue

This was from an in person request at Kubecon EU.

## Changes

- Added "Node Pool" column to node list view — automatically shown when any node has a pool label, hidden otherwise. Multi-select filterable.
- Added "Node Pool" row to node details view — conditionally shown only when label exists
- Added Node to resource map under a new "Cluster" source group (disabled by default)
- Added `Node.getNodePool()` method 

```ts
// frontend/src/lib/k8s/node.ts
getNodePool(): string {
  const labels = this.metadata.labels ?? {};
  return (
    labels['cloud.google.com/gke-nodepool'] ??
    labels['kubernetes.azure.com/agentpool'] ??
    labels['eks.amazonaws.com/nodegroup'] ??
    labels['kops.k8s.io/instancegroup'] ??
    labels['cluster.x-k8s.io/deployment-name'] ??
    ''
  );
}
```

## Steps to Test

1. Connect to a managed K8s cluster (GKE/AKS/EKS) with node pools, or use KWOK to create nodes with node pool labels
2. Navigate to Nodes list — verify "Node Pool" column automatically appears when nodes have pool labels, and is absent on clusters without them (e.g. kind, minikube)
3. Click a node — verify "Node Pool" row appears in details (absent for nodes without pool labels)
4. Open Map view — enable "Cluster" source, verify nodes render

## Screenshots (if applicable)

**Node list with Node Pool column auto-shown (KWOK cluster):**

<img src="https://github.com/user-attachments/assets/525f2ae1-a581-4555-a6ad-f6ef94ebd62b">

**Node details showing Node Pool info:**

<img src="https://github.com/user-attachments/assets/305bd68e-5e20-47c9-be09-ba3c72279262">


Assisted by copilot