### PR TITLE
frontend: App: Remove unused themeName dependency 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,20 +30,14 @@ import { useElectronI18n } from './i18n/electronI18n';
 import ThemeProviderNexti18n from './i18n/ThemeProviderNexti18n';
 import { queryClient } from './lib/queryClient';
 import { setStore } from './lib/router/createRouteURL';
-import { createMuiTheme, getThemeName, usePrefersColorScheme } from './lib/themes';
-import { useTypedSelector } from './redux/hooks';
+import { createMuiTheme, usePrefersColorScheme } from './lib/themes';
 import store from './redux/stores/store';
 
 setStore(store);
 
 function AppWithRedux(props: React.PropsWithChildren<{}>) {
-  let themeName = useTypedSelector(state => state.theme.name);
   usePrefersColorScheme();
   useElectronI18n();
-
-  if (!themeName) {
-    themeName = getThemeName();
-  }
 
   const currentAppTheme = useCurrentAppTheme();
   const muiTheme = useMemo(() => createMuiTheme(currentAppTheme), [currentAppTheme]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,8 +46,7 @@ function AppWithRedux(props: React.PropsWithChildren<{}>) {
   }
 
   const currentAppTheme = useCurrentAppTheme();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const muiTheme = useMemo(() => createMuiTheme(currentAppTheme), [themeName, currentAppTheme]);
+  const muiTheme = useMemo(() => createMuiTheme(currentAppTheme), [currentAppTheme]);
 
   return (
     <I18nextProvider i18n={i18n}>


### PR DESCRIPTION
## Summary

This PR removes the unused dependency from the  hook that creates the MUI theme, and drops the associated eslint-disable comment.
- The  variable was not used within the hook's callback, which triggered a react-hooks/exhaustive-deps violation.
- Since changing the theme already yields a structurally distinct  object, relying on alone is sufficient to correctly trigger recomputations.

## Related Issue

Fixes #5765 (Sub-issue of #5183)

## Changes
- Removed unused `themeName` dependency from the dependency array.

## Steps to Test

1.`cd frontend && npm install`
2.`npm run lint` passes and no react-hooks/exhaustive-deps violation surfaces for this hook.
3.`npm run tsc` passes.

## Screenshots (if applicable)
N/A. No functional change.

## Notes for the Reviewer
- DCO sign-off applied (Signed-off-by: in the commit).
- Listed as an unchecked exhaustive-deps bullet in umbrella issue https://github.com/kubernetes-sigs/headlamp/issues/5183
