### PR TITLE
frontend: fix react-hooks/rules-of-hooks in AuthVisible

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -56,22 +56,17 @@ export interface AuthVisibleProps extends React.PropsWithChildren<{}> {
 export default function AuthVisible(props: AuthVisibleProps) {
   const { item, authVerb, subresource, namespace, onError, onAuthResult, children } = props;
 
-  if (!VALID_AUTH_VERBS.includes(authVerb)) {
-    console.warn(`Invalid authVerb provided: "${authVerb}". Skipping authorization check.`);
-    return null;
-  }
-
+  const isValidVerb = VALID_AUTH_VERBS.includes(authVerb);
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { data } = useQuery<any>({
-    enabled: !!item,
+    enabled: !!item && isValidVerb,
     queryKey: [
       'authVisible',
       itemName,
-      itemClass.apiName,
-      itemClass.apiVersion,
+      itemClass?.apiName,
+      itemClass?.apiVersion,
       authVerb,
       subresource,
       namespace,
@@ -92,7 +87,6 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const visible = data?.status?.allowed ?? false;
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (data) {
       onAuthResult?.({
@@ -102,6 +96,11 @@ export default function AuthVisible(props: AuthVisibleProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
+
+  if (!isValidVerb) {
+    console.warn(`Invalid authVerb provided: "${authVerb}". Skipping authorization check.`);
+    return null;
+  }
 
   if (!visible) {
     return null;


### PR DESCRIPTION
## Summary

`AuthVisible` calls `useQuery` and `useEffect` after an early `return null` guard for invalid `authVerb`. This violates `react-hooks/rules-of-hooks`. It also has a latent crash: `itemClass.apiName` is read inside the `queryKey` even when `item` is null, in which case `itemClass` is null too.

This PR:
- Moves `useQuery` and `useEffect` above the early-return guard
- Gates the query with both `!!item` AND the new `isValidVerb` flag via the `enabled` option, so no request fires when the verb is invalid
- Uses optional chaining on `itemClass?.apiName` / `itemClass?.apiVersion` to avoid the latent null-deref in `queryKey`
- Removes two `eslint-disable-next-line react-hooks/rules-of-hooks` suppressions (keeps the `exhaustive-deps` suppression on `useEffect` since that was an existing, intentional choice)

## Related Issue

Fixes #5187
Refs #5183

## Changes

- Reorder: hooks now run before any early returns
- Add `isValidVerb` boolean computed once at top
- Pass `enabled: !!item && isValidVerb` to `useQuery`
- Use optional chaining on `itemClass` in `queryKey`

## Steps to Test

1. `npx eslint frontend/src/components/common/Resource/AuthVisible.tsx` — passes with no warnings
2. Render `<AuthVisible item={pod} authVerb="get">` — confirm children render when allowed, hide when not allowed
3. Render `<AuthVisible item={pod} authVerb="bogus">` — confirm `console.warn` fires and children are hidden, and **no** SubjectAccessReview is sent (check Network tab)
4. Render `<AuthVisible item={null} authVerb="get">` — confirm no crash and no request fired

## Notes for the Reviewer

The behavior change for invalid `authVerb`: previously the early return ran *before* `useQuery` was even constructed, so no SubjectAccessReview was sent. Now `useQuery` is constructed but its `enabled` flag is false, so still no request is sent. End user behavior is identical; rendered output is identical. Just the hook call order is now correct.

The optional-chaining on `itemClass` is a defensive fix for a latent bug — when `item` is null, `itemClass` is also null, and the previous code would throw on `itemClass.apiName`. This was only unreachable in practice because callers seem to always pass a non-null item, but optional chaining is safer.

/kind cleanup
/kind bug
