### PR TITLE
frontend: Headlamp web app crash on firefox browsers

### DIFF
--- a/frontend/src/i18n/ThemeProviderNexti18n.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.tsx
@@ -42,8 +42,8 @@ import { supportedLanguages } from './config';
  * @param locale - The language code to retrieve the locale for.
  * @returns A Material-UI locale object, defaults to enUS if locale is unsupported.
  */
-function getLocale(locale: string): typeof enUS {
-  const normalizedLocale = locale.toLowerCase();
+function getLocale(locale: string | undefined): typeof enUS {
+  const normalizedLocale = locale?.toLowerCase() ?? 'en';
 
   const LOCALES = {
     en: enUS,


### PR DESCRIPTION
## Summary

This PR fixes Headlamp web app crashing on firefox browsers

## Related Issue

Fixes #5801

## Changes

- Removed i18 normalisation due to which the headlamp app is crashing on firefox browsers

## Steps to Test

1. Run `npm run start`
2. Open `localhost:3000` on firefox browser window

## Screenshots

<img width="1464" height="947" alt="Screenshot-494" src="https://github.com/user-attachments/assets/8279ff33-9eeb-45b3-b118-2726843b5cca" />




## Notes for the Reviewer

This is quite a major regression because currently, Headlamp web app will be crashing for all Firefox users. It would be helpful if this could be taken in P0 priority. Thank you!

cc: @illume @joaquimrocha 
