### PR TITLE
frontend: themes: Replace deprecated MediaQueryList listener methods

### DIFF
--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -132,9 +132,11 @@ describe('themes.ts', () => {
 
     it('should return light when system prefers light', () => {
       Object.defineProperty(window, 'matchMedia', {
-        value: vi
-          .fn()
-          .mockReturnValue({ matches: false, addListener: vi.fn(), removeListener: vi.fn() }),
+        value: vi.fn().mockReturnValue({
+          matches: false,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }),
         writable: true,
         configurable: true,
       });
@@ -144,9 +146,11 @@ describe('themes.ts', () => {
 
     it('should return dark when system prefers dark', () => {
       Object.defineProperty(window, 'matchMedia', {
-        value: vi
-          .fn()
-          .mockReturnValue({ matches: true, addListener: vi.fn(), removeListener: vi.fn() }),
+        value: vi.fn().mockReturnValue({
+          matches: true,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }),
         writable: true,
         configurable: true,
       });
@@ -155,17 +159,24 @@ describe('themes.ts', () => {
     });
 
     it('should register and clean up the media query listener', () => {
-      const addListener = vi.fn();
-      const removeListener = vi.fn();
+      const addEventListener = vi.fn();
+      const removeEventListener = vi.fn();
       Object.defineProperty(window, 'matchMedia', {
-        value: vi.fn().mockReturnValue({ matches: false, addListener, removeListener }),
+        value: vi.fn().mockReturnValue({ matches: false, addEventListener, removeEventListener }),
         writable: true,
         configurable: true,
       });
       const { unmount } = renderHook(() => usePrefersColorScheme());
-      expect(addListener).toHaveBeenCalledTimes(1);
+
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+      const handler = addEventListener.mock.calls[0][1];
+
       unmount();
-      expect(removeListener).toHaveBeenCalledTimes(1);
+
+      expect(removeEventListener).toHaveBeenCalledTimes(1);
+      expect(removeEventListener).toHaveBeenCalledWith('change', handler);
     });
   });
 

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -178,6 +178,27 @@ describe('themes.ts', () => {
       expect(removeEventListener).toHaveBeenCalledTimes(1);
       expect(removeEventListener).toHaveBeenCalledWith('change', handler);
     });
+
+    it('should register and clean up the media query listener using fallback methods when addEventListener is not defined', () => {
+      const addListener = vi.fn();
+      const removeListener = vi.fn();
+      Object.defineProperty(window, 'matchMedia', {
+        value: vi.fn().mockReturnValue({ matches: false, addListener, removeListener }),
+        writable: true,
+        configurable: true,
+      });
+      const { unmount } = renderHook(() => usePrefersColorScheme());
+
+      expect(addListener).toHaveBeenCalledTimes(1);
+      expect(addListener).toHaveBeenCalledWith(expect.any(Function));
+
+      const handler = addListener.mock.calls[0][0];
+
+      unmount();
+
+      expect(removeListener).toHaveBeenCalledTimes(1);
+      expect(removeListener).toHaveBeenCalledWith(handler);
+    });
   });
 
   describe('getThemeName with backend configuration', () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -579,7 +579,12 @@ export function usePrefersColorScheme() {
 
   React.useEffect(() => {
     if (!mql) return;
-    const handler = (x: MediaQueryListEvent | MediaQueryList) => setValue(x.matches);
+    const handler = (x: MediaQueryListEvent) => setValue(x.matches);
+    if (typeof mql.addEventListener === 'function') {
+      mql.addEventListener('change', handler);
+      return () => mql.removeEventListener('change', handler);
+    }
+    // Legacy fallback (e.g. older Safari/WebViews)
     mql.addListener(handler);
     return () => mql.removeListener(handler);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Summary
The `usePrefersColorScheme` hook in `frontend/src/lib/themes.ts` was using the deprecated `MediaQueryList.addListener()` and `MediaQueryList.removeListener()` methods. This PR refactors it to use the standard `addEventListener('change', ...)` and `removeEventListener('change', ...)` API. 

Additionally, the type annotation for the handler parameter was narrowed from `MediaQueryListEvent | MediaQueryList` to `MediaQueryListEvent`, as standard event listeners only receive `MediaQueryListEvent`.

### Related Issue
Fixes #5784

### Changes
- Updated `usePrefersColorScheme` in `frontend/src/lib/themes.ts` to use standard event listener methods.
- Updated mocked `matchMedia` structures and assertions in `frontend/src/lib/themes.test.ts` to reflect the change.

### Steps to Test
1. Run `npm run frontend:test` to ensure all tests pass (including `themes.test.ts`).
2. Run the Headlamp frontend and verify theme switching behaves correctly based on OS/browser system color scheme preferences.