### PR TITLE
resourceMap: Hide Gateway API filter when empty

### DIFF
--- a/frontend/src/components/resourceMap/sources/definitions/sources.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/sources.tsx
@@ -15,8 +15,10 @@
  */
 
 import { Icon } from '@iconify/react';
+import { useQuery } from '@tanstack/react-query';
 import React, { useMemo } from 'react';
-import { useCluster } from '../../../../lib/k8s';
+import { useCluster, useSelectedClusters } from '../../../../lib/k8s';
+import { apiDiscovery } from '../../../../lib/k8s/api/v2/apiDiscovery';
 import BackendTLSPolicy from '../../../../lib/k8s/backendTLSPolicy';
 import BackendTrafficPolicy from '../../../../lib/k8s/backendTrafficPolicy';
 import ConfigMap from '../../../../lib/k8s/configMap';
@@ -127,9 +129,19 @@ const generateCRSources = (crds: CRD[], vpaEnabled: boolean): GraphSource[] => {
 };
 
 export function useGetAllSources(): GraphSource[] {
-  const { items: CustomResourceDefinition } = CRD.useList({ namespace: useNamespaces() });
+  const namespaces = useNamespaces();
+  const { items: CustomResourceDefinition } = CRD.useList({ namespace: namespaces });
   const cluster = useCluster();
+  const selectedClusters = useSelectedClusters();
   const [vpaEnabled, setVpaEnabled] = React.useState(false);
+
+  // Show the Gateway (beta) group only when the Gateway API group is served.
+  const { data: discoveredResources } = useQuery({
+    queryFn: () => apiDiscovery([...selectedClusters]),
+    queryKey: ['api-discovery', ...selectedClusters],
+  });
+  const gatewayEnabled =
+    discoveredResources?.some(r => r.groupName === 'gateway.networking.k8s.io') ?? false;
 
   React.useEffect(() => {
     let cancelled = false;
@@ -241,28 +253,32 @@ export function useGetAllSources(): GraphSource[] {
           makeKubeSource(Lease),
         ],
       },
-      {
-        id: 'gateway-beta',
-        label: 'Gateway (beta)',
-        icon: (
-          <Icon
-            icon="mdi:lan-connect"
-            width="100%"
-            height="100%"
-            color={getKindGroupColor('network')}
-          />
-        ),
-        isEnabledByDefault: false,
-        sources: [
-          makeKubeSource(GatewayClass),
-          makeKubeSource(Gateway),
-          makeKubeSource(HTTPRoute),
-          makeKubeSource(GRPCRoute),
-          makeKubeSource(ReferenceGrant),
-          makeKubeSource(BackendTLSPolicy),
-          makeKubeSource(BackendTrafficPolicy),
-        ],
-      },
+      ...(gatewayEnabled
+        ? [
+            {
+              id: 'gateway-beta',
+              label: 'Gateway (beta)',
+              icon: (
+                <Icon
+                  icon="mdi:lan-connect"
+                  width="100%"
+                  height="100%"
+                  color={getKindGroupColor('network')}
+                />
+              ),
+              isEnabledByDefault: false,
+              sources: [
+                makeKubeSource(GatewayClass),
+                makeKubeSource(Gateway),
+                makeKubeSource(HTTPRoute),
+                makeKubeSource(GRPCRoute),
+                makeKubeSource(ReferenceGrant),
+                makeKubeSource(BackendTLSPolicy),
+                makeKubeSource(BackendTrafficPolicy),
+              ],
+            },
+          ]
+        : []),
     ];
 
     if (CustomResourceDefinition !== null) {
@@ -283,5 +299,5 @@ export function useGetAllSources(): GraphSource[] {
     }
 
     return sources;
-  }, [CustomResourceDefinition, vpaEnabled]);
+  }, [CustomResourceDefinition, vpaEnabled, gatewayEnabled]);
 }


### PR DESCRIPTION
This change hides the "Gateway (beta)" group from the map's filter list when the cluster doesn't serve the Gateway API, preventing the infinite-loading state caused by clicking a filter whose CRDs aren't installed.

Fixes: #5770 

### Changes
- In `useGetAllSources()`, check via `apiDiscovery` whether the `gateway.networking.k8s.io` API group is served by any selected cluster, and gate the `gateway-beta` group on that
- Drop the now-unused MSW handlers for the `gateways` list endpoints from `GraphView.stories.tsx`

### Testing
- [x] Verified the "Gateway (beta)" filter is hidden on a cluster without Gateway CRDs
- [x] Storybook tests pass and no TS errors added

<img width="328" height="381" alt="image" src="https://github.com/user-attachments/assets/6e75f468-2eaf-48d1-a4b9-b7342a98807e" />