### PR TITLE
app: Add a setting to disable the system tray icon

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -52,7 +52,13 @@ import {
   PluginManager,
 } from './plugin-management';
 import { addRunCmdConsent, removeRunCmdConsent, runScript, setupRunCmdHandlers } from './runCmd';
-import { cleanupHeadlampTray, createHeadlampTray } from './tray';
+import {
+  cleanupHeadlampTray,
+  createHeadlampTray,
+  isHeadlampTrayCreated,
+  isTrayIconEnabled,
+  setTrayIconEnabled,
+} from './tray';
 import windowSize from './windowSize';
 
 if (process.env.APPIMAGE) {
@@ -1722,6 +1728,17 @@ function startElectron() {
       mainWindow?.webContents.send('backend-port', actualPort);
     });
 
+    ipcMain.on('request-tray-icon', () => {
+      mainWindow?.webContents.send('tray-icon', isTrayIconEnabled());
+    });
+
+    ipcMain.on('set-tray-icon', (event: IpcMainEvent, enabled: boolean) => {
+      if (typeof enabled !== 'boolean') {
+        return;
+      }
+      applyTrayIconSetting(enabled);
+    });
+
     setupRunCmdHandlers(mainWindow, ipcMain);
 
     new PluginManagerEventListeners().setupEventHandlers();
@@ -1790,9 +1807,8 @@ function startElectron() {
     app.disableHardwareAcceleration();
   }
 
