### PR TITLE
backend: helm: refactor createFullPath to avoid truncating existing repo config

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -246,11 +246,12 @@ type ListRepoResponse struct {
 }
 
 func createFullPath(p string) error {
-	if err := os.MkdirAll(filepath.Dir(p), defaultNewConfigFolderMode); err != nil {
+	cleanPath := filepath.Clean(p)
+	if err := os.MkdirAll(filepath.Dir(cleanPath), defaultNewConfigFolderMode); err != nil {
 		return err
 	}
 
-	file, err := os.OpenFile(filepath.Clean(p), os.O_CREATE|os.O_WRONLY, defaultNewConfigFileMode)
+	file, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_WRONLY, defaultNewConfigFileMode)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -251,8 +251,11 @@ func createFullPath(p string) error {
 		return err
 	}
 
-	file, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_WRONLY, defaultNewConfigFileMode)
+	file, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, defaultNewConfigFileMode)
 	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil
+		}
 		return err
 	}
 

--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -73,12 +73,7 @@ func (r AddUpdateRepoRequest) Validate() error {
 func createFileIfNotThere(fileName string) error {
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
-		file, err := createFullPath(fileName)
-		if err != nil {
-			return err
-		}
-
-		return file.Close()
+		return createFullPath(fileName)
 	}
 
 	return err
@@ -250,12 +245,17 @@ type ListRepoResponse struct {
 	Repositories []repositoryInfo `json:"repositories"`
 }
 
-func createFullPath(p string) (*os.File, error) {
+func createFullPath(p string) error {
 	if err := os.MkdirAll(filepath.Dir(p), defaultNewConfigFolderMode); err != nil {
-		return nil, err
+		return err
 	}
 
-	return os.Create(p) //nolint:gosec
+	file, err := os.OpenFile(filepath.Clean(p), os.O_CREATE|os.O_WRONLY, defaultNewConfigFileMode)
+	if err != nil {
+		return err
+	}
+
+	return file.Close()
 }
 
 func listRepositories(settings *cli.EnvSettings) ([]repositoryInfo, error) {

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -19,6 +19,7 @@ package helm
 import (
 	"errors"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -53,15 +54,44 @@ func TestEnsureRepositoryFileLocked(t *testing.T) {
 		lockErr := fs.ErrPermission
 
 		err := ensureRepositoryFileLocked(false, lockErr)
-
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, lockErr))
 	})
 
 	t.Run("not_locked_without_error", func(t *testing.T) {
 		err := ensureRepositoryFileLocked(false, nil)
-
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, errRepositoryLockNotAcquired))
+	})
+}
+
+func TestCreateFullPathDoesNotTruncateExistingFile(t *testing.T) {
+	t.Run("creates_new_file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "repos", "test.yaml")
+
+		err := createFullPath(path)
+		require.NoError(t, err)
+
+		_, err = os.Stat(path)
+		assert.NoError(t, err)
+	})
+
+	t.Run("does_not_truncate_existing_file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "repos", "test.yaml")
+
+		// Create the file with some content
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), defaultNewConfigFolderMode))
+		require.NoError(t, os.WriteFile(path, []byte("existing content"), defaultNewConfigFileMode))
+
+		// Call createFullPath again - it should not truncate the file
+		err := createFullPath(path)
+		require.NoError(t, err)
+
+		// Verify the content is still there
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "existing content", string(content))
 	})
 }

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -83,14 +83,14 @@ func TestCreateFullPathDoesNotTruncateExistingFile(t *testing.T) {
 
 		// Create the file with some content
 		require.NoError(t, os.MkdirAll(filepath.Dir(path), defaultNewConfigFolderMode))
-		require.NoError(t, os.WriteFile(path, []byte("existing content"), defaultNewConfigFileMode))
+		require.NoError(t, os.WriteFile(path, []byte("existing content"), defaultNewConfigFileMode)) //nolint:gosec
 
 		// Call createFullPath again - it should not truncate the file
 		err := createFullPath(path)
 		require.NoError(t, err)
 
 		// Verify the content is still there
-		content, err := os.ReadFile(path)
+		content, err := os.ReadFile(path) //nolint:gosec
 		require.NoError(t, err)
 		assert.Equal(t, "existing content", string(content))
 	})

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -94,4 +94,22 @@ func TestCreateFullPathDoesNotTruncateExistingFile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "existing content", string(content))
 	})
+
+	t.Run("uses_o_excl_and_returns_nil_on_eexist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "repos", "test.yaml")
+
+		// Create the file first
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), defaultNewConfigFolderMode))
+		require.NoError(t, os.WriteFile(path, []byte("existing content"), defaultNewConfigFileMode)) //nolint:gosec
+
+		// Call createFullPath - it should return nil without opening the file
+		err := createFullPath(path)
+		require.NoError(t, err)
+
+		// Verify the content is still there (file was never opened for write)
+		content, err := os.ReadFile(path) //nolint:gosec
+		require.NoError(t, err)
+		assert.Equal(t, "existing content", string(content))
+	})
 }

--- a/backend/pkg/helm/repository_internal_test.go
+++ b/backend/pkg/helm/repository_internal_test.go
@@ -103,7 +103,14 @@ func TestCreateFullPathDoesNotTruncateExistingFile(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(path), defaultNewConfigFolderMode))
 		require.NoError(t, os.WriteFile(path, []byte("existing content"), defaultNewConfigFileMode)) //nolint:gosec
 
-		// Call createFullPath - it should return nil without opening the file
+		// Make the file read-only so that any attempt to open it for write fails
+		require.NoError(t, os.Chmod(path, 0o444))
+		// Restore permissions after the test so t.TempDir() cleanup can remove it
+		t.Cleanup(func() {
+			_ = os.Chmod(path, defaultNewConfigFileMode)
+		})
+
+		// Call createFullPath - with O_EXCL it should return nil without opening the file
 		err := createFullPath(path)
 		require.NoError(t, err)
 


### PR DESCRIPTION
Refactor createFullPath to open repo config files with O_CREATE|O_WRONLY instead of O_TRUNC|O_RDWR, avoiding truncation of existing configs. This also removes the need for the //nolint:gosec directive.

Also computes filepath.Clean(p) once and reuses it for both MkdirAll and OpenFile.