### PR TITLE
frontend: ObjectEventList: Handle events without a source field

### DIFF
--- a/frontend/src/components/common/ObjectEventList.stories.tsx
+++ b/frontend/src/components/common/ObjectEventList.stories.tsx
@@ -100,6 +100,31 @@ const mockEvents: KubeEvent[] = [
     count: 1,
     type: 'Normal',
   },
+  {
+    kind: 'Event',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'event3.789',
+      namespace: 'default',
+      uid: 'event-uid-3',
+      creationTimestamp: new Date(getTestDate().getTime() - 60 * 1000).toISOString(),
+    },
+    involvedObject: {
+      kind: 'Pod',
+      namespace: 'default',
+      name: 'test-pod-for-events',
+      uid: 'owner-pod-uid-123',
+      apiVersion: 'v1',
+      resourceVersion: '1',
+      fieldPath: '',
+    },
+    reason: 'Started',
+    message: 'Started container nginx',
+    firstTimestamp: new Date(getTestDate().getTime() - 60 * 1000).toISOString(),
+    lastTimestamp: new Date(getTestDate().getTime() - 60 * 1000).toISOString(),
+    count: 1,
+    type: 'Normal',
+  },
 ];
 
 export default {

--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -119,7 +119,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
           {
             label: t('From'),
             getter: item => {
-              return item.source.component;
+              return item.source?.component;
             },
           },
           {

--- a/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ObjectEventList.WithEvents.stories.storyshot
@@ -179,6 +179,48 @@
                   </p>
                 </td>
               </tr>
+              <tr
+                class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+              >
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  Normal
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  Started
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                />
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <div
+                    class="MuiBox-root css-k008qs"
+                  >
+                    <span
+                      id="event-uid-3"
+                      style="word-break: break-all; white-space: normal;"
+                    >
+                      Started container nginx
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                >
+                  <p
+                    aria-label="2024-02-14T23:59:00.000Z"
+                    class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                    data-mui-internal-clone-element="true"
+                  >
+                    90d
+                  </p>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
Fixes #5823.

The `From` column getter in `ObjectEventList` reads `item.source.component` directly, which throws a `TypeError` when the Kubernetes API omits `source`. Events emitted under the `events.k8s.io/v1` API routinely lack this field, breaking the events table on resource detail pages.

Use optional chaining so the column renders empty for events without `source`, matching the existing null-safe pattern used elsewhere in the same file.

Also add a Storybook mock event without `source` to the `WithEvents` story so it exercises the no-source path and prevents regression.

### Testing

- `npx tsc --noEmit` clean
- `eslint` clean
- `npx vitest run src/storybook.test.tsx` — 542 tests pass with the updated snapshot
- Reverting the `?.` change makes the `WithEvents` story throw, confirming the snapshot covers the regression