### PR TITLE
frontend: useKubeObjectList: Fix state overwrite during render

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -347,6 +347,62 @@ describe('useKubeObjectList', () => {
     expect(spy.mock.calls[3][0].connections.length).toBe(1); // updated connections after we removed namespace 'b'
   });
 
+  it('should handle simultaneous add and remove of namespaces without state loss', async () => {
+    const spy = vi.spyOn(websocket, 'useWebSockets');
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'pods', 'default', 'a', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'default',
+      namespace: 'a',
+    });
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'pods', 'default', 'b', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'default',
+      namespace: 'b',
+    });
+
+    const result = renderHook(
+      (props: { requests: Array<{ cluster: string; namespaces: string[] }> }) =>
+        useKubeObjectList({
+          kubeObjectClass: mockClass,
+          requests: props.requests,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        ),
+        initialProps: {
+          requests: [{ cluster: 'default', namespaces: ['a', 'b'] }],
+        },
+      }
+    );
+
+    expect(spy.mock.calls[0][0].connections.length).toBe(0); // initial render
+    expect(spy.mock.calls[1][0].connections.length).toBe(2); // watching 'a' and 'b'
+
+    // Prepopulate cache for namespace 'c' so the hook can discover it
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'pods', 'default', 'c', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'default',
+      namespace: 'c',
+    });
+
+    // Rerender: remove 'a', keep 'b', add 'c' — both add and remove in same render
+    result.rerender({
+      requests: [{ cluster: 'default', namespaces: ['b', 'c'] }],
+    });
+
+    // After the consolidated update, we should end up with exactly 2 connections: 'b' and 'c'
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1][0];
+    expect(lastCall.connections.length).toBe(2);
+    const watchedNamespaces = lastCall.connections.map((c: { url: string }) => {
+      const match = c.url.match(/namespaces\/([^/]+)\//);
+      return match ? match[1] : null;
+    });
+    expect(watchedNamespaces.sort()).toEqual(['b', 'c']);
+  });
+
   it('should clean up cluster-scoped resources when cluster is removed', async () => {
     const spy = vi.spyOn(websocket, 'useWebSockets');
     const queryClient = new QueryClient();

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -537,19 +537,52 @@ export function useKubeObjectList<K extends KubeObject>({
 
   if (listsNotYetWatched.length > 0 || listsToStopWatching.length > 0) {
     setListsToWatch(prev => {
-      let next = prev;
-      if (listsNotYetWatched.length > 0) {
-        next = [...next, ...listsNotYetWatched];
+      const additions = query.data
+        .filter(Boolean)
+        .filter(
+          data =>
+            prev.find(
+              watching =>
+                watching.cluster === data?.cluster && watching.namespace === data.namespace
+            ) === undefined
+        )
+        .map(data => ({
+          cluster: data!.cluster,
+          namespace: data!.namespace,
+          resourceVersion: data!.list.metadata.resourceVersion,
+        }));
+
+      const removals = prev.filter(
+        watching =>
+          requests.find(request => {
+            if (watching.cluster !== request?.cluster) return false;
+            return !request.namespaces?.length
+              ? !watching.namespace
+              : !!watching.namespace && request.namespaces.includes(watching.namespace);
+          }) === undefined
+      );
+
+      if (additions.length === 0 && removals.length === 0) {
+        return prev;
       }
-      if (listsToStopWatching.length > 0) {
+
+      let next = prev;
+      if (additions.length > 0) {
+        next = [...next, ...additions];
+      }
+      if (removals.length > 0) {
         next = next.filter(
           it =>
-            !listsToStopWatching.some(
-              stop => stop.cluster === it.cluster && stop.namespace === it.namespace
-            )
+            !removals.some(stop => stop.cluster === it.cluster && stop.namespace === it.namespace)
         );
       }
-      return next;
+
+      // Deduplicate by cluster and namespace
+      return next.filter(
+        (watching, index, self) =>
+          index ===
+          self.findIndex(w => w.cluster === watching.cluster && w.namespace === watching.namespace)
+      );
     });
   }
 

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -525,10 +525,6 @@ export function useKubeObjectList<K extends KubeObject>({
       resourceVersion: data!.list.metadata.resourceVersion,
     }));
 
-  if (listsNotYetWatched.length > 0) {
-    setListsToWatch([...listsToWatch, ...listsNotYetWatched]);
-  }
-
   const listsToStopWatching = listsToWatch.filter(
     watching =>
       requests.find(request => {
@@ -539,8 +535,22 @@ export function useKubeObjectList<K extends KubeObject>({
       }) === undefined
   );
 
-  if (listsToStopWatching.length > 0) {
-    setListsToWatch(listsToWatch.filter(it => !listsToStopWatching.includes(it)));
+  if (listsNotYetWatched.length > 0 || listsToStopWatching.length > 0) {
+    setListsToWatch(prev => {
+      let next = prev;
+      if (listsNotYetWatched.length > 0) {
+        next = [...next, ...listsNotYetWatched];
+      }
+      if (listsToStopWatching.length > 0) {
+        next = next.filter(
+          it =>
+            !listsToStopWatching.some(
+              stop => stop.cluster === it.cluster && stop.namespace === it.namespace
+            )
+        );
+      }
+      return next;
+    });
   }
 
   useWatchKubeObjectLists({

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -537,52 +537,38 @@ export function useKubeObjectList<K extends KubeObject>({
 
   if (listsNotYetWatched.length > 0 || listsToStopWatching.length > 0) {
     setListsToWatch(prev => {
-      const additions = query.data
-        .filter(Boolean)
-        .filter(
-          data =>
-            prev.find(
-              watching =>
-                watching.cluster === data?.cluster && watching.namespace === data.namespace
-            ) === undefined
-        )
-        .map(data => ({
-          cluster: data!.cluster,
-          namespace: data!.namespace,
-          resourceVersion: data!.list.metadata.resourceVersion,
-        }));
+      // Use a Map keyed by cluster:namespace for O(1) inserts, deletes, and
+      // deduplication — replacing the previous O(n²) findIndex pass.
+      const getWatchKey = (cluster: string, namespace?: string) => `${cluster}:${namespace ?? ''}`;
 
-      const removals = prev.filter(
-        watching =>
-          requests.find(request => {
-            if (watching.cluster !== request?.cluster) return false;
-            return !request.namespaces?.length
-              ? !watching.namespace
-              : !!watching.namespace && request.namespaces.includes(watching.namespace);
-          }) === undefined
+      const nextByKey = new Map(
+        prev.map(watching => [getWatchKey(watching.cluster, watching.namespace), watching])
       );
 
-      if (additions.length === 0 && removals.length === 0) {
+      listsToStopWatching.forEach(watching => {
+        nextByKey.delete(getWatchKey(watching.cluster, watching.namespace));
+      });
+
+      listsNotYetWatched.forEach(data => {
+        const key = getWatchKey(data.cluster, data.namespace);
+        if (!nextByKey.has(key)) {
+          nextByKey.set(key, {
+            cluster: data.cluster,
+            namespace: data.namespace,
+            resourceVersion: data.resourceVersion,
+          });
+        }
+      });
+
+      // Return prev unchanged if nothing actually changed.
+      if (
+        nextByKey.size === prev.length &&
+        [...nextByKey.values()].every((w, i) => w === prev[i])
+      ) {
         return prev;
       }
 
-      let next = prev;
-      if (additions.length > 0) {
-        next = [...next, ...additions];
-      }
-      if (removals.length > 0) {
-        next = next.filter(
-          it =>
-            !removals.some(stop => stop.cluster === it.cluster && stop.namespace === it.namespace)
-        );
-      }
-
-      // Deduplicate by cluster and namespace
-      return next.filter(
-        (watching, index, self) =>
-          index ===
-          self.findIndex(w => w.cluster === watching.cluster && w.namespace === watching.namespace)
-      );
+      return [...nextByKey.values()];
     });
   }
 


### PR DESCRIPTION


## Description
In `useKubeObjectList.ts`, we are using "render-phase state updates" to set `listsToWatch`. However, because we were calling `setListsToWatch` twice in the same render cycle using separate `if` blocks, it was causing a state overwrite bug.

If a user action caused both `listsNotYetWatched.length > 0` and `listsToStopWatching.length > 0` to be true at the same time, the second `setListsToWatch` completely erased the changes made by the first one. This forced React to do unnecessary extra render loops to correct the missing state.

To fix this, we have combined both updates into a single functional state setter (`setListsToWatch(prev => ...)`). This ensures we safely calculate the additions and removals together without any race conditions or dropped state.


## Changes Made
* **`frontend/src/lib/k8s/api/v2/useKubeObjectList.ts`**:
  * Removed the two separate `if` blocks that were calling `setListsToWatch` during the render phase.
  * Replaced them with a single functional update using `prev` state to apply both additions (`listsNotYetWatched`) and removals (`listsToStopWatching`) in one go safely.

