### PR TITLE
frontend: common/Resource/DeleteButton: Add Storybook stories

### DIFF
--- a/frontend/src/components/common/Resource/DeleteButton.stories.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.stories.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MenuList from '@mui/material/MenuList';
+import { Meta, StoryFn } from '@storybook/react';
+import { getTestDate } from '../../../helpers/testHelpers';
+import { KubeObject } from '../../../lib/k8s/KubeObject';
+import { TestContext } from '../../../test';
+import DeleteButton from './DeleteButton';
+
+export default {
+  title: 'Resource/DeleteButton',
+  component: DeleteButton,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const createMockItem = (name: string, namespace: string = 'default', kind: string = 'ConfigMap') =>
+  ({
+    metadata: {
+      uid: `uid-${name}`,
+      name,
+      namespace,
+      creationTimestamp: getTestDate().toISOString(),
+    },
+    kind,
+    getAuthorization: async () => ({ status: { allowed: true, reason: '' } }),
+    delete: async () => undefined,
+    evict: async () => undefined,
+    getListLink: () => `/${kind.toLowerCase()}s`,
+    _class: () => ({ apiName: kind.toLowerCase() + 's', apiVersion: 'v1' }),
+  } as unknown as KubeObject);
+
+const Template: StoryFn<typeof DeleteButton> = args => <DeleteButton {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  item: createMockItem('my-configmap'),
+};
+
+export const WithAfterConfirmCallback = Template.bind({});
+WithAfterConfirmCallback.args = {
+  item: createMockItem('my-configmap'),
+  afterConfirm: () => {},
+};
+
+export const MenuButtonStyle = Template.bind({});
+MenuButtonStyle.args = {
+  item: createMockItem('my-configmap'),
+  buttonStyle: 'menu',
+};
+MenuButtonStyle.decorators = [
+  Story => (
+    <MenuList>
+      <Story />
+    </MenuList>
+  ),
+];
+
+export const PodEvict = Template.bind({});
+PodEvict.args = {
+  item: createMockItem('my-pod', 'default', 'Pod'),
+};
+PodEvict.parameters = {
+  docs: {
+    description: {
+      story:
+        'When the item is a Pod, demonstrates the Pod-specific delete path. The button shows "Evict" instead of "Delete" when the useEvict cluster setting is enabled.',
+    },
+  },
+};
+
+export const NoItem = Template.bind({});
+NoItem.args = {
+  item: undefined,
+};
+NoItem.parameters = {
+  docs: {
+    description: {
+      story: 'When no item is provided, the button renders nothing.',
+    },
+  },
+};

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteButton.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteButton.Default.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <button
+      aria-label="Delete"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteButton.MenuButtonStyle.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteButton.MenuButtonStyle.stories.storyshot
@@ -1,0 +1,32 @@
+<body>
+  <div>
+    <ul
+      class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      role="menu"
+      tabindex="-1"
+    >
+      <li
+        class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-1sgjfx9-MuiButtonBase-root-MuiMenuItem-root"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <div
+          class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+        />
+        <div
+          class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+          >
+            Delete
+          </span>
+        </div>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </li>
+      <div />
+    </ul>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteButton.NoItem.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteButton.NoItem.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteButton.PodEvict.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteButton.PodEvict.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <button
+      aria-label="Evict"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/DeleteButton.WithAfterConfirmCallback.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/DeleteButton.WithAfterConfirmCallback.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <button
+      aria-label="Delete"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div />
+  </div>
+</body>


### PR DESCRIPTION
## Summary

This PR adds Storybook stories for the `DeleteButton` component by creating `DeleteButton.stories.tsx` with five stories covering the main visual states of the component. The component previously had no stories and 42.85% test coverage with no visual state coverage.

## Related Issue

Part of #931
Closes #5892 

## Changes

- Added `frontend/src/components/common/Resource/DeleteButton.stories.tsx` with five stories: Default, WithAfterConfirmCallback, MenuButtonStyle, PodEvict, and NoItem
- Added storyshot snapshots in `frontend/src/components/common/Resource/__snapshots__/` for all five stories

## Steps to Test

1. `cd frontend && npm install`
2. `npm run storybook -- --no-open`
3. Open `http://localhost:6006` and navigate to **Resource → DeleteButton**
4. Verify **Default** — trash icon renders; clicking opens "Delete item" dialog with "Are you sure you want to delete item my-configmap?", Force Delete checkbox, and Cancel/Delete buttons
5. Verify **MenuButtonStyle** — renders as a "Delete" menu list item
6. Verify **PodEvict** — clicking opens "Evict Pod" dialog with "Are you sure you want to evict pod my-pod?" and no Force Delete checkbox
7. Verify **NoItem** — blank canvas, nothing renders

## Screenshots

### 1. Default:
 
<img width="1918" height="904" alt="image" src="https://github.com/user-attachments/assets/55f6493b-ba9e-4e25-9409-0c33425937ff" />

### 2. WithAfterConfirmCallback:
 
<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/ebb3743b-61fb-4899-8995-7cecda02e7af" />

### 3. MenuButtonStyle:
  
<img width="1919" height="903" alt="image" src="https://github.com/user-attachments/assets/33b4663c-f28a-4e28-a6c9-e3471690a6d9" />

### 4. PodEvict:
<img width="1919" height="906" alt="image" src="https://github.com/user-attachments/assets/adbdd8d3-e942-4fae-bd52-f4dc527f15d7" />

### 5. NoItem:
<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/f74211e5-fe48-4de5-a143-7552e684847a" />


## Note for the Reviewer

The mock item pattern follows `ScaleMultipleButton.stories.tsx` — no new patterns introduced