### PR TITLE
backend: stateless: Fix empty-user stateless key cache collisions in WebSockets

### DIFF
--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -31,11 +31,12 @@ import (
 
 const statelessContextKeySep = "\x00"
 
+// statelessContextKey generates a structured context key by joining the cluster name
+// and user ID with a NUL character separator (statelessContextKeySep) to avoid
+// ambiguous concatenation collisions between different (clusterName, userID) pairs.
+// It always appends the separator (even if userID is empty) to prevent collisions
+// with normal (non-stateless) contexts of the same name.
 func statelessContextKey(clusterName, userID string) string {
-	if userID == "" {
-		return clusterName
-	}
-
 	return clusterName + statelessContextKeySep + userID
 }
 
@@ -219,9 +220,14 @@ func websocketConnContextKey(r *http.Request, clusterName string) string {
 	// Expected number of submatches in the regular expression
 	const expectedSubmatches = 2
 
-	var userID string
+	var (
+		userID          string
+		isStatelessConn bool
+	)
+
 	// Define a regular expression pattern for base64url.headlamp.authorization.k8s.io
-	pattern := `base64url\.headlamp\.authorization\.k8s\.io\.([a-zA-Z0-9_-]+)`
+	// Use * instead of + to support matching empty user IDs.
+	pattern := `base64url\.headlamp\.authorization\.k8s\.io\.([a-zA-Z0-9_-]*)`
 
 	// Compile the regular expression
 	re := regexp.MustCompile(pattern)
@@ -232,6 +238,7 @@ func websocketConnContextKey(r *http.Request, clusterName string) string {
 	// Check if a match is found
 	if len(matches) >= expectedSubmatches {
 		userID = matches[1]
+		isStatelessConn = true
 	}
 
 	// Remove the base64url.headlamp.authorization.k8s.io subprotocol from the list
@@ -254,7 +261,7 @@ func websocketConnContextKey(r *http.Request, clusterName string) string {
 	// Add the updated Sec-Websocket-Protocol header
 	r.Header.Add("Sec-Websocket-Protocol", updatedProtocol)
 
-	if userID == "" {
+	if !isStatelessConn {
 		return clusterName
 	}
 

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -416,7 +416,7 @@ func TestStatelessContextKeyCollision(t *testing.T) {
 }
 
 func TestStatelessContextKeyWithoutUserID(t *testing.T) {
-	assert.Equal(t, "cluster-a", statelessContextKey("cluster-a", ""))
+	assert.Equal(t, "cluster-a"+statelessContextKeySep, statelessContextKey("cluster-a", ""))
 }
 
 func TestWebsocketConnContextKey(t *testing.T) {
@@ -432,6 +432,13 @@ func TestWebsocketConnContextKey(t *testing.T) {
 			protocols:      "base64url.headlamp.authorization.k8s.io.user123, v4.channel.k8s.io",
 			clusterName:    "test-cluster",
 			expectedKey:    statelessContextKey("test-cluster", "user123"),
+			expectedHeader: "v4.channel.k8s.io",
+		},
+		{
+			name:           "With empty user authorization protocol",
+			protocols:      "base64url.headlamp.authorization.k8s.io., v4.channel.k8s.io",
+			clusterName:    "test-cluster",
+			expectedKey:    statelessContextKey("test-cluster", ""),
 			expectedHeader: "v4.channel.k8s.io",
 		},
 		{
@@ -455,6 +462,18 @@ func TestWebsocketConnContextKey(t *testing.T) {
 	}
 }
 
+func TestWebsocketConnContextKeyStatelessStore(t *testing.T) {
+	clusterName := "my-stateless-cluster"
+	statelessKey := statelessContextKey(clusterName, "")
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/", nil)
+	req.Header.Set("Sec-Websocket-Protocol", "base64url.headlamp.authorization.k8s.io., v4.channel.k8s.io")
+
+	key := websocketConnContextKey(req, clusterName)
+	assert.Equal(t, statelessKey, key)
+	assert.Equal(t, "v4.channel.k8s.io", req.Header.Get("Sec-Websocket-Protocol"))
+}
+
 func TestMarshalCustomObject_InvalidJSON(t *testing.T) {
 	mockInfo := &runtime.Unknown{
 		Raw: []byte(`{invalid-json`),
@@ -462,4 +481,9 @@ func TestMarshalCustomObject_InvalidJSON(t *testing.T) {
 
 	_, err := MarshalCustomObject(mockInfo, "test-context")
 	assert.Error(t, err)
+}
+
+func TestStatelessContextKeyFormat(t *testing.T) {
+	assert.Equal(t, "ab"+statelessContextKeySep+"c", statelessContextKey("ab", "c"))
+	assert.Equal(t, "a"+statelessContextKeySep+"bc", statelessContextKey("a", "bc"))
 }


### PR DESCRIPTION
## Problem
Previously, when the frontend connected to a stateless cluster with an empty user ID, it sent the subprotocol `base64url.headlamp.authorization.k8s.io.`. Because the backend regex pattern used `+` instead of `*`, it failed to match this empty subprotocol, falling back to checking cache store contexts. 

Under this fallback, if the cache contained `clusterName + "\x00"`, any normal (non-stateless) WebSocket connection for the same cluster (which also has no userID) was incorrectly routed through the stateless credentials context.

## Solution
- Updated the backend's WebSocket subprotocol regex pattern to use `*` instead of `+` to match empty user ID protocols.
- Introduced an explicit `isStatelessConn` check based on the subprotocol marker.
- Discarded fallback cache store lookups for non-stateless WebSocket connections, ensuring ordinary WebSockets are never routed into the stateless context.
- Removed the unused `store` parameter from the `websocketConnContextKey` signature to resolve `golangci-lint` warning.

## Changes
- Updated `websocketConnContextKey()` in `backend/cmd/stateless.go` to parse empty user ID protocols and track `isStatelessConn`.
- Removed unused `store` parameter from `websocketConnContextKey()` and updated its call in `getContextKeyForRequest()`.
- Updated unit tests in `backend/cmd/stateless_test.go` to cover empty user protocols and verify routing.

## Testing
All tests passing:
- `go test -v ./cmd` — PASS
- `go fmt ./cmd/...` — Format OK


Fixes #5722