### PR TITLE
charts: Use official Cluster Inventory secretreader images

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -101,10 +101,10 @@ config:
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: /access-plugins/secretreader
       - name: kubeconfig-secretreader
-        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3@sha256:b92966cc6e4ac78002a63862921022a71d54956826f6e4febcb7247495eb98c0
         mountPath: /access-plugins/kubeconfig-secretreader
 ```
 
@@ -230,10 +230,10 @@ config:
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: /access-plugins/secretreader
       - name: kubeconfig-secretreader
-        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3@sha256:b92966cc6e4ac78002a63862921022a71d54956826f6e4febcb7247495eb98c0
         mountPath: /access-plugins/kubeconfig-secretreader
 ```
 

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -220,8 +220,8 @@ config:
 `plugins[]` is for Cluster Inventory access provider binaries, not Headlamp UI
 plugins. Each entry renders as a Kubernetes `image` volume and is mounted
 read-only into the Headlamp container. If an access provider `execConfig.command`
-is configured, the command's parent directory must match one of the
-absolute `plugins[].mountPath` values.
+is configured, the command must be under one of the absolute
+`plugins[].mountPath` values.
 
 ### Deployment Configuration
 

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -93,10 +93,19 @@ config:
             command: /access-plugins/secretreader/bin/secretreader-plugin
             interactiveMode: Never
             provideClusterInfo: true
+        - name: kubeconfig-secretreader
+          execConfig:
+            apiVersion: client.authentication.k8s.io/v1
+            command: /access-plugins/kubeconfig-secretreader/bin/kubeconfig-secretreader-plugin
+            interactiveMode: Never
+            provideClusterInfo: true
     plugins:
       - name: secretreader
         image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader
+      - name: kubeconfig-secretreader
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        mountPath: /access-plugins/kubeconfig-secretreader
 ```
 
 `plugins[]` mounts Cluster Inventory access provider binaries as Kubernetes
@@ -213,10 +222,19 @@ config:
             command: /access-plugins/secretreader/bin/secretreader-plugin
             interactiveMode: Never
             provideClusterInfo: true
+        - name: kubeconfig-secretreader
+          execConfig:
+            apiVersion: client.authentication.k8s.io/v1
+            command: /access-plugins/kubeconfig-secretreader/bin/kubeconfig-secretreader-plugin
+            interactiveMode: Never
+            provideClusterInfo: true
     plugins:
       - name: secretreader
         image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader
+      - name: kubeconfig-secretreader
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        mountPath: /access-plugins/kubeconfig-secretreader
 ```
 
 `plugins[]` is for Cluster Inventory access provider binaries, not Headlamp UI

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -90,11 +90,12 @@ config:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/secretreader-plugin
+            command: /access-plugins/secretreader/bin/secretreader-plugin
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader
 ```
 
@@ -209,11 +210,12 @@ config:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/secretreader-plugin
+            command: /access-plugins/secretreader/bin/secretreader-plugin
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader
 ```
 

--- a/charts/headlamp/templates/cluster-inventory-configmap.yaml
+++ b/charts/headlamp/templates/cluster-inventory-configmap.yaml
@@ -13,11 +13,17 @@
 {{-   $mountPaths = append $mountPaths $mountPath }}
 {{- end }}
 {{- range ($clusterInventory.accessProvidersConfig.providers | default list) }}
-{{-   $cmd := (.execConfig | default dict).command | default "" }}
-{{-   if $cmd }}
-{{-     $cmdDir := dir $cmd | clean }}
-{{-     if not (has $cmdDir $mountPaths) }}
-{{-       fail (printf "provider %q: command dir %q does not match any config.clusterInventory.plugins[].mountPath %v" .name $cmdDir $mountPaths) }}
+{{-   $rawCmd := (.execConfig | default dict).command | default "" | toString }}
+{{-   $cmd := $rawCmd | clean }}
+{{-   if $rawCmd }}
+{{-     $matched := false }}
+{{-     range $mountPath := $mountPaths }}
+{{-       if hasPrefix (printf "%s/" $mountPath) $cmd }}
+{{-         $matched = true }}
+{{-       end }}
+{{-     end }}
+{{-     if not $matched }}
+{{-       fail (printf "provider %q: command %q is not under any config.clusterInventory.plugins[].mountPath %v" .name $cmd $mountPaths) }}
 {{-     end }}
 {{-   end }}
 {{- end }}

