### PR TITLE
github: Use GH_TOKEN for website trigger

### DIFF
--- a/.github/workflows/trigger-website-build.yml
+++ b/.github/workflows/trigger-website-build.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - name: Trigger via gh
         env:
-          GITHUB_TOKEN: ${{ secrets.KINVOLK_REPOS_TOKEN }}
+          GH_TOKEN: ${{ secrets.KINVOLK_REPOS_TOKEN }}
         run: |
           gh api repos/headlamp-k8s/headlamp-website/dispatches --raw-field event_type=headlamp-docs-update


### PR DESCRIPTION
This change updates the website trigger workflow to provide the GitHub CLI token through `GH_TOKEN`, which fixes authentication for the `gh api` dispatch call.

### Error output

<img width="1059" height="535" alt="image" src="https://github.com/user-attachments/assets/dc5ecb95-7347-4589-91bf-59a990367f46" />

### Testing

- Confirmed the workflow now uses `GH_TOKEN` as required by GitHub CLI in Actions
- Not run locally; workflow-only change.