### PR TITLE
frontend: KubeObject: guard against undefined name in getDetailsLink

### DIFF
--- a/frontend/src/components/common/Link.tsx
+++ b/frontend/src/components/common/Link.tsx
@@ -15,6 +15,7 @@
  */
 
 import MuiLink from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
 import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
@@ -66,6 +67,16 @@ function KubeObjectLink(props: {
   const { namespace, name } = kubeObject.metadata;
   const { endpoint } = useEndpoints(kubeObject._class().apiEndpoint.apiInfo, kubeObject.cluster);
 
+  const detailsLink = kubeObject.getDetailsLink();
+
+  if (!detailsLink) {
+    return (
+      <Typography component="span" {...otherProps}>
+        {props.children || kubeObject!.getName()}
+      </Typography>
+    );
+  }
+
   return (
     <MuiLink
       onClick={e => {
@@ -75,10 +86,7 @@ function KubeObjectLink(props: {
           namespace,
           name,
         });
-        // prepopulate the query cache with existing object
         client.setQueryData(key, kubeObject);
-        // and invalidate it (mark as stale)
-        // so that the latest version will be downloaded in the background
         client.invalidateQueries({ queryKey: key });
 
         if (onClick) {
@@ -87,7 +95,7 @@ function KubeObjectLink(props: {
         }
       }}
       component={RouterLink}
-      to={kubeObject.getDetailsLink()}
+      to={detailsLink}
       {...otherProps}
     >
       {props.children || kubeObject!.getName()}

--- a/frontend/src/components/common/Resource/RollbackButton.tsx
+++ b/frontend/src/components/common/Resource/RollbackButton.tsx
@@ -102,7 +102,7 @@ export function RollbackButton(props: RollbackButtonProps) {
 
   function handleConfirm(toRevision?: number) {
     const itemName = rollbackResource.metadata.name;
-
+    const detailsLink = rollbackResource.getDetailsLink();
     dispatch(
       clusterAction(() => performRollback(toRevision), {
         startMessage: t('Rolling back {{ itemName }} to previous version…', { itemName }),
@@ -110,8 +110,8 @@ export function RollbackButton(props: RollbackButtonProps) {
         successMessage: t('Rolled back {{ itemName }} to previous version.', { itemName }),
         errorMessage: t('Failed to rollback {{ itemName }}.', { itemName }),
         cancelUrl: location.pathname,
-        startUrl: rollbackResource.getDetailsLink(),
-        errorUrl: rollbackResource.getDetailsLink(),
+        startUrl: detailsLink ?? undefined,
+        errorUrl: detailsLink ?? undefined,
       })
     );
 

--- a/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
+++ b/frontend/src/components/endpointSlices/__snapshots__/EndpointSliceList.Items.stories.storyshot
@@ -711,9 +711,8 @@
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                  href="/"
+                <span
+                  class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
                 />
               </td>
               <td

--- a/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
+++ b/frontend/src/components/endpoints/__snapshots__/EndpointList.Items.stories.storyshot
@@ -601,9 +601,8 @@
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
               >
-                <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                  href="/"
+                <span
+                  class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
                 />
               </td>
               <td

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -181,14 +181,16 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     return this.jsonData.kind;
   }
 
-  getDetailsLink() {
+  getDetailsLink(): string | null {
+    const name = this.getName();
+    if (!name) {
+      return null;
+    }
     const selectedClusters = getSelectedClusters();
-
     const cluster = formatClusterPathParam(selectedClusters, this.cluster);
-
     const params = {
       namespace: this.getNamespace(),
-      name: this.getName(),
+      name,
       cluster,
     };
     const link = createRouteURL(this.detailsRoute, params);


### PR DESCRIPTION
When a Kubernetes resource has no metadata.name (which can happen
with newer event APIs), getDetailsLink() would pass undefined to
createRouteURL causing a TypeError crash.

Guard against this by returning null from getDetailsLink() when name
is missing, and handle the null case in KubeObjectLink by rendering
a plain span instead of a clickable link.

Fixes #5791