### PR TITLE
backend: auth/kubeconfig: Skip empty OIDC CA cert instead of failing

### DIFF
--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -247,7 +247,7 @@ func ConfigureTLSContext(ctx context.Context, skipTLSVerify *bool, caCert *strin
 		ctx = oidc.ClientContext(ctx, &http.Client{Transport: tlsSkipTransport})
 	}
 
-	if caCert != nil {
+	if caCert != nil && *caCert != "" {
 		caCertPool := x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM([]byte(*caCert)) {
 			logger.Log(logger.LevelError, nil,

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -1095,6 +1095,15 @@ func TestConfigureTLSContext_CACert(t *testing.T) {
 	assert.True(t, caCertParsed.IsCA, "Generated certificate should be a CA certificate")
 }
 
+// TestConfigureTLSContext_EmptyCACert verifies that a non-nil pointer
+// to an empty string is treated the same as nil (no custom CA configured).
+func TestConfigureTLSContext_EmptyCACert(t *testing.T) {
+	baseCtx := context.Background()
+	emptyCert := ""
+	resultCtx := auth.ConfigureTLSContext(baseCtx, nil, &emptyCert)
+	assert.Equal(t, baseCtx, resultCtx, "Context should not be modified when caCert is empty")
+}
+
 // TestConfigureTLSContext_SkipTLS_PreservesDefaults verifies that cloning
 // http.DefaultTransport preserves proxy and timeout settings.
 func TestConfigureTLSContext_SkipTLS_PreservesDefaults(t *testing.T) {

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -1113,6 +1113,11 @@ func newInClusterContextFromConfig(
 	var oidcConf *OidcConfig
 
 	if oidcClientID != "" && oidcIssuerURL != "" && oidcScopes != "" {
+		var caCert *string
+		if oidcCACert != "" {
+			caCert = &oidcCACert
+		}
+
 		// client secret is optional for in-cluster OIDC configuration
 		oidcConf = &OidcConfig{
 			ClientID:      oidcClientID,
@@ -1120,7 +1125,7 @@ func newInClusterContextFromConfig(
 			IdpIssuerURL:  oidcIssuerURL,
 			Scopes:        strings.Split(oidcScopes, ","),
 			SkipTLSVerify: &oidcSkipTLSVerify,
-			CACert:        &oidcCACert,
+			CACert:        caCert,
 		}
 	}
 


### PR DESCRIPTION
## Summary

When no custom OIDC CA certificate is configured, `oidcCACert` defaults to `""`. The code unconditionally takes its address (`&oidcCACert`), making `CACert` a non-nil pointer to an empty string. `ConfigureTLSContext` then tries to parse `""` as PEM, fails, and returns early — breaking the OIDC login flow.

This blocks any OIDC setup using a public provider (Entra ID, Okta, Google, etc.) where no custom CA is needed.

## Related Issue

Fixes #5793

## Changes

- `backend/pkg/kubeconfig/kubeconfig.go`: Only set `CACert` pointer when `oidcCACert` is non-empty, leave it `nil` otherwise.
- `backend/pkg/auth/auth.go`: Added `*caCert != ""` guard in `ConfigureTLSContext` so an empty string is treated the same as `nil`.
- `backend/pkg/auth/auth_test.go`: Added `TestConfigureTLSContext_EmptyCACert` covering this case.
