### PR TITLE
frontend: authchooser: Make back button keyboard-accessible

### DIFF
--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AnError.stories.storyshot
@@ -137,6 +137,7 @@
               class="MuiBox-root css-oo0cqs"
               role="button"
               style="cursor: pointer;"
+              tabindex="0"
             >
               <div
                 class="MuiBox-root css-37urdo"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidc.stories.storyshot
@@ -146,6 +146,7 @@
               class="MuiBox-root css-oo0cqs"
               role="button"
               style="cursor: pointer;"
+              tabindex="0"
             >
               <div
                 class="MuiBox-root css-37urdo"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -132,6 +132,7 @@
               class="MuiBox-root css-oo0cqs"
               role="button"
               style="cursor: pointer;"
+              tabindex="0"
             >
               <div
                 class="MuiBox-root css-37urdo"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -132,6 +132,7 @@
               class="MuiBox-root css-oo0cqs"
               role="button"
               style="cursor: pointer;"
+              tabindex="0"
             >
               <div
                 class="MuiBox-root css-37urdo"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.Testing.stories.storyshot
@@ -129,6 +129,7 @@
               class="MuiBox-root css-oo0cqs"
               role="button"
               style="cursor: pointer;"
+              tabindex="0"
             >
               <div
                 class="MuiBox-root css-37urdo"

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -336,7 +336,11 @@ export function PureAuthChooser({
           style={{ cursor: 'pointer' }}
           onClick={handleBackButtonPress}
           onKeyDown={e => {
+            if (e.repeat) {
+              return;
+            }
             if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
               handleBackButtonPress();
             }
           }}

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -335,6 +335,12 @@ export function PureAuthChooser({
           alignItems="center"
           style={{ cursor: 'pointer' }}
           onClick={handleBackButtonPress}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              handleBackButtonPress();
+            }
+          }}
+          tabIndex={0}
           role="button"
         >
           <Box pt={0.5}>


### PR DESCRIPTION
### Summary
Makes the "Back" action on the cluster authentication chooser screen keyboard-accessible. 

### Changes
* Added `tabIndex={0}` to the custom Back button (`Box` element) to allow keyboard focus/tabbing.
* Added an `onKeyDown` listener to handle `Enter` or `Space` key presses.
* Updated corresponding storybook snapshots to reflect the new `tabindex` attribute.

Fixes #5867
