### PR TITLE
ci: validate workflow run SHA before uploading release assets

### DIFF
--- a/.github/workflows/push-release-assets.yml
+++ b/.github/workflows/push-release-assets.yml
@@ -8,7 +8,7 @@ on:
         required: true
       run_ids:
         description: 'Comma-separated run IDs of workflows with artifacts to download'
-        required: false
+        required: true
       force:
         description: 'Force upload even if the release is no longer a draft'
         type: boolean
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write # need to write to releases and download artifacts
       id-token: write # needed for cosign keyless signing via GitHub OIDC
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -36,6 +37,42 @@ jobs:
 
       - name: Create artifacts directory
         run: mkdir -p ./artifacts
+        
+      # Ensure workflow runs used to generate release artifacts were executed
+      # from the same commit as the release tag. See app/scripts/validate-run-shas.sh.
+      - name: Validate workflow run SHAs match release tag
+        id: validate_run_shas
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Source the script so we can reuse resolve_tag/get_tag_sha/validate_runs
+          # without executing its main() function.
+          # shellcheck source=app/scripts/validate-run-shas.sh
+          source app/scripts/validate-run-shas.sh
+
+          gh_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+          if [ -z "$gh_token" ]; then
+            echo "Error: GH_TOKEN or GITHUB_TOKEN is required for GitHub CLI authentication." >&2
+            exit 1
+          fi
+          export GH_TOKEN="$gh_token"
+
+          # Ensure tags are available locally before resolving.
+          git fetch --tags --force origin
+
+          tag_name="$(resolve_tag "${{ inputs.release_name }}")" || exit 1
+          if ! expected_sha=$(get_tag_sha "$tag_name"); then
+            echo "Error: Failed to determine SHA for tag '$tag_name'." >&2
+            exit 1
+          fi
+          if [ -z "$expected_sha" ]; then
+            echo "Error: Could not determine SHA for tag '$tag_name'." >&2
+            exit 1
+          fi
+
+          validate_runs "$expected_sha" "$tag_name" "${{ github.repository }}" "${{ inputs.run_ids }}"
+
+          echo "tag_name=$tag_name" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts from workflow runs
         if: ${{ inputs.run_ids != '' }}
@@ -46,7 +83,9 @@ jobs:
           IFS=',' read -ra RUN_IDS <<< "${{ inputs.run_ids }}"
 
           for run_id in "${RUN_IDS[@]}"; do
