### PR TITLE
frontend: deps: Bump yaml from 2.8.3 to 2.9.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17281,9 +17281,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
# frontend: deps: Bump yaml from 2.8.3 to 2.9.0

## Summary
Updates the `yaml` package in `frontend/` from `2.8.3` to `2.9.0` (latest).

## Changes
- Bumped `yaml` from `2.8.3` → `2.9.0` in `frontend/package.json`
- Updated `frontend/package-lock.json` accordingly

## Motivation
Routine dependency maintenance to keep `yaml` current with upstream bug fixes and improvements. See the [yaml v2.9.0 release notes](https://github.com/eemeli/yaml/releases/tag/v2.9.0) for details.

This is a minor version bump (semver-compatible), so no breaking changes are expected.

## Steps to Test
1. Pull the branch: `git checkout update-yaml-dep`
2. Install dependencies: `npm run frontend:install`
3. Build: `npm run frontend:build`
4. Run lint: `npm run frontend:lint`
5. Run tests: `npm run frontend:test`
6. Run type check: `npm run frontend:tsc`
7. Smoke test the UI areas that parse/serialize YAML (e.g., resource editor, manifest viewer) via `npm start`.

## Notes for the Reviewer
- Only `frontend/package.json` and `frontend/package-lock.json` are modified.
- No source code changes required, the `yaml` API used by Headlamp is unchanged between `2.8.3` and `2.9.0`.
