### PR TITLE
docs: rework oidc.md into a focused configuration reference (#5816)

### DIFF
--- a/docs/installation/in-cluster/oidc-troubleshooting.md
+++ b/docs/installation/in-cluster/oidc-troubleshooting.md
@@ -1,0 +1,19 @@
+---
+title: OIDC Troubleshooting
+sidebar_label: OIDC Troubleshooting
+---
+
+## Real-time updates not working (Ingress NGINX and large JWT tokens)
+
+If real-time updates in Headlamp stop working after OIDC login, oversized JWT tokens are a common cause.
+
+If your OIDC provider issues large JWT tokens (e.g., >8KB), WebSocket connections may fail or authentication headers may be truncated when Headlamp is behind an Ingress NGINX controller.
+
+To resolve this, increase the header buffer size using the following annotation in your [NGINX Ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) resource:
+
+```yaml
+nginx.ingress.kubernetes.io/server-snippet: |-
+  large_client_header_buffers 4 64k;
+```
+
+> **Note:** Regular HTTP requests may still work even with large tokens, but WebSocket connections are more sensitive to header size limits and will fail without this change.

--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -7,25 +7,21 @@ Headlamp supports OIDC for cluster users to effortlessly log in using a "Sign in
 
 ![screenshot the login dialog for a cluster](./oidc_button.png)
 
-To use OIDC, Headlamp needs to know how to configure it, so you have to provide the following OIDC-related arguments to Headlamp from your OIDC provider:
+To use OIDC, Headlamp needs the following arguments from your OIDC provider:
 
 - the client ID: `-oidc-client-id` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_ID`
 - the client secret: `-oidc-client-secret` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_SECRET`
 - the issuer URL: `-oidc-idp-issuer-url` or env var `HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL`
-- (optionally) the OpenId scopes: `-oidc-scopes` or env var `HEADLAMP_CONFIG_OIDC_SCOPES`
-
-and you have to tell the OIDC provider about the callback URL, which in Headlamp it is your URL + the `/oidc-callback` path, e.g.:
-`https://YOUR_URL/oidc-callback`.
+- (optionally) the OpenID scopes: `-oidc-scopes` or env var `HEADLAMP_CONFIG_OIDC_SCOPES`
 
 ### Callback URL
 
 You must tell your OIDC provider the callback URL that Headlamp will use after login. This is your Headlamp URL plus `/oidc-callback`, for example:
-
 ```
 https://YOUR_URL/oidc-callback
 ```
 
-> **ℹ️ Note:** If you're running Headlamp behind an ingress or load balancer (e.g., NGINX, AWS ALB/NLB), make sure it forwards the `X-Forwarded-Proto` header. Otherwise, Headlamp may generate the callback URL using `http` instead of `https`, which can cause a mismatch with your OIDC provider.
+> **Note:** If you're running Headlamp behind an ingress or load balancer (e.g., NGINX, AWS ALB/NLB), make sure it forwards the `X-Forwarded-Proto` header. Otherwise, Headlamp may generate the callback URL using `http` instead of `https`, which can cause a mismatch with your OIDC provider.
 >
 > For [NGINX ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/), you can add:
 >
@@ -34,83 +30,38 @@ https://YOUR_URL/oidc-callback
 >   proxy_set_header X-Forwarded-Proto $scheme;
 > ```
 
-### Troubleshooting: Real time updates not working, Large JWT Tokens with Ingress NGINX
-
-If you notice real time updates not working, this could be the cause.
-
-If your OIDC provider issues large JWT tokens (e.g., >8KB), you may encounter issues with WebSocket connections or authentication headers being truncated when using Headlamp behind an Ingress NGINX controller.
-
-To resolve this, increase the header buffer size using the following annotation in your [NGINX Ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) resource:
-
-```yaml
-nginx.ingress.kubernetes.io/server-snippet: |-
-  large_client_header_buffers 4 64k;
-```
-
-> **ℹ️ Note:** Regular HTTP requests may still work even with large tokens, but WebSocket connections are more sensitive to header size limits and may fail unless this buffer is increased.
-
 ### Scopes
 
-Besides the mandatory _openid_ scope, Headlamp also requests the optional
-_profile_ and _email_
+Besides the mandatory _openid_ scope, Headlamp also requests the optional _profile_ and _email_
 [scopes](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes).
-Scopes can be overridden by using the `-oidc-scopes` option. Remember to
-include the default ones if you need them when using that option.
-For example, if you need to keep the default scopes and add Github's `repo`,
-then add them all to the option:
+Scopes can be overridden by using the `-oidc-scopes` option. Remember to include the default ones if you need them when using that option. For example, to keep the defaults and add GitHub's `repo` scope:
 
 `-oidc-scopes=profile,email,repo`
 
-**Note:** Before Headlamp 0.3.0, a scope _groups_ was also included, as it's
-used by Dex and other services, but since it's not part of the default spec,
-it was removed in the mentioned version.
+**Note:** Before Headlamp 0.3.0, a scope _groups_ was also included, as it's used by Dex and other services, but since it's not part of the default spec, it was removed in the mentioned version.
 
 ### Token Validation Overrides
 
-In the event your OIDC Provider issues `access_tokens` from a different Issuer URL or clientID audience than its `id_tokens` (i.e. Azure Entra ID) you may have need of the following parameters to configure what is used in validation of tokens.
+If your OIDC provider issues an `access_token` from a different issuer URL or clientID audience than its `id_token` (e.g. Azure Entra ID), use the following parameters to configure token validation:
 
-- `-oidc-validator-client-id=<clientID audience to validate in token>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID` which is the clientID headlamp should be verifying in the `aud` field of the token provided back from the OIDC provider.
-- `-oidc-validator-idp-issuer-url=<issuerURL to use in validation>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL` which is the IssuerURL headlamp should be verifying in the `iss` field of the token provided back from the OIDC Provider
+- `-oidc-validator-client-id=<clientID audience to validate in token>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID` — the clientID Headlamp should verify in the `aud` field of the token.
+- `-oidc-validator-idp-issuer-url=<issuerURL to use in validation>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL` — the issuer URL Headlamp should verify in the `iss` field of the token.
 
 ### Use Access Tokens instead of ID Tokens
 
-By default, headlamp leverages the `id_token` provided back from the OIDC Provider after authentication returned to the `/oidc-callback` endpoint. For some Identity Providers like Azure Entra ID, the `access_token` is what is used for authorization to Kubernetes clusters. To instruct headlamp to use the `access_token` instead of the `id_token`, the following flag can be used.
+By default, Headlamp uses the `id_token` returned after authentication. For some providers like Azure Entra ID, the `access_token` is required for Kubernetes cluster authorization. To switch:
 
 - `-oidc-use-access-token=true` or env var `HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN`
 
-### Example: OIDC with Keycloak in Minikube
+### Provider Tutorials
 
-If you are interested in a comprehensive example of using OIDC and Headlamp,
-you can check the
-[tutorial on setting up OIDC with Keycloack in Minikube](./keycloak/).
+For step-by-step setup guides with specific providers, see:
 
-### Example: OIDC with Entra ID in AKS
+- [Keycloak in Minikube](./keycloak/)
+- [Azure Entra ID in AKS](./azure-entra-id/)
+- [Dex](./dex/)
+- [OpenUnison](./openunison/)
 
-If you are interested in a comprehensive tutorial of using OIDC and Headlamp in AKS,
-you can check the
-[tutorial on setting up OIDC with Entra ID in AKS](./azure-entra-id/).
+### Troubleshooting
 
-For quick reference if you are already familiar with setting up Entra ID,
-
-- Add the callback URL (e.g. `https://YOUR_URL/oidc-callback`) to your Azure App Registration's `redirectURIs`
-- Set `-oidc-client-id` to your Azure App Registration's clientID
-- Set `-oidc-client-secret` to your Azure App Registration's clientSecret
-- Set `-oidc-idp-issuer-url` to `https://login.microsoftonline.com/<Your Azure Directory (tenant) ID>/v2.0`
-- Set `-oidc-scopes` to `6dae42f8-4368-4678-94ff-3960e28e3630/user.read,openid,email,profile`
-- Set `--oidc-validator-idp-issuer-url` to `https://sts.windows.net/<Your Directory (tenant) ID>/`
-- Set `-oidc-validator-client-id` to `6dae42f8-4368-4678-94ff-3960e28e3630`
-- Set `-oidc-use-access-token=true`
-
-
-### Example: OIDC with Dex
-
-If you are using Dex and want to configure Headlamp to use it for OIDC,
-then you have to:
-
-- Add the callback URL (e.g. `https://YOUR_URL/oidc-callback`) to Dex's `staticClient.redirectURIs`
-- Set `-oidc-client-id` as Dex's `staticClient.id`
-- Set `-oidc-client-secret` as Dex's `staticClient.secret`
-- Set `-oidc-idp-issuer-url` as Dex's URL (same as in `--oidc-issuer-url` in the Kubernetes APIServer)
-- Set `-oidc-scopes` if needed, e.g. `-oidc-scopes=profile,email,groups`
-
-**Note** If you already have another static client configured for Kubernetes for the [apiserver's OIDC](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server) (OpenID Connect) configuration, use a **single static client ID** i.e `-oidc-client-id` for both Dex and Headlamp. Additionally, the **redirectURIs** need to be specified for each client.
+See the [OIDC troubleshooting guide](./oidc-troubleshooting.md) for help with common issues including real-time updates not working and large JWT token handling.

--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -7,25 +7,21 @@ Headlamp supports OIDC for cluster users to effortlessly log in using a "Sign in
 
 ![screenshot the login dialog for a cluster](./oidc_button.png)
 
-To use OIDC, Headlamp needs to know how to configure it, so you have to provide the following OIDC-related arguments to Headlamp from your OIDC provider:
+To use OIDC, Headlamp needs the following arguments from your OIDC provider:
 
 - the client ID: `-oidc-client-id` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_ID`
 - the client secret: `-oidc-client-secret` or env var `HEADLAMP_CONFIG_OIDC_CLIENT_SECRET`
 - the issuer URL: `-oidc-idp-issuer-url` or env var `HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL`
-- (optionally) the OpenId scopes: `-oidc-scopes` or env var `HEADLAMP_CONFIG_OIDC_SCOPES`
-
-and you have to tell the OIDC provider about the callback URL, which in Headlamp it is your URL + the `/oidc-callback` path, e.g.:
-`https://YOUR_URL/oidc-callback`.
+- (optionally) the OpenID scopes: `-oidc-scopes` or env var `HEADLAMP_CONFIG_OIDC_SCOPES`
 
 ### Callback URL
 
 You must tell your OIDC provider the callback URL that Headlamp will use after login. This is your Headlamp URL plus `/oidc-callback`, for example:
-
 ```
 https://YOUR_URL/oidc-callback
 ```
 
-> **ℹ️ Note:** If you're running Headlamp behind an ingress or load balancer (e.g., NGINX, AWS ALB/NLB), make sure it forwards the `X-Forwarded-Proto` header. Otherwise, Headlamp may generate the callback URL using `http` instead of `https`, which can cause a mismatch with your OIDC provider.
+> **Note:** If you're running Headlamp behind an ingress or load balancer (e.g., NGINX, AWS ALB/NLB), make sure it forwards the `X-Forwarded-Proto` header. Otherwise, Headlamp may generate the callback URL using `http` instead of `https`, which can cause a mismatch with your OIDC provider.
 >
 > For [NGINX ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/), you can add:
 >
@@ -34,91 +30,45 @@ https://YOUR_URL/oidc-callback
 >   proxy_set_header X-Forwarded-Proto $scheme;
 > ```
 
-### Troubleshooting: Real time updates not working, Large JWT Tokens with Ingress NGINX
-
-If you notice real time updates not working, this could be the cause.
-
-If your OIDC provider issues large JWT tokens (e.g., >8KB), you may encounter issues with WebSocket connections or authentication headers being truncated when using Headlamp behind an Ingress NGINX controller.
-
-To resolve this, increase the header buffer size using the following annotation in your [NGINX Ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) resource:
-
-```yaml
-nginx.ingress.kubernetes.io/server-snippet: |-
-  large_client_header_buffers 4 64k;
-```
-
-> **ℹ️ Note:** Regular HTTP requests may still work even with large tokens, but WebSocket connections are more sensitive to header size limits and may fail unless this buffer is increased.
-
 ### Scopes
 
-Besides the mandatory _openid_ scope, Headlamp also requests the optional
-_profile_ and _email_
+Besides the mandatory _openid_ scope, Headlamp also requests the optional _profile_ and _email_
 [scopes](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes).
-Scopes can be overridden by using the `-oidc-scopes` option. Remember to
-include the default ones if you need them when using that option.
-For example, if you need to keep the default scopes and add Github's `repo`,
-then add them all to the option:
+Scopes can be overridden by using the `-oidc-scopes` option. Remember to include the default ones if you need them when using that option. For example, to keep the defaults and add GitHub's `repo` scope:
 
 `-oidc-scopes=profile,email,repo`
 
-**Note:** Before Headlamp 0.3.0, a scope _groups_ was also included, as it's
-used by Dex and other services, but since it's not part of the default spec,
-it was removed in the mentioned version.
+**Note:** Before Headlamp 0.3.0, a scope _groups_ was also included, as it's used by Dex and other services, but since it's not part of the default spec, it was removed in the mentioned version.
 
 ### Token Validation Overrides
 
-In the event your OIDC Provider issues `access_tokens` from a different Issuer URL or clientID audience than its `id_tokens` (i.e. Azure Entra ID) you may have need of the following parameters to configure what is used in validation of tokens.
+If your OIDC provider issues an `access_token` from a different issuer URL or clientID audience than its `id_token` (e.g. Azure Entra ID), use the following parameters to configure token validation:
 
-- `-oidc-validator-client-id=<clientID audience to validate in token>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID` which is the clientID headlamp should be verifying in the `aud` field of the token provided back from the OIDC provider.
-- `-oidc-validator-idp-issuer-url=<issuerURL to use in validation>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL` which is the IssuerURL headlamp should be verifying in the `iss` field of the token provided back from the OIDC Provider
+- `-oidc-validator-client-id=<clientID audience to validate in token>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_CLIENT_ID` — the clientID Headlamp should verify in the `aud` field of the token.
+- `-oidc-validator-idp-issuer-url=<issuerURL to use in validation>` or env var `HEADLAMP_CONFIG_OIDC_VALIDATOR_IDP_ISSUER_URL` — the issuer URL Headlamp should verify in the `iss` field of the token.
 
 ### Use Access Tokens instead of ID Tokens
 
-By default, headlamp leverages the `id_token` provided back from the OIDC Provider after authentication returned to the `/oidc-callback` endpoint. For some Identity Providers like Azure Entra ID, the `access_token` is what is used for authorization to Kubernetes clusters. To instruct headlamp to use the `access_token` instead of the `id_token`, the following flag can be used.
+By default, Headlamp uses the `id_token` returned after authentication. For some providers like Azure Entra ID, the `access_token` is required for Kubernetes cluster authorization. To switch:
 
 - `-oidc-use-access-token=true` or env var `HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN`
 
-### Example: OIDC with Keycloak in Minikube
+### Provider Tutorials
 
-If you are interested in a comprehensive example of using OIDC and Headlamp,
-you can check the
-[tutorial on setting up OIDC with Keycloack in Minikube](./keycloak/).
+For step-by-step setup guides with specific providers, see:
 
-### Example: OIDC with Entra ID in AKS
+- [Keycloak in Minikube](./keycloak/)
+- [Azure Entra ID in AKS](./azure-entra-id/)
+- [OpenUnison](./openunison/)
 
-If you are interested in a comprehensive tutorial of using OIDC and Headlamp in AKS,
-you can check the
-[tutorial on setting up OIDC with Entra ID in AKS](./azure-entra-id/).
+### Troubleshooting
 
-For quick reference if you are already familiar with setting up Entra ID,
-
-- Add the callback URL (e.g. `https://YOUR_URL/oidc-callback`) to your Azure App Registration's `redirectURIs`
-- Set `-oidc-client-id` to your Azure App Registration's clientID
-- Set `-oidc-client-secret` to your Azure App Registration's clientSecret
-- Set `-oidc-idp-issuer-url` to `https://login.microsoftonline.com/<Your Azure Directory (tenant) ID>/v2.0`
-- Set `-oidc-scopes` to `6dae42f8-4368-4678-94ff-3960e28e3630/user.read,openid,email,profile`
-- Set `--oidc-validator-idp-issuer-url` to `https://sts.windows.net/<Your Directory (tenant) ID>/`
-- Set `-oidc-validator-client-id` to `6dae42f8-4368-4678-94ff-3960e28e3630`
-- Set `-oidc-use-access-token=true`
-
-
-### Example: OIDC with Dex
-
-If you are using Dex and want to configure Headlamp to use it for OIDC,
-then you have to:
-
-- Add the callback URL (e.g. `https://YOUR_URL/oidc-callback`) to Dex's `staticClient.redirectURIs`
-- Set `-oidc-client-id` as Dex's `staticClient.id`
-- Set `-oidc-client-secret` as Dex's `staticClient.secret`
-- Set `-oidc-idp-issuer-url` as Dex's URL (same as in `--oidc-issuer-url` in the Kubernetes APIServer)
-- Set `-oidc-scopes` if needed, e.g. `-oidc-scopes=profile,email,groups`
-
-**Note** If you already have another static client configured for Kubernetes for the [apiserver's OIDC](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server) (OpenID Connect) configuration, use a **single static client ID** i.e `-oidc-client-id` for both Dex and Headlamp. Additionally, the **redirectURIs** need to be specified for each client.
-
-### Troubleshooting: OIDC sign-in succeeds but the cluster rejects your token
+#### OIDC sign-in succeeds but the cluster rejects your token
 
 If you can sign in via OIDC but are returned to the "Sign in" screen with a message that the cluster rejected your token (and cannot load cluster resources), the cluster's **API server** is most likely not configured to trust the same OIDC provider as Headlamp. Headlamp only forwards the token to the API server, and the API server is what accepts or rejects it, so it must be OIDC-aware with a matching issuer, client ID, and audience.
 
 Make sure the API server is configured for the same OIDC provider (via its `--oidc-issuer-url` / `--oidc-client-id` flags or the equivalent [structured authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server)), so that `--oidc-issuer-url` matches Headlamp's `-oidc-idp-issuer-url` and `--oidc-client-id` matches Headlamp's `-oidc-client-id`.
 
 Managed control planes (e.g. AKS, EKS, GKE) may not accept arbitrary OIDC flags on the API server. If that is the case, use the provider's managed identity/OIDC integration instead. When the API server rejects the token, Headlamp logs a warning containing `API server rejected the forwarded bearer token (401)`.
+
+For other common issues including real-time updates not working and large JWT token handling, see the [OIDC troubleshooting guide](./oidc-troubleshooting.md).


### PR DESCRIPTION
## Summary
This PR fixes the confusing structure of `oidc.md` by splitting it into a focused configuration reference and a separate troubleshooting page.

## Related Issue
Fixes #5816

## Changes
- Refocused `oidc.md` to cover only provider-agnostic configuration: required flags, callback URL, scopes, token validation overrides, and the access token flag
- Removed the inline Entra ID and Dex quick-reference blocks, which partially duplicated the dedicated tutorial pages without full context, and replaced them with a clean "Provider Tutorials" link list so there is one source of truth per provider
- Extracted the NGINX large JWT / `large_client_header_buffers` troubleshooting content into a new `oidc-troubleshooting.md`, linked from the main page
- Minor prose cleanup throughout for clarity and consistency

## Steps to Test
1. Navigate to the rendered `oidc.md` page
2. Confirm the page contains only universal configuration content with no provider-specific quick-reference blocks
3. Follow the "Provider Tutorials" links and confirm each points to the correct existing tutorial page
4. Follow the "Troubleshooting" link and confirm it renders the new `oidc-troubleshooting.md` with the NGINX large JWT content intact

## Notes for the Reviewer
- The Entra ID and Dex quick-reference blocks were not deleted from the project, only from `oidc.md`. Their content lives in full in `azure-entra-id/index.md` and `dex/index.md` respectively.
- The new `oidc-troubleshooting.md` should be checked to confirm it appears correctly in the sidebar, depending on how the Docusaurus sidebar is configured for this section.

## Screenshots

**Reworked `oidc.md` ==> top of page (required flags and callback URL):**
<img width="1866" height="1016" alt="Screenshot from 2026-05-30 13-36-11" src="https://github.com/user-attachments/assets/a165e53b-1425-4b6b-afb6-66092675fabb" />


**Reworked `oidc.md` ==> scopes and token validation overrides:**
<img width="1866" height="1016" alt="Screenshot from 2026-05-30 13-36-22" src="https://github.com/user-attachments/assets/0f60ed19-967f-44b7-8767-94ec9c9580a3" />

**Reworked `oidc.md` ==> provider tutorials and troubleshooting link:**
<img width="1866" height="1016" alt="Screenshot from 2026-05-30 13-36-30" src="https://github.com/user-attachments/assets/56e6a1e8-068e-43c8-8676-a74d73eb9809" />

**New `oidc-troubleshooting.md` page:**
<img width="1866" height="1016" alt="Screenshot from 2026-05-30 13-36-39" src="https://github.com/user-attachments/assets/e397b5ed-89c4-4b83-8a19-22cd7b8fd62f" />