### PR TITLE
backend: logging: Clean format strings and normalize defer

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -52,7 +52,7 @@ func main() {
 
 	conf, err := config.Parse(os.Args)
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "fetching config:%v")
+		logger.Log(logger.LevelError, nil, err, "fetching config")
 		os.Exit(1)
 	}
 
@@ -380,7 +380,7 @@ func handleCacheAuthorization(
 func runListPlugins() {
 	conf, err := config.Parse(os.Args[2:])
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "fetching config:%v")
+		logger.Log(logger.LevelError, nil, err, "fetching config")
 		os.Exit(1)
 	}
 

--- a/backend/pkg/exec/exec_test.go
+++ b/backend/pkg/exec/exec_test.go
@@ -938,7 +938,7 @@ func TestRoundTripper(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != statusCode {
 			t.Errorf("wanted status %d got %d", statusCode, resp.StatusCode)
 		}


### PR DESCRIPTION
## Summary

This PR fixes two minor backend convention bugs by cleaning up a hardcoded format string in the logger and normalizing a missing defer error suppression in the tests.

## Related Issue

Fixes #5924 

## Changes

-Fixed a hardcoded %v formatting bug in backend/cmd/server.go leaking into raw string logs.
-Updated backend/pkg/exec/exec_test.go to wrap the Close() defer in an anonymous function (defer func() { _ = resp.Body.Close() }()) to match internal linter conventions.

## Steps to Test

1. Run the Headlamp backend locally with an invalid flag (go run ./cmd -invalid-flag).
2.Observe that the "fetching config:%v" error string is now correctly printed as "fetching config".
3.Verify that npm run backend:lint and npm run backend:test still pass successfully without any Close() warnings.

## Screenshots (if applicable)


## Notes for the Reviewer

- Very small cleanup PR to align the codebase. The :%v bug was likely a reflex from standard log.Printf usage.