-            run_id=$(echo $run_id | xargs)  # Trim whitespace
+            # Trim surrounding whitespace
+            run_id="${run_id#"${run_id%%[![:space:]]*}"}"
+            run_id="${run_id%"${run_id##*[![:space:]]}"}"
             if [ -n "$run_id" ]; then
               echo "Downloading artifacts from run ID: $run_id"
 
@@ -55,7 +94,7 @@ jobs:
 
               # Download artifacts for this run ID
               # Note: This action will automatically download all artifacts from the run
-              gh run download $run_id --dir "./artifacts/run-$run_id"
+              gh run download "$run_id" --repo "${{ github.repository }}" --dir "./artifacts/run-$run_id"
             fi
           done
         env:
@@ -68,6 +107,7 @@ jobs:
 
       # Flatten directory structure for easier upload
       - name: Prepare artifacts for upload
+        id: prepare_artifacts
         run: |
           mkdir -p ./flattened-artifacts
           find ./artifacts -type f -not -path "*/\.*" -exec cp {} ./flattened-artifacts/ \;
@@ -78,13 +118,16 @@ jobs:
           echo "Files prepared for upload:"
           ls -la ./flattened-artifacts/
 
-          # Exit if no files are found
-          if [ -z "$(ls -A ./flattened-artifacts)" ]; then
+          # Check if any files are found and set output
+          if [ -z "$(find ./flattened-artifacts -mindepth 1 -print -quit)" ]; then
             echo "No artifacts found to upload!"
-            exit 0
+            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_artifacts=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Prepare GPG key
+        if: ${{ steps.prepare_artifacts.outputs.has_artifacts == 'true' }}
         run: |
           gpg_dir=.cr-gpg
           mkdir "$gpg_dir"
@@ -113,33 +156,41 @@ jobs:
           GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
 
       - name: Install script dependencies
+        if: ${{ steps.prepare_artifacts.outputs.has_artifacts == 'true' }}
         working-directory: ./app/scripts/push-release-assets
         run: npm ci
 
       - name: Upload assets to release
+        if: ${{ steps.prepare_artifacts.outputs.has_artifacts == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}
         run: |
-          FORCE_FLAG=""
-          if [ "${{ github.event.inputs.force }}" == "true" ]; then
-            FORCE_FLAG="--force"
-          fi
-
           ARTIFACTS_PATH="$(pwd)/flattened-artifacts"
-          ASSETS=($(ls -1 $ARTIFACTS_PATH))
+          
+          # Gather assets safely into an array
+          ASSETS=()
+          while IFS= read -r -d '' file; do
+            ASSETS+=("$file")
+          done < <(find "$ARTIFACTS_PATH" -maxdepth 1 -type f -print0 | sort -z)
 
-          # Create the command with all artifact paths
           cd ./app/scripts/push-release-assets/
-          CMD="node push-release-assets.js $FORCE_FLAG ${{ inputs.release_name }}"
+          
+          # Build the command arguments
+          ARGS=()
+          if [ "${{ inputs.force }}" == "true" ]; then
+            ARGS+=("--force")
+          fi
+          RELEASE_NAME="${{ inputs.release_name }}"
+          ARGS+=("$RELEASE_NAME")
+          ARGS+=("${ASSETS[@]}")
 
-          for asset in "${ASSETS[@]}"; do
-            CMD+=" $ARTIFACTS_PATH/$asset"
-          done
-
-          echo "Executing: $CMD"
-          eval $CMD
+          printf 'Executing: node push-release-assets.js'
+          printf ' %q' "${ARGS[@]}"
+          printf '\n'
+          node push-release-assets.js "${ARGS[@]}"
 
       - name: Create and sign checksums signature
+        if: ${{ steps.prepare_artifacts.outputs.has_artifacts == 'true' }}
         run: |
           # Wait a moment for the checksums.txt to be available
           sleep 5
@@ -148,14 +199,13 @@ jobs:
           mkdir -p ./temp-checksums
 
           # Download the checksums.txt file that was just uploaded
-          gh release download ${{ inputs.release_name }} --pattern "checksums.txt" --dir ./temp-checksums --clobber
+          gh release download "${{ steps.validate_run_shas.outputs.tag_name }}" --repo "${{ github.repository }}" --pattern "checksums.txt" --dir ./temp-checksums --clobber
 
           # Create detached signature for checksums.txt
           gpg --batch --yes --passphrase-file "$CR_PASSPHRASE_FILE" --default-key "${{ secrets.GPG_SIGNING_KEY_NAME }}" --armor --detach-sign ./temp-checksums/checksums.txt
 
           # Upload the signature file
-          gh release upload ${{ inputs.release_name }} ./temp-checksums/checksums.txt.asc --clobber
-
+          gh release upload "${{ steps.validate_run_shas.outputs.tag_name }}" --repo "${{ github.repository }}" ./temp-checksums/checksums.txt.asc --clobber           
           echo "Checksums signature created and uploaded successfully"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_UPDATE_TOKEN }}

