### PR TITLE
backend: Stop cluster delete after kubeconfig removal error

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2391,7 +2391,9 @@ func (c *HeadlampConfig) deleteCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.handleDeleteCluster(w, r, ctx, span, name)
+	if !c.handleDeleteCluster(w, r, ctx, span, name) {
+		return
+	}
 
 	c.getConfig(w, r)
 }
@@ -2403,15 +2405,16 @@ func (c *HeadlampConfig) handleDeleteCluster(
 	ctx context.Context,
 	span trace.Span,
 	name string,
-) {
+) bool {
 	removeKubeConfig := r.URL.Query().Get("removeKubeConfig") == "true"
 	if removeKubeConfig {
-		c.handleRemoveKubeConfig(w, r, ctx, span, name)
-		return
+		return c.handleRemoveKubeConfig(w, r, ctx, span, name)
 	}
 
 	logger.Log(logger.LevelInfo, map[string]string{logFieldCluster: name, "proxy": name},
 		nil, "removed cluster successfully")
+
+	return true
 }
 
 // handleRemoveKubeConfig removes the cluster from the kubeconfig file.
@@ -2421,7 +2424,7 @@ func (c *HeadlampConfig) handleRemoveKubeConfig(
 	ctx context.Context,
 	span trace.Span,
 	name string,
-) {
+) bool {
 	configPath := r.URL.Query().Get("configPath")
 	originalName := r.URL.Query().Get("originalName")
 	clusterID := r.URL.Query().Get("clusterID")
@@ -2436,7 +2439,10 @@ func (c *HeadlampConfig) handleRemoveKubeConfig(
 
 	if err := kubeconfig.RemoveContextFromFile(configName, configPath); err != nil {
 		c.handleError(w, ctx, span, err, "failed to remove cluster from kubeconfig", http.StatusInternalServerError)
+		return false
 	}
+
+	return true
 }
 
 // Get path of kubeconfig we load headlamp with from source.

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -387,9 +387,7 @@ func TestDynamicClusters(t *testing.T) {
 }
 
 func TestDynamicClustersKubeConfig(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("APPDATA", t.TempDir())
+	useTempHeadlampConfigHome(t)
 
 	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")
 	require.NoError(t, err)
@@ -441,6 +439,49 @@ func TestDynamicClustersKubeConfig(t *testing.T) {
 		assert.Equal(t, minikubeName, minikubeCluster.Name)
 		assert.Equal(t, "default", minikubeCluster.Metadata["namespace"])
 	}
+}
+
+func TestDeleteClusterRemoveKubeConfigStopsOnFileError(t *testing.T) {
+	useTempHeadlampConfigHome(t)
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	require.NoError(t, kubeConfigStore.AddContext(&kubeconfig.Context{
+		Name:        "test-cluster",
+		KubeContext: &api.Context{Cluster: "test-cluster", AuthInfo: "test-user"},
+		Cluster:     &api.Cluster{Server: "https://test-cluster.example.com"},
+		AuthInfo:    &api.AuthInfo{},
+		Source:      kubeconfig.DynamicCluster,
+	}))
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+	handler := createHeadlampHandler(context.Background(), c)
+
+	query := url.Values{}
+	query.Set("removeKubeConfig", "true")
+	query.Set("configPath", filepath.Join(t.TempDir(), "missing-kubeconfig"))
+
+	resp, err := getResponseFromRestrictedEndpoint(
+		handler,
+		http.MethodDelete,
+		"/cluster/test-cluster?"+query.Encode(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Contains(t, resp.Body.String(), "does not exist")
+	assert.NotContains(t, resp.Body.String(), "\"clusters\"")
 }
 
 func TestGetClustersClusterInventorySource(t *testing.T) {
@@ -3104,6 +3145,30 @@ func setEnvForTest(t *testing.T, key, value string) func() {
 		} else {
 			_ = os.Unsetenv(key)
 		}
+	}
+}
+
+func useTempHeadlampConfigHome(t *testing.T) {
+	t.Helper()
+
+	tempConfigHome := filepath.Join(t.TempDir(), "config-home")
+	t.Setenv("HOME", tempConfigHome)
+	t.Setenv("XDG_CONFIG_HOME", tempConfigHome)
+	t.Setenv("APPDATA", tempConfigHome)
+
+	switch runtime.GOOS {
+	case "darwin":
+		require.NoError(t, os.MkdirAll(
+			filepath.Join(tempConfigHome, "Library", "Application Support", "Headlamp", "kubeconfigs"),
+			0o750,
+		))
+	case "windows":
+		require.NoError(t, os.MkdirAll(
+			filepath.Join(tempConfigHome, "Headlamp", "Config", "kubeconfigs"),
+			0o750,
+		))
+	default:
+		require.NoError(t, os.MkdirAll(filepath.Join(tempConfigHome, "Headlamp", "kubeconfigs"), 0o750))
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR fixes `deleteCluster` so it stops after kubeconfig removal fails instead of writing an error response and then continuing to write the config response.

## Related Issue

Fixes #5846

## Changes

- Updated cluster deletion helpers to report whether kubeconfig removal succeeded.
- Return early from `deleteCluster` when `RemoveContextFromFile` writes an error response.
- Added a regression test for `DELETE /cluster/{name}?removeKubeConfig=true` with a missing kubeconfig path.

## Steps to Test

1. Run `env GOCACHE=/Users/apple/headlamp/.gocache GOMODCACHE=/Users/apple/headlamp/.gomodcache go test ./cmd -run TestDeleteClusterRemoveKubeConfigStopsOnFileError -count=1` from `backend/`.
2. Confirm the test passes.

## Screenshots (if applicable)

N/A, backend-only change.

## Notes for the Reviewer

- Targeted regression test passed locally.
- Full `npm run backend:test` was not run locally.
