### PR TITLE
frontend: LogViewer: Fix search addon event listener leak

### DIFF
--- a/frontend/src/components/common/LogViewer.tsx
+++ b/frontend/src/components/common/LogViewer.tsx
@@ -334,11 +334,12 @@ export function SearchPopover(props: SearchPopoverProps) {
       searchAddonRef.current?.findNext('');
     }
 
-    searchAddonRef.current?.onDidChangeResults(args => {
+    const disposable = searchAddonRef.current?.onDidChangeResults(args => {
       setSearchResult(args);
     });
 
     return function cleanup() {
+      disposable?.dispose();
       // eslint-disable-next-line react-hooks/exhaustive-deps
       searchAddonRef.current?.findNext('');
     };


### PR DESCRIPTION
## Summary

This PR fixes a memory leak in the LogViewer's search functionality where xterm search addon event listeners accumulated on every effect re-run without being cleaned up.

## Changes

- Fixed `LogViewer.tsx` `onDidChangeResults` returns an `IDisposable` that was previously discarded. Now stored and called in the effect cleanup, so stale listeners are removed before new ones are registered.

## Notes for the Reviewer

- `onDidChangeResults` is `IEvent<T>` from xterm, which returns `IDisposable` with a `.dispose()` method that removes the specific callback from the internal listener array, confirmed from xterm source.
- The component already disposes the entire addon on unmount but that doesn't cover effect re-runs during the component's lifetime