### PR TITLE
frontend: clusterSettings: Add unit tests

### DIFF
--- a/frontend/src/helpers/clusterSettings.test.ts
+++ b/frontend/src/helpers/clusterSettings.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ClusterSettings, loadClusterSettings, storeClusterSettings } from './clusterSettings';
+
+describe('clusterSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('storeClusterSettings', () => {
+    it('writes the settings under cluster_settings.<name>', () => {
+      const settings: ClusterSettings = { defaultNamespace: 'kube-system' };
+
+      storeClusterSettings('prod', settings);
+
+      expect(JSON.parse(localStorage.getItem('cluster_settings.prod') || '{}')).toEqual(settings);
+    });
+
+    it('round-trips a full settings object including nested fields', () => {
+      const settings: ClusterSettings = {
+        defaultNamespace: 'app',
+        allowedNamespaces: ['app', 'app-staging'],
+        currentName: 'Production',
+        nodeShellTerminal: {
+          linuxImage: 'alpine:latest',
+          namespace: 'kube-system',
+          isEnabled: true,
+        },
+        podDebugTerminal: {
+          debugImage: 'busybox:1.36',
+          isEnabled: false,
+        },
+        appearance: {
+          accentColor: '#ff0000',
+          icon: 'mdi:server',
+        },
+      };
+
+      storeClusterSettings('prod', settings);
+
+      expect(loadClusterSettings('prod')).toEqual(settings);
+    });
+
+    it('overwrites an existing entry for the same cluster name', () => {
+      storeClusterSettings('prod', { defaultNamespace: 'old' });
+      storeClusterSettings('prod', { defaultNamespace: 'new' });
+
+      expect(loadClusterSettings('prod')).toEqual({ defaultNamespace: 'new' });
+    });
+
+    it('keeps settings for other clusters isolated', () => {
+      storeClusterSettings('alpha', { defaultNamespace: 'a' });
+      storeClusterSettings('beta', { defaultNamespace: 'b' });
+
+      expect(loadClusterSettings('alpha')).toEqual({ defaultNamespace: 'a' });
+      expect(loadClusterSettings('beta')).toEqual({ defaultNamespace: 'b' });
+    });
+
+    it('is a no-op when clusterName is an empty string', () => {
+      storeClusterSettings('', { defaultNamespace: 'app' });
+
+      // No key should have been written for an empty clusterName.
+      expect(localStorage.getItem('cluster_settings.')).toBeNull();
+    });
+
+    it('persists an empty settings object', () => {
+      storeClusterSettings('prod', {});
+
+      expect(localStorage.getItem('cluster_settings.prod')).toBe('{}');
+      expect(loadClusterSettings('prod')).toEqual({});
+    });
+  });
+
+  describe('loadClusterSettings', () => {
+    it('returns an empty object when no entry exists', () => {
+      expect(loadClusterSettings('never-stored')).toEqual({});
+    });
+
+    it('returns an empty object when clusterName is empty', () => {
+      // Even if a value happens to live under the bare prefix, an empty name
+      // should never read it.
+      localStorage.setItem('cluster_settings.', JSON.stringify({ defaultNamespace: 'leak' }));
+
+      expect(loadClusterSettings('')).toEqual({});
+    });
+
+    it('returns the parsed object for a stored cluster', () => {
+      localStorage.setItem(
+        'cluster_settings.prod',
+        JSON.stringify({ defaultNamespace: 'kube-system', currentName: 'Prod' })
+      );
+
+      expect(loadClusterSettings('prod')).toEqual({
+        defaultNamespace: 'kube-system',
+        currentName: 'Prod',
+      });
+    });
+
+    it('namespaces cluster names so two clusters never alias each other', () => {
+      storeClusterSettings('prod', { defaultNamespace: 'p' });
+
+      // A cluster name that happens to be a prefix of another stored key.
+      expect(loadClusterSettings('pro')).toEqual({});
+      expect(loadClusterSettings('prod.extra')).toEqual({});
+    });
+
+    // Documents current behaviour: corrupted localStorage payloads surface as
+    // a parse error rather than silently falling back to {}. A future change
+    // could add defensive recovery; this test should be updated alongside it.
+    it('throws when the stored payload is not valid JSON', () => {
+      localStorage.setItem('cluster_settings.prod', '{not json');
+
+      expect(() => loadClusterSettings('prod')).toThrow(SyntaxError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds **unit test coverage** for `frontend/src/helpers/clusterSettings.ts`, which manages cluster-specific configuration in `localStorage` (default namespace, node-shell terminal, pod-debug terminal, appearance). The module is imported by **14 files** across the app but previously had zero test coverage, so silent regressions in `storeClusterSettings` / `loadClusterSettings` would not be caught by CI.

## Related Issue
#5828 

## Changes

- Added `frontend/src/helpers/clusterSettings.test.ts` with 11 tests covering:
  - Round-trip of a full settings object (every nested field — `nodeShellTerminal`, `podDebugTerminal`, `appearance`)
  - Overwriting an existing entry
  - Isolation between cluster names (no aliasing across keys)
  - No-op behavior when `clusterName` is empty (both `store` and `load`)
  - Persistence of an empty settings object
  - Empty-object return when no entry exists or the cluster name is empty
  - Documented current behavior on corrupted localStorage payloads (`SyntaxError` thrown)
- No changes to the source module.
- No new translation strings.

## Steps to Test

1. From the repo root: `cd frontend && npx vitest run src/helpers/clusterSettings.test.ts`
2. Confirm **11 tests pass**.
3. Run the full frontend lint to confirm no regressions: `npm run frontend:lint`

## Screenshots (if applicable)

N/A — test-only PR, no UI.

## Notes for the Reviewer

- The follows the existing pattern in [`tableSettings.test.ts`](frontend/src/helpers/tableSettings.test.ts): nested `describe`-per-function, `beforeEach(localStorage.clear())`, copyright header.
- One test (`throws when the stored payload is not valid JSON`) intentionally **documents the current behavior** — `loadClusterSettings` throws on corrupt JSON rather than recovering. A follow-up could harden the helper; this test should be updated alongside such a change.
