### PR TITLE
frontend: NumRowsInput: Fix react-hooks/exhaustive-deps 

### DIFF
--- a/frontend/src/components/App/Settings/NumRowsInput.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.tsx
@@ -25,7 +25,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { SelectChangeEvent } from '@mui/material/Select';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import {
@@ -48,22 +48,20 @@ export default function NumRowsInput(props: { defaultValue: number[]; nameLabelI
       node.focus();
     }
   }, []);
-  const defaultRowsPerPageValue = useMemo(() => {
+  const [selectedValue, setSelectedValue] = useState(() => {
     const val = getTablesRowsPerPage();
-    if (options.includes(val)) {
+    if (defaultValue.includes(val)) {
       return val;
     }
     return defaultTableRowsPerPageOptions[0];
-  }, [options]);
-  const [selectedValue, setSelectedValue] = useState(defaultRowsPerPageValue);
-  const storedCustomValue = useMemo(() => {
-    const val = options.find(val => !defaultTableRowsPerPageOptions.includes(val));
+  });
+  const [customValue, setCustomValue] = useState(() => {
+    const val = defaultValue.find(val => !defaultTableRowsPerPageOptions.includes(val));
     if (!val) {
-      return defaultTableRowsPerPageOptions[0];
+      return defaultTableRowsPerPageOptions[0].toString();
     }
-    return val;
-  }, [options]);
-  const [customValue, setCustomValue] = useState(storedCustomValue.toString());
+    return val.toString();
+  });
   const [errorMessage, setErrorMessage] = useState('');
   const dispatch = useDispatch();
 

--- a/frontend/src/components/App/Settings/NumRowsInput.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.tsx
@@ -54,8 +54,7 @@ export default function NumRowsInput(props: { defaultValue: number[]; nameLabelI
       return val;
     }
     return defaultTableRowsPerPageOptions[0];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [options]);
   const [selectedValue, setSelectedValue] = useState(defaultRowsPerPageValue);
   const storedCustomValue = useMemo(() => {
     const val = options.find(val => !defaultTableRowsPerPageOptions.includes(val));
@@ -63,16 +62,14 @@ export default function NumRowsInput(props: { defaultValue: number[]; nameLabelI
       return defaultTableRowsPerPageOptions[0];
     }
     return val;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [options]);
   const [customValue, setCustomValue] = useState(storedCustomValue.toString());
   const [errorMessage, setErrorMessage] = useState('');
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(setAppSettings({ tableRowsPerPageOptions: options }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options]);
+  }, [options, dispatch]);
 
   // Make sure we update the value in the localStorage when the user selects a new value.
   useEffect(() => {


### PR DESCRIPTION
## Summary
This PR removes the `react-hooks/exhaustive-deps` suppression in `frontend/src/components/App/Settings/NumRowsInput.tsx` by adding missing options dependency to `defaultRowsPerPageValue` and `storedCustomValue` in `useMemo` and adding 'dispatch' to the `useEffect` dependency array.

## Related Issue
Fixes #5766 (Sub-issue of #5183)

## Changes

- Added missing options dependency to defaultRowsPerPageValue and storedCustomValue in useMemos
- Added 'dispatch' to the useEffect dependency array.
- This allowed all eslint suppressions to be safely removed without causing re-renders


## Steps to Test

1.`cd frontend && npm install`
2.`npm run lint` passes and no react-hooks/exhaustive-deps violation surfaces for this hook.
3.`npm run tsc` passes.

## Screenshots (if applicable)
N/A. No functional change.

## Notes for the Reviewer
- DCO sign-off applied (Signed-off-by: in the commit).
- Listed as an unchecked exhaustive-deps bullet in umbrella issue https://github.com/kubernetes-sigs/headlamp/issues/5183