### PR TITLE
backend: oidc: Evict abandoned state tokens to prevent memory leak

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -184,6 +184,23 @@ type OauthConfig struct {
 	createdAt    time.Time
 }
 
+// evictExpiredOidcStates removes entries from m whose createdAt timestamp is
+// older than ttl. It is called by the background cleanup goroutine in
+// createHeadlampHandler and is also used directly in tests so that both paths
+// exercise the same production logic.
+func evictExpiredOidcStates(m map[string]*OauthConfig, mu *sync.Mutex, ttl time.Duration) {
+	cutoff := time.Now().Add(-ttl)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for state, entry := range m {
+		if entry.createdAt.Before(cutoff) {
+			delete(m, state)
+		}
+	}
+}
+
 // returns True if a file exists.
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
@@ -846,17 +863,7 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				cutoff := time.Now().Add(-OidcStateTTL)
-
-				oauthMu.Lock()
-
-				for state, entry := range oauthRequestMap {
-					if entry.createdAt.Before(cutoff) {
-						delete(oauthRequestMap, state)
-					}
-				}
-
-				oauthMu.Unlock()
+				evictExpiredOidcStates(oauthRequestMap, &oauthMu, OidcStateTTL)
 			}
 		}
 	}()

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -135,9 +135,10 @@ const ContextUpdateCacheTTL = 20 * time.Second // seconds
 const JWTExpirationTTL = 10 * time.Second // seconds
 
 // OidcStateTTL is the maximum time an OIDC state token is kept in memory
-// waiting for the callback. Entries that are never completed (e.g. the user
-// closed the tab) are evicted after this duration to prevent unbounded growth.
-const OidcStateTTL = 10 * time.Minute
+// waiting for the callback. Entries that are never completed are evicted after
+// this duration to prevent unbounded growth while still allowing slow/manual
+// login flows enough time to complete.
+const OidcStateTTL = 60 * time.Minute
 
 const (
 	// serverReadHeaderTimeout is the maximum time to read the request headers.

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -134,6 +134,11 @@ const ContextUpdateCacheTTL = 20 * time.Second // seconds
 
 const JWTExpirationTTL = 10 * time.Second // seconds
 
+// OidcStateTTL is the maximum time an OIDC state token is kept in memory
+// waiting for the callback. Entries that are never completed (e.g. the user
+// closed the tab) are evicted after this duration to prevent unbounded growth.
+const OidcStateTTL = 10 * time.Minute
+
 const (
 	// serverReadHeaderTimeout is the maximum time to read the request headers.
 	serverReadHeaderTimeout = 10 * time.Second
@@ -176,6 +181,7 @@ type OauthConfig struct {
 	Ctx          context.Context
 	CodeVerifier string // PKCE code verifier
 	Cluster      string // cluster context name this is associated with
+	createdAt    time.Time
 }
 
 // returns True if a file exists.
@@ -828,6 +834,33 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		oauthMu         sync.Mutex
 	)
 
+	// Evict OIDC state entries that were never completed (e.g. the user closed
+	// the browser tab before finishing the auth flow). Without this, every
+	// abandoned /oidc request would leak an OauthConfig in memory forever.
+	go func() {
+		ticker := time.NewTicker(OidcStateTTL / 2)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cutoff := time.Now().Add(-OidcStateTTL)
+
+				oauthMu.Lock()
+
+				for state, entry := range oauthRequestMap {
+					if entry.createdAt.Before(cutoff) {
+						delete(oauthRequestMap, state)
+					}
+				}
+
+				oauthMu.Unlock()
+			}
+		}
+	}()
+
 	r.HandleFunc("/oidc", func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 		cluster := r.URL.Query().Get("cluster")
@@ -930,10 +963,11 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		}
 
 		entry := &OauthConfig{
-			Config:   oauthConfig,
-			Verifier: verifier,
-			Ctx:      ctx,
-			Cluster:  cluster,
+			Config:    oauthConfig,
+			Verifier:  verifier,
+			Ctx:       ctx,
+			Cluster:   cluster,
+			createdAt: time.Now(),
 		}
 
 		var authURL string

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1833,6 +1833,8 @@ func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
 // TestOidcStateMapEviction verifies that abandoned OIDC state entries (where
 // the user never completes the callback) are evicted from oauthRequestMap once
 // they exceed OidcStateTTL, preventing unbounded memory growth.
