### PR TITLE
fix: check 'patch' instead of 'update' permission for Restart button

### DIFF
--- a/frontend/src/components/common/Resource/RestartButton.tsx
+++ b/frontend/src/components/common/Resource/RestartButton.tsx
@@ -97,21 +97,26 @@ function RestartButtonInner(
   }
 
   return (
-    <AuthVisible
-      item={item}
-      authVerb="update"
-      onError={(err: Error) => {
-        console.error(`Error while getting authorization for restart button in ${item}:`, err);
-      }}
-    >
-      <ActionButton
-        description={t('translation|Restart')}
-        buttonStyle={buttonStyle}
-        onClick={() => {
-          setOpenDialog(true);
+    <>
+      <AuthVisible
+        item={item}
+        authVerb="patch"
+        onError={(err: Error) => {
+          console.error(
+            `Error while getting authorization for restart button in ${item.kind} ${item.metadata.namespace}/${item.metadata.name}:`,
+            err
+          );
         }}
-        icon="mdi:restart"
-      />
+      >
+        <ActionButton
+          description={t('translation|Restart')}
+          buttonStyle={buttonStyle}
+          onClick={() => {
+            setOpenDialog(true);
+          }}
+          icon="mdi:restart"
+        />
+      </AuthVisible>
       <ConfirmDialog
         open={openDialog}
         title={t('translation|Restart')}
@@ -132,6 +137,6 @@ function RestartButtonInner(
         cancelLabel={t('Cancel')}
         confirmLabel={t('Restart')}
       />
-    </AuthVisible>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes #5906

The Restart button was checking for `update` permission to control visibility, but the actual restart operation calls `item.patch()` which requires `patch` permission. This caused two issues: users with only `patch` couldn't see the button, and users with only `update` could see it but got an error on click. This fix aligns with `kubectl rollout restart` which only needs `patch`.

## Related Issue

Fixes #5906

## Changes

- Fixed `RestartButton.tsx`: changed `authVerb="update"` to `authVerb="patch"` in the `AuthVisible` wrapper
- Moved all React hooks before the conditional early return, fixing a pre-existing Rules of Hooks violation (previously suppressed with eslint-disable comments)
- Moved `ConfirmDialog` outside `AuthVisible` so the dialog is not hidden by the auth check

## Steps to Test

1. Create a user with only `patch` permission on deployments (no `update`)
2. Navigate to a Deployment in Headlamp and open the three-dot menu
3. The Restart button should now be visible and work without errors
4. Repeat with a user that only has `update` (no `patch`) and confirm the button does not appear

## Screenshots (if applicable)


## Notes for the Reviewer

- Only `RestartButton.tsx` is changed, no API or i18n impact
- `tsc --noEmit` and pre-commit hooks (ESLint + Prettier) pass cleanly
