### PR TITLE
frontend: NumRowsInput: Refactor state initialization using lazy state initializers

### DIFF
--- a/frontend/src/components/App/Settings/NumRowsInput.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.tsx
@@ -25,7 +25,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { SelectChangeEvent } from '@mui/material/Select';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import {
@@ -48,24 +48,18 @@ export default function NumRowsInput(props: { defaultValue: number[]; nameLabelI
       node.focus();
     }
   }, []);
-  const defaultRowsPerPageValue = useMemo(() => {
+  const [selectedValue, setSelectedValue] = useState(() => {
     const val = getTablesRowsPerPage();
-    if (options.includes(val)) {
+    if (defaultValue.includes(val)) {
       return val;
     }
     return defaultTableRowsPerPageOptions[0];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  const [selectedValue, setSelectedValue] = useState(defaultRowsPerPageValue);
-  const storedCustomValue = useMemo(() => {
-    const val = options.find(val => !defaultTableRowsPerPageOptions.includes(val));
-    if (!val) {
-      return defaultTableRowsPerPageOptions[0];
-    }
-    return val;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  const [customValue, setCustomValue] = useState(storedCustomValue.toString());
+  });
+  const [customValue, setCustomValue] = useState(() => {
+    const val = defaultValue.find(v => !defaultTableRowsPerPageOptions.includes(v));
+    const initVal = val || defaultTableRowsPerPageOptions[0];
+    return initVal.toString();
+  });
   const [errorMessage, setErrorMessage] = useState('');
   const dispatch = useDispatch();
 


### PR DESCRIPTION
### Summary
This PR refactors the state initialization logic inside the settings module (`NumRowsInput.tsx`) to use React's standard lazy state initialization pattern instead of redundant `useMemo` hooks.

### Rationale
In the current implementation, `useMemo` hooks with empty dependency arrays were being used solely to compute the initial values of `selectedValue` and `customValue` state variables. Since these hook blocks access outer variables but restrict re-runs on updates, they violated standard React linter rules, requiring inline `eslint-disable` overrides to pass checks.

Using `useMemo` to initialize state is a known React anti-pattern. Migrating this logic to lazy state initializers passed directly into the `useState` hook ensures that the initial values are computed exactly once when the component mounts, aligns perfectly with official React guidelines, and cleanly eliminates the need for linter silencing flags.

### Changes
*   Removed the redundant `useMemo` calculations and their corresponding React imports.
*   Refactored `selectedValue` and `customValue` hooks to use clean, standard lazy state initialization functions.
*   Removed deprecated `eslint-disable-next-line react-hooks/exhaustive-deps` directives from the settings component.