### PR TITLE
backend: k8cache: Bypass non-API cluster paths

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2299,6 +2299,57 @@ func httpRequestWithContext(ctx context.Context, url string, method string) (*ht
 
 const istrue = true
 
+func TestCacheMiddleware_BypassesNonKubernetesAPIPaths(t *testing.T) {
+	fakeK8s := newFakeK8sServer(true)
+	defer fakeK8s.Close()
+
+	c := newHeadlampConfig(fakeK8s, t.Name())
+
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("ok"))
+		assert.NoError(t, err)
+	})
+
+	router := mux.NewRouter()
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
+		CacheMiddleWare(c)(proxyHandler),
+	)
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "healthz",
+			path: "/clusters/test/healthz",
+		},
+		{
+			name: "non-api path",
+			path: "/clusters/test/readyz",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := httpRequestWithContext(context.Background(), ts.URL+tc.path, http.MethodGet)
+			require.NoError(t, err)
+
+			defer func() { _ = resp.Body.Close() }()
+
+			respString, err := stringResponse(resp)
+			require.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "ok", respString)
+			assert.Equal(t, "", resp.Header.Get("X-HEADLAMP-CACHE"))
+		})
+	}
+}
+
 // TestCacheMiddleware_CacheHitAndCacheMiss test whether the k8s is storing into the cache
 // and returns the data if the data is present in the cache.
 func TestCacheMiddleware_CacheHitAndCacheMiss(t *testing.T) {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2223,6 +2223,8 @@ func TestProcessTokenProtocol(t *testing.T) {
 // newFakeK8sServer create a mock k8s server for testing purpose,
 // this would help to test Caching Machanism without making request
 // to the k8s server.
+const fakeK8sResourceListResponse = `{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`
+
 func newFakeK8sServer(authAllowed bool) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews" {
@@ -2239,7 +2241,7 @@ func newFakeK8sServer(authAllowed bool) *httptest.Server {
 		w.WriteHeader(http.StatusOK)
 
 		if authAllowed {
-			_, _ = w.Write([]byte(`{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`))
+			_, _ = w.Write([]byte(fakeK8sResourceListResponse))
 		} else {
 			_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","metadata":{"resourceVersion":""},` +
 				`"message":"resource is forbidden: User \"system:serviceaccount:default:test\" cannot get resource ` +
@@ -2350,6 +2352,71 @@ func TestCacheMiddleware_BypassesNonKubernetesAPIPaths(t *testing.T) {
 	}
 }
 
+func TestCacheMiddleware_CachesResourceNamedVersion(t *testing.T) {
+	oldCache := k8sResponseCache
+	k8sResponseCache = cache.New[string]()
+
+	t.Cleanup(func() { k8sResponseCache = oldCache })
+
+	fakeK8s := newFakeK8sServer(true)
+	defer fakeK8s.Close()
+
+	c := newHeadlampConfig(fakeK8s, t.Name())
+
+	proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, fakeK8s.URL+r.URL.Path, nil) //nolint:gosec
+		if err != nil {
+			http.Error(w, "failed to create request", http.StatusInternalServerError)
+			return
+		}
+
+		resp, err := http.DefaultClient.Do(req) //nolint:gosec
+		if err != nil {
+			http.Error(w, "proxy error", http.StatusInternalServerError)
+			return
+		}
+
+		defer func() { _ = resp.Body.Close() }()
+
+		_, err = io.Copy(w, resp.Body)
+		assert.NoError(t, err)
+	})
+
+	router := mux.NewRouter()
+	router.PathPrefix("/clusters/{clusterName}/{api:.*}").Handler(
+		CacheMiddleWare(c)(proxyHandler),
+	)
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	resourceURL := ts.URL + "/clusters/test/api/v1/namespaces/ns/configmaps/version"
+	expectedResponse := fakeK8sResourceListResponse
+
+	resp1, err := httpRequestWithContext(context.Background(), resourceURL, http.MethodGet)
+	require.NoError(t, err)
+
+	defer func() { _ = resp1.Body.Close() }()
+
+	resp1String, err := stringResponse(resp1)
+	require.NoError(t, err)
+
+	resp2, err := httpRequestWithContext(context.Background(), resourceURL, http.MethodGet)
+	require.NoError(t, err)
+
+	defer func() { _ = resp2.Body.Close() }()
+
+	resp2String, err := stringResponse(resp2)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp1.StatusCode)
+	assert.Equal(t, expectedResponse, resp1String)
+	assert.Equal(t, "", resp1.Header.Get("X-HEADLAMP-CACHE"))
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+	assert.Equal(t, expectedResponse, resp2String)
+	assert.Equal(t, "true", resp2.Header.Get("X-HEADLAMP-CACHE"))
+}
+
 // TestCacheMiddleware_CacheHitAndCacheMiss test whether the k8s is storing into the cache
 // and returns the data if the data is present in the cache.
 func TestCacheMiddleware_CacheHitAndCacheMiss(t *testing.T) {
@@ -2393,7 +2460,7 @@ func TestCacheMiddleware_CacheHitAndCacheMiss(t *testing.T) {
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
-	expectedResponse := `{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`
+	expectedResponse := fakeK8sResourceListResponse
 
 	resp1, err := httpRequestWithContext(ctx, ts.URL+"/clusters/test/api/v1/resource", "GET")
 	assert.NoError(t, err)
@@ -2521,7 +2588,7 @@ func TestCacheMiddleware_CacheInvalidation(t *testing.T) {
 
 	ctx := context.Background()
 
-	expectedResponse := `{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`
+	expectedResponse := fakeK8sResourceListResponse
 
 	resp, err := httpRequestWithContext(ctx, ts.URL+"/clusters/test/api/v1/resource", "POST")
 	assert.NoError(t, err)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2220,9 +2220,8 @@ func TestProcessTokenProtocol(t *testing.T) {
 	}
 }
 
-// newFakeK8sServer create a mock k8s server for testing purpose,
-// this would help to test Caching Machanism without making request
-// to the k8s server.
+// newFakeK8sServer creates a mock Kubernetes API server for testing the cache
+// mechanism without making requests to a real Kubernetes server.
 const fakeK8sResourceListResponse = `{"kind":"List","apiVersion":"v1","items":[{"metadata":{"name":"resource-test"}}]}`
 
 func newFakeK8sServer(authAllowed bool) *httptest.Server {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -44,11 +44,6 @@ import (
 
 var k8sResponseCache = cache.New[string]()
 
-const (
-	selfSubjectAccessReviewsPathSuffix = "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews"
-	selfSubjectRulesReviewsPathSuffix  = "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews"
-)
-
 func main() {
 	if len(os.Args) == 2 && os.Args[1] == "list-plugins" {
 		runListPlugins()
@@ -286,19 +281,12 @@ func CacheMiddleWare(c *HeadlampConfig) mux.MiddlewareFunc {
 	}
 }
 
-func isSelfSubjectReviewAPIPath(urlPath string) bool {
-	urlPath = strings.TrimRight(urlPath, "/")
-
-	return strings.HasSuffix(urlPath, selfSubjectAccessReviewsPathSuffix) ||
-		strings.HasSuffix(urlPath, selfSubjectRulesReviewsPathSuffix)
-}
-
 func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.ResponseWriter, r *http.Request) {
 	if k8cache.SkipWebSocket(r, next, w) {
 		return
 	}
 
-	if !k8cache.IsKubernetesAPIPath(r.URL.Path) || isSelfSubjectReviewAPIPath(r.URL.Path) {
+	if !k8cache.IsKubernetesAPIPath(r.URL.Path) || k8cache.IsSelfSubjectReviewAPIPath(r.URL.Path) {
 		next.ServeHTTP(w, r)
 		return
 	}

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -298,7 +298,7 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
-	if !k8cache.IsKubernetesResourceAPIPath(r.URL.Path) || isSelfSubjectReviewAPIPath(r.URL.Path) {
+	if !k8cache.IsKubernetesAPIPath(r.URL.Path) || isSelfSubjectReviewAPIPath(r.URL.Path) {
 		next.ServeHTTP(w, r)
 		return
 	}

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -286,6 +286,11 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 		return
 	}
 
+	if !k8cache.IsKubernetesResourceAPIPath(r.URL.Path) || !k8cache.IsAuthBypassURL(r.URL.Path) {
+		next.ServeHTTP(w, r)
+		return
+	}
+
 	ctx, span, contextKey, kContext, err := GetContextKeyAndKContext(w, r, c)
 	if err != nil {
 		return

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -44,6 +44,11 @@ import (
 
 var k8sResponseCache = cache.New[string]()
 
+const (
+	selfSubjectAccessReviewsPathSuffix = "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews"
+	selfSubjectRulesReviewsPathSuffix  = "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews"
+)
+
 func main() {
 	if len(os.Args) == 2 && os.Args[1] == "list-plugins" {
 		runListPlugins()
@@ -281,12 +286,19 @@ func CacheMiddleWare(c *HeadlampConfig) mux.MiddlewareFunc {
 	}
 }
 
+func isSelfSubjectReviewAPIPath(urlPath string) bool {
+	urlPath = strings.TrimRight(urlPath, "/")
+
+	return strings.HasSuffix(urlPath, selfSubjectAccessReviewsPathSuffix) ||
+		strings.HasSuffix(urlPath, selfSubjectRulesReviewsPathSuffix)
+}
+
 func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.ResponseWriter, r *http.Request) {
 	if k8cache.SkipWebSocket(r, next, w) {
 		return
 	}
 
-	if !k8cache.IsKubernetesResourceAPIPath(r.URL.Path) || !k8cache.IsAuthBypassURL(r.URL.Path) {
+	if !k8cache.IsKubernetesResourceAPIPath(r.URL.Path) || isSelfSubjectReviewAPIPath(r.URL.Path) {
 		next.ServeHTTP(w, r)
 		return
 	}

--- a/backend/pkg/k8cache/authErrResp.go
+++ b/backend/pkg/k8cache/authErrResp.go
@@ -45,12 +45,14 @@ func IsAuthBypassURL(urlPath string) bool {
 }
 
 // IsSelfSubjectReviewAPIPath returns true when path targets a self-subject review API endpoint
-// under /apis/authorization.k8s.io/v1 (either directly, or proxied via /clusters/{name}/...).
+// under /apis/authorization.k8s.io/{version} (either directly, or proxied via
+// /clusters/{name}/...). The version segment is intentionally not enumerated so
+// future authorization API versions keep the same cache-bypass behavior.
 func IsSelfSubjectReviewAPIPath(urlPath string) bool {
 	urlPath = strings.TrimRight(urlPath, "/")
 
-	return isDirectOrProxiedAPIEndpoint(urlPath, "authorization.k8s.io", "v1", "selfsubjectaccessreviews") ||
-		isDirectOrProxiedAPIEndpoint(urlPath, "authorization.k8s.io", "v1", "selfsubjectrulesreviews")
+	return isDirectOrProxiedAPIResourceEndpoint(urlPath, "authorization.k8s.io", "selfsubjectaccessreviews") ||
+		isDirectOrProxiedAPIResourceEndpoint(urlPath, "authorization.k8s.io", "selfsubjectrulesreviews")
 }
 
 func isDirectOrProxiedEndpoint(urlPath, endpoint string) bool {
@@ -60,12 +62,12 @@ func isDirectOrProxiedEndpoint(urlPath, endpoint string) bool {
 		len(parts) == 4 && parts[1] == "clusters" && parts[3] == endpoint
 }
 
-func isDirectOrProxiedAPIEndpoint(urlPath, group, version, endpoint string) bool {
+func isDirectOrProxiedAPIResourceEndpoint(urlPath, group, resource string) bool {
 	parts := strings.Split(urlPath, "/")
 
-	return len(parts) == 5 && parts[1] == "apis" && parts[2] == group && parts[3] == version && parts[4] == endpoint ||
+	return len(parts) == 5 && parts[1] == "apis" && parts[2] == group && parts[3] != "" && parts[4] == resource ||
 		len(parts) == 7 && parts[1] == "clusters" && parts[3] == "apis" && parts[4] == group &&
-			parts[5] == version && parts[6] == endpoint
+			parts[5] != "" && parts[6] == resource
 }
 
 // ReturnAuthErrorResponse return the AuthErrorResponse if the user is not Authorized

--- a/backend/pkg/k8cache/authErrResp.go
+++ b/backend/pkg/k8cache/authErrResp.go
@@ -31,12 +31,41 @@ type AuthErrResponse struct {
 }
 
 // IsAuthBypassURL returns true if the given URL path should be checked for authorization errors,
-// excluding known public or health-check endpoints.
+// excluding known public, health-check, or self-subject review endpoints.
 func IsAuthBypassURL(urlPath string) bool {
-	return !strings.Contains(urlPath, "/version") &&
-		!strings.Contains(urlPath, "/healthz") &&
-		!strings.Contains(urlPath, "/selfsubjectrulesreviews") &&
-		!strings.Contains(urlPath, "/selfsubjectaccessreviews")
+	urlPath = strings.TrimRight(urlPath, "/")
+
+	if isDirectOrProxiedEndpoint(urlPath, "version") ||
+		isDirectOrProxiedEndpoint(urlPath, "healthz") ||
+		IsSelfSubjectReviewAPIPath(urlPath) {
+		return false
+	}
+
+	return true
+}
+
+// IsSelfSubjectReviewAPIPath returns true when path targets a self-subject review API endpoint
+// under /apis/authorization.k8s.io/v1 (either directly, or proxied via /clusters/{name}/...).
+func IsSelfSubjectReviewAPIPath(urlPath string) bool {
+	urlPath = strings.TrimRight(urlPath, "/")
+
+	return isDirectOrProxiedAPIEndpoint(urlPath, "authorization.k8s.io", "v1", "selfsubjectaccessreviews") ||
+		isDirectOrProxiedAPIEndpoint(urlPath, "authorization.k8s.io", "v1", "selfsubjectrulesreviews")
+}
+
+func isDirectOrProxiedEndpoint(urlPath, endpoint string) bool {
+	parts := strings.Split(urlPath, "/")
+
+	return len(parts) == 2 && parts[1] == endpoint ||
+		len(parts) == 4 && parts[1] == "clusters" && parts[3] == endpoint
+}
+
+func isDirectOrProxiedAPIEndpoint(urlPath, group, version, endpoint string) bool {
+	parts := strings.Split(urlPath, "/")
+
+	return len(parts) == 5 && parts[1] == "apis" && parts[2] == group && parts[3] == version && parts[4] == endpoint ||
+		len(parts) == 7 && parts[1] == "clusters" && parts[3] == "apis" && parts[4] == group &&
+			parts[5] == version && parts[6] == endpoint
 }
 
 // ReturnAuthErrorResponse return the AuthErrorResponse if the user is not Authorized

--- a/backend/pkg/k8cache/authErrResp_test.go
+++ b/backend/pkg/k8cache/authErrResp_test.go
@@ -39,10 +39,26 @@ func TestIsAuthBypassUR(t *testing.T) {
 		{"Resource named healthz", "/clusters/kind/api/v1/namespaces/ns/configmaps/healthz", true},
 		{"Direct selfsubjectrulesreviews endpoint", "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews", false},
 		{"Direct selfsubjectaccessreviews endpoint", "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", false},
-		{"Proxied selfsubjectrulesreviews endpoint", "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectrulesreviews", false},
-		{"Proxied selfsubjectaccessreviews endpoint", "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", false},
-		{"Resource named selfsubjectrulesreviews", "/clusters/kind/api/v1/namespaces/ns/configmaps/selfsubjectrulesreviews", true},
-		{"Resource named selfsubjectaccessreviews", "/clusters/kind/api/v1/namespaces/ns/configmaps/selfsubjectaccessreviews", true},
+		{
+			name:     "Proxied selfsubjectrulesreviews endpoint",
+			urlPath:  "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectrulesreviews",
+			expected: false,
+		},
+		{
+			name:     "Proxied selfsubjectaccessreviews endpoint",
+			urlPath:  "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectaccessreviews",
+			expected: false,
+		},
+		{
+			name:     "Resource named selfsubjectrulesreviews",
+			urlPath:  "/clusters/kind/api/v1/namespaces/ns/configmaps/selfsubjectrulesreviews",
+			expected: true,
+		},
+		{
+			name:     "Resource named selfsubjectaccessreviews",
+			urlPath:  "/clusters/kind/api/v1/namespaces/ns/configmaps/selfsubjectaccessreviews",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/pkg/k8cache/authErrResp_test.go
+++ b/backend/pkg/k8cache/authErrResp_test.go
@@ -31,10 +31,18 @@ func TestIsAuthBypassUR(t *testing.T) {
 		expected bool
 	}{
 		{"No restricted paths", "/api/v1/resource", true},
-		{"Contains /version", "/version", false},
-		{"Contains /healthz", "/healthz", false},
-		{"Contains /selfsubjectrulesreviews", "/apis/selfsubjectrulesreviews", false},
-		{"Contains /selfsubjectaccessreviews", "/apis/selfsubjectaccessreviews", false},
+		{"Direct version endpoint", "/version", false},
+		{"Direct healthz endpoint", "/healthz", false},
+		{"Proxied version endpoint", "/clusters/kind/version", false},
+		{"Proxied healthz endpoint", "/clusters/kind/healthz", false},
+		{"Resource named version", "/clusters/kind/api/v1/namespaces/ns/configmaps/version", true},
+		{"Resource named healthz", "/clusters/kind/api/v1/namespaces/ns/configmaps/healthz", true},
+		{"Direct selfsubjectrulesreviews endpoint", "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews", false},
+		{"Direct selfsubjectaccessreviews endpoint", "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", false},
+		{"Proxied selfsubjectrulesreviews endpoint", "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectrulesreviews", false},
+		{"Proxied selfsubjectaccessreviews endpoint", "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", false},
+		{"Resource named selfsubjectrulesreviews", "/clusters/kind/api/v1/namespaces/ns/configmaps/selfsubjectrulesreviews", true},
+		{"Resource named selfsubjectaccessreviews", "/clusters/kind/api/v1/namespaces/ns/configmaps/selfsubjectaccessreviews", true},
 	}
 
 	for _, tt := range tests {

--- a/backend/pkg/k8cache/authErrResp_test.go
+++ b/backend/pkg/k8cache/authErrResp_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsAuthBypassUR(t *testing.T) {
+func TestIsAuthBypassURL(t *testing.T) {
 	tests := []struct {
 		name     string
 		urlPath  string
@@ -37,8 +37,8 @@ func TestIsAuthBypassUR(t *testing.T) {
 		{"Proxied healthz endpoint", "/clusters/kind/healthz", false},
 		{"Resource named version", "/clusters/kind/api/v1/namespaces/ns/configmaps/version", true},
 		{"Resource named healthz", "/clusters/kind/api/v1/namespaces/ns/configmaps/healthz", true},
-		{"Direct selfsubjectrulesreviews endpoint", "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews", false},
-		{"Direct selfsubjectaccessreviews endpoint", "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", false},
+		{"Direct selfsubjectrulesreviews v1 endpoint", "/apis/authorization.k8s.io/v1/selfsubjectrulesreviews", false},
+		{"Direct selfsubjectaccessreviews v1 endpoint", "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", false},
 		{
 			name:     "Proxied selfsubjectrulesreviews endpoint",
 			urlPath:  "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectrulesreviews",
@@ -57,6 +57,42 @@ func TestIsAuthBypassUR(t *testing.T) {
 		{
 			name:     "Resource named selfsubjectaccessreviews",
 			urlPath:  "/clusters/kind/api/v1/namespaces/ns/configmaps/selfsubjectaccessreviews",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := k8cache.IsAuthBypassURL(tt.urlPath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsAuthBypassURLSelfSubjectReviewVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		urlPath  string
+		expected bool
+	}{
+		{
+			name:     "v1beta1 access review",
+			urlPath:  "/apis/authorization.k8s.io/v1beta1/selfsubjectaccessreviews",
+			expected: false,
+		},
+		{
+			name:     "future access review version",
+			urlPath:  "/apis/authorization.k8s.io/v2/selfsubjectaccessreviews",
+			expected: false,
+		},
+		{
+			name:     "proxied future rules review version",
+			urlPath:  "/clusters/kind/apis/authorization.k8s.io/v2/selfsubjectrulesreviews",
+			expected: false,
+		},
+		{
+			name:     "different API group",
+			urlPath:  "/apis/apps/v1/selfsubjectaccessreviews",
 			expected: true,
 		},
 	}

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -620,6 +620,7 @@ func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) 
 	called := 0
 	next := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		called++
+
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"kind":"ConfigMap"}`))
 	})

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -564,8 +565,8 @@ func TestHandleNonGETCacheInvalidation_GETSkipped(t *testing.T) {
 }
 
 // TestHandleNonGETCacheInvalidation_BypassURLExcluded verifies that a POST
-// on a URL containing "/selfsubjectrulesreviews" is NOT invalidated because
-// IsAuthBypassURL returns false for those paths — the function returns nil.
+// on a selfsubjectrulesreviews authorization endpoint is NOT invalidated because
+// IsAuthBypassURL returns false for that path — the function returns nil.
 func TestHandleNonGETCacheInvalidation_BypassURLExcluded(t *testing.T) {
 	mockCache := NewMockCache()
 	called := false
@@ -576,7 +577,7 @@ func TestHandleNonGETCacheInvalidation_BypassURLExcluded(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	targetURL := &url.URL{Path: "/clusters/kind/api/v1/selfsubjectrulesreviews"}
+	targetURL := &url.URL{Path: "/clusters/kind/apis/authorization.k8s.io/v1/selfsubjectrulesreviews"}
 	r := httptest.NewRequestWithContext(
 		context.Background(), http.MethodPost, targetURL.String(), nil,
 	)
@@ -609,6 +610,35 @@ func TestHandleNonGETCacheInvalidation_PostOnNormalURL(t *testing.T) {
 	// IsAuthBypassURL("/…/pods") == true → full invalidation → ErrHandled.
 	err := k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
 	assert.ErrorIs(t, err, k8cache.ErrHandled)
+}
+
+func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) {
+	mockCache := NewMockCache()
+	cacheKey := "+version+ns+ctx"
+	require.NoError(t, mockCache.Set(context.Background(), cacheKey, `{"body":"stale"}`))
+
+	called := 0
+	next := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		called++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"ConfigMap"}`))
+	})
+
+	w := httptest.NewRecorder()
+	targetURL := &url.URL{Path: "/clusters/kind/api/v1/namespaces/ns/configmaps/version"}
+	r := httptest.NewRequestWithContext(
+		context.Background(), http.MethodPost, targetURL.String(), nil,
+	)
+	r.URL = targetURL
+
+	err := k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
+	assert.ErrorIs(t, err, k8cache.ErrHandled)
+	assert.Equal(t, 2, called, "original POST and fresh GET should both be forwarded")
+
+	cachedValue, err := mockCache.Get(context.Background(), cacheKey)
+	require.NoError(t, err)
+	assert.Contains(t, cachedValue, "ConfigMap")
+	assert.NotContains(t, cachedValue, "stale")
 }
 
 func TestSyncWatchers(t *testing.T) {

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -614,7 +614,9 @@ func TestHandleNonGETCacheInvalidation_PostOnNormalURL(t *testing.T) {
 
 func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) {
 	mockCache := NewMockCache()
-	cacheKey := "+version+ns+ctx"
+	targetURL := &url.URL{Path: "/clusters/kind/api/v1/namespaces/ns/configmaps/version"}
+	cacheKey, err := k8cache.GenerateKey(targetURL, "ctx")
+	require.NoError(t, err)
 	require.NoError(t, mockCache.Set(context.Background(), cacheKey, `{"body":"stale"}`))
 
 	called := 0
@@ -626,13 +628,12 @@ func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) 
 	})
 
 	w := httptest.NewRecorder()
-	targetURL := &url.URL{Path: "/clusters/kind/api/v1/namespaces/ns/configmaps/version"}
 	r := httptest.NewRequestWithContext(
 		context.Background(), http.MethodPost, targetURL.String(), nil,
 	)
 	r.URL = targetURL
 
-	err := k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
+	err = k8cache.HandleNonGETCacheInvalidation(mockCache, w, r, next, "ctx")
 	assert.ErrorIs(t, err, k8cache.ErrHandled)
 	assert.Equal(t, 2, called, "original POST and fresh GET should both be forwarded")
 

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -52,8 +52,8 @@ func kubernetesAPIPathIndex(parts []string) int {
 	return -1
 }
 
-// IsKubernetesResourceAPIPath returns true when path points to a Kubernetes
-// resource API endpoint that can be keyed by the cache layer.
+// IsKubernetesResourceAPIPath returns true when path targets a Kubernetes API endpoint
+// under /api or /apis (either directly, or proxied via /clusters/{name}/...).
 func IsKubernetesResourceAPIPath(path string) bool {
 	path = strings.TrimRight(path, "/")
 	parts := strings.Split(path, "/")

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -40,6 +40,27 @@ const (
 	apisPathSegment = "apis"
 )
 
+func kubernetesAPIPathIndex(parts []string) int {
+	if len(parts) > 1 && (parts[1] == apiPathSegment || parts[1] == apisPathSegment) {
+		return 1
+	}
+
+	if len(parts) > 3 && parts[1] == "clusters" && (parts[3] == apiPathSegment || parts[3] == apisPathSegment) {
+		return 3
+	}
+
+	return -1
+}
+
+// IsKubernetesResourceAPIPath returns true when path points to a Kubernetes
+// resource API endpoint that can be keyed by the cache layer.
+func IsKubernetesResourceAPIPath(path string) bool {
+	path = strings.TrimRight(path, "/")
+	parts := strings.Split(path, "/")
+
+	return kubernetesAPIPathIndex(parts) != -1
+}
+
 // CachedResponseData stores information such as StatusCode, Headers, and Body.
 // It helps cache responses efficiently and serve them from the cache.
 type CachedResponseData struct {
@@ -79,26 +100,29 @@ func GetResponseBody(bodyBytes []byte, encoding string) (string, error) {
 func GetAPIGroup(path string) (apiGroup, version string, err error) {
 	path = strings.TrimRight(path, "/")
 	parts := strings.Split(path, "/")
+	apiIdx := kubernetesAPIPathIndex(parts)
 
-	switch {
-	case len(parts) >= 4 && parts[3] == apiPathSegment:
+	if apiIdx == -1 {
+		return "", "", fmt.Errorf("invalid url format")
+	}
+
+	switch parts[apiIdx] {
+	case apiPathSegment:
 		// Core API group
 		apiGroup = ""
 
-		if len(parts) >= 5 {
-			version = parts[4]
+		if len(parts) > apiIdx+1 {
+			version = parts[apiIdx+1]
 		}
-	case len(parts) >= 4 && parts[3] == apisPathSegment:
+	case apisPathSegment:
 		// Named API group
-		if len(parts) >= 5 {
-			apiGroup = parts[4]
+		if len(parts) > apiIdx+1 {
+			apiGroup = parts[apiIdx+1]
 		}
 
-		if len(parts) >= 6 {
-			version = parts[5]
+		if len(parts) > apiIdx+2 {
+			version = parts[apiIdx+2]
 		}
-	default:
-		return "", "", fmt.Errorf("invalid url format")
 	}
 
 	return
@@ -118,16 +142,8 @@ func ExtractNamespace(rawURL string) (string, string) {
 	urls := strings.Split(rawURL, "/")
 
 	n := len(urls)
-	apiIdx := -1
 
-	// Kubernetes API paths either start directly at /api (index 1)
-	// or are proxied via /clusters/{name}/api (index 3)
-	if n > 1 && (urls[1] == apiPathSegment || urls[1] == apisPathSegment) {
-		apiIdx = 1
-	} else if n > 3 && urls[1] == "clusters" && (urls[3] == apiPathSegment || urls[3] == apisPathSegment) {
-		apiIdx = 3
-	}
-
+	apiIdx := kubernetesAPIPathIndex(urls)
 	if apiIdx == -1 {
 		return "", ""
 	}

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -135,7 +135,7 @@ func ExtractNamespace(rawURL string) (string, string) {
 		rawURL = rawURL[:idx]
 	}
 
-	rawURL = strings.TrimSuffix(rawURL, "/")
+	rawURL = strings.TrimRight(rawURL, "/")
 
 	var namespace, kind string
 

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -52,9 +52,9 @@ func kubernetesAPIPathIndex(parts []string) int {
 	return -1
 }
 
-// IsKubernetesResourceAPIPath returns true when path targets a Kubernetes API endpoint
+// IsKubernetesAPIPath returns true when path targets a Kubernetes API endpoint
 // under /api or /apis (either directly, or proxied via /clusters/{name}/...).
-func IsKubernetesResourceAPIPath(path string) bool {
+func IsKubernetesAPIPath(path string) bool {
 	path = strings.TrimRight(path, "/")
 	parts := strings.Split(path, "/")
 

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -349,30 +349,45 @@ func TestExtractNamespace(t *testing.T) {
 	}
 }
 
-func TestIsKubernetesResourceAPIPath(t *testing.T) {
+func TestIsKubernetesAPIPath(t *testing.T) {
 	tests := []struct {
 		name     string
 		path     string
 		expected bool
 	}{
 		{
-			name:     "proxied core api path",
+			name:     "proxied core resource path",
 			path:     "/clusters/kind-kind/api/v1/pods",
 			expected: true,
 		},
 		{
-			name:     "proxied named api path",
+			name:     "proxied named resource path",
 			path:     "/clusters/kind-kind/apis/apps/v1/deployments",
 			expected: true,
 		},
 		{
-			name:     "direct core api path",
+			name:     "direct core resource path",
 			path:     "/api/v1/pods",
 			expected: true,
 		},
 		{
-			name:     "direct named api path",
+			name:     "direct named resource path",
 			path:     "/apis/apps/v1/deployments",
+			expected: true,
+		},
+		{
+			name:     "direct core api root",
+			path:     "/api",
+			expected: true,
+		},
+		{
+			name:     "proxied named api root with trailing slash",
+			path:     "/clusters/kind-kind/apis/",
+			expected: true,
+		},
+		{
+			name:     "proxied discovery path",
+			path:     "/clusters/kind-kind/api/",
 			expected: true,
 		},
 		{
@@ -389,7 +404,7 @@ func TestIsKubernetesResourceAPIPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, k8cache.IsKubernetesResourceAPIPath(tc.path))
+			assert.Equal(t, tc.expected, k8cache.IsKubernetesAPIPath(tc.path))
 		})
 	}
 }

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -202,6 +202,20 @@ func TestGetAPIGroup(t *testing.T) {
 			expectedError:    nil,
 		},
 		{
+			name:             "return empty apiGroup from direct API path",
+			urlPath:          "/api/v1/pods",
+			expectedAPIGroup: "",
+			expectedVersion:  "v1",
+			expectedError:    nil,
+		},
+		{
+			name:             "return non-empty apiGroup from direct API path",
+			urlPath:          "/apis/apps/v1/deployments",
+			expectedAPIGroup: "apps",
+			expectedVersion:  "v1",
+			expectedError:    nil,
+		},
+		{
 			name:             "core discovery path with trailing slash",
 			urlPath:          "/clusters/kind-kind/api/",
 			expectedAPIGroup: "",
@@ -335,6 +349,51 @@ func TestExtractNamespace(t *testing.T) {
 	}
 }
 
+func TestIsKubernetesResourceAPIPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "proxied core api path",
+			path:     "/clusters/kind-kind/api/v1/pods",
+			expected: true,
+		},
+		{
+			name:     "proxied named api path",
+			path:     "/clusters/kind-kind/apis/apps/v1/deployments",
+			expected: true,
+		},
+		{
+			name:     "direct core api path",
+			path:     "/api/v1/pods",
+			expected: true,
+		},
+		{
+			name:     "direct named api path",
+			path:     "/apis/apps/v1/deployments",
+			expected: true,
+		},
+		{
+			name:     "proxied healthz path",
+			path:     "/clusters/kind-kind/healthz",
+			expected: false,
+		},
+		{
+			name:     "proxied version path",
+			path:     "/clusters/kind-kind/version",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, k8cache.IsKubernetesResourceAPIPath(tc.path))
+		})
+	}
+}
+
 // TestGenerateKey ensures the generated key is valid for both normal
 // and empty cluster name scenarios.
 //
@@ -357,6 +416,13 @@ func TestGenerateKey(t *testing.T) {
 		{
 			name:        "key with empty apiGroup",
 			urlPath:     url.URL{Path: "/clusters/kind-kind/api/v1/namespaces/test-kube/pods"},
+			contextKey:  "kind-kind",
+			expectedKey: "+pods+test-kube+kind-kind",
+			expectedErr: nil,
+		},
+		{
+			name:        "key with direct api path",
+			urlPath:     url.URL{Path: "/api/v1/namespaces/test-kube/pods"},
 			contextKey:  "kind-kind",
 			expectedKey: "+pods+test-kube+kind-kind",
 			expectedErr: nil,

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -322,6 +322,12 @@ func TestExtractNamespace(t *testing.T) {
 			kind:       "services",
 		},
 		{
+			name:       "valid namespaced resource with multiple trailing slashes",
+			urlPath:    url.URL{Path: "/api/v1/namespaces/dev/services//"},
+			namespaces: "dev",
+			kind:       "services",
+		},
+		{
 			name:       "internal cluster URL without API group",
 			urlPath:    url.URL{Path: "/clusters/production-cluster"},
 			namespaces: "",


### PR DESCRIPTION
Summary

 Fix cache handling for proxied apiserver endpoints that are not Kubernetes resource API paths.

 Requests such as:

 ```http
   GET /clusters/<cluster>/healthz
 ```

 were reaching the cache middleware and failing with:

 ```text
   invalid url format
 ```

 The cache layer builds keys from resource data: API group, kind, namespace, and context. That works for /api/... and /apis/..., but not for non-resource apiserver endpoints like /healthz or /version.

 Related Issue

 Fixes #5797

 Changes

 - Add a helper to detect Kubernetes resource API paths.
 - Skip resource cache handling for non-resource apiserver endpoints.
 - Reuse the same path detection logic in cache key parsing.
 - Add regression coverage for:
     - /clusters/<cluster>/healthz
     - other non-resource cluster paths
     - direct and proxied /api and /apis paths

 Steps to Test

 1. Run the targeted backend tests:

    ```bash
      cd backend
      go test ./cmd ./pkg/k8cache -count=1
    ```
 2. Start Headlamp with cache enabled.
 3. Open a configured cluster.
 4. Confirm this request succeeds instead of returning invalid url format:

    ```http
      GET /clusters/<cluster-name>/healthz
    ```

 Test Results

 ```bash
   cd backend && go test ./cmd ./pkg/k8cache -count=1
   # 312 passed in 2 packages
 ```

 Notes for the Reviewer

 /healthz is served by the Kubernetes apiserver, but it is not a resource API path. It has no API group, namespace, or kind, so the cache middleware should proxy it without trying to build a resource cache key.