### PR TITLE
backend: Config: Add a testcase for Headlamp kubeconfig paths.

### DIFF
--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -916,12 +915,15 @@ func TestValidateTracing(t *testing.T) {
 
 func TestMakeHeadlampKubeConfigsDir(t *testing.T) {
 	tmpDir := t.TempDir()
+	expectedDir := filepath.Join(tmpDir, "Headlamp", "kubeconfigs")
 
 	switch runtime.GOOS {
 	case "windows":
 		t.Setenv("APPDATA", tmpDir)
+		expectedDir = filepath.Join(tmpDir, "Headlamp", "Config", "kubeconfigs")
 	case "darwin":
 		t.Setenv("HOME", tmpDir)
+		expectedDir = filepath.Join(tmpDir, "Library", "Application Support", "Headlamp", "kubeconfigs")
 	default:
 		t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	}
@@ -933,17 +935,20 @@ func TestMakeHeadlampKubeConfigsDir(t *testing.T) {
 	info, err := os.Stat(dir)
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
-	assert.True(t, strings.HasPrefix(dir, tmpDir))
+	assert.Equal(t, expectedDir, dir)
 }
 
 func TestDefaultHeadlampKubeConfigFile(t *testing.T) {
 	tmpDir := t.TempDir()
+	expectedDir := filepath.Join(tmpDir, "Headlamp", "kubeconfigs")
 
 	switch runtime.GOOS {
 	case "windows":
 		t.Setenv("APPDATA", tmpDir)
+		expectedDir = filepath.Join(tmpDir, "Headlamp", "Config", "kubeconfigs")
 	case "darwin":
 		t.Setenv("HOME", tmpDir)
+		expectedDir = filepath.Join(tmpDir, "Library", "Application Support", "Headlamp", "kubeconfigs")
 	default:
 		t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	}
@@ -952,7 +957,7 @@ func TestDefaultHeadlampKubeConfigFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, path)
 	assert.Equal(t, "config", filepath.Base(path))
-	assert.True(t, strings.HasPrefix(path, tmpDir))
+	assert.Equal(t, filepath.Join(expectedDir, "config"), path)
 
 	info, err := os.Stat(filepath.Dir(path))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
This PR adds a regression test for the Headlamp kubeconfig path behavior so the OS-specific directory layout and final config file path are covered explicitly

## Related Issue
#NAN

## Changes
- Added coverage for `MakeHeadlampKubeConfigsDir` to verify the Headlamp-specific kubeconfig directory shape
- Included Windows-specific path expectations alongside the non-Windows layout

## Steps to Test
1. Run the backend config tests
2. Confirm the new kubeconfig path tests pass on the current platform

## Notes for the Reviewer
- This is a test-only change