### PR TITLE
frontend: resourceMap: Fix Space key not activating graph nodes

### DIFF
--- a/frontend/src/components/resourceMap/nodes/GroupNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/GroupNode.tsx
@@ -67,9 +67,18 @@ export const GroupNodeComponent = memo(({ id }: { id: string }) => {
       role="button"
       onClick={handleSelect}
       onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === 'Space') {
-          handleSelect();
+        if (e.key !== 'Enter' && e.key !== ' ') {
+          return;
         }
+        // Space scrolls the page by default; prevent it even on key repeat.
+        if (e.key === ' ') {
+          e.preventDefault();
+        }
+        // Ignore auto-repeat so holding the key does not re-trigger activation.
+        if (e.repeat) {
+          return;
+        }
+        handleSelect();
       }}
     >
       {(node?.label || node?.subtitle) && (

--- a/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/KubeObjectNode.tsx
@@ -243,9 +243,18 @@ export const KubeObjectNodeComponent = memo(({ id }: NodeProps) => {
         setHovered(false);
       }}
       onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === 'Space') {
-          openDetails();
+        if (e.key !== 'Enter' && e.key !== ' ') {
+          return;
         }
+        // Space scrolls the page by default; prevent it even on key repeat.
+        if (e.key === ' ') {
+          e.preventDefault();
+        }
+        // Ignore auto-repeat so holding the key does not re-trigger activation.
+        if (e.repeat) {
+          return;
+        }
+        openDetails();
       }}
     >
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />


### PR DESCRIPTION
## Summary

Graph nodes in the Map view are focusable and use `role="button"`, but pressing Space doesn't activate them. The `onKeyDown` handlers compare `e.key === 'Space'`, and for the spacebar `KeyboardEvent.key` is `' '` (a space) - `'Space'` is what `e.code` returns. So the Space branch never matched, and keyboard users could only select/open a node with Enter.

I changed the check to `e.key === ' '`, which is how the rest of the frontend already handles it (e.g. `resourceMap/sources/GraphSourcesView.tsx`, `advancedSearch/ApiResourcePicker.tsx`, `App/Settings/Settings.tsx`). I also added `e.preventDefault()` so Space activates the node without scrolling the page - same as the existing GraphSourcesView handler.

These were the only two places in the frontend comparing `e.key` to `'Space'`.

## Changes

- `GroupNode.tsx` - fix the Space key check, `preventDefault()` on activate
- `KubeObjectNode.tsx` - same fix for the resource node

## Steps to Test

1. Open the Map view and press Tab until a node (group or resource) is focused.
2. Press Space.
3. Before this change nothing happens; after it, the node selects / opens its details and the page no longer scrolls. Enter keeps working as before.

## Screenshots

N/A - this is keyboard interaction only (see Steps to Test).

## Notes for the Reviewer

There's no existing test harness around these ReactFlow node components, so I kept this to the minimal fix. Happy to add a regression test for the key handling if you'd prefer. There wasn't an open issue for this; I can file one if that's the preferred flow.
