### PR TITLE
CI: Parallelize and speed up plugins-test

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -113,8 +113,8 @@ jobs:
         run: |
           make frontend-build-rsbuild
 
-  testplugins:
-    name: test plugins
+  test-headlamp-plugin:
+    name: test headlamp-plugin
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -129,11 +129,62 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: plugins/headlamp-plugin/package-lock.json
 
-      - name: Test plugins
+      - name: Test headlamp-plugin
         run: |
-          make plugins-test
+          cd plugins/headlamp-plugin && ./test-headlamp-plugin.js
+
+  test-plugin-examples:
+    name: test plugin examples
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [22.x]
+        os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: |
+            plugins/headlamp-plugin/package-lock.json
+            plugins/examples/*/package-lock.json
+
+      - name: Test plugin examples
+        run: |
+          cd plugins/headlamp-plugin && npm ci && ./test-plugins-examples.sh
+
+  test-pluginctl:
+    name: test pluginctl
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [22.x]
+        os: [ubuntu-22.04] # [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: plugins/pluginctl/package-lock.json
+
+      - name: Test pluginctl
+        working-directory: plugins/pluginctl
+        run: |
+          npm ci
+          cd src && node ./plugin-management.e2e.js
+          cd ..
+          npx jest --runInBand src/multi-plugin-management.test.js src/plugin-management.test.js
+          npm run test
 
   builddocs:
     name: build docs

--- a/Makefile
+++ b/Makefile
@@ -349,12 +349,13 @@ lint: backend-lint frontend-lint
 .PHONY: lint-fix
 lint-fix: backend-lint-fix frontend-lint-fix
 
+.PHONY: plugins-test
 plugins-test:
-	cd plugins/headlamp-plugin && npm install && ./test-headlamp-plugin.js
+	cd plugins/headlamp-plugin && ./test-headlamp-plugin.js
 	cd plugins/headlamp-plugin && ./test-plugins-examples.sh
-	cd plugins/pluginctl/src && npm install && node ./plugin-management.e2e.js
-	cd plugins/pluginctl && npx jest src/multi-plugin-management.test.js
-	cd plugins/pluginctl && npx jest src/plugin-management.test.js
+	cd plugins/pluginctl && npm ci
+	cd plugins/pluginctl/src && node ./plugin-management.e2e.js
+	cd plugins/pluginctl && npx jest --runInBand src/multi-plugin-management.test.js src/plugin-management.test.js
 	cd plugins/pluginctl && npm run test
 
 # IMAGE_BASE can be used to specify a base final image.

--- a/plugins/headlamp-plugin/test-plugins-examples.sh
+++ b/plugins/headlamp-plugin/test-plugins-examples.sh
@@ -9,22 +9,46 @@ npm run build
 npm run copy-package-lock
 npm pack
 
+# Resolve the tarball to an absolute path before cd-ing so parallel workers
+# can find it from any cwd.
+TARBALL_NAME="$(ls -t kinvolk-headlamp-plugin-*.tgz 2>/dev/null | head -1)"
+if [ -z "$TARBALL_NAME" ] || [ ! -f "$TARBALL_NAME" ]; then
+  echo "Error: no kinvolk-headlamp-plugin-*.tgz tarball found after npm pack" >&2
+  exit 1
+fi
+TARBALL="$(pwd)/$TARBALL_NAME"
+export TARBALL
+
+# Parallelism. Override with PARALLEL=1 for sequential, easier-to-debug runs.
+PARALLEL="${PARALLEL:-4}"
+
 cd ../examples
-for i in * ; do
-  if [ -d "$i" ]; then
-    cd "$i"
-    # First, do a fast clean install of all dependencies from the lockfile.
-    npm ci
-    # Then override headlamp-plugin with the locally built tarball so we test
-    # PR/repo changes that the released registry version might not have.
-    # npm ci cannot do this — it ignores positional package arguments and would
-    # silently keep the registry version.
-    npm install `ls -t ../../headlamp-plugin/kinvolk-headlamp-plugin-*.tgz | head -1`
-    npm run lint
-    npm run format
-    npm run build
-    npm run tsc
-    cd ..
-  fi
+
+# Build a concurrently invocation: one --names entry and one command per
+# example. A POSIX `for dir in */` glob avoids the brittle `ls | tr | xargs`
+# pipeline, whose `ls` failure `set -e` would not catch.
+names=""
+set --
+for dir in */; do
+  dir=${dir%/}
+  # Skip the literal `*/` (no matches) and any stale node_modules tree.
+  [ -d "$dir" ] || continue
+  [ "$dir" = "node_modules" ] && continue
+  names="${names:+$names,}$dir"
+  # `npm ci` from the lockfile, then overlay the locally built tarball so we
+  # test repo changes the published version may not have. `npm ci` can't do
+  # the overlay itself (it ignores positional package args); `--no-save
+  # --no-package-lock` keeps the example's package.json / lockfile clean.
+  set -- "$@" "cd '$dir' && npm ci && npm install --no-save --no-package-lock \"\$TARBALL\" && npm run lint && npm run format && npm run build && npm run tsc"
 done
 
+[ -n "$names" ] || { echo "Error: no example directories found in $(pwd)" >&2; exit 1; }
+
+# Run in parallel via concurrently: colored per-example prefixes, serialized
+# line writes, abort siblings on first failure. Pinned via `npx -p` so npm
+# caches it without bloating headlamp-plugin's published dependencies.
+exec npx --yes -p concurrently@8.2.2 concurrently \
+  --max-processes "$PARALLEL" \
+  --kill-others-on-fail \
+  --names "$names" \
+  -- "$@"

--- a/plugins/pluginctl/test-pluginctl.js
+++ b/plugins/pluginctl/test-pluginctl.js
@@ -32,9 +32,6 @@ function testPluginctl() {
   // remove some temporary files.
   cleanup();
 
-  // Install dependencies
-  run("npm", ["install"]);
-
   // Use "link" to test the repo version of the pluginctl tool.
   run("npm", ["link"]);
   curDir = process.cwd();


### PR DESCRIPTION
This change reduces plugin-test CI wall-clock time from ~16 min to ~8 min by splitting jobs and parallelizing the example plugin tests.

Follow-up from #5885

### Changes
- Split `testplugins` into `test-headlamp-plugin`, `test-plugin-examples`, and `test-pluginctl` jobs that run in parallel
- Each job caches only the lockfiles it needs and installs its own dependencies
- In `test-plugins-examples.sh`, run example plugin tests in parallel (default `PARALLEL=4`, override with env var) using `xargs -P`
- In `Makefile`, remove the redundant `npm install` before `test-headlamp-plugin.js` (it installs internally), use `npm ci` for pluginctl, combine two Jest commands into one `--runInBand` invocation, and add the missing `.PHONY` declaration

### Testing

- [x] `git diff --check` passes (no whitespace issues)
- [x] `make -n plugins-test` shows expected command flow
- [x] CI run confirms all three jobs pass and total wall-clock time is reduced