### PR TITLE
frontend: guard event source field against undefined in ObjectEventList

### DIFF
--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -119,7 +119,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
           {
             label: t('From'),
             getter: item => {
-              return item.source.component;
+              return item.source?.component ?? '';
             },
           },
           {

--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -130,7 +130,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
           {
             label: t('From'),
             getter: item => {
-              return item.source.component;
+              return item.source?.component ?? '';
             },
           },
           {

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEventsNoSource.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEventsNoSource.stories.storyshot
@@ -1,0 +1,53 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+            >
+              Events
+            </h2>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          aria-atomic="true"
+          aria-live="polite"
+          class="MuiBox-root css-ty8jgw"
+          role="status"
+        >
+          No data to be shown.
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-19midj6"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+            >
+              No data to be shown.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary:
Fixes a TypeError crash in the Events table when `event.source` is absent. Kubernetes omits this field on newer event API responses.


## Related Issue:
Fixes #5823


## Changes:
- Guard `item.source.component` with optional chaining (`item.source?.component ?? ''`) in ObjectEventList

## Steps to Test:
1. Open a resource detail page (e.g. a Pod) on a cluster using the newer Event API
2. Check the Events table renders without crashing
3. Confirm the "From" column shows empty instead of throwing a TypeError

## Screenshots: 
N/A