### PR TITLE
frontend: Fix malformed i18n interpolation strings

### DIFF
--- a/frontend/src/components/namespace/CreateNamespaceButton.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.tsx
@@ -74,10 +74,10 @@ export default function CreateNamespaceButton() {
 
     dispatch(
       clusterAction(() => namespaceRequest(), {
-        startMessage: t('translation|Applying {{  newItemName  }}…', {
+        startMessage: t('translation|Applying {{ newItemName }}…', {
           newItemName: newNamespaceName,
         }),
-        cancelledMessage: t('translation|Cancelled applying  {{  newItemName  }}.', {
+        cancelledMessage: t('translation|Cancelled applying {{ newItemName }}.', {
           newItemName: newNamespaceName,
         }),
         successMessage: t('translation|Applied {{ newItemName }}.', {

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -658,8 +658,6 @@
   "Max": "الحد الأقصى",
   "Min": "الحد الأدنى",
   "A namespace with this name already exists.": "يوجد نطاق بهذا الاسم بالفعل",
-  "Applying {{  newItemName  }}…": "جارٍ تطبيق {{  newItemName  }}…",
-  "Cancelled applying  {{  newItemName  }}.": "تم إلغاء تطبيق {{  newItemName  }}",
   "Namespaces must be under 64 characters.": "يجب أن يكون اسم النطاق أقل من 64 حرفًا",
   "Create Namespace": "إنشاء نطاق",
   "To": "إلى",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -638,8 +638,6 @@
   "Max": "সর্বোচ্চ",
   "Min": "সর্বনিম্ন",
   "A namespace with this name already exists.": "এই নাম সহ একটি namespace ইতিমধ্যে বিদ্যমান।",
-  "Applying {{  newItemName  }}…": "Apply {{  newItemName  }}…",
-  "Cancelled applying  {{  newItemName  }}.": "আবেদন বাতিল  {{  newItemName  }}।",
   "Namespaces must be under 64 characters.": "namespace গুলি অবশ্যই 64 টি অক্ষরের অধীনে থাকতে হবে।",
   "Create Namespace": "namespace Create করুন",
   "To": "থেকে",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -638,8 +638,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -638,8 +638,6 @@
   "Max": "Max",
   "Min": "Min",
   "A namespace with this name already exists.": "A namespace with this name already exists.",
-  "Applying {{  newItemName  }}…": "Applying {{  newItemName  }}…",
-  "Cancelled applying  {{  newItemName  }}.": "Cancelled applying  {{  newItemName  }}.",
   "Namespaces must be under 64 characters.": "Namespaces must be under 64 characters.",
   "Create Namespace": "Create Namespace",
   "To": "To",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -643,8 +643,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -643,8 +643,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -643,8 +643,6 @@
   "Max": "Max",
   "Min": "Min",
   "A namespace with this name already exists.": "A namespace with this name already exists.",
-  "Applying {{  newItemName  }}…": "Applying {{  newItemName  }}…",
-  "Cancelled applying  {{  newItemName  }}.": "Cancelled applying  {{  newItemName  }}.",
   "Namespaces must be under 64 characters.": "Namespaces must be under 64 characters.",
   "Create Namespace": "Create Namespace",
   "To": "To",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -638,8 +638,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -643,8 +643,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -633,8 +633,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -633,8 +633,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -643,8 +643,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -648,8 +648,6 @@
   "Max": "Макс",
   "Min": "Мин",
   "A namespace with this name already exists.": "Пространство имён с таким именем уже существует.",
-  "Applying {{  newItemName  }}…": "Применение {{  newItemName  }}…",
-  "Cancelled applying  {{  newItemName  }}.": "Применение {{  newItemName  }} отменено.",
   "Namespaces must be under 64 characters.": "Пространства имён должны содержать менее 64 символов.",
   "Create Namespace": "Создать пространство имён",
   "To": "К",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -638,8 +638,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -638,8 +638,6 @@
   "Max": "زیادہ سے زیادہ",
   "Min": "کم سے کم",
   "A namespace with this name already exists.": "اس نام کا نیم اسپیس پہلے سے موجود ہے",
-  "Applying {{  newItemName  }}…": "{{  newItemName  }} لاگو کیا جا رہا ہے…",
-  "Cancelled applying  {{  newItemName  }}.": "{{  newItemName  }} کو لاگو کرنا منسوخ کر دیا گیا",
   "Namespaces must be under 64 characters.": "نیم اسپیس 64 حروف سے کم ہونا چاہیے",
   "Create Namespace": "نیم اسپیس بنائیں",
   "To": "تک",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -633,8 +633,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -633,8 +633,6 @@
   "Max": "",
   "Min": "",
   "A namespace with this name already exists.": "",
-  "Applying {{  newItemName  }}…": "",
-  "Cancelled applying  {{  newItemName  }}.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",
   "To": "",


### PR DESCRIPTION
## Summary

This PR normalizes i18n interpolation syntax in CreateNamespaceButton by replacing malformed interpolation strings with the standard {{ newItemName }} format.

The previous formatting resulted in duplicate translation keys being generated during the i18n extraction process. This change aligns the component with the existing interpolation style used elsewhere in the codebase and removes the redundant locale entries.

## Related Issue

Fixes #5918 

## Changes

- Fixed two notification strings using non-standard interpolation spacing: `{{  newItemName  }}` → `{{ newItemName }}`, and removed a double space in `Cancelled applying  {{`.
- Regenerated locale files (`npm run i18n`), dropping the duplicate keys from all 16 locales.

## Steps to Test

1. `cd frontend && npm run i18n` — should produce no changes (locales are in sync).
2. Grep the locales for `newItemName  }}` — no matches remain.
3. Create a namespace and cancel it; the notification reads "Cancelled applying <name>." with correct spacing.