### PR TITLE
frontend: ObjectEventList: Fix Age column text clipping in details panel

### DIFF
--- a/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Default.stories.storyshot
@@ -34,7 +34,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Disabled.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/PodDebugSettings.Disabled.stories.storyshot
@@ -34,7 +34,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.Default.stories.storyshot
@@ -517,7 +517,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.DynamicCluster.stories.storyshot
@@ -562,7 +562,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.MultipleAllowedNamespaces.stories.storyshot
@@ -650,7 +650,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.NamespaceValidation.stories.storyshot
@@ -562,7 +562,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithAppearance.stories.storyshot
@@ -540,7 +540,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsCluster.WithSavedSettings.stories.storyshot
@@ -607,7 +607,7 @@
           >
             <p
               aria-label="Ephemeral debug containers cannot be removed via Kubernetes API. They will remain in the pod specification even after the terminal closes. To remove them, the pod must be recreated."
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               <span

--- a/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
+++ b/frontend/src/components/advancedSearch/__snapshots__/ResourceSearch.Default.stories.storyshot
@@ -551,7 +551,7 @@
             >
               <p
                 aria-label="2025-06-09T10:00:00.000Z"
-                class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                 data-mui-internal-clone-element="true"
               >
                 90d

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -202,16 +202,17 @@ export interface HoverInfoLabelProps {
 
 export function HoverInfoLabel(props: HoverInfoLabelProps) {
   const { label, hoverInfo, icon = null, iconProps = {}, labelProps, iconPosition = 'end' } = props;
+  const { sx: labelSx, ...restLabelProps } = labelProps || {};
   const labelFirst = iconPosition === 'end';
 
   return (
     <LightTooltip title={hoverInfo || ''}>
       <Typography
-        sx={{
-          display: 'inline-flex',
-          whiteSpace: 'nowrap',
-        }}
-        {...labelProps}
+        sx={[
+          { display: 'inline-flex', whiteSpace: 'nowrap' },
+          ...(Array.isArray(labelSx) ? labelSx : labelSx ? [labelSx] : []),
+        ]}
+        {...restLabelProps}
       >
         {labelFirst && label}
         {hoverInfo && (

--- a/frontend/src/components/common/ObjectEventList.stories.tsx
+++ b/frontend/src/components/common/ObjectEventList.stories.tsx
@@ -100,6 +100,32 @@ const mockEvents: KubeEvent[] = [
     count: 1,
     type: 'Normal',
   },
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event3.789',
+      namespace: 'default',
+      uid: 'event-uid-3',
+      creationTimestamp: new Date(getTestDate().getTime() - 60 * 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-for-events',
+      uid: 'owner-pod-uid-123',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'BackOff',
+    message: 'Back-off restarting failed container nginx in pod test-pod-for-events_default',
+    source: { component: 'kubelet' },
+    firstTimestamp: new Date(getTestDate().getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 60 * 60 * 1000).toISOString(),
+    count: 5,
+    type: 'Warning',
+  },
 ];
 
 export default {

--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -154,6 +154,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
                   label={label}
                   hoverInfo={localeDate(item.lastOccurrence)}
                   icon="mdi:calendar"
+                  labelProps={{ sx: { whiteSpace: 'normal', overflowWrap: 'anywhere' } }}
                 />
               );
             },

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceListView.OneHiddenColumn.stories.storyshot
@@ -467,7 +467,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -548,7 +548,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -629,7 +629,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -710,7 +710,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -791,7 +791,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NameSearch.stories.storyshot
@@ -403,7 +403,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.NoFilter.stories.storyshot
@@ -338,7 +338,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d
@@ -374,7 +374,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d
@@ -410,7 +410,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d
@@ -446,7 +446,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d

--- a/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/ResourceTable.WithHiddenCols.stories.storyshot
@@ -273,7 +273,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d
@@ -299,7 +299,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d
@@ -325,7 +325,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d
@@ -351,7 +351,7 @@
           >
             <p
               aria-label="2021-12-15T14:57:13.000Z"
-              class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
               data-mui-internal-clone-element="true"
             >
               90d

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -128,7 +128,7 @@
                 >
                   <p
                     aria-label="2024-02-14T23:55:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-i4elv1-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -172,10 +172,54 @@
                 >
                   <p
                     aria-label="2024-02-14T23:58:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-i4elv1-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
+                  </p>
+                </td>
+              </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  Warning
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  BackOff
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  kubelet
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <div
+                    class="MuiBox-root css-k008qs"
+                  >
+                    <span
+                      id="event-uid-3"
+                      style="word-break: break-all; white-space: normal;"
+                    >
+                      Back-off restarting failed container nginx in pod test-pod-for-events_default
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <p
+                    aria-label="2024-02-14T23:00:00.000Z"
+                    class="MuiTypography-root MuiTypography-body1 css-i4elv1-MuiTypography-root"
+                    data-mui-internal-clone-element="true"
+                  >
+                    90d (5 times since 90d)
                   </p>
                 </td>
               </tr>

--- a/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/configmap/__snapshots__/List.Items.stories.storyshot
@@ -628,7 +628,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -714,7 +714,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -1127,7 +1127,7 @@
                     >
                       <p
                         aria-label="2021-12-15T14:57:13.000Z"
-                        class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                        class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                         data-mui-internal-clone-element="true"
                       >
                         90d
@@ -1213,7 +1213,7 @@
                     >
                       <p
                         aria-label="2021-12-15T14:57:13.000Z"
-                        class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                        class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                         data-mui-internal-clone-element="true"
                       >
                         90d

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.List.stories.storyshot
@@ -645,7 +645,7 @@
               >
                 <p
                   aria-label="2021-12-15T14:57:13.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDetails.NoError.stories.storyshot
@@ -186,7 +186,7 @@
                   >
                     <p
                       aria-label="My description"
-                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                       data-mui-internal-clone-element="true"
                     >
                       mycustomresource

--- a/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceList.List.stories.storyshot
@@ -638,7 +638,7 @@
               >
                 <p
                   aria-label="2021-12-15T14:57:13.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -724,7 +724,7 @@
               >
                 <p
                   aria-label="2021-12-15T14:57:13.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryAst.stories.storyshot
@@ -217,7 +217,7 @@
                   >
                     <p
                       aria-label=""
-                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                       data-mui-internal-clone-element="true"
                     >
                       *

--- a/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/CronJobDetails.EveryMinute.stories.storyshot
@@ -217,7 +217,7 @@
                   >
                     <p
                       aria-label="Every minute"
-                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                       data-mui-internal-clone-element="true"
                     >
                       * * * * *

--- a/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/cronjob/__snapshots__/List.Items.stories.storyshot
@@ -898,7 +898,7 @@
               >
                 <p
                   aria-label="Every minute"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   * * * * *
@@ -944,7 +944,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1025,7 +1025,7 @@
               >
                 <p
                   aria-label=""
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   *
@@ -1071,7 +1071,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1152,7 +1152,7 @@
               >
                 <p
                   aria-label="Every hour"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   0 * * * *
@@ -1198,7 +1198,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1279,7 +1279,7 @@
               >
                 <p
                   aria-label="At 09:00 AM, Monday through Friday"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   0 9 * * 1-5
@@ -1325,7 +1325,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1406,7 +1406,7 @@
               >
                 <p
                   aria-label="At 12:00 AM, on the last day of the month"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   0 0 L * *
@@ -1452,7 +1452,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.DaemonSets.stories.storyshot
@@ -1015,7 +1015,7 @@
                 >
                   <p
                     aria-label="2023-05-02T04:34:53.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d

--- a/frontend/src/components/daemonset/__snapshots__/List.LongName.stories.storyshot
+++ b/frontend/src/components/daemonset/__snapshots__/List.LongName.stories.storyshot
@@ -1009,7 +1009,7 @@
                 >
                   <p
                     aria-label="2023-05-02T04:34:53.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -893,7 +893,7 @@
                 >
                   <p
                     aria-label="2025-02-03T09:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -1021,7 +1021,7 @@
                 >
                   <p
                     aria-label="2025-02-01T10:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -751,7 +751,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -625,7 +625,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTLSPolicyList.Items.stories.storyshot
@@ -700,7 +700,7 @@
               >
                 <p
                   aria-label="2025-06-16T09:18:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/BackendTrafficPolicyList.Items.stories.storyshot
@@ -700,7 +700,7 @@
               >
                 <p
                   aria-label="2025-07-24T12:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ClassList.Items.stories.storyshot
@@ -532,7 +532,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GRPCRouteList.Items.stories.storyshot
@@ -568,7 +568,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.Items.stories.storyshot
@@ -751,7 +751,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/HTTPRouteList.Items.stories.storyshot
@@ -694,7 +694,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -783,7 +783,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/ReferenceGrantList.Items.stories.storyshot
@@ -700,7 +700,7 @@
               >
                 <p
                   aria-label="2025-06-16T09:18:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPADetails.Default.stories.storyshot
@@ -457,7 +457,7 @@
                       >
                         <p
                           aria-label="2022-10-20T11:11:01.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -473,7 +473,7 @@
                       >
                         <p
                           aria-label="the HPA controller was able to get the target's current scale"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           SucceededGetScale
@@ -502,7 +502,7 @@
                       >
                         <p
                           aria-label="2022-10-26T12:53:22.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -518,7 +518,7 @@
                       >
                         <p
                           aria-label="the HPA was unable to compute the replica count: failed to get memory utilization: unable to get metrics for resource memory: no metrics returned from resource metrics API"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           FailedGetResourceMetric
@@ -547,7 +547,7 @@
                       >
                         <p
                           aria-label="2022-10-20T11:11:01.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -563,7 +563,7 @@
                       >
                         <p
                           aria-label="the desired count is within the acceptable range"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           DesiredWithinRange

--- a/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
+++ b/frontend/src/components/horizontalPodAutoscaler/__snapshots__/HPAList.Items.stories.storyshot
@@ -896,7 +896,7 @@
               >
                 <p
                   aria-label="2022-10-20T11:10:58.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/ClassList.Items.stories.storyshot
@@ -590,7 +590,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -674,7 +674,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/ingress/__snapshots__/List.Items.stories.storyshot
@@ -759,7 +759,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -865,7 +865,7 @@
               >
                 <p
                   aria-label="2023-07-19T09:48:42.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/JobList.Items.stories.storyshot
@@ -890,7 +890,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1018,7 +1018,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1146,7 +1146,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1274,7 +1274,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
+++ b/frontend/src/components/jobset/__snapshots__/JobSetList.Items.stories.storyshot
@@ -628,7 +628,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -714,7 +714,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -800,7 +800,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -886,7 +886,7 @@
               >
                 <p
                   aria-label="2020-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/Details.LeaseDetail.stories.storyshot
@@ -211,7 +211,7 @@
                   >
                     <p
                       aria-label="2021-03-01T00:00:00.000Z"
-                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                       data-mui-internal-clone-element="true"
                     >
                       90d

--- a/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/lease/__snapshots__/List.Items.stories.storyshot
@@ -628,7 +628,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/List.Items.stories.storyshot
@@ -568,7 +568,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
+++ b/frontend/src/components/namespace/__snapshots__/NamespaceList.Regular.stories.storyshot
@@ -536,7 +536,7 @@
               >
                 <p
                   aria-label="2024-08-16T11:12:37.179Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/networkpolicy/__snapshots__/List.Items.stories.storyshot
@@ -692,7 +692,7 @@
               >
                 <p
                   aria-label="2024-05-01T10:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -787,7 +787,7 @@
               >
                 <p
                   aria-label="2024-05-01T10:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/List.Nodes.stories.storyshot
@@ -903,7 +903,7 @@
                 >
                   <p
                     aria-label="2022-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -1020,7 +1020,7 @@
                 >
                   <p
                     aria-label="2022-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -1008,7 +1008,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1162,7 +1162,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1298,7 +1298,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1434,7 +1434,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1570,7 +1570,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1706,7 +1706,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1842,7 +1842,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1978,7 +1978,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
+++ b/frontend/src/components/podDisruptionBudget/__snapshots__/pdbList.Items.stories.storyshot
@@ -748,7 +748,7 @@
               >
                 <p
                   aria-label="2022-10-06T05:17:14.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
+++ b/frontend/src/components/priorityClass/__snapshots__/priorityClassList.Items.stories.storyshot
@@ -534,7 +534,7 @@
               >
                 <p
                   aria-label="2022-10-26T13:46:17.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
+++ b/frontend/src/components/replicaset/__snapshots__/List.ReplicaSets.stories.storyshot
@@ -965,7 +965,7 @@
                 >
                   <p
                     aria-label="2023-07-07T05:36:02.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -1105,7 +1105,7 @@
                 >
                   <p
                     aria-label="2023-05-25T05:15:05.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d

--- a/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
+++ b/frontend/src/components/resourceQuota/__snapshots__/resourceQuotaList.Items.stories.storyshot
@@ -712,7 +712,7 @@
               >
                 <p
                   aria-label="2022-10-25T11:48:48.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/runtimeClass/__snapshots__/List.Items.stories.storyshot
@@ -474,7 +474,7 @@
               >
                 <p
                   aria-label="2022-01-01T00:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
+++ b/frontend/src/components/secret/__snapshots__/List.Items.stories.storyshot
@@ -719,7 +719,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -810,7 +810,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.Items.stories.storyshot
@@ -886,7 +886,7 @@
               >
                 <p
                   aria-label="2022-10-25T11:48:48.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
+++ b/frontend/src/components/service/__snapshots__/ServiceList.WithOwnerAnnotation.stories.storyshot
@@ -946,7 +946,7 @@
               >
                 <p
                   aria-label="2022-10-26T10:30:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.Default.stories.storyshot
@@ -820,7 +820,7 @@
               >
                 <p
                   aria-label="2023-05-16T11:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -935,7 +935,7 @@ sidecar:2.1"
               >
                 <p
                   aria-label="2023-05-15T10:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.SingleItem.stories.storyshot
@@ -822,7 +822,7 @@ sidecar:2.1"
               >
                 <p
                   aria-label="2023-05-15T10:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
+++ b/frontend/src/components/statefulset/__snapshots__/List.WithNotReadyReplicas.stories.storyshot
@@ -822,7 +822,7 @@ sidecar:2.1"
               >
                 <p
                   aria-label="2023-05-15T10:00:00.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClaimList.Items.stories.storyshot
@@ -952,7 +952,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1078,7 +1078,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d
@@ -1195,7 +1195,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -712,7 +712,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -706,7 +706,7 @@
               >
                 <p
                   aria-label="2023-04-27T20:31:27.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPADetails.Default.stories.storyshot
@@ -506,7 +506,7 @@
                       >
                         <p
                           aria-label="2023-11-23T07:18:48.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d

--- a/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
+++ b/frontend/src/components/verticalPodAutoscaler/__snapshots__/VPAList.List.stories.storyshot
@@ -748,7 +748,7 @@
               >
                 <p
                   aria-label="2023-11-23T07:18:45.000Z"
-                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                   data-mui-internal-clone-element="true"
                 >
                   90d

--- a/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/MutatingWebhookConfigList.Items.stories.storyshot
@@ -477,7 +477,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -553,7 +553,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -629,7 +629,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -705,7 +705,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -781,7 +781,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -857,7 +857,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d

--- a/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
+++ b/frontend/src/components/webhookconfiguration/__snapshots__/ValidatingWebhookConfigList.Items.stories.storyshot
@@ -477,7 +477,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -553,7 +553,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -629,7 +629,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -705,7 +705,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -781,7 +781,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d
@@ -857,7 +857,7 @@
                 >
                   <p
                     aria-label="2020-01-01T00:00:00.000Z"
-                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                     data-mui-internal-clone-element="true"
                   >
                     90d

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1698,7 +1698,7 @@
                       >
                         <p
                           aria-label="2025-05-20T12:00:00.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -1789,7 +1789,7 @@
                       >
                         <p
                           aria-label="2025-05-20T09:30:00.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -1880,7 +1880,7 @@
                       >
                         <p
                           aria-label="2025-05-20T09:00:00.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -1971,7 +1971,7 @@
                       >
                         <p
                           aria-label="2025-05-20T08:00:00.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -2062,7 +2062,7 @@
                       >
                         <p
                           aria-label="2025-05-20T07:00:00.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d
@@ -2153,7 +2153,7 @@
                       >
                         <p
                           aria-label="2025-05-20T06:00:00.000Z"
-                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body1 css-1t59wre-MuiTypography-root"
                           data-mui-internal-clone-element="true"
                         >
                           90d


### PR DESCRIPTION
The age column in the events table was getting clipped inside the details panel because `HoverInfoLabel` forces `whiteSpace: nowrap` on its label. In a narrow panel like the right side drawer so this causes the age text to overflow and get cut off.

Fixes #5729

After fix it looks like

<img width="3024" height="1712" alt="image" src="https://github.com/user-attachments/assets/50e62204-c973-42c3-bcf5-3f7606bfd755" />
