### PR TITLE
frontend: useKubeObjectList: Use Set for O(1) watched-list lookup

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -124,6 +124,15 @@ export function kubeObjectListQuery<K extends KubeObject>(
 }
 
 /**
+ * Returns a stable string key for a (cluster, namespace) pair.
+ * Used to build Sets and Maps for O(1) membership checks across the
+ * watch-list reconciliation logic.
+ */
+function watchKey(cluster: string, namespace: string | undefined): string {
+  return `${cluster}:${namespace || ''}`;
+}
+
+/**
  * Accepts a list of lists to watch.
  * Upon receiving update it will modify query data for list query
  */
@@ -204,7 +213,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
     }
 
     return lists.map(list => {
-      const key = `${list.cluster}:${list.namespace || ''}`;
+      const key = watchKey(list.cluster, list.namespace);
 
       // Always use the latest resource version from the server
       latestResourceVersions.current[key] = list.resourceVersion;
@@ -230,7 +239,7 @@ function useWatchKubeObjectListsMultiplexed<K extends KubeObject>({
         return;
       }
 
-      const key = `${cluster}:${namespace || ''}`;
+      const key = watchKey(cluster, namespace);
 
       // Update resource version from incoming message
       if (update.object?.metadata?.resourceVersion) {
@@ -515,31 +524,39 @@ export function useKubeObjectList<K extends KubeObject>({
   >([]);
 
   const currentlyWatchedKeys = useMemo(
-    () => new Set(listsToWatch.map(w => `${w.cluster}:${w.namespace || ''}`)),
+    () => new Set(listsToWatch.map(w => watchKey(w.cluster, w.namespace))),
     [listsToWatch]
   );
 
   const listsNotYetWatched = query.data
-    .filter(Boolean)
-    .filter(data => !currentlyWatchedKeys.has(`${data!.cluster}:${data!.namespace || ''}`))
+    .filter((data): data is ListResponse<K> => data !== null && data !== undefined)
+    .filter(data => !currentlyWatchedKeys.has(watchKey(data.cluster, data.namespace)))
     .map(data => ({
-      cluster: data!.cluster,
-      namespace: data!.namespace,
-      resourceVersion: data!.list.metadata.resourceVersion,
+      cluster: data.cluster,
+      namespace: data.namespace,
+      resourceVersion: data.list.metadata.resourceVersion,
     }));
 
   if (listsNotYetWatched.length > 0) {
     setListsToWatch([...listsToWatch, ...listsNotYetWatched]);
   }
 
+  // Build a Set of (cluster, namespace) keys that are still requested so the
+  // stop-watching check is O(1) instead of a nested find/includes scan.
+  const requestedKeys = useMemo(
+    () =>
+      new Set(
+        requests.flatMap(request =>
+          request.namespaces?.length
+            ? request.namespaces.map(ns => watchKey(request.cluster, ns))
+            : [watchKey(request.cluster, undefined)]
+        )
+      ),
+    [requests]
+  );
+
   const listsToStopWatching = listsToWatch.filter(
-    watching =>
-      requests.find(request => {
-        if (watching.cluster !== request?.cluster) return false;
-        return !request.namespaces?.length
-          ? !watching.namespace
-          : !!watching.namespace && request.namespaces.includes(watching.namespace);
-      }) === undefined
+    watching => !requestedKeys.has(watchKey(watching.cluster, watching.namespace))
   );
 
   if (listsToStopWatching.length > 0) {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -514,15 +514,14 @@ export function useKubeObjectList<K extends KubeObject>({
     { cluster: string; namespace?: string; resourceVersion: string }[]
   >([]);
 
+  const currentlyWatchedKeys = useMemo(
+    () => new Set(listsToWatch.map(w => `${w.cluster}:${w.namespace || ''}`)),
+    [listsToWatch]
+  );
+
   const listsNotYetWatched = query.data
     .filter(Boolean)
-    .filter(
-      data =>
-        listsToWatch.find(
-          // resourceVersion is intentionally omitted to avoid recreating WS connection when list is updated
-          watching => watching.cluster === data?.cluster && watching.namespace === data.namespace
-        ) === undefined
-    )
+    .filter(data => !currentlyWatchedKeys.has(`${data!.cluster}:${data!.namespace || ''}`))
     .map(data => ({
       cluster: data!.cluster,
       namespace: data!.namespace,

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -541,22 +541,14 @@ export function useKubeObjectList<K extends KubeObject>({
     setListsToWatch([...listsToWatch, ...listsNotYetWatched]);
   }
 
-  // Build a Set of (cluster, namespace) keys that are still requested so the
-  // stop-watching check is O(1) instead of a nested find/includes scan.
-  const requestedKeys = useMemo(
-    () =>
-      new Set(
-        requests.flatMap(request =>
-          request.namespaces?.length
-            ? request.namespaces.map(ns => watchKey(request.cluster, ns))
-            : [watchKey(request.cluster, undefined)]
-        )
-      ),
-    [requests]
-  );
-
   const listsToStopWatching = listsToWatch.filter(
-    watching => !requestedKeys.has(watchKey(watching.cluster, watching.namespace))
+    watching =>
+      requests.find(request => {
+        if (watching.cluster !== request?.cluster) return false;
+        return !request.namespaces?.length
+          ? !watching.namespace
+          : !!watching.namespace && request.namespaces.includes(watching.namespace);
+      }) === undefined
   );
 
   if (listsToStopWatching.length > 0) {


### PR DESCRIPTION
## Description

In `useKubeObjectList`, the reconciliation logic that determines which lists to start watching uses a nested loop pattern. For every item returned by the query, it scans through the entire `listsToWatch` array using `.find()` to check if that `(cluster, namespace)` combination is already being watched. This results in `O(N×M)` time complexity, which scales poorly when there are many clusters and namespaces.

This PR optimizes the `listsNotYetWatched` check by pre-computing a `Set` of currently watched `(cluster, namespace)` keys via `useMemo`. This changes the nested `.find()` scan into a direct `O(1)` `Set.has()` lookup, reducing per-render overhead without altering any existing behaviour.

A `watchKey` helper is also extracted to centralize the `cluster:namespace` key format used across the watch-list logic, avoiding future drift if the separator or normalization ever changes.

## Changes Made

### `frontend/src/lib/k8s/api/v2/useKubeObjectList.ts`

- Added `watchKey(cluster, namespace)` helper function that returns a stable string key for a `(cluster, namespace)` pair, used across all `Set`/`Map` lookups in the reconciliation logic.

- Added `currentlyWatchedKeys` — a `useMemo`-wrapped `Set` built from `listsToWatch`, replacing the previous nested `.find()` scan.

- Updated `listsNotYetWatched` filter to use `currentlyWatchedKeys.has()` for `O(1)` lookups instead of a linear `.find()` over `listsToWatch`.

- Replaced `.filter(Boolean)` with a typed predicate:
  ```ts
  (data): data is ListResponse<K>
  ```
  so the pipeline is properly type-narrowed and downstream non-null assertions are eliminated.