### PR TITLE
frontend: util: handle invalid timezone in localeDate to prevent Chrome crash

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -18,6 +18,7 @@ import {
   combineClusterListErrors,
   flattenClusterListItems,
   formatDuration,
+  localeDate,
   normalizeUnit,
   timeAgo,
 } from './util';
@@ -316,5 +317,13 @@ describe('normalizeUnit', () => {
     it('shows plural cores', () => {
       expect(normalizeUnit('cpu', '2')).toBe('2 cores');
     });
+  });
+});
+
+describe('localeDate', () => {
+  it('returns a formatted date string', () => {
+    const result = localeDate('2024-01-15T10:00:00.000Z');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -203,21 +203,29 @@ export function formatDuration(duration: number, options: TimeAgoOptions = {}) {
   return humanDuration(duration);
 }
 
-export function localeDate(date: DateParam) {
+function formatLocaleDate(date: DateParam, timezone: string | undefined) {
   const options: Intl.DateTimeFormatOptions = { timeZoneName: 'short' };
-  let locale: string | undefined = undefined;
+  options.timeZone = timezone;
 
-  // Force the same conditions under test, so snapshots are the same.
-  if (import.meta.env.UNDER_TEST) {
-    options.timeZone = 'UTC';
-    options.hour12 = true;
-    locale = 'en-US';
-    return new Date(date).toISOString();
-  } else {
-    options.timeZone = store.getState().config.settings.timezone;
+  const d = new Date(date);
+  try {
+    return d.toLocaleString(undefined, options);
+  } catch (e) {
+    if (!(e instanceof RangeError)) {
+      throw e;
+    }
+    // Fall back without timeZone if the configured one is invalid (e.g. ':/etc/localtime')
+    const fallbackOptions = { ...options };
+    delete fallbackOptions.timeZone;
+    return d.toLocaleString(undefined, fallbackOptions);
   }
+}
 
-  return new Date(date).toLocaleString(locale, options);
+export function localeDate(date: DateParam) {
+  if (import.meta.env.UNDER_TEST) {
+    return new Date(date).toISOString();
+  }
+  return formatLocaleDate(date, store.getState().config.settings.timezone);
 }
 
 export function getPercentStr(value: number, total: number) {


### PR DESCRIPTION
When the system timezone is set as `:/etc/localtime` (with a colon 
prefix), Chrome throws a RangeError: "Invalid time zone specified: 
Etc/Unknown" in Date.toLocaleString().

Wrap the toLocaleString call in a try-catch that falls back to the 
default timezone when the configured one is invalid.

Fixes #5741