+// It calls evictExpiredOidcStates directly so it exercises the same production
+// code path used by the background goroutine in createHeadlampHandler.
 func TestOidcStateMapEviction(t *testing.T) {
 	oauthRequestMap := make(map[string]*OauthConfig)
 
@@ -1852,18 +1854,8 @@ func TestOidcStateMapEviction(t *testing.T) {
 		createdAt: time.Now(),
 	}
 
-	// Run one eviction pass (mirrors the goroutine logic in createHeadlampHandler).
-	cutoff := time.Now().Add(-OidcStateTTL)
-
-	oauthMu.Lock()
-
-	for state, entry := range oauthRequestMap {
-		if entry.createdAt.Before(cutoff) {
-			delete(oauthRequestMap, state)
-		}
-	}
-
-	oauthMu.Unlock()
+	// Call the production helper — same function used by the goroutine.
+	evictExpiredOidcStates(oauthRequestMap, &oauthMu, OidcStateTTL)
 
 	oauthMu.Lock()
 	_, stalePresent := oauthRequestMap[staleState]

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1830,6 +1830,50 @@ func TestOidcCallbackEmptyStateDoesNotLogStaleError(t *testing.T) {
 		"missing-state log must not carry a stale error from the outer createHeadlampHandler scope")
 }
 
+// TestOidcStateMapEviction verifies that abandoned OIDC state entries (where
+// the user never completes the callback) are evicted from oauthRequestMap once
+// they exceed OidcStateTTL, preventing unbounded memory growth.
+func TestOidcStateMapEviction(t *testing.T) {
+	oauthRequestMap := make(map[string]*OauthConfig)
+
+	var oauthMu sync.Mutex
+
+	// Insert a stale entry that is already past the TTL.
+	staleState := "stale-state-token"
+	oauthRequestMap[staleState] = &OauthConfig{
+		Cluster:   "test-cluster",
+		createdAt: time.Now().Add(-OidcStateTTL - time.Second),
+	}
+
+	// Insert a fresh entry that should survive eviction.
+	freshState := "fresh-state-token"
+	oauthRequestMap[freshState] = &OauthConfig{
+		Cluster:   "test-cluster",
+		createdAt: time.Now(),
+	}
+
+	// Run one eviction pass (mirrors the goroutine logic in createHeadlampHandler).
+	cutoff := time.Now().Add(-OidcStateTTL)
+
+	oauthMu.Lock()
+
+	for state, entry := range oauthRequestMap {
+		if entry.createdAt.Before(cutoff) {
+			delete(oauthRequestMap, state)
+		}
+	}
+
+	oauthMu.Unlock()
+
+	oauthMu.Lock()
+	_, stalePresent := oauthRequestMap[staleState]
+	_, freshPresent := oauthRequestMap[freshState]
+	oauthMu.Unlock()
+
+	assert.False(t, stalePresent, "stale OIDC state entry should have been evicted")
+	assert.True(t, freshPresent, "fresh OIDC state entry should still be present")
+}
+
 func TestOIDCTokenRefreshMiddleware(t *testing.T) {
 	kubeConfigStore := kubeconfig.NewContextStore()
 	config := &HeadlampConfig{


### PR DESCRIPTION
## Description

This PR fixes an unbounded memory growth issue in the OIDC login flow.

When a user starts OIDC login, the backend creates a random state token and stores the related login config in `oauthRequestMap`. That entry is normally deleted when the user completes login and reaches `/oidc-callback`.

However, if the user closes the tab, abandons the IdP login, loses network, or repeatedly starts login without completing it, the callback never happens and the entry currently stays in memory until the Headlamp process restarts.

This PR adds a TTL-based cleanup path for those abandoned OIDC state entries. Each entry now records when it was created, and a background cleanup goroutine periodically removes entries older than `OidcStateTTL`.

The TTL is set to 60 minutes to avoid interrupting slow/manual login flows while still bounding memory growth. Since cleanup runs every `OidcStateTTL / 2`, the eviction check runs every 30 minutes.

## Changes Made

- Added `OidcStateTTL = 60 * time.Minute`.
- Added `createdAt` to `OauthConfig`.
- Set `createdAt` when storing a new OIDC state entry.
- Added cleanup for abandoned OIDC state entries older than the TTL.
- Ensured the cleanup goroutine exits when the server context is cancelled.
- Added `TestOidcStateMapEviction` to verify stale entries are removed and fresh entries remain.

## Testing

```sh
go test ./cmd -run TestOidcStateMapEviction -count=1 -v