--- a/charts/headlamp/tests/expected_templates/cluster-inventory-plugins.yaml
+++ b/charts/headlamp/tests/expected_templates/cluster-inventory-plugins.yaml
@@ -177,7 +177,7 @@ spec:
                 path: config.json
         - name: secretreader
           image:
-            reference: "registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3"
+            reference: "registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d"
         - name: kubeconfig-secretreader
           image:
-            reference: "registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3"
+            reference: "registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3@sha256:b92966cc6e4ac78002a63862921022a71d54956826f6e4febcb7247495eb98c0"

--- a/charts/headlamp/tests/expected_templates/cluster-inventory-plugins.yaml
+++ b/charts/headlamp/tests/expected_templates/cluster-inventory-plugins.yaml
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/version: "0.42.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  config.json: "{\"providers\":[{\"execConfig\":{\"apiVersion\":\"client.authentication.k8s.io/v1\",\"command\":\"/access-plugins/secretreader/bin/secretreader-plugin\",\"interactiveMode\":\"Never\",\"provideClusterInfo\":true},\"name\":\"secretreader\"}]}"
+  config.json: "{\"providers\":[{\"execConfig\":{\"apiVersion\":\"client.authentication.k8s.io/v1\",\"command\":\"/access-plugins/secretreader/bin/secretreader-plugin\",\"interactiveMode\":\"Never\",\"provideClusterInfo\":true},\"name\":\"secretreader\"},{\"execConfig\":{\"apiVersion\":\"client.authentication.k8s.io/v1\",\"command\":\"/access-plugins/kubeconfig-secretreader/bin/kubeconfig-secretreader-plugin\",\"interactiveMode\":\"Never\",\"provideClusterInfo\":true},\"name\":\"kubeconfig-secretreader\"}]}"
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -165,6 +165,9 @@ spec:
             - name: secretreader
               mountPath: /access-plugins/secretreader
               readOnly: true
+            - name: kubeconfig-secretreader
+              mountPath: /access-plugins/kubeconfig-secretreader
+              readOnly: true
       volumes:
         - name: cluster-inventory-config
           configMap:
@@ -175,3 +178,6 @@ spec:
         - name: secretreader
           image:
             reference: "registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3"
+        - name: kubeconfig-secretreader
+          image:
+            reference: "registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3"

--- a/charts/headlamp/tests/expected_templates/cluster-inventory-plugins.yaml
+++ b/charts/headlamp/tests/expected_templates/cluster-inventory-plugins.yaml
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/version: "0.42.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  config.json: "{\"providers\":[{\"execConfig\":{\"apiVersion\":\"client.authentication.k8s.io/v1\",\"command\":\"/access-plugins/secretreader/secretreader-plugin\",\"provideClusterInfo\":true},\"name\":\"secretreader\"}]}"
+  config.json: "{\"providers\":[{\"execConfig\":{\"apiVersion\":\"client.authentication.k8s.io/v1\",\"command\":\"/access-plugins/secretreader/bin/secretreader-plugin\",\"interactiveMode\":\"Never\",\"provideClusterInfo\":true},\"name\":\"secretreader\"}]}"
 ---
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -174,4 +174,4 @@ spec:
                 path: config.json
         - name: secretreader
           image:
-            reference: "registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1"
+            reference: "registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3"

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-command-equals-mount-path.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-command-equals-mount-path.yaml
@@ -11,5 +11,5 @@ config:
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: /access-plugins/secretreader

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-command-equals-mount-path.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-command-equals-mount-path.yaml
@@ -7,8 +7,9 @@ config:
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
             command: /access-plugins/secretreader
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-command-equals-mount-path.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-command-equals-mount-path.yaml
@@ -1,0 +1,14 @@
+config:
+  clusterInventory:
+    enabled: true
+    accessProvidersConfig:
+      providers:
+        - name: secretreader
+          execConfig:
+            apiVersion: client.authentication.k8s.io/v1
+            command: /access-plugins/secretreader
+            provideClusterInfo: true
+    plugins:
+      - name: secretreader
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        mountPath: /access-plugins/secretreader

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-invalid-name.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-invalid-name.yaml
@@ -6,9 +6,10 @@ config:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/secretreader-plugin
+            command: /access-plugins/secretreader/bin/secretreader-plugin
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: SecretReader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-invalid-name.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-invalid-name.yaml
@@ -11,5 +11,5 @@ config:
             provideClusterInfo: true
     plugins:
       - name: SecretReader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: /access-plugins/secretreader

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-mount-mismatch.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-mount-mismatch.yaml
@@ -11,5 +11,5 @@ config:
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: /access-plugins/other

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-mount-mismatch.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-mount-mismatch.yaml
@@ -6,9 +6,10 @@ config:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/secretreader-plugin
+            command: /access-plugins/secretreader/bin/secretreader-plugin
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/other

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-relative-mount-path.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-relative-mount-path.yaml
@@ -11,5 +11,5 @@ config:
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: access-plugins/secretreader

--- a/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-relative-mount-path.yaml
+++ b/charts/headlamp/tests/failing_test_cases/cluster-inventory-plugin-relative-mount-path.yaml
@@ -6,9 +6,10 @@ config:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/secretreader-plugin
+            command: /access-plugins/secretreader/bin/secretreader-plugin
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: access-plugins/secretreader

--- a/charts/headlamp/tests/test_cases/cluster-inventory-plugins.yaml
+++ b/charts/headlamp/tests/test_cases/cluster-inventory-plugins.yaml
@@ -6,9 +6,10 @@ config:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/secretreader-plugin
+            command: /access-plugins/secretreader/bin/secretreader-plugin
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader/

--- a/charts/headlamp/tests/test_cases/cluster-inventory-plugins.yaml
+++ b/charts/headlamp/tests/test_cases/cluster-inventory-plugins.yaml
@@ -9,7 +9,16 @@ config:
             command: /access-plugins/secretreader/bin/secretreader-plugin
             interactiveMode: Never
             provideClusterInfo: true
+        - name: kubeconfig-secretreader
+          execConfig:
+            apiVersion: client.authentication.k8s.io/v1
+            command: /access-plugins/kubeconfig-secretreader/bin/kubeconfig-secretreader-plugin
+            interactiveMode: Never
+            provideClusterInfo: true
     plugins:
       - name: secretreader
         image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader/
+      - name: kubeconfig-secretreader
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        mountPath: /access-plugins/kubeconfig-secretreader/

--- a/charts/headlamp/tests/test_cases/cluster-inventory-plugins.yaml
+++ b/charts/headlamp/tests/test_cases/cluster-inventory-plugins.yaml
@@ -17,8 +17,8 @@ config:
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: /access-plugins/secretreader/
       - name: kubeconfig-secretreader
-        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3@sha256:b92966cc6e4ac78002a63862921022a71d54956826f6e4febcb7247495eb98c0
         mountPath: /access-plugins/kubeconfig-secretreader/

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -139,13 +139,14 @@ config:
     #     - name: secretreader
     #       execConfig:
     #         apiVersion: client.authentication.k8s.io/v1
-    #         command: /access-plugins/secretreader/secretreader-plugin
+    #         command: /access-plugins/secretreader/bin/secretreader-plugin
+    #         interactiveMode: Never
     #         provideClusterInfo: true
     # plugins[] uses the Kubernetes "image" volume type to mount experimental/alpha access provider binaries.
     plugins: []
     # plugins:
     #   - name: secretreader
-    #     image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+    #     image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
     #     mountPath: /access-plugins/secretreader
     # -- Kubernetes label selector used to filter experimental/alpha ClusterProfile resources.
     labelSelector: "!headlamp.dev/ignore"

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -142,12 +142,21 @@ config:
     #         command: /access-plugins/secretreader/bin/secretreader-plugin
     #         interactiveMode: Never
     #         provideClusterInfo: true
+    #     - name: kubeconfig-secretreader
+    #       execConfig:
+    #         apiVersion: client.authentication.k8s.io/v1
+    #         command: /access-plugins/kubeconfig-secretreader/bin/kubeconfig-secretreader-plugin
+    #         interactiveMode: Never
+    #         provideClusterInfo: true
     # plugins[] uses the Kubernetes "image" volume type to mount experimental/alpha access provider binaries.
     plugins: []
     # plugins:
     #   - name: secretreader
     #     image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
     #     mountPath: /access-plugins/secretreader
+    #   - name: kubeconfig-secretreader
+    #     image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+    #     mountPath: /access-plugins/kubeconfig-secretreader
     # -- Kubernetes label selector used to filter experimental/alpha ClusterProfile resources.
     labelSelector: "!headlamp.dev/ignore"
     # -- Override the experimental/alpha Cluster Inventory root reconcile interval. Empty uses the Headlamp default.

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -152,10 +152,10 @@ config:
     plugins: []
     # plugins:
     #   - name: secretreader
-    #     image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+    #     image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
     #     mountPath: /access-plugins/secretreader
     #   - name: kubeconfig-secretreader
-    #     image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+    #     image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3@sha256:b92966cc6e4ac78002a63862921022a71d54956826f6e4febcb7247495eb98c0
     #     mountPath: /access-plugins/kubeconfig-secretreader
     # -- Kubernetes label selector used to filter experimental/alpha ClusterProfile resources.
     labelSelector: "!headlamp.dev/ignore"

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -58,10 +58,10 @@ config:
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3@sha256:ec3090dc166aa2b42fb35d714d161c417d8b27bbc463404c8f615f5f4c610a1d
         mountPath: /access-plugins/secretreader
       - name: kubeconfig-secretreader
-        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3@sha256:b92966cc6e4ac78002a63862921022a71d54956826f6e4febcb7247495eb98c0
         mountPath: /access-plugins/kubeconfig-secretreader
 ```
 

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -47,11 +47,12 @@ config:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /access-plugins/secretreader/secretreader-plugin
+            command: /access-plugins/secretreader/bin/secretreader-plugin
+            interactiveMode: Never
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader
 ```
 

--- a/docs/installation/in-cluster/index.md
+++ b/docs/installation/in-cluster/index.md
@@ -50,10 +50,19 @@ config:
             command: /access-plugins/secretreader/bin/secretreader-plugin
             interactiveMode: Never
             provideClusterInfo: true
+        - name: kubeconfig-secretreader
+          execConfig:
+            apiVersion: client.authentication.k8s.io/v1
+            command: /access-plugins/kubeconfig-secretreader/bin/kubeconfig-secretreader-plugin
+            interactiveMode: Never
+            provideClusterInfo: true
     plugins:
       - name: secretreader
         image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
         mountPath: /access-plugins/secretreader
+      - name: kubeconfig-secretreader
+        image: registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+        mountPath: /access-plugins/kubeconfig-secretreader
 ```
 
 Then install Headlamp with the values file:


### PR DESCRIPTION
## Summary

This PR updates the Headlamp Helm chart Cluster Inventory examples to use the official `secretreader` and `kubeconfig-secretreader` images from [`cluster-inventory-api` v0.1.3](https://github.com/kubernetes-sigs/cluster-inventory-api/releases/tag/v0.1.3).

## Related Issue

N/A

## Changes

- Updated Cluster Inventory Helm chart support so users can mount and run the
  official `secretreader` and `kubeconfig-secretreader` v0.1.3 images directly.

## Steps to Test

1. Run `make helm-template-test`.
2. Run `helm lint charts/headlamp`.
3. Verify the official image manifests:
   `docker manifest inspect registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3`
   and
   `docker manifest inspect registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3`.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- This only affects the experimental Cluster Inventory Helm chart configuration.
- Default chart installs are unchanged because `config.clusterInventory.enabled` remains `false`.
