### PR TITLE
frontend: resource-editor: Fix missing/incorrect aria-controls on action buttons

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -46,15 +46,18 @@ vi.mock('../ConfirmButton', () => ({
     onConfirm,
     disabled,
     ariaLabel,
+    'aria-controls': ariaControls,
   }: {
     children: React.ReactNode;
     onConfirm: () => void;
     disabled?: boolean;
     ariaLabel?: string;
+    'aria-controls'?: string;
   }) => (
     <Button
       aria-label={ariaLabel}
       disabled={disabled}
+      aria-controls={ariaControls}
       onClick={() => {
         if (!disabled) {
           onConfirm();
@@ -121,5 +124,24 @@ describe('EditorDialog', () => {
     });
 
     expect(screen.queryByText('Invalid YAML')).not.toBeInTheDocument();
+  });
+
+  it('correctly associates action buttons with the editor via aria-controls', () => {
+    renderEditorDialog();
+
+    const editor = screen.getByRole('textbox', { name: /code$/i });
+    const editorId = editor.getAttribute('id');
+    expect(editorId).toBeTruthy();
+
+    fireEvent.change(editor, { target: { value: 'some changes' } });
+
+    const undoButton = screen.getByRole('button', { name: /undo/i });
+    expect(undoButton.getAttribute('aria-controls')).toBe(editorId);
+
+    const dryRunButton = screen.getByRole('button', { name: /dry run/i });
+    expect(dryRunButton.getAttribute('aria-controls')).toBe(editorId);
+
+    const saveButton = screen.getByRole('button', { name: /save & apply/i });
+    expect(saveButton.getAttribute('aria-controls')).toBe(editorId);
   });
 });

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -421,9 +421,9 @@ export default function EditorDialog(props: EditorDialogProps) {
   function makeEditor() {
     const language = originalCodeRef.current.format || 'yaml';
     return (
-      <Box height="100%" id={editorId}>
+      <Box height="100%">
         {useSimpleEditor ? (
-          <SimpleEditor language={language} value={code.code} onChange={onChange} />
+          <SimpleEditor id={editorId} language={language} value={code.code} onChange={onChange} />
         ) : (
           <Editor
             language={language}
@@ -432,6 +432,7 @@ export default function EditorDialog(props: EditorDialogProps) {
             options={editorOptions}
             onChange={onChange}
             height="100%"
+            wrapperProps={{ id: editorId }}
           />
         )}
       </Box>
@@ -603,7 +604,7 @@ export default function EditorDialog(props: EditorDialogProps) {
             color="secondary"
             variant="contained"
             disabled={originalCodeRef.current.code === code.code || !!error}
-            // @todo: aria-controls should point to the textarea id
+            aria-controls={editorId}
             sx={{ whiteSpace: 'nowrap' }}
           >
             {t('translation|Dry Run')}
@@ -616,7 +617,6 @@ export default function EditorDialog(props: EditorDialogProps) {
             variant="contained"
             disabled={originalCodeRef.current.code === code.code || !!error}
             aria-controls={editorId}
-            // @todo: aria-controls should point to the textarea id
             sx={{ whiteSpace: 'nowrap' }}
           >
             {saveLabel || t('translation|Save & Apply')}

--- a/frontend/src/components/common/Resource/SimpleEditor.tsx
+++ b/frontend/src/components/common/Resource/SimpleEditor.tsx
@@ -28,13 +28,16 @@ export interface SimpleEditorProps {
   value: string | undefined;
   /** When things in the editor change. */
   onChange(value: string | undefined, ev: any): void;
+  /** Optional ID for the textarea element. */
+  id?: string;
 }
 
 /** A very basic code editor. */
-function SimpleEditor({ language, value, onChange }: SimpleEditorProps) {
+function SimpleEditor({ language, value, onChange, id }: SimpleEditorProps) {
   // TextareaAutosize doesn't react well within a dialog/tab
   return (
     <SizedTextarea
+      id={id}
       aria-label={`${language} Code`}
       onChange={event => onChange(event.target.value, event)}
       value={value}

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -214,7 +214,6 @@
           >
             <div
               class="MuiBox-root css-10klw3m"
-              id="editor-textarea-id"
             >
               <div
                 class="mock-monaco-editor"
@@ -281,6 +280,7 @@
             />
           </button>
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-1uk0gch-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -217,6 +217,7 @@
             >
               <div
                 class="mock-monaco-editor"
+                id="editor-textarea-id"
               />
             </div>
           </div>

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -250,7 +250,6 @@
           >
             <div
               class="MuiBox-root css-10klw3m"
-              id="editor-textarea-id"
             >
               <div
                 class="mock-monaco-editor"
@@ -317,6 +316,7 @@
             />
           </button>
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-1uk0gch-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -253,6 +253,7 @@
             >
               <div
                 class="mock-monaco-editor"
+                id="editor-textarea-id"
               />
             </div>
           </div>

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -69,11 +69,11 @@ vi.mock('@iconify/react', () => ({
 }));
 
 vi.mock('@monaco-editor/react', () => ({
-  Editor: () => <div className="mock-monaco-editor" />,
-  DiffEditor: () => <div className="mock-monaco-diff-editor" />,
+  Editor: (props: any) => <div className="mock-monaco-editor" {...props.wrapperProps} />,
+  DiffEditor: (props: any) => <div className="mock-monaco-diff-editor" {...props.wrapperProps} />,
   useMonaco: () => null,
   loader: { config: () => null },
-  default: () => <div className="mock-monaco-editor" />,
+  default: (props: any) => <div className="mock-monaco-editor" {...props.wrapperProps} />,
 }));
 
 window.matchMedia = () => ({


### PR DESCRIPTION
### Summary
Fixes the accessibility controls in the core `EditorDialog` by properly setting `aria-controls` on the "Dry Run" and "Save & Apply" buttons so they point directly to the interactive code textarea.

### Changes
* Added `id` propagation to the custom `SimpleEditor`'s `textarea` element.
* Propagated `editorId` to Monaco Editor wrapper via `wrapperProps`.
* Added `aria-controls={editorId}` to the **Dry Run** button and removed the obsolete `@todo` comment.
* Corrected the **Save & Apply** button's `aria-controls` binding to target the interactive textarea ID and removed the obsolete `@todo` comment.
* Updated corresponding storybook snapshots to reflect the accessibility markup changes.

Fixes #5869
