### PR TITLE
backend: Reject unsupported Jaeger tracing endpoint

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -157,25 +157,40 @@ func (c *Config) Validate() error {
 		return errors.New("session-ttl cannot be greater than 1 year")
 	}
 
-	if c.TracingEnabled != nil && *c.TracingEnabled {
-		if c.ServiceName == "" {
-			return errors.New("service-name is required when tracing is enabled")
-		}
-
-		if (c.JaegerEndpoint != nil && *c.JaegerEndpoint == "") &&
-			(c.OTLPEndpoint != nil && *c.OTLPEndpoint == "") &&
-			(c.StdoutTraceEnabled != nil && *c.StdoutTraceEnabled) {
-			return errors.New("at least one tracing exporter (jaeger, otlp, or stdout) must be configured")
-		}
-
-		if (c.UseOTLPHTTP != nil && *c.UseOTLPHTTP) &&
-			(c.OTLPEndpoint == nil || *c.OTLPEndpoint == "") {
-			return errors.New("otlp-endpoint must be configured when use-otlp-http is enabled")
-		}
+	if err := c.validateTracing(); err != nil {
+		return err
 	}
 
 	if err := c.validateClusterInventory(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (c *Config) validateTracing() error {
+	if c.TracingEnabled == nil || !*c.TracingEnabled {
+		return nil
+	}
+
+	if c.ServiceName == "" {
+		return errors.New("service-name is required when tracing is enabled")
+	}
+
+	if c.JaegerEndpoint != nil && *c.JaegerEndpoint != "" &&
+		(c.StdoutTraceEnabled == nil || !*c.StdoutTraceEnabled) {
+		return errors.New("jaeger-endpoint is not supported; use otlp-endpoint or stdout tracing")
+	}
+
+	if (c.UseOTLPHTTP != nil && *c.UseOTLPHTTP) &&
+		(c.OTLPEndpoint == nil || *c.OTLPEndpoint == "") {
+		return errors.New("otlp-endpoint must be configured when use-otlp-http is enabled")
+	}
+
+	if (c.JaegerEndpoint == nil || *c.JaegerEndpoint == "") &&
+		(c.OTLPEndpoint == nil || *c.OTLPEndpoint == "") &&
+		(c.StdoutTraceEnabled == nil || !*c.StdoutTraceEnabled) {
+		return errors.New("at least one tracing exporter (otlp or stdout) must be configured")
 	}
 
 	return nil
@@ -621,6 +636,7 @@ func addTelemetryFlags(f *flag.FlagSet) {
 	f.String("service-version", "0.30.0", "Service version for telemetry")
 	f.Bool("tracing-enabled", false, "Enable distributed tracing")
 	f.Bool("metrics-enabled", false, "Enable metrics collection")
+	f.String("jaeger-endpoint", "", "Jaeger collector endpoint (unsupported; use otlp-endpoint or stdout tracing)")
 	f.String("otlp-endpoint", "localhost:4317", "OTLP collector endpoint")
 	f.Bool("use-otlp-http", false, "Use HTTP instead of gRPC for OTLP export")
 	f.Bool("stdout-trace-enabled", false, "Enable tracing output to stdout")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -855,6 +855,50 @@ var validateTracingTests = []struct {
 		errorContains: "otlp-endpoint must be configured when use-otlp-http is enabled",
 	},
 	{
+		name: "tracing_enabled_without_exporter",
+		args: []string{
+			"go run ./cmd",
+			"--tracing-enabled=true",
+			"--service-name=myapp",
+			"--otlp-endpoint=",
+		},
+		expectError:   true,
+		errorContains: "at least one tracing exporter (otlp or stdout) must be configured",
+	},
+	{
+		name: "stdout_trace_enabled_without_endpoint",
+		args: []string{
+			"go run ./cmd",
+			"--tracing-enabled=true",
+			"--service-name=myapp",
+			"--otlp-endpoint=",
+			"--stdout-trace-enabled=true",
+		},
+		expectError: false,
+	},
+	{
+		name: "jaeger_endpoint_without_stdout",
+		args: []string{
+			"go run ./cmd",
+			"--tracing-enabled=true",
+			"--service-name=myapp",
+			"--jaeger-endpoint=http://jaeger:14268/api/traces",
+		},
+		expectError:   true,
+		errorContains: "jaeger-endpoint is not supported; use otlp-endpoint or stdout tracing",
+	},
+	{
+		name: "jaeger_endpoint_with_stdout_is_valid",
+		args: []string{
+			"go run ./cmd",
+			"--tracing-enabled=true",
+			"--service-name=myapp",
+			"--jaeger-endpoint=http://jaeger:14268/api/traces",
+			"--stdout-trace-enabled=true",
+		},
+		expectError: false,
+	},
+	{
 		name: "tracing_disabled_no_validation",
 		args: []string{
 			"go run ./cmd",

--- a/backend/pkg/telemetry/telemetry.go
+++ b/backend/pkg/telemetry/telemetry.go
@@ -204,17 +204,14 @@ func createTracingExporter(cfg cfg.Config) (trace.SpanExporter, error) { //nolin
 	isJaegerConfigured := *cfg.JaegerEndpoint != ""
 	isOTLPConfigured := *cfg.OTLPEndpoint != ""
 
-	if isJaegerConfigured {
-		enabledExporters++
-
-		enabledTypes = append(enabledTypes, "Jaeger")
-
-		if !isOTLPConfigured {
-			isOTLPConfigured = true
-		}
+	if isJaegerConfigured && !*cfg.StdoutTraceEnabled {
+		return nil, fmt.Errorf(
+			"jaeger endpoint %s is not supported; use an OTLP endpoint or stdout tracing instead",
+			*cfg.JaegerEndpoint,
+		)
 	}
 
-	if isOTLPConfigured && !isJaegerConfigured {
+	if isOTLPConfigured {
 		enabledExporters++
 
 		enabledTypes = append(enabledTypes, "OTLP")

--- a/backend/pkg/telemetry/telemetry_test.go
+++ b/backend/pkg/telemetry/telemetry_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	tel "github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,6 +15,7 @@ func TestNewTelemetry(t *testing.T) { //nolint:funlen // multiple test cases fun
 	testVersion := "1.0.0"
 	sampleRate := 1.0
 	emptyStr := ""
+	jaegerEndpoint := "http://jaeger:14268/api/traces"
 	trueVal := true
 	falseVal := false
 
@@ -68,6 +70,23 @@ func TestNewTelemetry(t *testing.T) { //nolint:funlen // multiple test cases fun
 			expectError:   true,
 			errorContains: "service name cannot be empty",
 		},
+		{
+			name: "jaeger endpoint is rejected instead of falling back to otlp",
+			config: cfg.Config{
+				ServiceName:        "test-service",
+				ServiceVersion:     &testVersion,
+				TracingEnabled:     &trueVal,
+				StdoutTraceEnabled: &falseVal,
+				SamplingRate:       &sampleRate,
+				MetricsEnabled:     &falseVal,
+				JaegerEndpoint:     &jaegerEndpoint,
+				OTLPEndpoint:       &emptyStr,
+				UseOTLPHTTP:        &falseVal,
+			},
+			expectError: true,
+			errorContains: "jaeger endpoint http://jaeger:14268/api/traces is not supported; " +
+				"use an OTLP endpoint or stdout tracing instead",
+		},
 	}
 
 	for _, tc := range tests {
@@ -94,4 +113,43 @@ func TestNewTelemetry(t *testing.T) { //nolint:funlen // multiple test cases fun
 			}
 		})
 	}
+}
+
+func TestNewTelemetryDoesNotCountJaegerInExporterWarning(t *testing.T) {
+	testVersion := "1.0.0"
+	sampleRate := 1.0
+	jaegerEndpoint := "http://jaeger:14268/api/traces"
+	otlpEndpoint := "localhost:4317"
+	trueVal := true
+	falseVal := false
+
+	var warningFields map[string]string
+
+	originalLogFunc := logger.SetLogFunc(func(level uint, str map[string]string, err interface{}, msg string) {
+		if level == logger.LevelWarn && msg == "Multiple trace exporters configured, using highest priority exporter" {
+			warningFields = str
+		}
+	})
+	defer logger.SetLogFunc(originalLogFunc)
+
+	telemetry, err := tel.NewTelemetry(cfg.Config{
+		ServiceName:        "test-service",
+		ServiceVersion:     &testVersion,
+		TracingEnabled:     &trueVal,
+		StdoutTraceEnabled: &trueVal,
+		SamplingRate:       &sampleRate,
+		MetricsEnabled:     &falseVal,
+		JaegerEndpoint:     &jaegerEndpoint,
+		OTLPEndpoint:       &otlpEndpoint,
+		UseOTLPHTTP:        &falseVal,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, telemetry)
+	assert.Equal(t, "stdout, OTLP", warningFields["configured"])
+	assert.Equal(t, "stdout", warningFields["selected"])
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	assert.NoError(t, telemetry.Shutdown(ctx))
 }


### PR DESCRIPTION
## Summary
Reject unsupported Jaeger tracing endpoints instead of silently routing them through the OTLP exporter path.

Fixes #5799

## Changes
- Add the jaeger-endpoint flag to config parsing so usage gets a clear validation error.
- Keep stdout tracing as the highest-priority exporter when enabled.
- Stop treating Jaeger configuration as an OTLP fallback in telemetry exporter selection.
- Add regression coverage for config validation and telemetry setup.

## Steps to Test
1. Run `go test ./pkg/config ./pkg/telemetry` from `backend/`.
2. Run `npm run backend:lint`.
3. Run `npm run backend:format`.
4. Run `npm run backend:test`.

## Screenshots
N/A

## Notes for the Reviewer
This intentionally rejects Jaeger export instead of adding a Jaeger exporter dependency, because current telemetry export support is OTLP/stdout.