### PR TITLE
frontend: fix: Harden isValidRedirectPath against whitespace and URL-encoded protocol bypass

### DIFF
--- a/frontend/src/components/App/AppContainer.test.tsx
+++ b/frontend/src/components/App/AppContainer.test.tsx
@@ -53,4 +53,41 @@ describe('isValidRedirectPath', () => {
     expect(isValidRedirectPath(null as any)).toBe(false);
     expect(isValidRedirectPath(undefined as any)).toBe(false);
   });
+
+  it('should block URL-encoded protocol bypass attempts', () => {
+    expect(isValidRedirectPath('java%73cript:alert("XSS")')).toBe(false);
+    expect(isValidRedirectPath('%64ata:text/html,<script>alert("XSS")</script>')).toBe(false);
+    expect(isValidRedirectPath('javascript%3Aalert("XSS")')).toBe(false);
+    expect(() => isValidRedirectPath('%zz')).not.toThrow();
+    expect(isValidRedirectPath('%zz')).toBe(true);
+  });
+
+  it('should block scheme-based URLs without //', () => {
+    expect(isValidRedirectPath('http:evil.com')).toBe(false);
+    expect(isValidRedirectPath('https:evil.com')).toBe(false);
+  });
+
+  it('should block paths with leading whitespace containing dangerous protocols', () => {
+    expect(isValidRedirectPath(' javascript:alert("XSS")')).toBe(false);
+    expect(isValidRedirectPath('\tdata:text/html,<script>alert("XSS")</script>')).toBe(false);
+    expect(isValidRedirectPath('\njavascript:void(0)')).toBe(false);
+  });
+
+  it('should allow valid paths with special characters', () => {
+    expect(isValidRedirectPath('/dashboard?tab=overview')).toBe(true);
+    expect(isValidRedirectPath('/settings/cluster#section')).toBe(true);
+    expect(isValidRedirectPath('/namespaces/default/pods?labelSelector=app%3Dnginx')).toBe(true);
+  });
+
+  it('should block protocol-relative URLs with whitespace', () => {
+    expect(isValidRedirectPath(' //malicious.com')).toBe(false);
+    expect(isValidRedirectPath('\t//evil.com/path')).toBe(false);
+  });
+
+  it('should handle edge cases', () => {
+    expect(isValidRedirectPath('/')).toBe(true);
+    expect(isValidRedirectPath('/a')).toBe(true);
+    expect(isValidRedirectPath('javascript')).toBe(true);
+    expect(isValidRedirectPath('data')).toBe(true);
+  });
 });

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -45,25 +45,39 @@ window.desktopApi?.receive('open-about-dialog', () => {
  * @returns true if the path is safe, false otherwise
  */
 export const isValidRedirectPath = (redirectPath: string): boolean => {
-  // Reject empty or null paths
-  if (!redirectPath || redirectPath.trim() === '') {
+  if (!redirectPath) {
+    return false;
+  }
+
+  const trimmedPath = redirectPath.trim();
+
+  // Reject empty paths
+  if (trimmedPath === '') {
     return false;
   }
 
   // Reject paths that start with dangerous protocols
   const dangerousProtocols = ['javascript:', 'data:', 'vbscript:', 'file:', 'ftp:'];
-  const lowerPath = redirectPath.toLowerCase();
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(trimmedPath);
+  } catch {
+    decodedPath = trimmedPath;
+  }
+  const lowerPath = decodedPath.toLowerCase();
   if (dangerousProtocols.some(protocol => lowerPath.startsWith(protocol))) {
     return false;
   }
 
-  // Reject absolute URLs (external redirects)
-  if (redirectPath.startsWith('http://') || redirectPath.startsWith('https://')) {
+  // Reject absolute URLs (external redirects), including scheme-based forms
+  // without slashes (e.g. http:evil.com), which the URL parser still treats
+  // as absolute
+  if (/^https?:/.test(lowerPath)) {
     return false;
   }
 
   // Reject protocol-relative URLs (//example.com)
-  if (redirectPath.startsWith('//')) {
+  if (lowerPath.startsWith('//')) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
This PR fixes open-redirect bypass vulnerabilities in `isValidRedirectPath` by trimming leading whitespace before all protocol checks and decoding URL-encoded sequences before matching dangerous protocols.

## Related Issue

## Changes
- Added `trimmedPath` variable so all protocol checks (`http://`, `https://`, `//`) operate on the whitespace-stripped path instead of the raw input
- Added `decodeURIComponent` with `try/catch` fallback before the dangerous-protocol check to block URL-encoded bypass attempts like `java%73cript:` or `%6aavascript:`
- Expanded `AppContainer.test.tsx` with six new test blocks covering leading-whitespace bypass, URL-encoded protocol bypass (including the malformed-percent-encoding fallback), scheme-based URLs without `//`, protocol-relative URLs with whitespace, valid paths with query strings and fragments, and edge cases like bare words `javascript` and `data` without a colon

## Steps to Test
1. Run `npm test` from `frontend/` and verify all 11 tests in `AppContainer.test.tsx` pass
2. In a running Headlamp instance navigate to `/?to=%6aavascript:alert(1)` and confirm no redirect occurs
3. Navigate to `/?to= //malicious.com` and confirm no redirect occurs
4. Navigate to `/?to=/settings/cluster` and confirm the redirect works correctly

## Screenshots (if applicable)
N/A

## Notes for the Reviewer
- The `decodeURIComponent` call is wrapped in `try/catch` because malformed percent-sequences like `%zz` throw a `URIError`; in that case the raw trimmed path is used as a safe fallback
- The two whitespace cases inside the existing `should block dangerous protocols` block are intentional duplicates of cases in the new dedicated whitespace block; the first documents the fix in context, the second groups all whitespace coverage together