### PR TITLE
frontend: Fix Backstage receiver listener leak on Home remount

### DIFF
--- a/frontend/src/components/App/Home/index.tsx
+++ b/frontend/src/components/App/Home/index.tsx
@@ -113,7 +113,7 @@ function HomeComponent(props: HomeComponentProps) {
   React.useEffect(() => {
     if (isBackstage()) {
       window.parent.postMessage({ type: 'HEADLAMP_READY' }, '*');
-      setupBackstageMessageReceiver();
+      return setupBackstageMessageReceiver();
     }
   }, []);
 

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -146,5 +146,10 @@ export function setupBackstageMessageReceiver() {
     };
 
     window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
   }
+
+  return () => {};
 }

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -110,12 +110,13 @@ interface BackstageMessage {
 const BACKSTAGE_ACK_TIMEOUT_MS = 1000;
 
 /**
+ * Sets up the Backstage message receiver for the given cluster.
  * setupBackstageMessageReceiver sets up a listener for messages from the backstage app
  * and sets the backend token if it is received
  *
- * @returns void
+ * @returns A cleanup function that removes the registered message event listener.
  */
-export function setupBackstageMessageReceiver() {
+export function setupBackstageMessageReceiver(): () => void {
   if (isBackstage()) {
     const handleMessage = async (event: MessageEvent) => {
       try {

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -110,9 +110,9 @@ interface BackstageMessage {
 const BACKSTAGE_ACK_TIMEOUT_MS = 1000;
 
 /**
- * Sets up the Backstage message receiver for the given cluster.
- * setupBackstageMessageReceiver sets up a listener for messages from the backstage app
- * and sets the backend token if it is received
+ * Sets up a listener for messages from the Backstage app.
+ * Handles Backstage auth token messages by storing the Backstage token,
+ * and kubeconfig messages by storing the kubeconfig for stateless use.
  *
  * @returns A cleanup function that removes the registered message event listener.
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -145,6 +152,39 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -209,12 +249,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -234,6 +291,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shell-quote": {
@@ -315,6 +395,22 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",


### PR DESCRIPTION
## Problem
The `Home` component registered a `window` event listener via
`setupBackstageMessageReceiver()` but never removed it on unmount,
causing listener accumulation on each remount.

## Solution
- Refactored `setupBackstageMessageReceiver()` to return an unsubscribe function
- Updated `useEffect` in `Home/index.tsx` to return the unsubscribe as cleanup

## Changes
- `frontend/src/helpers/backstageMessageReceiver.ts` — return unsubscribe fn
- `frontend/src/components/App/Home/index.tsx` — use cleanup in useEffect

## Testing
- ✅ `npm run frontend:test` — PASS
- ✅ `npm run frontend:tsc` — PASS
- ✅ `npm run frontend:lint` — No issues

Fixes #5775