### PR TITLE
backend: Add test coverage for headlamp_info custom cluster name parsing

### DIFF
--- a/backend/pkg/kubeconfig/contextStore_test.go
+++ b/backend/pkg/kubeconfig/contextStore_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestContextStore(t *testing.T) {
@@ -133,4 +135,35 @@ func TestContextStoreGetContextKeys(t *testing.T) {
 	require.Len(t, keys, 2)
 	require.Contains(t, keys, "test-key-1")
 	require.Contains(t, keys, "test-key-2")
+}
+
+func TestAddContextWithHeadlampInfo(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customInfo := kubeconfig.CustomObject{
+		CustomName: "my-custom-cluster-name",
+	}
+
+	// Create context with headlamp_info extension
+	ctx := &kubeconfig.Context{
+		Name: "original-name",
+		KubeContext: &api.Context{
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &customInfo,
+			},
+		},
+	}
+
+	err := store.AddContext(ctx)
+	require.NoError(t, err)
+
+	// Verify the context was saved under the custom name
+	savedCtx, err := store.GetContext("my-custom-cluster-name")
+	require.NoError(t, err)
+	require.Equal(t, "my-custom-cluster-name", savedCtx.Name)
+
+	// Verify original name is NOT in store
+	_, err = store.GetContext("original-name")
+	require.Error(t, err)
+	require.Equal(t, cache.ErrNotFound, err)
 }


### PR DESCRIPTION
## Summary
This PR adds missing unit test coverage to the `kubeconfig` backend package. Specifically, it tests the logic inside `contextStore.go`'s `AddContext()` where a custom cluster name (`CustomName`) is parsed from a context's `headlamp_info` extension and used to override the context name. 

## Related Issue
Fixes #5910 

## Changes
- **Added**: `TestAddContextWithHeadlampInfo` unit test inside `backend/pkg/kubeconfig/contextStore_test.go` to explicitly mock and verify `headlamp_info` extraction.

## Steps to Test
1. Pull the branch locally.
2. Navigate to the root directory and run the backend tests using `npm run backend:test`.
3. Verify that the new `TestAddContextWithHeadlampInfo` test passes successfully.
4. Run `npm run backend:coverage` to observe the increased coverage inside `contextStore.go`.

## Screenshots
<img width="1581" height="313" alt="image" src="https://github.com/user-attachments/assets/0548f476-3b89-4049-8035-fd42074dc96d" />

## Notes for the Reviewer
This is a standard, standalone unit test that increases the overall robustness of the `kubeconfig` parsing logic. It introduces no breaking changes and is fully backward compatible. All linting (`npm run backend:lint`) and builds pass locally.And also I ran the testcases in my local device they all passed for both backend:coverage and backend:test but couldn't have included those super big screenshots so just gave the above screenshot, thank you.