### PR TITLE
frontend: ResourceTable: Fix react-hooks purity and exhaustive-deps

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.test.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.test.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadTableSettings, storeTableSettings } from '../../../helpers/tableSettings';
+import { createMuiTheme } from '../../../lib/themes';
+import { TestContext } from '../../../test';
+import ResourceTable from './ResourceTable';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+vi.mock('../../../lib/k8s', () => ({
+  useSelectedClusters: vi.fn(() => ['test-cluster']),
+}));
+
+// Capture the props passed to Table using a hoisted holder object
+const { lastTablePropsHolder } = vi.hoisted(() => ({
+  lastTablePropsHolder: { current: null as any },
+}));
+
+vi.mock('../Table', () => {
+  return {
+    default: (props: any) => {
+      lastTablePropsHolder.current = props;
+      return <div data-testid="mock-table" />;
+    },
+  };
+});
+
+const theme = createMuiTheme({ base: 'light', name: 'light' });
+
+const mockData = [
+  {
+    kind: 'Pod',
+    metadata: {
+      name: 'mypod1',
+      namespace: 'namespace1',
+      uid: 'uid1',
+      creationTimestamp: '2021-12-15T14:57:13Z',
+    },
+  },
+];
+
+describe('ResourceTable Column Visibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    lastTablePropsHolder.current = null;
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderTable = (props: any) => {
+    return render(
+      <TestContext>
+        <ThemeProvider theme={theme}>
+          <ResourceTable {...props} />
+        </ThemeProvider>
+      </TestContext>
+    );
+  };
+
+  it('initializes column visibility with default settings if none stored', async () => {
+    const columns = [
+      {
+        id: 'name',
+        label: 'Name',
+        getValue: (item: any) => item.metadata.name,
+      },
+      {
+        id: 'namespace',
+        label: 'Namespace',
+        getValue: (item: any) => item.metadata.namespace,
+        show: false,
+      },
+    ];
+
+    renderTable({
+      id: 'test-table-id',
+      columns,
+      data: mockData,
+    });
+
+    expect(lastTablePropsHolder.current).not.toBeNull();
+    // Only columns with explicit show parameter or labels column default are present
+    expect(lastTablePropsHolder.current.state.columnVisibility).toEqual({
+      namespace: false,
+    });
+  });
+
+  it('loads and applies persisted settings from localStorage', async () => {
+    // Save settings: name hidden (show: false), namespace shown (show: true)
+    storeTableSettings('test-table-id', [
+      { id: 'name', show: false },
+      { id: 'namespace', show: true },
+    ]);
+
+    const columns = [
+      {
+        id: 'name',
+        label: 'Name',
+        getValue: (item: any) => item.metadata.name,
+      },
+      {
+        id: 'namespace',
+        label: 'Namespace',
+        getValue: (item: any) => item.metadata.namespace,
+      },
+    ];
+
+    renderTable({
+      id: 'test-table-id',
+      columns,
+      data: mockData,
+    });
+
+    expect(lastTablePropsHolder.current).not.toBeNull();
+    expect(lastTablePropsHolder.current.state.columnVisibility).toEqual({
+      name: false,
+      namespace: true,
+    });
+  });
+
+  it('persists column visibility changes to localStorage and updates state', async () => {
+    const columns = [
+      {
+        id: 'name',
+        label: 'Name',
+        getValue: (item: any) => item.metadata.name,
+      },
+      {
+        id: 'namespace',
+        label: 'Namespace',
+        getValue: (item: any) => item.metadata.namespace,
+      },
+    ];
+
+    renderTable({
+      id: 'test-table-id',
+      columns,
+      data: mockData,
+    });
+
+    expect(lastTablePropsHolder.current).not.toBeNull();
+
+    // Simulate MRT calling onColumnVisibilityChange
+    act(() => {
+      lastTablePropsHolder.current.onColumnVisibilityChange({
+        name: false,
+        namespace: true,
+      });
+    });
+
+    // Check that settings are persisted in local storage
+    const storedSettings = loadTableSettings('test-table-id');
+    expect(storedSettings).toEqual([
+      { id: 'name', show: false },
+      { id: 'namespace', show: true },
+    ]);
+
+    // Check that state has updated on the next render
+    expect(lastTablePropsHolder.current.state.columnVisibility).toEqual({
+      name: false,
+      namespace: true,
+    });
+  });
+});

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -200,7 +200,7 @@ function TableFromResourceClass<KubeClass extends KubeObjectClass>(
 
   useEffect(() => {
     dispatchHeadlampEvent({
-      resources: items!,
+      resources: items ?? [],
       resourceKind: resourceClass.className,
       error: errors?.[0] || undefined,
     });

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -204,8 +204,7 @@ function TableFromResourceClass<KubeClass extends KubeObjectClass>(
       resourceKind: resourceClass.className,
       error: errors?.[0] || undefined,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items, errors]);
+  }, [dispatchHeadlampEvent, errors, items, resourceClass.className]);
 
   return (
     <ResourceTableContent
@@ -353,10 +352,6 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
       columns.find(it => typeof it === 'string' && it === DEFAULT_SORT_COLUMN_ID)
       ? [{ id: DEFAULT_SORT_COLUMN_ID, desc: false }]
       : []
-  );
-
-  const [tableSettings] = useState<{ id: string; show: boolean }[]>(
-    !!id ? loadTableSettings(id) : []
   );
 
   // Determine if any item in the current dataset carries a8r.io/owner
