### PR TITLE
docs: update build system references and document vitest testing setup

### DIFF
--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -30,8 +30,10 @@ Once built, it can be run in development mode (auto-refresh) using:
 npm run frontend:start
 ```
 
-This command leverages the `create-react-app`'s start script that launches
-a development server for the frontend (by default at `localhost:3000`).
+This command leverages **Vite** to launch the development server for the frontend (by default at `localhost:3000`).
+
+> [!NOTE]
+> Headlamp has migrated to **Vite** as its default bundler and development server, and also supports **Rsbuild** as an alternative dev server and bundler option. To run Rsbuild, use `cd frontend && npm run star`. Here, `star` is the actual script name in `frontend/` and is not a typo for `start`.
 
 We use [react-query](https://tanstack.com/query/latest/docs/framework/react/overview) 
 for network request, if you need the devtools for react-query, you can simply set `REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS=true` in the `.env` file.
@@ -53,6 +55,16 @@ cd frontend && npm run ci-lint
 ```
 
 You can run `ci-lint` locally before pushing to catch any react-hooks violations that CI would flag.
+
+## Testing
+
+For running the frontend unit and component tests, Headlamp uses **Vitest**:
+
+```bash
+npm run frontend:test
+```
+
+This runs Vitest and reports the test coverage. You can append options as needed (e.g., `-- --run` to run once without watch mode).
 
 ## API documentation
 


### PR DESCRIPTION
## Summary

This PR updates the development documentation to reflect the frontend build system migration from Create React App to Vite/Rsbuild, and documents the previously missing testing workflow.

## Related Issue

This is a standalone documentation improvement discovered while setting up the local development environment. It does not have a pre-existing open tracking issue.

## Changes

- **Updated:** `docs/development/frontend.md` to change outdated references regarding `create-react-app` scripts to Vite and Rsbuild.
- **Added:** A new `## Testing` section in `docs/development/frontend.md` detailing the use of Vitest for running unit and component tests locally.

## Steps to Test

1. Open `docs/development/frontend.md` in a Markdown viewer or locally.
2. Verify that the explanation for launching the development server accurately points to Vite and Rsbuild.
3. Verify that the new testing section clearly outlines how to execute the test suite using `npm run frontend:test`.

## Notes for the Reviewer

The adjustments are entirely localized to a Markdown guide. Local unit tests were executed successfully using `npm run frontend:test -- --run` to verify workspace health.