### PR TITLE
frontend: Export ApiError from K8s package for plugin access

### DIFF
--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -488,3 +488,4 @@ export * as serviceAccount from './serviceAccount';
 export * as statefulSet from './statefulSet';
 export * as storageClass from './storageClass';
 export * as volumeAttributesClass from './volumeAttributesClass';
+export { ApiError } from './api/v2/ApiError';

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -346,6 +346,7 @@
   "Headlamp": [Function],
   "Iconify": "Present",
   "K8s": {
+    "ApiError": [Function],
     "ResourceClasses": {
       "ClusterRole": [Function],
       "ClusterRoleBinding": [Function],

--- a/plugins/headlamp-plugin/config/vite.config.mjs
+++ b/plugins/headlamp-plugin/config/vite.config.mjs
@@ -34,6 +34,7 @@ const externalModules = {
   '@kinvolk/headlamp-plugin/lib/Router': 'pluginLib.Router',
   '@kinvolk/headlamp-plugin/lib/Utils': 'pluginLib.Utils',
   '@kinvolk/headlamp-plugin/lib/Notification': 'pluginLib.Notification',
+  '@kinvolk/headlamp-plugin/lib/k8s/api/v2/ApiError': 'pluginLib.K8s',
   // We also point k8s (lowercase) to it, since users may use it instead as it's closer to
   // how it's used in Headlamp's source code.
   '@kinvolk/headlamp-plugin/lib/k8s': 'pluginLib.K8s',


### PR DESCRIPTION
## Problem
The Flux plugin crashed on the Canaries page with:
`Cannot read properties of undefined (reading 'ApiError')`

`ApiError` was not exported from the core K8s package, making it
unavailable on `window.pluginLib.K8s` at runtime.

## Solution
- Export `ApiError` from `frontend/src/lib/k8s/index.ts`
- Add explicit Vite external mapping in `vite.config.mjs`

## Testing
- ✅ 1,554 tests passing
- ✅ `npm run frontend:lint` — No issues
- ✅ `npm run frontend:tsc` — No issues

Fixes #5821