### PR TITLE
frontend: Chart: Fix react-hooks/refs violation

### DIFF
--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -201,7 +201,10 @@ export function PercentageBar(props: PercentageBarProps) {
   const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
 
   useEffect(() => {
-    setContainerRect(containerRef.current?.getBoundingClientRect() ?? null);
+    const handle = requestAnimationFrame(() => {
+      setContainerRect(containerRef.current?.getBoundingClientRect() ?? null);
+    });
+    return () => cancelAnimationFrame(handle);
   }, []);
 
   const handleMouseEnter = useCallback(() => {

--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -208,7 +208,16 @@ export function PercentageBar(props: PercentageBarProps) {
   }, []);
 
   const handleMouseEnter = useCallback(() => {
-    setContainerRect(containerRef.current?.getBoundingClientRect() ?? null);
+    const next = containerRef.current?.getBoundingClientRect() ?? null;
+
+    setContainerRect(prev =>
+      prev?.left === next?.left &&
+      prev?.top === next?.top &&
+      prev?.width === next?.width &&
+      prev?.height === next?.height
+        ? prev
+        : next
+    );
   }, []);
 
   function formatData() {

--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -201,11 +201,14 @@ export function PercentageBar(props: PercentageBarProps) {
   const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
 
   useEffect(() => {
+    if (!tooltipFunc) {
+      return;
+    }
     const handle = requestAnimationFrame(() => {
       setContainerRect(containerRef.current?.getBoundingClientRect() ?? null);
     });
     return () => cancelAnimationFrame(handle);
-  }, []);
+  }, [tooltipFunc]);
 
   const handleMouseEnter = useCallback(() => {
     const next = containerRef.current?.getBoundingClientRect() ?? null;
@@ -242,8 +245,8 @@ export function PercentageBar(props: PercentageBarProps) {
         layout="vertical"
         maxBarSize={5}
         data={[formatData()]}
-        onMouseEnter={handleMouseEnter}
-        onMouseMove={handleMouseEnter}
+        onMouseEnter={tooltipFunc ? handleMouseEnter : undefined}
+        onMouseMove={tooltipFunc ? handleMouseEnter : undefined}
       >
         {tooltipFunc && (
           <Tooltip

--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -234,6 +234,7 @@ export function PercentageBar(props: PercentageBarProps) {
         maxBarSize={5}
         data={[formatData()]}
         onMouseEnter={handleMouseEnter}
+        onMouseMove={handleMouseEnter}
       >
         {tooltipFunc && (
           <Tooltip

--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -221,39 +221,42 @@ export function PercentageBar(props: PercentageBarProps) {
     theme.palette.mode === 'dark' ? theme.palette.primary.light : theme.palette.primary.main;
 
   return (
-    <div onMouseEnter={handleMouseEnter}>
-      <StyledResponsiveContainer width="95%" height={20} ref={containerRef}>
-        <StyledBarChart layout="vertical" maxBarSize={5} data={[formatData()]}>
-          {tooltipFunc && (
-            <Tooltip
-              content={props => (
-                <PaperTooltip
-                  rechartsProps={props}
-                  tooltipFunc={tooltipFunc}
-                  data={data}
-                  containerRect={containerRect}
-                />
-              )}
-            />
-          )}
-          <XAxis hide domain={[0, 100]} type="number" />
-          <YAxis hide type="category" />
-          {data.map((item, index) => {
-            return (
-              <Bar
-                key={index}
-                dataKey={item.name}
-                stackId="1"
-                fill={item.fill || barColor}
-                layout="vertical"
-                radius={theme.shape.borderRadius}
-                background={{ fill: barBackground }}
+    <StyledResponsiveContainer width="95%" height={20} ref={containerRef}>
+      <StyledBarChart
+        layout="vertical"
+        maxBarSize={5}
+        data={[formatData()]}
+        onMouseEnter={handleMouseEnter}
+      >
+        {tooltipFunc && (
+          <Tooltip
+            content={props => (
+              <PaperTooltip
+                rechartsProps={props}
+                tooltipFunc={tooltipFunc}
+                data={data}
+                containerRect={containerRect}
               />
-            );
-          })}
-        </StyledBarChart>
-      </StyledResponsiveContainer>
-    </div>
+            )}
+          />
+        )}
+        <XAxis hide domain={[0, 100]} type="number" />
+        <YAxis hide type="category" />
+        {data.map((item, index) => {
+          return (
+            <Bar
+              key={index}
+              dataKey={item.name}
+              stackId="1"
+              fill={item.fill || barColor}
+              layout="vertical"
+              radius={theme.shape.borderRadius}
+              background={{ fill: barBackground }}
+            />
+          );
+        })}
+      </StyledBarChart>
+    </StyledResponsiveContainer>
   );
 }
 
@@ -265,7 +268,8 @@ interface PaperTooltipProps {
 }
 
 function PaperTooltip({ rechartsProps, tooltipFunc, data, containerRect }: PaperTooltipProps) {
-  if (!rechartsProps || !rechartsProps.active || !rechartsProps.coordinate) return null;
+  if (!rechartsProps || !rechartsProps.active || !rechartsProps.coordinate || !containerRect)
+    return null;
 
   const { x, y } = rechartsProps.coordinate;
   const left = (containerRect?.left ?? 0) + x;

--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -19,7 +19,7 @@ import Paper from '@mui/material/Paper';
 import { useTheme } from '@mui/material/styles';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import React, { ReactNode, useCallback, useRef, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import {
   Bar,
@@ -199,6 +199,10 @@ export function PercentageBar(props: PercentageBarProps) {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    setContainerRect(containerRef.current?.getBoundingClientRect() ?? null);
+  }, []);
 
   const handleMouseEnter = useCallback(() => {
     setContainerRect(containerRef.current?.getBoundingClientRect() ?? null);

--- a/frontend/src/components/common/Chart.tsx
+++ b/frontend/src/components/common/Chart.tsx
@@ -19,8 +19,7 @@ import Paper from '@mui/material/Paper';
 import { useTheme } from '@mui/material/styles';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import React, { ReactNode } from 'react';
-import { useRef } from 'react';
+import React, { ReactNode, useCallback, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import {
   Bar,
@@ -199,6 +198,11 @@ export function PercentageBar(props: PercentageBarProps) {
   const { data, total = 100, tooltipFunc = null } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    setContainerRect(containerRef.current?.getBoundingClientRect() ?? null);
+  }, []);
 
   function formatData() {
     const dataItems: { [name: string]: number } = {};
@@ -217,37 +221,39 @@ export function PercentageBar(props: PercentageBarProps) {
     theme.palette.mode === 'dark' ? theme.palette.primary.light : theme.palette.primary.main;
 
   return (
-    <StyledResponsiveContainer width="95%" height={20} ref={containerRef}>
-      <StyledBarChart layout="vertical" maxBarSize={5} data={[formatData()]}>
-        {tooltipFunc && (
-          <Tooltip
-            content={props => (
-              <PaperTooltip
-                rechartsProps={props}
-                tooltipFunc={tooltipFunc}
-                data={data}
-                containerRef={containerRef}
-              />
-            )}
-          />
-        )}
-        <XAxis hide domain={[0, 100]} type="number" />
-        <YAxis hide type="category" />
-        {data.map((item, index) => {
-          return (
-            <Bar
-              key={index}
-              dataKey={item.name}
-              stackId="1"
-              fill={item.fill || barColor}
-              layout="vertical"
-              radius={theme.shape.borderRadius}
-              background={{ fill: barBackground }}
+    <div onMouseEnter={handleMouseEnter}>
+      <StyledResponsiveContainer width="95%" height={20} ref={containerRef}>
+        <StyledBarChart layout="vertical" maxBarSize={5} data={[formatData()]}>
+          {tooltipFunc && (
+            <Tooltip
+              content={props => (
+                <PaperTooltip
+                  rechartsProps={props}
+                  tooltipFunc={tooltipFunc}
+                  data={data}
+                  containerRect={containerRect}
+                />
+              )}
             />
-          );
-        })}
-      </StyledBarChart>
-    </StyledResponsiveContainer>
+          )}
+          <XAxis hide domain={[0, 100]} type="number" />
+          <YAxis hide type="category" />
+          {data.map((item, index) => {
+            return (
+              <Bar
+                key={index}
+                dataKey={item.name}
+                stackId="1"
+                fill={item.fill || barColor}
+                layout="vertical"
+                radius={theme.shape.borderRadius}
+                background={{ fill: barBackground }}
+              />
+            );
+          })}
+        </StyledBarChart>
+      </StyledResponsiveContainer>
+    </div>
   );
 }
 
@@ -255,18 +261,15 @@ interface PaperTooltipProps {
   rechartsProps?: any;
   tooltipFunc: (data: any) => ReactNode;
   data: any;
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRect: DOMRect | null;
 }
 
-function PaperTooltip({ rechartsProps, tooltipFunc, data, containerRef }: PaperTooltipProps) {
+function PaperTooltip({ rechartsProps, tooltipFunc, data, containerRect }: PaperTooltipProps) {
   if (!rechartsProps || !rechartsProps.active || !rechartsProps.coordinate) return null;
 
-  // eslint-disable-next-line react-hooks/refs
-  const rect = containerRef.current?.getBoundingClientRect();
-
   const { x, y } = rechartsProps.coordinate;
-  const left = (rect?.left || 0) + x;
-  const top = (rect?.top ?? 0) + y - 5;
+  const left = (containerRect?.left ?? 0) + x;
+  const top = (containerRect?.top ?? 0) + y - 5;
 
   return ReactDOM.createPortal(
     <Paper


### PR DESCRIPTION
## Summary
This PR removes the `react-hooks/refs` suppression in `frontend/src/components/common/Chart.tsx` by eliminating containerRef.current access during render. The container rect is now captured in an onMouseEnter handler using useState/useCallback, and PaperTooltip receives a plain DOMRect | null from state, ensuring no ref access occurs during the render phase.

## Related Issue

Fixes #5773  (Sub-issue of #5183)

## Changes

- Removed `// eslint-disable-next-line react-hooks/refs` from `PaperTooltip`
- `containerRef.current` was read during render via PaperTooltip, violating react-hooks/refs.
- Capture the rect in an onMouseEnter handler via useState/useCallback instead.
- PaperTooltip now receives a plain `DOMRect | null` from state, no ref access during render.

## Steps to Test

1. cd frontend && npm install
2. npm run lint passes and no react-hooks/refs violation surfaces for PaperTooltip
3. npm run tsc passes
4. Hover over chart tooltips and verify positioning behaves as expected

## Screenshots (if applicable)
N/A. No functional change.

## Notes for the Reviewer
- DCO sign-off applied (Signed-off-by: in the commit)
- Listed as an unchecked react-hooks/refs item in umbrella issue https://github.com/kubernetes-sigs/headlamp/issues/5183
