### PR TITLE
frontend: units: Fix parseRam not handling milli-bytes (m) suffix

### DIFF
--- a/frontend/src/lib/units.test.ts
+++ b/frontend/src/lib/units.test.ts
@@ -35,6 +35,12 @@ describe('parseRam', () => {
     expect(parseRam('1G')).toBe(1000000000);
   });
 
+  it('should parse milli-bytes suffix (m)', () => {
+    expect(parseRam('1000m')).toBe(1);
+    expect(parseRam('11973899059200m')).toBe(11973899059.2);
+    expect(parseRam('14712779571200m')).toBe(14712779571.2);
+  });
+
   it('should parse exponential notation', () => {
     expect(parseRam('1e3')).toBe(1000);
     expect(parseRam('1e6')).toBe(1000000);

--- a/frontend/src/lib/units.test.ts
+++ b/frontend/src/lib/units.test.ts
@@ -39,6 +39,7 @@ describe('parseRam', () => {
     expect(parseRam('1000m')).toBe(1);
     expect(parseRam('11973899059200m')).toBe(11973899059.2);
     expect(parseRam('14712779571200m')).toBe(14712779571.2);
+    expect(parseRam('1.5m')).toBeCloseTo(0.0015, 10);
   });
 
   it('should parse exponential notation', () => {

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -38,6 +38,11 @@ export function parseRam(value: string) {
 function parseUnitsOfBytes(value: string): number {
   if (!value) return 0;
 
+  // "m" suffix means milli-bytes (1/1000 of a byte), e.g. "11973899059200m" from kubectl
+  if (/^\d+m$/.test(value)) {
+    return parseInt(value, 10) / 1000;
+  }
+
   const groups = value.match(/(\d+(?:\.\d+)?)([BKMGTPEe])?(i)?(\d+)?/) || [];
   const number = parseFloat(groups[1]);
 

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -39,8 +39,9 @@ function parseUnitsOfBytes(value: string): number {
   if (!value) return 0;
 
   // "m" suffix means milli-bytes (1/1000 of a byte), e.g. "11973899059200m" from kubectl
-  if (/^\d+m$/.test(value)) {
-    return parseInt(value, 10) / 1000;
+  // Support integer and decimal milli-byte values like "1000m" or "1.5m"
+  if (/^\d+(?:\.\d+)?m$/.test(value)) {
+    return parseFloat(value.slice(0, -1)) / 1000;
   }
 
   const groups = value.match(/(\d+(?:\.\d+)?)([BKMGTPEe])?(i)?(\d+)?/) || [];


### PR DESCRIPTION
## Summary

  This PR fixes memory quantity parsing by adding support for the milli-bytes (`m`) suffix in `parseRam`, which caused node memory allocation to display wildly incorrect values
  (e.g., ~9131% instead of ~77%) in the Node detail view.


## Changes

  - Fixed `parseUnitsOfBytes` in `frontend/src/lib/units.ts` to correctly handle the `m` (milli-bytes) suffix by dividing by 1000
  - Added test cases in `frontend/src/lib/units.test.ts` for milli-bytes parsing

## Steps to Test

  1. Find a Kubernetes node where `kubectl describe node <node>` shows memory requests in `m` suffix (e.g., `11973899059200m`)
  2. Open Headlamp and navigate to the Node detail page
  3. Check the **Resource Allocation** section — Memory Requests/Limits percentage should match the value shown in `kubectl describe node`

## Screenshots (if applicable)

  **Before:** Memory Requests shown as `1.3 Ti / 9131.1%`  
  **After:** Memory Requests shown as `~11.1 GiB / ~77%`

## Notes for the Reviewer

  - The `m` suffix in memory context means milli-bytes (1/1000 of a byte), which is valid Kubernetes quantity syntax but was not handled in `parseUnitsOfBytes`. Note this is 
  different from CPU's `m` suffix (millicores).
  - The fix is guarded by `/^\d+(?:\.\d+)?m$/` so it applies to both integer and decimal values ending in `m` (e.g., `1000m` or `1.5m`), avoiding any conflict with existing unit parsing.