@@ -541,82 +536,76 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
     >;
 
     return [allColumns];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    columnsWithA8rOwner,
-    hideColumns,
-    id,
-    noProcessing,
-    defaultSortingColumn,
-    tableProcessors,
-    tableSettings,
-    sorting,
-  ]);
+  }, [columnsWithA8rOwner, clusters, hideColumns, id, noProcessing, tableProcessors, t, theme]);
 
-  const defaultActions: RowAction[] = [
-    {
-      id: DefaultHeaderAction.RESTART,
-      action: ({ item }) => <RestartButton item={item} buttonStyle="menu" key="restart" />,
-    },
-    {
-      id: DefaultHeaderAction.SCALE,
-      action: ({ item }) => <ScaleButton item={item} buttonStyle="menu" key="scale" />,
-    },
-    {
-      id: DefaultHeaderAction.EDIT,
-      action: ({ item, closeMenu }) => (
-        <EditButton item={item} buttonStyle="menu" afterConfirm={closeMenu} key="edit" />
-      ),
-    },
-    {
-      id: DefaultHeaderAction.DOWNLOAD,
-      action: ({ item }) => <DownloadButton item={item} buttonStyle="menu" key="download" />,
-    },
-    {
-      id: DefaultHeaderAction.VIEW,
-      action: ({ item }) => <ViewButton item={item} buttonStyle="menu" key="view" />,
-    },
-    {
-      id: DefaultHeaderAction.DELETE,
-      action: ({ item, closeMenu }) => (
-        <DeleteButton item={item} buttonStyle="menu" afterConfirm={closeMenu} key="delete" />
-      ),
-    },
-  ];
-  let hAccs: RowAction[] = [];
-  if (actions !== undefined && actions !== null) {
-    hAccs = actions;
-  }
+  const defaultActions = useMemo<RowAction[]>(
+    () => [
+      {
+        id: DefaultHeaderAction.RESTART,
+        action: ({ item }) => <RestartButton item={item} buttonStyle="menu" key="restart" />,
+      },
+      {
+        id: DefaultHeaderAction.SCALE,
+        action: ({ item }) => <ScaleButton item={item} buttonStyle="menu" key="scale" />,
+      },
+      {
+        id: DefaultHeaderAction.EDIT,
+        action: ({ item, closeMenu }) => (
+          <EditButton item={item} buttonStyle="menu" afterConfirm={closeMenu} key="edit" />
+        ),
+      },
+      {
+        id: DefaultHeaderAction.DOWNLOAD,
+        action: ({ item }) => <DownloadButton item={item} buttonStyle="menu" key="download" />,
+      },
+      {
+        id: DefaultHeaderAction.VIEW,
+        action: ({ item }) => <ViewButton item={item} buttonStyle="menu" key="view" />,
+      },
+      {
+        id: DefaultHeaderAction.DELETE,
+        action: ({ item, closeMenu }) => (
+          <DeleteButton item={item} buttonStyle="menu" afterConfirm={closeMenu} key="delete" />
+        ),
+      },
+    ],
+    []
+  );
 
