### PR TITLE
frontend: MetadataDisplay: Fix owner ref link when apiVersion mismatc…

### DIFF
--- a/frontend/src/components/common/Resource/MetadataDisplay.stories.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.stories.tsx
@@ -98,6 +98,26 @@ WithExtraRows.args = {
   ],
 };
 
+export const WithOwnerReferenceMismatchedApiVersion = Template.bind({});
+WithOwnerReferenceMismatchedApiVersion.args = {
+  resource: {
+    ...mockResource,
+    metadata: {
+      ...mockResource.metadata,
+      ownerReferences: [
+        {
+          apiVersion: 'batch.volcano.sh/v1alpha1',
+          kind: 'Job',
+          name: 'volcano-job',
+          uid: '456',
+          controller: true,
+          blockOwnerDeletion: true,
+        },
+      ],
+    },
+  },
+};
+
 export const WithManyLabels = Template.bind({});
 WithManyLabels.args = {
   resource: {

--- a/frontend/src/components/common/Resource/MetadataDisplay.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.tsx
@@ -69,10 +69,16 @@ export function MetadataDisplay<T extends KubeObject>(props: MetadataDisplayProp
 
     return ownerReferences
       .map((ownerRef, i) => {
-        if (ownerRef.kind in ResourceClasses) {
+        const resourceClass =
+          ownerRef.kind in ResourceClasses
+            ? ResourceClasses[ownerRef.kind as keyof typeof ResourceClasses]
+            : null;
+        const apiVersionMatches =
+          resourceClass !== null && resourceClass.apiVersion === ownerRef.apiVersion;
+        if (apiVersionMatches) {
           let routeName;
           try {
-            routeName = ResourceClasses[ownerRef.kind as keyof typeof ResourceClasses].detailsRoute;
+            routeName = resourceClass.detailsRoute;
           } catch (e) {
             console.error(`Error getting routeName for {ownerRef.kind}`, e);
             return null;

--- a/frontend/src/components/common/Resource/MetadataDisplay.tsx
+++ b/frontend/src/components/common/Resource/MetadataDisplay.tsx
@@ -74,13 +74,16 @@ export function MetadataDisplay<T extends KubeObject>(props: MetadataDisplayProp
             ? ResourceClasses[ownerRef.kind as keyof typeof ResourceClasses]
             : null;
         const apiVersionMatches =
-          resourceClass !== null && resourceClass.apiVersion === ownerRef.apiVersion;
+          resourceClass !== null &&
+          (Array.isArray(resourceClass.apiVersion)
+            ? resourceClass.apiVersion.includes(ownerRef.apiVersion)
+            : resourceClass.apiVersion === ownerRef.apiVersion);
         if (apiVersionMatches) {
           let routeName;
           try {
             routeName = resourceClass.detailsRoute;
           } catch (e) {
-            console.error(`Error getting routeName for {ownerRef.kind}`, e);
+            console.error(`Error getting routeName for ${ownerRef.kind}`, e);
             return null;
           }
           return (

--- a/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.WithOwnerReferenceMismatchedApiVersion.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/MetadataDisplay.WithOwnerReferenceMismatchedApiVersion.stories.storyshot
@@ -1,0 +1,97 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <dl
+        class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+      >
+        <dt
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+        >
+          Name
+        </dt>
+        <dd
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+          >
+            my-new-kind
+          </span>
+        </dd>
+        <dt
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+        >
+          Namespace
+        </dt>
+        <dd
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+        >
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+            href="/"
+          >
+            kube-system
+          </a>
+        </dd>
+        <dt
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+        >
+          Creation
+        </dt>
+        <dd
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+          >
+            2021-06-02T00:00:00.000Z
+          </span>
+        </dd>
+        <dt
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+        >
+          Labels
+        </dt>
+        <dd
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-0"
+          >
+            <div
+              class="MuiBox-root css-yi3mkw"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+              >
+                label1: My Label 1
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+              >
+                label2: My Label 2
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+              >
+                label3: My Label 3
+              </p>
+            </div>
+          </div>
+        </dd>
+        <dt
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+        >
+          Controlled by
+        </dt>
+        <dd
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+        >
+          Job: volcano-job
+        </dd>
+      </dl>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

Fix incorrect owner reference links when a custom resource shares the same `kind` as a built-in Kubernetes resource but has a different `apiVersion`.

## Related Issue

Fixes #5569

## Changes

`frontend/src/components/common/Resource/MetadataDisplay.tsx`: In `makeOwnerReferences`, added an `apiVersion` check alongside the existing `kind` check before rendering a link. If the `apiVersion` does not match the built-in resource class, the reference renders as plain text instead of incorrectly linking to the wrong resource page.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer
Currently, owner references are resolved by kind alone. This PR adds an apiVersion check so a custom resource with the same kind but a different apiVersion no longer incorrectly links to the built-in resource page.