### PR TITLE
redraw lost edges when nodes move

### DIFF
--- a/frontend/src/components/resourceMap/graph/graphFiltering.test.ts
+++ b/frontend/src/components/resourceMap/graph/graphFiltering.test.ts
@@ -57,6 +57,18 @@ describe('filterGraph', () => {
     { id: 'e2', source: '3', target: '4' },
   ];
 
+  it('doesnt drop edges when filtering', () => {
+    const nodes: GraphNode[] = [{ id: 'node1', status: 'error' }, { id: 'node2' }, { id: 'node3' }];
+    const edges: GraphEdge[] = [
+      { id: 'edge1', source: 'node1', target: 'node2' },
+      { id: 'edge2', source: 'node2', target: 'node3' },
+      { id: 'edge3', source: 'node1', target: 'node3' },
+    ];
+    const result = filterGraph(nodes, edges, [{ type: 'hasErrors' }]);
+
+    expect(result.edges.length).toBe(3);
+  });
+
   it('filters nodes by namespace', () => {
     const filters: GraphFilter[] = [{ type: 'namespace', namespaces: new Set(['ns3']) }];
     const { nodes: filteredNodes } = filterGraph(nodes, edges, filters);

--- a/frontend/src/components/resourceMap/graph/graphFiltering.ts
+++ b/frontend/src/components/resourceMap/graph/graphFiltering.ts
@@ -28,89 +28,71 @@ export type GraphFilter =
     };
 
 /**
- * Filters the graph nodes and edges based on the provided filters
- * The filters are applied using AND logic, meaning node must match all active filters
+ * Filters graph nodes and edges.
  *
- * Along with the matched node result also includes all the nodes that are related to it,
- * even if they don't match the filter
+ * Important:
+ * First discover every node that should remain visible, including related nodes.
+ * Then keep every original edge whose source and target are both still visible.
  *
- * The filters can be of the following types:
- * - `hasErrors`: Filters nodes that have a warning or error status based on their graph node status.
- * - `namespace`: Filters nodes by their namespace
- *
- * @param nodes - List of all the nodes in the graph
- * @param edges - List of all the edges in the graph
- * @param filters - List of fitlers to apply
+ * This avoids losing valid non-tree edges during DFS traversal.
  */
 export function filterGraph(nodes: GraphNode[], edges: GraphEdge[], filters: GraphFilter[]) {
   if (filters.length === 0) {
     return { nodes, edges };
   }
 
-  const filteredNodes: GraphNode[] = [];
-  const filteredEdges: GraphEdge[] = [];
-
-  const visitedNodes = new Set();
-  const visitedEdges = new Set();
-
   const graphLookup = makeGraphLookup(nodes, edges);
+  const visibleNodeIds = new Set<string>();
 
-  /**
-   * Add all the nodes that are related to the given node
-   * Related means connected by an edge
-   * @param node - Given node
-   */
-  function pushRelatedNodes(node: GraphNode) {
-    if (visitedNodes.has(node.id)) return;
-    visitedNodes.add(node.id);
-    filteredNodes.push(node);
+  function nodeMatchesFilters(node: GraphNode): boolean {
+    return filters.every(filter => {
+      if (filter.type === 'hasErrors') {
+        return getGraphNodeStatus(node) !== 'success';
+      }
+
+      if (filter.type === 'namespace' && filter.namespaces.size > 0) {
+        const namespace = node.kubeObject?.metadata?.namespace;
+        return !!namespace && filter.namespaces.has(namespace);
+      }
+
+      return true;
+    });
+  }
+
+  function addRelatedNode(node: GraphNode) {
+    if (visibleNodeIds.has(node.id)) return;
+
+    visibleNodeIds.add(node.id);
 
     graphLookup.getOutgoingEdges(node.id)?.forEach(edge => {
-      const targetNode = graphLookup.getNode(edge.target);
-      if (targetNode && !visitedNodes.has(targetNode.id)) {
-        if (!visitedEdges.has(edge.id)) {
-          visitedEdges.add(edge.id);
-          filteredEdges.push(edge);
-        }
-        pushRelatedNodes(targetNode);
+      const target = graphLookup.getNode(edge.target);
+      if (target) {
+        addRelatedNode(target);
       }
     });
 
     graphLookup.getIncomingEdges(node.id)?.forEach(edge => {
-      const sourceNode = graphLookup.getNode(edge.source);
-      if (sourceNode && !visitedNodes.has(sourceNode.id)) {
-        if (!visitedEdges.has(edge.id)) {
-          visitedEdges.add(edge.id);
-          filteredEdges.push(edge);
-        }
-        pushRelatedNodes(sourceNode);
+      const source = graphLookup.getNode(edge.source);
+      if (source) {
+        addRelatedNode(source);
       }
     });
   }
 
   nodes.forEach(node => {
-    let keep = true;
-
-    filters.forEach(filter => {
-      if (filter.type === 'hasErrors') {
-        keep &&= getGraphNodeStatus(node) !== 'success';
-      }
-      if (filter.type === 'namespace' && filter.namespaces.size > 0) {
-        keep &&=
-          'kubeObject' in node &&
-          node.kubeObject !== undefined &&
-          !!node.kubeObject.metadata?.namespace &&
-          filter.namespaces.has(node.kubeObject?.metadata?.namespace);
-      }
-    });
-
-    if (keep) {
-      pushRelatedNodes(node);
+    if (nodeMatchesFilters(node)) {
+      addRelatedNode(node);
     }
   });
 
+  const filteredNodes = nodes.filter(node => visibleNodeIds.has(node.id));
+
+  const filteredEdges = edges.filter(
+    edge => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target)
+  );
+
   return {
-    edges: filteredEdges,
     nodes: filteredNodes,
+    edges: filteredEdges,
   };
 }


### PR DESCRIPTION
frontend: resourceMap.graphFiltering: add edge redrawing for nodes that move

Nodes can move when switching from cloud to namespace-specific view. This requires a second pass to redraw lost edges for the nodes that moved.

<img width="1280" height="1440" alt="image" src="https://github.com/user-attachments/assets/7ffaeb1a-7f96-4780-9c07-afd4dd94ab27" />
