### PR TITLE
frontend: CreateResourceForm: Tolerate partial YAML in container field

### DIFF
--- a/frontend/src/components/common/Resource/CreateResourceForm.test.tsx
+++ b/frontend/src/components/common/Resource/CreateResourceForm.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../../../i18n/config';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Avoid pulling the lib/k8s barrel (and its circular ResourceClasses chain) into
+// the test. ContainerTextField does not use Namespace, but CreateResourceForm
+// imports it for NamespaceTextField, which is enough to trigger the cycle.
+vi.mock('../../../lib/k8s/namespace', () => ({
+  default: { useList: () => [[], null] },
+}));
+
+const { ContainerTextField } = await import('./CreateResourceForm');
+
+function renderContainers(value: unknown) {
+  return render(<ContainerTextField value={value as any} onChange={() => {}} />);
+}
+
+// Reproduces the YAML-editor edit paths from #5780. The Create dialog mounts the
+// form panel even while the user is typing in the editor tab, so any partial
+// shape js-yaml hands back has to render without throwing.
+describe('ContainerTextField partial-input tolerance', () => {
+  it('renders a null sequence entry without crashing (containers:\\n  -)', () => {
+    expect(() => renderContainers([null])).not.toThrow();
+  });
+
+  it('renders a mix of valid and null entries without crashing', () => {
+    expect(() =>
+      renderContainers([{ name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }] }, null])
+    ).not.toThrow();
+  });
+
+  it('renders when value is a string instead of an array (containers: foo)', () => {
+    expect(() => renderContainers('foo')).not.toThrow();
+  });
+
+  it('renders when value is null', () => {
+    expect(() => renderContainers(null)).not.toThrow();
+  });
+
+  it('renders fully-populated entries as before', () => {
+    const { getAllByRole } = renderContainers([
+      { name: 'c1', image: 'nginx', ports: [{ containerPort: 80 }], imagePullPolicy: 'Always' },
+    ]);
+    expect(getAllByRole('textbox').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/common/Resource/CreateResourceForm.tsx
+++ b/frontend/src/components/common/Resource/CreateResourceForm.tsx
@@ -411,39 +411,42 @@ export function ContainerTextField(props: ContainerTextFieldProps) {
   const { value, onChange, label } = props;
   const { t } = useTranslation(['translation']);
   const groupLabelId = useId('container-group-');
-  const [rowIds, setRowIds] = React.useState<string[]>(() => value.map(() => nextContainerRowId()));
+  const safeValue = Array.isArray(value) ? value : [];
+  const [rowIds, setRowIds] = React.useState<string[]>(() =>
+    safeValue.map(() => nextContainerRowId())
+  );
 
   // Keep row IDs in sync when value changes externally (e.g. YAML editor).
   React.useEffect(() => {
     setRowIds(prev => {
-      if (prev.length === value.length) return prev;
-      if (prev.length < value.length) {
+      if (prev.length === safeValue.length) return prev;
+      if (prev.length < safeValue.length) {
         const next = [...prev];
-        while (next.length < value.length) {
+        while (next.length < safeValue.length) {
           next.push(nextContainerRowId());
         }
         return next;
       }
-      return prev.slice(0, value.length);
+      return prev.slice(0, safeValue.length);
     });
-  }, [value.length]);
+  }, [safeValue.length]);
 
   function handleAdd() {
     setRowIds(prev => [...prev, nextContainerRowId()]);
     onChange([
-      ...value,
+      ...safeValue,
       { name: '', image: '', ports: [{ containerPort: 80 }], imagePullPolicy: 'Always' },
     ]);
   }
 
   function handleRemove(index: number) {
     setRowIds(prev => prev.filter((_, i) => i !== index));
-    onChange(value.filter((_, i) => i !== index));
+    onChange(safeValue.filter((_, i) => i !== index));
   }
 
   function handleEdit(index: number, field: string, newVal: string) {
     onChange(
-      value.map((c, i) => {
+      safeValue.map((c, i) => {
         if (i !== index) return c;
         if (field === 'containerPort') {
           const portNum = parseInt(newVal, 10);
@@ -459,7 +462,7 @@ export function ContainerTextField(props: ContainerTextFieldProps) {
   }
 
   function getPort(container: Record<string, any>): string {
-    const port = container?.ports?.[0]?.containerPort ?? container.containerPort;
+    const port = container?.ports?.[0]?.containerPort ?? container?.containerPort;
     return port !== null && port !== undefined ? String(port) : '';
   }
 
@@ -470,55 +473,61 @@ export function ContainerTextField(props: ContainerTextFieldProps) {
           {label}
         </Typography>
       )}
-      {value.map((container, index) => (
-        <Box
-          key={rowIds[index] ?? `container-${index}`}
-          sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 2, mb: 2 }}
-        >
-          <FormTextField
-            label={t('translation|Name')}
-            value={container.name ?? ''}
-            onChange={e => handleEdit(index, 'name', e.target.value)}
-            inputProps={{ 'aria-label': t('translation|Container name') }}
-          />
-          <FormTextField
-            label={t('translation|Image')}
-            value={container.image ?? ''}
-            onChange={e => handleEdit(index, 'image', e.target.value)}
-            inputProps={{ 'aria-label': t('translation|Container image') }}
-          />
-          <FormTextField
-            label={t('translation|Container Port')}
-            value={getPort(container)}
-            onChange={e => handleEdit(index, 'containerPort', e.target.value)}
-            inputProps={{ 'aria-label': t('translation|Container port') }}
-            type="number"
-          />
-          <FormTextField
-            label={t('translation|Pull Policy')}
-            value={container.imagePullPolicy ?? 'Always'}
-            onChange={e => handleEdit(index, 'imagePullPolicy', e.target.value)}
-            inputProps={{ 'aria-label': t('translation|Image pull policy') }}
-            select
+      {safeValue.map((rawContainer, index) => {
+        const container =
+          rawContainer && typeof rawContainer === 'object' && !Array.isArray(rawContainer)
+            ? (rawContainer as Record<string, any>)
+            : {};
+        return (
+          <Box
+            key={rowIds[index] ?? `container-fallback-${index}`}
+            sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 2, mb: 2 }}
           >
-            {IMAGE_PULL_POLICIES.map(p => (
-              <MenuItem key={p} value={p}>
-                {p}
-              </MenuItem>
-            ))}
-          </FormTextField>
-          <IconButton
-            onClick={() => handleRemove(index)}
-            color="default"
-            size="small"
-            aria-label={t('translation|Remove container {{ name }}', {
-              name: container.name ?? index,
-            })}
-          >
-            <Icon icon="mdi:close-circle" width={24} height={24} />
-          </IconButton>
-        </Box>
-      ))}
+            <FormTextField
+              label={t('translation|Name')}
+              value={container.name ?? ''}
+              onChange={e => handleEdit(index, 'name', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Container name') }}
+            />
+            <FormTextField
+              label={t('translation|Image')}
+              value={container.image ?? ''}
+              onChange={e => handleEdit(index, 'image', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Container image') }}
+            />
+            <FormTextField
+              label={t('translation|Container Port')}
+              value={getPort(container)}
+              onChange={e => handleEdit(index, 'containerPort', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Container port') }}
+              type="number"
+            />
+            <FormTextField
+              label={t('translation|Pull Policy')}
+              value={container.imagePullPolicy ?? 'Always'}
+              onChange={e => handleEdit(index, 'imagePullPolicy', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Image pull policy') }}
+              select
+            >
+              {IMAGE_PULL_POLICIES.map(p => (
+                <MenuItem key={p} value={p}>
+                  {p}
+                </MenuItem>
+              ))}
+            </FormTextField>
+            <IconButton
+              onClick={() => handleRemove(index)}
+              color="default"
+              size="small"
+              aria-label={t('translation|Remove container {{ name }}', {
+                name: container.name ?? index,
+              })}
+            >
+              <Icon icon="mdi:close-circle" width={24} height={24} />
+            </IconButton>
+          </Box>
+        );
+      })}
       <Box sx={{ mt: 2 }}>
         <Button
           onClick={handleAdd}


### PR DESCRIPTION
## Summary

Fixes #5780. Typing `-` under `containers:` in the Create dialog's YAML editor crashes Headlamp. `ContainerTextField` reads `container.name`, `.image`, `.imagePullPolicy`, `.containerPort`, and the IconButton aria-label directly off each array entry, so any non-object entry (which js-yaml produces mid-edit) throws TypeError and escapes to the error boundary as a full app crash.

The Form tab stays mounted while the user is in the Editor tab (`TabPanel` toggles via `hidden`), so every keystroke that reparses the YAML and updates form state re-renders the form even though it's not visible. The form has to be tolerant of the lossy intermediate shapes the parser hands back.

## Approach

Coerce `value` to an array and normalize each entry to an object at render. Existing fully-populated entries render identically; bad intermediate shapes now render as an empty row instead of throwing.

Repro shapes from js-yaml that were crashing, now handled:

| YAML | Parses as | Before | After |
|---|---|---|---|
| `containers:\n  -` | `[null]` | crash | empty row |
| `containers:\n  - name: c1\n  -` | `[{...}, null]` | crash on iter 2 | first row intact, second empty |
| `containers: foo` | `'foo'` (string) | `value.map is not a function` | empty list |
| `containers: null` | `null` | already safe at caller | unchanged |

## Test plan

- [x] Added `CreateResourceForm.test.tsx` covering `[null]`, mixed valid + null, non-array value, null value, and the happy path (5 tests, all pass).
- [x] Full Resource test suite (65 tests across 11 files) passes.
- [x] `npm run tsc` clean.
- [x] `npm run lint` clean.
- [ ] Manual: click +, pick Pod, paste a single-container Pod YAML, add `\n  -` under `containers:`. No crash, second row appears empty in the Form tab.