### PR TITLE
backend: helm: Mark failed install verification

### DIFF
--- a/backend/pkg/helm/release.go
+++ b/backend/pkg/helm/release.go
@@ -682,25 +682,25 @@ func (h *Handler) getChart(
 	return chart, nil
 }
 
-// Verify the user has minimal privileges by performing a whoami check.
+// VerifyUser checks that the user has minimal privileges by performing a whoami check.
 // This prevents spurious downloads by ensuring basic authentication before proceeding.
-func VerifyUser(actionConfig *action.Configuration, req InstallRequest) bool {
+func VerifyUser(actionConfig *action.Configuration, req InstallRequest) error {
 	restConfig, err := actionConfig.RESTClientGetter.ToRESTConfig()
 	if err != nil {
 		logger.Log(logger.LevelError,
 			map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
-			err, "getting chart")
+			err, "verifying user")
 
-		return false
+		return err
 	}
 
 	cs, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		logger.Log(logger.LevelError,
 			map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
-			err, "getting chart")
+			err, "verifying user")
 
-		return false
+		return err
 	}
 
 	review, err := cs.AuthenticationV1().SelfSubjectReviews().Create(context.Background(),
@@ -708,19 +708,20 @@ func VerifyUser(actionConfig *action.Configuration, req InstallRequest) bool {
 	if err != nil {
 		logger.Log(logger.LevelError,
 			map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
-			err, "getting chart")
+			err, "verifying user")
 
-		return false
+		return err
 	}
 
 	if user := review.Status.UserInfo.Username; user == "" || user == "system:anonymous" {
+		err := errors.New("user is not authorized to perform this operation")
 		logger.Log(logger.LevelError, map[string]string{logFieldChart: req.Chart, logFieldReleaseName: req.Name},
-			errors.New("insufficient privileges"), "getting chart: user is not authorized to perform this operation")
+			err, "user verification failed")
 
-		return false
+		return err
 	}
 
-	return true
+	return nil
 }
 
 func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Configuration) {
@@ -731,7 +732,8 @@ func (h *Handler) installRelease(req InstallRequest, actionConfig *action.Config
 	installClient.CreateNamespace = req.CreateNamespace
 	installClient.Version = req.Version
 
-	if !VerifyUser(actionConfig, req) {
+	if err := VerifyUser(actionConfig, req); err != nil {
+		h.setReleaseStatusSilent("install", req.Name, failed, err)
 		return
 	}
 

--- a/backend/pkg/helm/release_internal_test.go
+++ b/backend/pkg/helm/release_internal_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,7 +14,32 @@ import (
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
+
+type failingRESTGetter struct{}
+
+var _ genericclioptions.RESTClientGetter = (*failingRESTGetter)(nil)
+
+func (f *failingRESTGetter) ToRESTConfig() (*rest.Config, error) {
+	return nil, errors.New("rest config failed")
+}
+
+func (f *failingRESTGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return nil, nil
+}
+
+func (f *failingRESTGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return nil, nil
+}
+
+func (f *failingRESTGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return nil
+}
 
 func TestGetActionStatus_NilErr(t *testing.T) {
 	h := &Handler{
@@ -73,4 +99,31 @@ func TestGetChart_InvalidType(t *testing.T) {
 	assert.Equal(t, "failed", statusMap.Status)
 	assert.NotNil(t, statusMap.Err)
 	assert.Contains(t, *statusMap.Err, "chart type \"library\" is not installable")
+}
+
+func TestInstallRelease_VerifyUserFailureSetsFailedStatus(t *testing.T) {
+	h := &Handler{
+		Cache:       cache.New[interface{}](),
+		EnvSettings: cli.New(),
+	}
+	actionConfig := &action.Configuration{
+		RESTClientGetter: &failingRESTGetter{},
+	}
+	req := InstallRequest{
+		CommonInstallUpdateRequest: CommonInstallUpdateRequest{
+			Name:      "test-release",
+			Namespace: "default",
+			Chart:     "test-repo/test-chart",
+		},
+	}
+
+	require.NoError(t, h.setReleaseStatus("install", req.Name, processing, nil))
+
+	h.installRelease(req, actionConfig)
+
+	status, err := h.getReleaseStatus("install", req.Name)
+	require.NoError(t, err)
+	assert.Equal(t, failed, status.Status)
+	require.NotNil(t, status.Err)
+	assert.Contains(t, *status.Err, "rest config failed")
 }

--- a/backend/pkg/helm/release_test.go
+++ b/backend/pkg/helm/release_test.go
@@ -337,8 +337,12 @@ func TestVerifyUser(t *testing.T) {
 				}
 			}
 
-			result := helm.VerifyUser(actionConfig, tt.req)
-			assert.Equal(t, result, tt.wantResult)
+			err = helm.VerifyUser(actionConfig, tt.req)
+			if tt.wantResult {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
 ## Summary

  This PR fixes a Helm install status bug where failed user verification could leave the install action stuck in processing.

  ## Related Issue

  Fixes #5839

  ## Changes

  - Updated VerifyUser to return an error instead of only a boolean, so the failure reason is preserved.
  - Updated installRelease to mark the install action as failed when user verification fails.
  - Added regression coverage for the verification failure path to ensure install status no longer remains processing.

  ## Steps to Test

  1. Run go test ./pkg/helm from the backend directory.
  2. Run npm run backend:format.
  3. Run npm run backend:test.
  4. Confirm Helm install verification failures now cache a failed action status with an error reason.

  ## Screenshots (if applicable)

  N/A. 

  ## Notes for the Reviewer

  This change is intentionally scoped to the Helm install verification path. It does not change Helm execution behavior after verification succeeds.