--- a/app/scripts/validate-run-shas.sh
+++ b/app/scripts/validate-run-shas.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# Copyright 2025 The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validate that the workflow runs used to produce release artifacts were
+# executed from the same commit as the release tag.
+#
+# Release integrity depends on this check: if an artifact was built from a
+# different commit than the one tagged for release, it cannot be trusted as
+# the canonical release binary.  Catching the mismatch here prevents
+# accidentally publishing artifacts built from an unrelated or unreviewed
+# commit.
+#
+# Usage:
+#   GH_TOKEN=<token> ./validate-run-shas.sh <release_name> <repo> <run_ids>
+#
+#   release_name  - Release version, e.g. "0.9.0" or "v0.9.0"
+#   repo          - GitHub repository in "owner/name" format
+#   run_ids       - Comma-separated list of workflow run IDs to validate
+#
+# Exit codes:
+#   0 - All run SHAs match the release tag SHA
+#   1 - Validation failed (tag not found, SHA mismatch, or empty run SHA)
+#
+# Environment variables:
+#   GH_TOKEN or GITHUB_TOKEN  - Required. GitHub token with 'actions: read' permission.
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+fi
+
+# ---------------------------------------------------------------------------
+# resolve_tag
+#
+# Resolves the git tag name for a given release name. Tries the name as-is
+# first; if that tag does not exist locally, tries the alternate form by
+# adding a "v" prefix or stripping a leading "v".
+#
+# Args:
+#   $1 - release_name (e.g. "0.9.0")
+#
+# Outputs (stdout):
+#   The resolved tag name, e.g. "0.9.0" or "v0.9.0"
+#
+# Returns:
+#   0 on success, 1 if neither tag variant exists.
+# ---------------------------------------------------------------------------
+resolve_tag() {
+  local release_name="$1"
+  local tag_name
+
+  if git rev-parse "refs/tags/$release_name" >/dev/null 2>&1; then
+    echo "$release_name"
+    return 0
+  fi
+
+  # Then try the alternate form (with or without a leading "v").
+  if [[ "$release_name" == v* ]]; then
+    tag_name="${release_name#v}"
+  else
+    tag_name="v$release_name"
+  fi
+
+  if git rev-parse "refs/tags/$tag_name" >/dev/null 2>&1; then
+    echo "$tag_name"
+    return 0
+  fi
+
+  echo "Error: Tag '$release_name' or '$tag_name' not found." >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# get_tag_sha
+#
+# Returns the commit SHA that a given tag points to.
+#
+# Args:
+#   $1 - tag_name (e.g. "v0.9.0")
+#
+# Outputs (stdout):
+#   The full 40-character commit SHA.
+# ---------------------------------------------------------------------------
+get_tag_sha() {
+  local tag_name="$1"
+  git rev-list -n 1 "refs/tags/$tag_name^{commit}"
+}
+
+# ---------------------------------------------------------------------------
+# get_run_sha
+#
+# Queries the GitHub API for the head commit SHA of a workflow run.
+#
+# Args:
+#   $1 - run_id   (numeric GitHub Actions run ID)
+#   $2 - repo     (owner/name, e.g. "kubernetes-sigs/headlamp")
+#
+# Outputs (stdout):
+#   The full 40-character head commit SHA of the run.
+# ---------------------------------------------------------------------------
+get_run_sha() {
+  local run_id="$1"
+  local repo="$2"
+  gh run view "$run_id" --repo "$repo" --json headSha -q .headSha
+}
+
+# ---------------------------------------------------------------------------
+# validate_runs
+#
+# Validates that every workflow run in a comma-separated list was executed
+# from the same commit as the release tag.
+#
+# Args:
+#   $1 - expected_sha  (commit SHA the tag resolves to)
+#   $2 - tag_name      (for diagnostic output only)
+#   $3 - repo          (owner/name)
+#   $4 - run_ids       (comma-separated list of run IDs)
+#
+# Returns:
+#   0 if all non-empty run IDs match, 1 on any mismatch or empty SHA.
+# ---------------------------------------------------------------------------
+validate_runs() {
+  local expected_sha="$1"
+  local tag_name="$2"
+  local repo="$3"
+  local run_ids_csv="$4"
+
+  local cleaned_run_ids="${run_ids_csv//[[:space:],]/}"
+  if [ -z "$cleaned_run_ids" ]; then
+    echo "Error: No workflow run IDs provided." >&2
+    return 1
+  fi
+
+  echo "Expected release SHA: $expected_sha (from tag $tag_name)"
+
+  local -a run_ids
+  IFS=',' read -ra run_ids <<< "$run_ids_csv"
+
+  for run_id in "${run_ids[@]}"; do
+    # Trim surrounding whitespace
+    run_id="${run_id#"${run_id%%[![:space:]]*}"}"
+    run_id="${run_id%"${run_id##*[![:space:]]}"}"
+
+    if [ -z "$run_id" ]; then
+      continue
+    fi
+
+    if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
+      echo "Error: Invalid workflow run ID '$run_id' (expected a numeric Actions run ID)." >&2
+      return 1
+    fi
+    local run_sha
+    if ! run_sha=$(get_run_sha "$run_id" "$repo"); then
+      echo "Error: Failed to query SHA for workflow run ID $run_id." >&2
+      return 1
+    fi
+    if [ -z "$run_sha" ]; then
+      echo "Error: Could not determine SHA for workflow run ID $run_id." >&2
+      return 1
+    fi
+
+    echo "Run ID: $run_id"
+    echo "Run SHA: $run_sha"
+
+    if [ "$expected_sha" != "$run_sha" ]; then
+      echo "Error: Workflow run SHA mismatch!" >&2
+      echo "  Run ID:      $run_id" >&2
+      echo "  Run SHA:     $run_sha" >&2
+      echo "  Expected:    $expected_sha (from tag $tag_name)" >&2
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# main
+#
+# Entry point.  Fetches tags, resolves the release tag, then validates every
+# provided workflow run ID against the tag's commit SHA.
+# ---------------------------------------------------------------------------
+main() {
+  local release_name="${1:-}"
+  local repo="${2:-}"
+  local run_ids="${3:-}"
+
+  if [ -z "$release_name" ] || [ -z "$repo" ] || [ -z "$run_ids" ]; then
+    echo "Usage: $0 <release_name> <repo> <run_ids>" >&2
+    echo "  release_name  e.g. 0.9.0 or v0.9.0" >&2
+    echo "  repo          e.g. kubernetes-sigs/headlamp" >&2
+    echo "  run_ids       comma-separated workflow run IDs" >&2
+    exit 1
+  fi
+
+  # Ensure GitHub auth is available for gh CLI.
+  # GitHub CLI supports both GH_TOKEN and GITHUB_TOKEN.
+  local gh_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [ -z "$gh_token" ]; then
+    echo "Error: GH_TOKEN or GITHUB_TOKEN is required for GitHub CLI authentication." >&2
+    exit 1
+  fi
+  export GH_TOKEN="$gh_token"
+
+  # Ensure tags are available locally before resolving
+  git fetch --tags --force origin
+
+  local tag_name
+  tag_name=$(resolve_tag "$release_name") || exit 1
+
+  local expected_sha
+  if ! expected_sha=$(get_tag_sha "$tag_name"); then
+    echo "Error: Failed to determine SHA for tag '$tag_name'." >&2
+    exit 1
+  fi
+  if [ -z "$expected_sha" ]; then
+    echo "Error: Could not determine SHA for tag '$tag_name'." >&2
+    exit 1
+  fi
+ 
+  validate_runs "$expected_sha" "$tag_name" "$repo" "$run_ids"
+}
+
+# Only execute main when the script is run directly, not when sourced.
+# This lets validate-run-shas.test.sh import the functions without side-effects.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/app/scripts/validate-run-shas.test.sh
+++ b/app/scripts/validate-run-shas.test.sh
@@ -1,0 +1,323 @@
+#!/bin/bash
+# Copyright 2025 The Kubernetes Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit tests for validate-run-shas.sh
+#
+# Tests are self-contained: they stub out git and gh commands so no network
+# access or real repository state is required.
+#
+# Usage:
+#   ./validate-run-shas.test.sh
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - One or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE_SCRIPT="$SCRIPT_DIR/validate-run-shas.sh"
+
+# ---------------------------------------------------------------------------
+# Test framework helpers
+# ---------------------------------------------------------------------------
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# pass <test_name>
+pass() {
+  echo "  PASS: $1"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+# fail <test_name> [reason]
+fail() {
+  echo "  FAIL: $1${2:+ — $2}"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+# assert_exit <expected_code> <actual_code> <test_name>
+assert_exit() {
+  local expected="$1"
+  local actual="$2"
+  local name="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected exit $expected, got $actual"
+  fi
+}
+
+# assert_output_contains <substring> <output> <test_name>
+assert_output_contains() {
+  local substring="$1"
+  local output="$2"
+  local name="$3"
+  if echo "$output" | grep -qF "$substring"; then
+    pass "$name"
+  else
+    fail "$name" "expected output to contain: $substring"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Source only the library functions (skip main) for unit testing.
+# We do this by sourcing the script with BASH_SOURCE guard awareness: the
+# script calls main "$@" only when executed directly, so we can source it
+# and then call individual functions.
+# ---------------------------------------------------------------------------
+
+# Source the script to import its functions. The BASH_SOURCE guard in
+# validate-run-shas.sh ensures main is NOT called during source.
+# shellcheck source=validate-run-shas.sh
+source "$VALIDATE_SCRIPT"
+
+# ---------------------------------------------------------------------------
+# Stubs: override git and gh so tests need no real repo or network access.
+# Each test sets the relevant stub variables before calling the function.
+# ---------------------------------------------------------------------------
+
+# Stub state (set per test)
+STUB_TAG_EXISTS=""       # tag name that should "exist", empty means none
+STUB_TAG_SHA=""          # SHA returned by git rev-list
+STUB_RUN_SHA=""          # SHA returned by gh run view
+STUB_GH_EMPTY=""         # set to "1" to make gh return empty string
+
+git() {
+  case "$1" in
+    rev-parse)
+      # The call is: git rev-parse "refs/tags/<name>" >/dev/null 2>&1
+      # After the subcommand ($1), the tag ref is the next argument ($2).
+      local tag="${2#refs/tags/}"
+      if [ "$tag" = "$STUB_TAG_EXISTS" ]; then
+        return 0
+      fi
+      return 1
+      ;;
+    rev-list)
+      echo "$STUB_TAG_SHA"
+      ;;
+    fetch)
+      # no-op: tests don't need a real remote
+      return 0
+      ;;
+    *)
+      echo "Unexpected git invocation in test stub: git $*" >&2
+      return 127
+      ;;
+  esac
+}
+
+gh() {
+  if [ "$STUB_GH_EMPTY" = "1" ]; then
+    echo ""
+  else
+    echo "$STUB_RUN_SHA"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Tests: resolve_tag
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== resolve_tag ==="
+
+test_resolve_tag_plain() {
+  STUB_TAG_EXISTS="0.9.0"
+  local result rc
+  # Capture stdout only; errors are not expected on the happy path.
+  result=$(resolve_tag "0.9.0")
+  rc=$?
+  assert_exit 0 "$rc" "resolve_tag: plain tag exists"
+  assert_output_contains "0.9.0" "$result" "resolve_tag: plain tag returns tag name"
+}
+
+test_resolve_tag_v_prefix() {
+  # Plain tag does not exist; "v0.9.0" does.
+  STUB_TAG_EXISTS="v0.9.0"
+  local result rc
+  result=$(resolve_tag "0.9.0")
+  rc=$?
+  assert_exit 0 "$rc" "resolve_tag: v-prefix fallback exists"
+  assert_output_contains "v0.9.0" "$result" "resolve_tag: v-prefix fallback returns v-prefixed name"
+}
+
+ test_resolve_tag_strip_v_prefix() {
+  # v-prefixed tag does not exist; plain tag does.
+  STUB_TAG_EXISTS="0.9.0"
+  local result rc
+  result=$(resolve_tag "v0.9.0")
+  rc=$?
+  assert_exit 0 "$rc" "resolve_tag: strip v-prefix fallback exists"
+  assert_output_contains "0.9.0" "$result" "resolve_tag: strip v-prefix fallback returns plain name"
+ }
+
+test_resolve_tag_missing() {
+  STUB_TAG_EXISTS=""
+  local result rc
+  # Capture both stdout and stderr; disable errexit so the non-zero return
+  # does not abort the test runner before we can inspect $?.
+  set +e
+  result=$(resolve_tag "0.9.0" 2>&1)
+  rc=$?
+  set -e
+  assert_exit 1 "$rc" "resolve_tag: missing tag returns exit 1"
+  assert_output_contains "not found" "$result" "resolve_tag: missing tag prints error"
+}
+
+test_resolve_tag_plain
+test_resolve_tag_v_prefix
+test_resolve_tag_strip_v_prefix
+test_resolve_tag_missing
+
+# ---------------------------------------------------------------------------
+# Tests: get_tag_sha
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== get_tag_sha ==="
+
+test_get_tag_sha() {
+  STUB_TAG_SHA="abc123def456"
+  local result
+  result=$(get_tag_sha "v0.9.0")
+  assert_output_contains "abc123def456" "$result" "get_tag_sha: returns expected SHA"
+}
+
+test_get_tag_sha
+
+# ---------------------------------------------------------------------------
+# Tests: validate_runs
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== validate_runs ==="
+
+test_validate_runs_matching_sha() {
+  STUB_GH_EMPTY=""
+  STUB_RUN_SHA="deadbeef1234"
+  local out rc
+  out=$(validate_runs "deadbeef1234" "v0.9.0" "kubernetes-sigs/headlamp" "111" 2>&1)
+  rc=$?
+  assert_exit 0 "$rc" "validate_runs: matching SHA passes"
+}
+
+test_validate_runs_mismatched_sha() {
+  STUB_GH_EMPTY=""
+  STUB_RUN_SHA="badc0ffee999"
+  local out rc
+  set +e
+  out=$(validate_runs "deadbeef1234" "v0.9.0" "kubernetes-sigs/headlamp" "222" 2>&1)
+  rc=$?
+  set -e
+  assert_exit 1 "$rc" "validate_runs: mismatched SHA fails"
+  assert_output_contains "mismatch" "$out" "validate_runs: mismatch prints diagnostic"
+}
+
+test_validate_runs_empty_run_sha() {
+  STUB_GH_EMPTY="1"
+  local out rc
+  set +e
+  out=$(validate_runs "deadbeef1234" "v0.9.0" "kubernetes-sigs/headlamp" "333" 2>&1)
+  rc=$?
+  set -e
+  assert_exit 1 "$rc" "validate_runs: empty run SHA fails"
+  assert_output_contains "Could not determine SHA" "$out" "validate_runs: empty SHA prints error"
+}
+
+test_validate_runs_multiple_run_ids_pass() {
+  STUB_GH_EMPTY=""
+  STUB_RUN_SHA="cafebabe5678"
+  local out rc
+  out=$(validate_runs "cafebabe5678" "v0.9.0" "kubernetes-sigs/headlamp" "101,102,103" 2>&1)
+  rc=$?
+  assert_exit 0 "$rc" "validate_runs: multiple matching IDs all pass"
+}
+
+test_validate_runs_multiple_run_ids_one_fails() {
+  # All IDs return the same (wrong) SHA from the stub, so the first mismatch
+  # fails the whole run — confirms a bad run ID in a list blocks the release.
+  STUB_GH_EMPTY=""
+  STUB_RUN_SHA="badc0de00000"
+  local out rc
+  set +e
+  out=$(validate_runs "cafebabe5678" "v0.9.0" "kubernetes-sigs/headlamp" "101,102" 2>&1)
+  rc=$?
+  set -e
+  assert_exit 1 "$rc" "validate_runs: mismatch in multi-ID list fails"
+}
+
+test_validate_runs_empty_run_ids() {
+  STUB_GH_EMPTY=""
+  STUB_RUN_SHA=""
+  local out rc
+  # All entries are whitespace / empty; should fail (nothing to validate).
+  set +e
+  out=$(validate_runs "deadbeef1234" "v0.9.0" "kubernetes-sigs/headlamp" ",, ," 2>&1)
+  rc=$?
+  set -e
+  assert_exit 1 "$rc" "validate_runs: all-empty run IDs fails (fail fast)"
+  assert_output_contains "Error: No workflow run IDs provided." "$out" "validate_runs: empty run IDs prints error"
+}
+
+test_validate_runs_get_run_sha_failure() (
+  # Simulate `gh`/API failure by making get_run_sha return non-zero.
+  get_run_sha() { return 2; }
+  local out rc
+  set +e
+  out=$(validate_runs "deadbeef1234" "v0.9.0" "kubernetes-sigs/headlamp" "444" 2>&1)
+  rc=$?
+  set -e
+  assert_exit 1 "$rc" "validate_runs: get_run_sha failure fails"
+  assert_output_contains "Failed to query SHA" "$out" "validate_runs: get_run_sha failure prints error"
+  )
+
+test_validate_runs_option_like_run_id() {
+  STUB_GH_EMPTY=""
+  STUB_RUN_SHA=""
+  local out rc
+  # Option-like run ID (-n) should fail validation as a non-numeric run ID, rather than being silently skipped.
+  set +e
+  out=$(validate_runs "deadbeef1234" "v0.9.0" "kubernetes-sigs/headlamp" " -n " 2>&1)
+  rc=$?
+  set -e
+  assert_exit 1 "$rc" "validate_runs: option-like run ID fails"
+  assert_output_contains "Invalid workflow run ID '-n'" "$out" "validate_runs: option-like run ID prints error"
+}
+
+test_validate_runs_matching_sha
+test_validate_runs_mismatched_sha
+test_validate_runs_empty_run_sha
+test_validate_runs_multiple_run_ids_pass
+test_validate_runs_multiple_run_ids_one_fails
+test_validate_runs_empty_run_ids
+test_validate_runs_get_run_sha_failure
+test_validate_runs_option_like_run_id
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Results ==="
+echo "  Passed: $TESTS_PASSED"
+echo "  Failed: $TESTS_FAILED"
+echo ""
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This PR adds validation to `push-release-assets.yml` to ensure workflow run SHAs match the target release tag SHA before uploading release artifacts.

## Related Issue

Fixes #5853 

## Changes

* Added workflow run SHA validation before artifact upload
* Prevented release artifacts from being uploaded if workflow run SHA does not match the release tag SHA
* Added fail-fast validation logic to improve release consistency and provenance verification

## Steps to Test

1. Trigger the `Upload Release Assets` workflow manually
2. Provide a valid `release_name` and matching workflow `run_ids`
3. Verify the workflow succeeds when SHAs match
4. Trigger the workflow again with a mismatched or older `run_id`
5. Verify the workflow fails with a SHA mismatch error before uploading artifacts

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

* This change is intentionally minimal and only adds validation logic before artifact download/upload.
* Existing release/upload behavior remains unchanged when SHAs match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release publishing now verifies selected workflow runs against the release tag before downloading artifacts.
  - Artifact signing, uploading, and checksum generation run only when artifacts are available.
  - Release workflows now require workflow run IDs and handle artifact filenames more safely.

- **Bug Fixes**
  - Improved validation for tags, run IDs, missing artifacts, and unavailable commit information.

- **Tests**
  - Added coverage for tag resolution, run validation, mismatches, query failures, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->