### PR TITLE
backend: changed format verb %v with %w

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -462,14 +462,14 @@ type ContextLoadError struct {
 func LoadContextsFromFile(kubeConfigPath string, source int) ([]Context, []ContextLoadError, error) {
 	data, err := os.ReadFile(kubeConfigPath) //nolint:gosec
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading kubeconfig file: %v", err)
+		return nil, nil, fmt.Errorf("error reading kubeconfig file: %w", err)
 	}
 
 	skipProxySetup := source != KubeConfig
 
 	contexts, contextErrors, err := loadContextsFromData(data, source, skipProxySetup)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error loading contexts from file: %v", err)
+		return nil, nil, fmt.Errorf("error loading contexts from file: %w", err)
 	}
 
 	// add the KubeConfigPath to each context
@@ -489,7 +489,7 @@ func LoadContextsFromFile(kubeConfigPath string, source int) ([]Context, []Conte
 func LoadContextsFromBase64String(kubeConfig string, source int) ([]Context, []ContextLoadError, error) {
 	kubeConfigByte, err := base64.StdEncoding.DecodeString(kubeConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error decoding base64 kubeconfig: %v", err)
+		return nil, nil, fmt.Errorf("error decoding base64 kubeconfig: %w", err)
 	}
 
 	skipProxySetup := source != KubeConfig
@@ -1118,7 +1118,7 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 
 	kubeConfigContexts, contextErrors, err := LoadContextsFromMultipleFiles(kubeConfigs, source)
 	if err != nil {
-		return fmt.Errorf("error loading kubeconfig files: %v", err)
+		return fmt.Errorf("error loading kubeconfig files: %w", err)
 	}
 
 	// if pass the shouldBeSkippedFunc=nil, it works like before

--- a/backend/pkg/kubeconfig/watcher.go
+++ b/backend/pkg/kubeconfig/watcher.go
@@ -123,13 +123,13 @@ func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignore
 	// First read all kubeconfig files to get new contexts
 	newContexts, _, err := LoadContextsFromMultipleFiles(paths, source)
 	if err != nil {
-		return fmt.Errorf("error reading kubeconfig files: %v", err)
+		return fmt.Errorf("error reading kubeconfig files: %w", err)
 	}
 
 	// Get existing contexts from store
 	existingContexts, err := kubeConfigStore.GetContexts()
 	if err != nil {
-		return fmt.Errorf("error getting existing contexts: %v", err)
+		return fmt.Errorf("error getting existing contexts: %w", err)
 	}
 
 	// Find and remove contexts that no longer exist in the kubeconfig
@@ -161,7 +161,7 @@ func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignore
 	// Now load and store the new configurations
 	err = LoadAndStoreKubeConfigs(kubeConfigStore, paths, source, ignoreFunc)
 	if err != nil {
-		return fmt.Errorf("error loading kubeconfig files: %v", err)
+		return fmt.Errorf("error loading kubeconfig files: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Updated error formatting to use `%w` instead of `%v` in `fmt.Errorf` calls where errors are being wrapped.

Using `%w` preserves the original error in the error chain, enabling proper error unwrapping through:
`errors.Is()`
`errors.As()`

## File Changes
`backend/pkg/kubeconfig/kubeconfig.go`
`backend/pkg/kubeconfig/watcher.go`




This pattern is already used in other parts of the codebase as well, so this change also improves consistency.