### PR TITLE
frontend: fix react-hooks/rules-of-hooks in RestartButton

### DIFF
--- a/frontend/src/components/common/Resource/RestartButton.tsx
+++ b/frontend/src/components/common/Resource/RestartButton.tsx
@@ -46,21 +46,16 @@ interface RestartButtonProps {
 }
 
 export function RestartButton(props: RestartButtonProps) {
-  const dispatch: AppDispatch = useDispatch();
   const { item, buttonStyle, afterConfirm } = props;
+  const dispatch: AppDispatch = useDispatch();
+  const [openDialog, setOpenDialog] = useState(false);
+  const location = useLocation();
+  const { t } = useTranslation(['translation']);
+  const dispatchRestartEvent = useEventCallback(HeadlampEventType.RESTART_RESOURCE);
 
   if (!item || !isRestartableResource(item)) {
     return null;
   }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const [openDialog, setOpenDialog] = useState(false);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const location = useLocation();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { t } = useTranslation(['translation']);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const dispatchRestartEvent = useEventCallback(HeadlampEventType.RESTART_RESOURCE);
 
   async function restartResource() {
     const patchData = {


### PR DESCRIPTION
## Summary

`RestartButton` calls `useState`, `useLocation`, `useTranslation`, and `useEventCallback` after an early `return null` guard. This violates `react-hooks/rules-of-hooks` — hooks must be invoked in the same order on every render. The violation was previously masked with four `eslint-disable-next-line` suppressions.

This PR moves all hook calls above the early-return guard and removes the four suppressions.

## Related Issue

Fixes #5190
Refs #5183

## Changes

- Moved `useState`, `useLocation`, `useTranslation`, and `useEventCallback` calls above the `if (!item || !isRestartableResource(item)) return null;` guard
- Removed four `// eslint-disable-next-line react-hooks/rules-of-hooks` comments
- No behavioral change — the early return still fires for invalid items; only the call order is corrected

## Steps to Test

1. `npx eslint frontend/src/components/common/Resource/RestartButton.tsx` — passes with no warnings
2. Render a `RestartButton` for a `Deployment` / `StatefulSet` / `DaemonSet` — confirm restart confirmation dialog still opens and the patch is dispatched
3. Render `RestartButton` for a `Pod` (non-restartable) — confirm component renders nothing

## Notes for the Reviewer

The hooks now run for every prop combination (including unrestartable items). They have no side effects on the early-return path — `useState` is just initial state, `useLocation`/`useTranslation` are read-only, and `useEventCallback` registers a callback that is never invoked when the component returns null.

/kind cleanup
/kind bug
