### PR TITLE
frontend: ObjectEventList: Guard optional event source in From column

### DIFF
--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -119,7 +119,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
           {
             label: t('From'),
             getter: item => {
-              return item.source.component;
+              return item.source?.component ?? '';
             },
           },
           {


### PR DESCRIPTION
## Summary

Fix a runtime error in the resource **Events** table when Kubernetes returns events without a `source` field. The **From** column now safely reads `source.component` using optional chaining and falls back to an empty string.


## Related Issue

Fixes #5823   

## Changes

- In the Kubernetes API, `Event.source` is optional (`EventSource` with optional `component` and `host`).
- Headlamp’s `Event.source` getter returns `undefined` when the field is absent (`getValue('source')`).
- Accessing `.component` on `undefined` throws and can break rendering of the events table for affected resources.
- Events from newer pipelines (e.g. `events.k8s.io`) may omit `source` entirely; this is expected cluster behavior, not bad data.
- Aligns with existing defensive access elsewhere (e.g. `event.source?.host` in cluster Overview).

## Steps to Test

1. Run the frontend: `npm run frontend:start`
2. Open any resource details view that shows the **Events** section (e.g. a Pod).
3. Confirm the Events table renders when events have no `source` (or only `source.host`).
4. Confirm events with `source.component` (e.g. `kubelet`, `default-scheduler`) still show the correct **From** value.
5. (Optional) `npm run frontend:storybook` → **common/ObjectEventList** stories still render.



## Notes for the Reviewer

- crash fix only, no mapping of `reportingController` into **From** (can be a follow-up).
- Same empty-cell behavior as other optional event fields in this table (`message || ''`).