-  app.on('ready', async () => {
-    await Promise.all([startServerIfNeeded(), createWindow()]);
-    hasTray = createHeadlampTray({
+  function buildTrayOptions() {
+    return {
       backendToken,
       createWindow,
       getBackendPort: () => actualPort,
@@ -1802,7 +1818,27 @@ function startElectron() {
         isQuitting = true;
         app.quit();
       },
-    });
+    };
+  }
+
+  /**
+   * Applies the system tray preference at runtime: persists it, then creates or
+   * removes the tray so the change takes effect without restarting the app.
+   */
+  function applyTrayIconSetting(enabled: boolean) {
+    setTrayIconEnabled(enabled);
+
+    if (enabled && !isHeadlampTrayCreated()) {
+      hasTray = createHeadlampTray(buildTrayOptions());
+    } else if (!enabled && isHeadlampTrayCreated()) {
+      cleanupHeadlampTray();
+      hasTray = false;
+    }
+  }
+
+  app.on('ready', async () => {
+    await Promise.all([startServerIfNeeded(), createWindow()]);
+    hasTray = createHeadlampTray(buildTrayOptions());
   });
   app.on('activate', async function () {
     if (mainWindow === null) {

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -16,6 +16,18 @@
 
 import { contextBridge, ipcRenderer } from 'electron';
 
+// Keeps the mapping between a caller-provided listener and the wrapped one we
+// actually register with ipcRenderer, so removeListener can still unsubscribe
+// the listener when callers pass the original function reference.
+// Using a WeakMap so the mapping itself doesn't retain listeners; note this
+// doesn't avoid leaks on its own - ipcRenderer holds a strong reference to
+// the wrapped listener (which closes over the original) until the caller
+// unsubscribes via the returned function or removeListener.
+const wrappedListeners = new WeakMap<
+  (...args: unknown[]) => void,
+  { channel: string; wrapped: (event: unknown, ...args: unknown[]) => void }
+>();
+
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('desktopApi', {
@@ -32,6 +44,8 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'request-plugin-permission-secrets',
       'open-plugin-folder',
       'request-backend-port',
+      'request-tray-icon',
+      'set-tray-icon',
       'cluster-changed',
     ];
     if (validChannels.includes(channel)) {
@@ -52,14 +66,30 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'plugin-permission-secrets',
       'open-about-dialog',
       'backend-port',
+      'tray-icon',
     ];
     if (validChannels.includes(channel)) {
       // Deliberately strip event as it includes `sender`
-      ipcRenderer.on(channel, (event, ...args) => func(...args));
+      const wrapped = (event: unknown, ...args: unknown[]) => func(...args);
+      ipcRenderer.on(channel, wrapped);
+      wrappedListeners.set(func, { channel, wrapped });
+      // Also return an unsubscribe function for new callers; older callers
+      // that prefer `removeListener(channel, originalFunc)` keep working too.
+      return () => {
+        ipcRenderer.removeListener(channel, wrapped);
+        wrappedListeners.delete(func);
+      };
     }
   },
 
   removeListener: (channel: string, func: (...args: unknown[]) => void) => {
+    const entry = wrappedListeners.get(func);
+    if (entry && entry.channel === channel) {
+      ipcRenderer.removeListener(channel, entry.wrapped);
+      wrappedListeners.delete(func);
+      return;
+    }
+    // Fallback for listeners registered without going through `receive`.
     ipcRenderer.removeListener(channel, func);
   },
 

--- a/app/electron/tray.test.ts
+++ b/app/electron/tray.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isTrayIconEnabled, setTrayIconEnabled } from './tray';
+
+function tmpPath(): string {
+  return path.join(os.tmpdir(), `tray-test-${Date.now()}-${Math.random()}.json`);
+}
+
+describe('tray icon setting', () => {
+  let filePath: string;
+
+  beforeEach(() => {
+    filePath = tmpPath();
+    try {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  afterEach(() => {
+    try {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('defaults to enabled when the settings file does not exist', () => {
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(isTrayIconEnabled(filePath)).toBe(true);
+  });
+
+  it('defaults to enabled when the setting is unset but other settings exist', () => {
+    fs.writeFileSync(filePath, JSON.stringify({ confirmedCommands: {} }), 'utf-8');
+    expect(isTrayIconEnabled(filePath)).toBe(true);
+  });
+
+  it('persists and reads back a disabled preference', () => {
+    setTrayIconEnabled(false, filePath);
+    expect(isTrayIconEnabled(filePath)).toBe(false);
+  });
+
+  it('persists and reads back an enabled preference', () => {
+    setTrayIconEnabled(false, filePath);
+    setTrayIconEnabled(true, filePath);
+    expect(isTrayIconEnabled(filePath)).toBe(true);
+  });
+
+  it('preserves unrelated settings when toggling', () => {
+    fs.writeFileSync(filePath, JSON.stringify({ confirmedCommands: { foo: true } }), 'utf-8');
+    setTrayIconEnabled(false, filePath);
+    const saved = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(saved.confirmedCommands).toEqual({ foo: true });
+    expect(saved.enableSystemTray).toBe(false);
+  });
+
+  it('falls back to enabled when the file contains valid non-object JSON', () => {
+    fs.writeFileSync(filePath, JSON.stringify(['not', 'an', 'object']), 'utf-8');
+    expect(isTrayIconEnabled(filePath)).toBe(true);
+  });
+
+  it('does not throw and writes an object when the file contains non-object JSON', () => {
+    fs.writeFileSync(filePath, JSON.stringify('a string'), 'utf-8');
+    expect(() => setTrayIconEnabled(false, filePath)).not.toThrow();
+    const saved = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(saved).toEqual({ enableSystemTray: false });
+  });
+
+  it('swallows write errors so an unwritable settings.json does not crash the main process', () => {
+    const unwritable = path.join(os.tmpdir(), `tray-test-${Date.now()}`, 'nope', 'settings.json');
+    expect(() => setTrayIconEnabled(false, unwritable)).not.toThrow();
+    expect(fs.existsSync(unwritable)).toBe(false);
+  });
+});

--- a/app/electron/tray.ts
+++ b/app/electron/tray.ts
@@ -17,6 +17,9 @@
 import { BrowserWindow, Menu, nativeImage, Tray } from 'electron';
 import { MenuItemConstructorOptions } from 'electron/main';
 import path from 'path';
+import { loadSettings, saveSettings, SETTINGS_PATH } from './settings';
+
+const TRAY_SETTING_KEY = 'enableSystemTray';
 
 type ClusterStatus = {
   name: string;
@@ -39,6 +42,40 @@ let trayUpdateTimeout: NodeJS.Timeout | null = null;
 
 export function shouldRunTray(): boolean {
   return ['darwin', 'linux', 'win32'].includes(process.platform);
+}
+
+// settings.json is user-editable, so it may contain valid JSON that is not a
+// plain object (e.g. an array or string). Treat anything else as empty.
+function asSettingsObject(value: unknown): Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, any>)
+    : {};
+}
+
+/**
+ * Whether the user has the system tray icon enabled.
+ * Defaults to true when the setting is unset, to preserve existing behavior.
+ */
+export function isTrayIconEnabled(settingsPath: string = SETTINGS_PATH): boolean {
+  const settings = asSettingsObject(loadSettings(settingsPath));
+  return settings[TRAY_SETTING_KEY] !== false;
+}
+
+/**
+ * Persists whether the system tray icon should be created.
+ * Errors writing the settings file are logged and swallowed so a failure here
+ * (e.g. unwritable settings.json) can't take down the Electron main process.
+ * The runtime tray state still updates; the on-disk setting just doesn't get
+ * the new value, so it falls back to the previously persisted one on restart.
+ */
+export function setTrayIconEnabled(enabled: boolean, settingsPath: string = SETTINGS_PATH): void {
+  try {
+    const settings = asSettingsObject(loadSettings(settingsPath));
+    settings[TRAY_SETTING_KEY] = enabled;
+    saveSettings(settingsPath, settings);
+  } catch (error) {
+    console.error('Failed to persist tray icon setting:', error);
+  }
 }
 
 export function isHeadlampTrayCreated(): boolean {
@@ -64,6 +101,10 @@ export function cleanupHeadlampTray(): void {
 
 export function createHeadlampTray(options: HeadlampTrayOptions): boolean {
   if (!shouldRunTray()) {
+    return false;
+  }
+
+  if (!isTrayIconEnabled()) {
     return false;
   }
 

--- a/frontend/src/components/App/Settings/Settings.tsx
+++ b/frontend/src/components/App/Settings/Settings.tsx
@@ -21,6 +21,7 @@ import { capitalize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
+import { isElectron } from '../../../helpers/isElectron';
 import LocaleSelect from '../../../i18n/LocaleSelect/LocaleSelect';
 import { setAppSettings } from '../../../redux/configSlice';
 import { defaultTableRowsPerPageOptions } from '../../../redux/configSlice';
@@ -50,6 +51,7 @@ export default function Settings() {
   );
   const [sortSidebar, setSortSidebar] = useState<boolean>(storedSortSidebar);
   const [useEvict, setUseEvict] = useState<boolean>(storedUseEvict);
+  const [trayIcon, setTrayIcon] = useState<boolean>(true);
   const dispatch = useDispatch();
   const themeName = useTypedSelector(state => state.theme.name);
   const appThemes = useAppThemes();
@@ -82,8 +84,28 @@ export default function Settings() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [useEvict]);
 
+  useEffect(() => {
+    if (!isElectron()) {
+      return;
+    }
+
+    const handler = (enabled: boolean) => setTrayIcon(enabled);
+    const unsubscribe = window.desktopApi?.receive('tray-icon', handler);
+    window.desktopApi?.send('request-tray-icon');
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
+
+  function handleTrayIconChange(enabled: boolean) {
+    setTrayIcon(enabled);
+    window.desktopApi?.send('set-tray-icon', enabled);
+  }
+
   const sidebarLabelID = 'sort-sidebar-label';
   const evictLabelID = 'use-evict-label';
+  const trayIconLabelID = 'tray-icon-label';
   const tableRowsLabelID = 'rows-per-page-label';
   const timezoneLabelID = 'timezone-label';
 
@@ -165,6 +187,24 @@ export default function Settings() {
             ),
             nameID: evictLabelID,
           },
+          ...(isElectron()
+            ? [
+                {
+                  name: t('translation|Show system tray icon'),
+                  value: (
+                    <Switch
+                      color="primary"
+                      checked={trayIcon}
+                      onChange={e => handleTrayIconChange(e.target.checked)}
+                      inputProps={{
+                        'aria-labelledby': trayIconLabelID,
+                      }}
+                    />
+                  ),
+                  nameID: trayIconLabelID,
+                },
+              ]
+            : []),
         ]}
       />
       <Box

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "المنطقة الزمنية لعرض التواريخ",
   "Sort sidebar items alphabetically": "ترتيب عناصر الشريط الجانبي أبجديًا",
   "Use evict for pod deletion": "استخدام evict لحذف الـ pod",
+  "Show system tray icon": "",
   "Theme": "السمة",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "اختصارات لوحة المفاتيح",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "তারিখের জন্য প্রদর্শিত টাইমজোন",
   "Sort sidebar items alphabetically": "সাইডবার itemগুলি বর্ণানুক্রমিকভাবে বাছাই করুন",
   "Use evict for pod deletion": "Pod delete করার জন্য উচ্ছেদ ব্যবহার করুন",
+  "Show system tray icon": "",
   "Theme": "থিম",
   "Theme has been forced by your administrator": "আপনার প্রশাসক দ্বারা থিম নির্ধারিত হয়েছে",
   "Keyboard Shortcuts": "কীবোর্ড শর্টকাট",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "Timezone to display for dates",
   "Sort sidebar items alphabetically": "Sort sidebar items alphabetically",
   "Use evict for pod deletion": "Use evict for pod deletion",
+  "Show system tray icon": "Show system tray icon",
   "Theme": "Theme",
   "Theme has been forced by your administrator": "Theme has been forced by your administrator",
   "Keyboard Shortcuts": "Keyboard Shortcuts",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "Timezone to display for dates",
   "Sort sidebar items alphabetically": "Sort sidebar items alphabetically",
   "Use evict for pod deletion": "Use evict for pod deletion",
+  "Show system tray icon": "",
   "Theme": "Theme",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "Keyboard Shortcuts",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "Часовой пояс для отображения дат",
   "Sort sidebar items alphabetically": "Сортировка элементов боковой панели по алфавиту",
   "Use evict for pod deletion": "Использовать Evict при удалении Pod",
+  "Show system tray icon": "",
   "Theme": "Тема",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "Сочетания клавиш",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "تاریخیں دکھانے کے لیے ٹائم زون",
   "Sort sidebar items alphabetically": "سائیڈ بار آئٹمز کو حروف تہجی کے مطابق ترتیب دیں",
   "Use evict for pod deletion": "پوڈ حذف کرنے کے لیے evict استعمال کریں",
+  "Show system tray icon": "",
   "Theme": "تھیم",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "کی بورڈ شارٹ کٹس",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -168,6 +168,7 @@
   "Timezone to display for dates": "",
   "Sort sidebar items alphabetically": "",
   "Use evict for pod deletion": "",
+  "Show system tray icon": "",
   "Theme": "",
   "Theme has been forced by your administrator": "",
   "Keyboard Shortcuts": "",


### PR DESCRIPTION
## Summary

This PR makes the desktop system tray icon optional by adding a persisted "Show system tray icon" setting, addressing the request that the tray (added in #4030 / #4452) is currently created unconditionally with no opt-out.

## Related Issue

Fixes #5753

## Changes

- Added `isTrayIconEnabled` / `setTrayIconEnabled` in `app/electron/tray.ts`, persisted via the existing `settings.json` (key `enableSystemTray`, defaults to `true` so current behavior is unchanged)
- `createHeadlampTray` now returns early when the tray is disabled
- `app/electron/main.ts`: extracted tray options into a shared builder and added `applyTrayIconSetting`, which creates or removes the tray at runtime (no restart needed); added `request-tray-icon` / `set-tray-icon` IPC handlers
- `app/electron/preload.ts`: whitelisted the new IPC channels
- Added a "Show system tray icon" toggle to General Settings, shown only in the desktop app (`isElectron()`), wired through the desktop API
- Ran `npm run i18n` to add the new translation key

## Steps to Test

1. Run the desktop app (`make run-app` or `npm start` in `app/`) on macOS/Linux/Windows
2. Observe the tray icon appears in the system tray/menu bar (default behavior unchanged)
3. Go to Settings → General → toggle off "Show system tray icon"
4. Observe the tray icon disappears immediately, without restarting
5. Toggle it back on and observe the tray icon reappears
6. Restart the app and confirm the chosen setting persists

## Screenshots (if applicable)


## Notes for the Reviewer

- This touches the i18n layer (new `translation` key across locale files) - only `translation.json` was changed; the parser's incidental `glossary.json` reformatting was reverted.
- The setting is desktop-only and defaults to enabled, so web and existing desktop users see no behavior change.
- Happy to add tests or adjust the setting key/label/placement if you'd prefer a different approach.