### PR TITLE
frontend: SimpleTable: Fix synchronous setPage(0) during render

### DIFF
--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -328,11 +328,9 @@ export default function SimpleTable(props: SimpleTableProps) {
     return filterFunction ? displayData.filter(filterFunction) : displayData;
   }, [displayData, filterFunction]);
 
-  React.useEffect(() => {
-    if (filteredData && filteredData.length <= page * rowsPerPage && page !== 0) {
-      setPage(0);
-    }
-  }, [filteredData, page, rowsPerPage, setPage]);
+  if (filteredData && filteredData.length <= page * rowsPerPage && page !== 0) {
+    setPage(0);
+  }
 
   let content;
   if (displayData === null) {

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -171,8 +171,9 @@ export default function SimpleTable(props: SimpleTableProps) {
   const shouldReflectInURL = reflectInURL !== undefined && reflectInURL !== false;
   const prefix = reflectInURL === true ? '' : reflectInURL || '';
   const [page, setPage] = usePageURLState(shouldReflectInURL ? 'p' : '', prefix, initialPage);
-  const [currentData, setCurrentData] = React.useState(data);
-  const [displayData, setDisplayData] = React.useState(data);
+  const normalizedData = data ?? null;
+  const [currentData, setCurrentData] = React.useState(normalizedData);
+  const [displayData, setDisplayData] = React.useState(normalizedData);
   const storeRowsPerPageOptions = useSettings('tableRowsPerPageOptions');
   const rowsPerPageOptions = props.rowsPerPage || storeRowsPerPageOptions;
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -231,19 +232,19 @@ export default function SimpleTable(props: SimpleTableProps) {
 
   React.useEffect(
     () => {
-      if (currentData === data) {
+      if (currentData === normalizedData) {
         return;
       }
 
       // If the currentData is not up to date and we are in the first page, then update
       // it directly. Otherwise it will require user's intervention.
       if (!currentData || currentData.length === 0 || page === 0) {
-        setCurrentData(data);
-        setDisplayData(getSortData() || data);
+        setCurrentData(normalizedData);
+        setDisplayData(getSortData() || normalizedData);
       }
     },
     // eslint-disable-next-line
-    [data, currentData]
+    [normalizedData, currentData]
   );
 
   function defaultSortingFunction(column: SimpleTableDatumColumn | SimpleTableGetterColumn) {
@@ -329,11 +330,7 @@ export default function SimpleTable(props: SimpleTableProps) {
   }, [displayData, filterFunction]);
 
   React.useEffect(() => {
-    if (
-      filteredData &&
-      (filteredData.length === 0 || filteredData.length < page * rowsPerPage) &&
-      page !== 0
-    ) {
+    if (filteredData && filteredData.length <= page * rowsPerPage && page !== 0) {
       setPage(0);
     }
   }, [filteredData, page, rowsPerPage, setPage]);
@@ -377,13 +374,13 @@ export default function SimpleTable(props: SimpleTableProps) {
           {
             // Show a refresh button if the data is not up to date, so we allow the user to keep
             // reading the current data without "losing" it or being sent to the first page
-            currentData !== data && page !== 0 && (
+            currentData !== normalizedData && page !== 0 && (
               <Box textAlign="center" p={2}>
                 <Button
                   variant="contained"
                   startIcon={<Icon icon="mdi:refresh" />}
                   onClick={() => {
-                    setCurrentData(data);
+                    setCurrentData(normalizedData);
                     setPage(0);
                   }}
                 >

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -288,8 +288,7 @@ export default function SimpleTable(props: SimpleTableProps) {
       (typeof sortFunction === 'boolean' && sortFunction) ||
       (typeof sortFunction === 'function' && sortFunction.length === 1)
     ) {
-      setDisplayData(data.slice().sort(defaultSortingFunction(columnAskingForSort)));
-      return;
+      return data.slice().sort(defaultSortingFunction(columnAskingForSort));
     }
 
     if (typeof sortFunction === 'function') {

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -336,7 +336,7 @@ export default function SimpleTable(props: SimpleTableProps) {
     ) {
       setPage(0);
     }
-  }, [filteredData, page, rowsPerPage]);
+  }, [filteredData, page, rowsPerPage, setPage]);
 
   let content;
   if (displayData === null) {

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -323,6 +323,21 @@ export default function SimpleTable(props: SimpleTableProps) {
     setAnnouncedStatus(statusMsg);
   }, [statusMsg]);
 
+  const filteredData = React.useMemo(() => {
+    if (!displayData) return null;
+    return filterFunction ? displayData.filter(filterFunction) : displayData;
+  }, [displayData, filterFunction]);
+
+  React.useEffect(() => {
+    if (
+      filteredData &&
+      (filteredData.length === 0 || filteredData.length < page * rowsPerPage) &&
+      page !== 0
+    ) {
+      setPage(0);
+    }
+  }, [filteredData, page, rowsPerPage]);
+
   let content;
   if (displayData === null) {
     if (!!errorMessage) {
@@ -331,21 +346,9 @@ export default function SimpleTable(props: SimpleTableProps) {
       content = <Loader title={t('Loading table data')} />;
     }
   } else {
-    let filteredData = displayData;
-    if (filterFunction) {
-      filteredData = displayData?.filter(filterFunction);
-    }
-
     function getPagedRows() {
       const startIndex = page * rowsPerPage;
       return filteredData!.slice(startIndex, startIndex + rowsPerPage);
-    }
-
-    if (
-      (filteredData?.length === 0 || (filteredData?.length ?? 0) < page * rowsPerPage) &&
-      page !== 0
-    ) {
-      setPage(0);
     }
 
     function sortClickHandler(isIncreasingOrder: boolean, index: number) {


### PR DESCRIPTION


## Description
In `SimpleTable.tsx`, we were previously calling `setPage(0)` directly during the render cycle if the `filteredData` became empty or too small for the current page size. This is a React anti-pattern because calling a state setter during the render phase forces React to synchronously drop the current render and start over.

The original code likely did this because there is an early return (`if (displayData === null) { ... }`) higher up, which prevented using a `useEffect` hook below it (Hooks cannot be placed after early returns). 

To fix this properly and align with React best practices, we have hoisted the `filteredData` calculation above the early return using `useMemo`. This allows us to cleanly handle the page boundary correction inside a `useEffect` hook, completely removing the synchronous state update from the render body.


## Changes Made
* **`frontend/src/components/common/SimpleTable.tsx`**:
  * Moved the `filteredData` calculation above the early return and wrapped it in `useMemo`.
  * Moved the `setPage(0)` boundary correction logic inside a proper `useEffect` hook.
  * Cleaned up the `else` block to remove the inline calculation.