-  const a8rAction: RowAction = {
-    id: 'a8r-actions',
-    action: ({ item, closeMenu }: { item: RowItem; closeMenu: () => void }) => {
-      const annotations = item?.metadata?.annotations ?? {};
-      const metadata = getA8RMetadata(annotations).filter(m => m.isLink);
-      if (metadata.length === 0) return null;
-      return (
-        <React.Fragment key="a8r-actions">
-          {metadata.map(meta => (
-            <MenuItem
-              key={meta.key}
-              onClick={() => {
-                window.open(meta.value, '_blank', 'noopener,noreferrer');
-                closeMenu();
-              }}
-            >
-              <ListItemIcon>
-                <Icon icon={meta.icon} width="20" />
-              </ListItemIcon>
-              <ListItemText>{t(meta.labelKey)}</ListItemText>
-            </MenuItem>
-          ))}
-        </React.Fragment>
-      );
-    },
-  };
+  const a8rAction = useMemo<RowAction>(
+    () => ({
+      id: 'a8r-actions',
+      action: ({ item, closeMenu }: { item: RowItem; closeMenu: () => void }) => {
+        const annotations = item?.metadata?.annotations ?? {};
+        const metadata = getA8RMetadata(annotations).filter(m => m.isLink);
+        if (metadata.length === 0) return null;
+        return (
+          <React.Fragment key="a8r-actions">
+            {metadata.map(meta => (
+              <MenuItem
+                key={meta.key}
+                onClick={() => {
+                  window.open(meta.value, '_blank', 'noopener,noreferrer');
+                  closeMenu();
+                }}
+              >
+                <ListItemIcon>
+                  <Icon icon={meta.icon} width="20" />
+                </ListItemIcon>
+                <ListItemText>{t(meta.labelKey)}</ListItemText>
+              </MenuItem>
+            ))}
+          </React.Fragment>
+        );
+      },
+    }),
+    [t]
+  );
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const actionsProcessed: RowAction[] = [...hAccs, a8rAction, ...defaultActions];
+  const actionsProcessed = useMemo<RowAction[]>(
+    () => [...(actions ?? []), a8rAction, ...defaultActions],
+    [actions, a8rAction, defaultActions]
+  );
 
   const renderRowActionMenuItems = useMemo(() => {
     if (actionsProcessed.length === 0) {

--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -197,14 +197,19 @@ function TableFromResourceClass<KubeClass extends KubeObjectClass>(
   // throttle the update of the table to once per second
   const throttledItems = useThrottle(items, 1000);
   const dispatchHeadlampEvent = useEventCallback(HeadlampEventType.LIST_VIEW);
+  const dispatchHeadlampEventRef = useRef(dispatchHeadlampEvent);
 
   useEffect(() => {
-    dispatchHeadlampEvent({
+    dispatchHeadlampEventRef.current = dispatchHeadlampEvent;
+  }, [dispatchHeadlampEvent]);
+
+  useEffect(() => {
+    dispatchHeadlampEventRef.current({
       resources: items ?? [],
       resourceKind: resourceClass.className,
       error: errors?.[0] || undefined,
     });
-  }, [dispatchHeadlampEvent, errors, items, resourceClass.className]);
+  }, [errors, items, resourceClass.className]);
 
   return (
     <ResourceTableContent


### PR DESCRIPTION
## Summary

This PR improves hook dependency handling and memoization in the table settings flow by making table settings initialization lazy, removing unused state, and memoizing row actions to resolve react-hooks/purity and react-hooks/exhaustive-deps without changing behavior.

## Related Issue

Fixes #5787 (sub-issue of #5183 )

## Changes

- Made table settings initialization lazy to avoid impure render calls.
- Removed unused tableSettings state and dropped it from useMemo dependency arrays.
- Memoized row actions and a8rAction to resolve react-hooks/exhaustive-deps warnings.
- Removed eslint suppressions while preserving existing behavior.

## Steps to Test

1. `cd frontend && npm install`
2. `npm run lint` passes and no violations surface for the updated hooks.
3. `npm run tsc` passes.

## Screenshots (if applicable)
N/A. No functional change.

## Notes for the Reviewer
- DCO sign-off applied (Signed-off-by: in the commit).
- Listed as an unchecked purity and exhaustive-deps cleanup work under umbrella issue https://github.com/kubernetes-sigs/headlamp/issues/5183