### PR TITLE
frontend: useKubeObjectList: Fix kind name replacement for individual items within a list

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -16,10 +16,11 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, type MockedFunction, vi } from 'vitest';
+import { clusterFetch } from './fetch';
 import {
   kubeObjectListQuery,
-  ListResponse,
+  type ListResponse,
   makeListRequests,
   useKubeObjectList,
   useWatchKubeObjectLists,
@@ -35,11 +36,24 @@ vi.mock('./webSocket', () => ({
   BASE_WS_URL: 'http://localhost:3000',
 }));
 
+vi.mock('./fetch', () => ({
+  clusterFetch: vi.fn(),
+}));
+
 vi.mock('./multiplexer', () => ({
   WebSocketManager: {
     subscribe: (...args: any[]) => mockSubscribe(...args),
   },
 }));
+
+const mockClusterFetch = clusterFetch as MockedFunction<typeof clusterFetch>;
+
+const mockJsonResponse = (data: unknown) =>
+  ({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  } as Response);
 
 describe('makeListRequests', () => {
   describe('for non namespaced resource', () => {
@@ -308,6 +322,30 @@ describe('useKubeObjectList', () => {
   beforeEach(() => {
     vi.stubEnv('REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER', 'false');
     vi.clearAllMocks();
+  });
+
+  it('should preserve List in the resource kind when parsing a list response', async () => {
+    mockClusterFetch.mockResolvedValue(
+      mockJsonResponse({
+        kind: 'EventListenerList',
+        apiVersion: 'example.com/v1',
+        metadata: { resourceVersion: '1' },
+        items: [{ metadata: { name: 'example' } }],
+      })
+    );
+
+    const query = kubeObjectListQuery(
+      mockClass,
+      { group: 'example.com', version: 'v1', resource: 'bucketlistitems' },
+      undefined,
+      'default',
+      {}
+    );
+    const queryFn = query.queryFn as () => Promise<ListResponse<any>>;
+
+    const response = await queryFn();
+
+    expect(response.list.items[0].jsonData.kind).toBe('EventListener');
   });
 
   it('should call useKubeObjectList with 1 namespace after reducing amount of namespaces', async () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -97,7 +97,7 @@ export function kubeObjectListQuery<K extends KubeObject>(
         list.items = list.items.map(item => {
           const itm = new kubeObjectClass({
             ...item,
-            kind: list.kind.replace('List', ''),
+            kind: list.kind.replace(/List$/, ''),
             apiVersion: list.apiVersion,
           });
           itm.cluster = cluster;


### PR DESCRIPTION
Originally reported on [slack](https://kubernetes.slack.com/archives/C01FXB5E8ER/p1779984731068429) 

```
So if you have resources with "List" in their names and try to map them, loco things happen :smiley:

In my case for tekton pipelines EventListener became evenTenerList or something like that
```

Fixes replacement to make sure we only replace List suffix, and not in the middle of the word

## Steps to Test

1. Go to a resource list page that has a `List` in the middle of the kind name, for example Event*List*ener
2. Inspect individual item and validate that the `kind` is EventListener and not `evenTenerList `


