### PR TITLE
frontend: globalSearch: Improve useLocalStorageState and fix sync bugs

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -78,7 +78,13 @@ jobs:
     - name: Run tsc type checker
       run: make app-tsc
     - name: App Windows ${{ matrix.arch }}
-      run: make app-build && cd app && npm run package -- --win --${{ matrix.arch }}
+      run: |
+        cd app
+        npm ci --force
+        cd ..
+        make app-build
+        cd app
+        npm run package -- --win --${{ matrix.arch }}
     - name: Verify Windows build
       shell: pwsh
       run: npm run app:verify-build-windows

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ frontend/build:
 
 .PHONY: app
 app-build: frontend/build
-	cd app && npm install && node ./scripts/setup-plugins.js && npm run build
+	cd app && npm ci && node ./scripts/setup-plugins.js && npm run build
 app: app-build
 	cd app && npm run package -- --win --linux --mac
 app-win: app-build

--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { labelSelectorToQuery } from '../../../lib/k8s';
 import Deployment from '../../../lib/k8s/deployment';
@@ -22,6 +22,7 @@ import Job from '../../../lib/k8s/job';
 import Pod from '../../../lib/k8s/pod';
 import StatefulSet from '../../../lib/k8s/statefulSet';
 import { TestContext } from '../../../test';
+import { useLocalStorageState } from '../../globalSearch/useLocalStorageState';
 import { launchWorkloadLogs, LogsButton, WorkloadLogs } from './LogsButton';
 
 const {
@@ -899,5 +900,58 @@ describe('LogsButton', () => {
 
     // Verify stream was not restarted
     expect(getLogsCallCount).toBe(1);
+  });
+  it('broadcasts severity updates to other hook instances', async () => {
+    const getLogsMock = vi.fn(() => {
+      return () => {};
+    });
+    Pod.prototype.getLogs = getLogsMock;
+
+    // 1. Render a consumer hook
+    const { result } = renderHook(() =>
+      useLocalStorageState<string[]>('headlamp.logs.severityFilter', ['error', 'warn', 'info'])
+    );
+
+    mockClusterFetch.mockResolvedValue({
+      json: async () => ({ items: [mockPodData] }),
+    });
+
+    mockActivityLaunch.mockClear();
+
+    // 2. Render the component and trigger log fetching
+    render(
+      <TestContext>
+        <LogsButton item={new Deployment(deploymentData as any)} />
+      </TestContext>
+    );
+    const button = screen.getByRole('button', { name: 'translation|Show logs' });
+    fireEvent.click(button);
+
+    const activityContent = mockActivityLaunch.mock.calls[0][0].content;
+    render(<TestContext>{activityContent}</TestContext>);
+
+    // 3. Wait for the popup to open and mock the log response
+    await waitFor(() => {
+      expect(getLogsMock).toHaveBeenCalled();
+    });
+
+    // 4. Change severity filter directly in the UI
+    const selects = document.querySelectorAll('.MuiSelect-select');
+    const severitySelect = selects[3];
+    fireEvent.mouseDown(severitySelect);
+
+    await waitFor(() => {
+      expect(document.querySelector('.MuiList-root')).toBeInTheDocument();
+    });
+
+    const infoOption = Array.from(document.querySelectorAll('.MuiMenuItem-root')).find(
+      el => el.textContent === 'INFO'
+    );
+    // Uncheck INFO
+    fireEvent.click(infoOption!);
+
+    // 5. Verify the hook state reflects the unchecked INFO severity
+    // (default was ['error', 'warn', 'info'], so unchecking INFO leaves ['error', 'warn'])
+    expect(result.current[0]).toEqual(['error', 'warn']);
   });
 });

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -117,24 +117,20 @@ export function WorkloadLogs({ item }: WorkloadLogsProps) {
   const [lines, setLines] = useState<number>(100);
   const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
   const [showReconnectButton, setShowReconnectButton] = useState(false);
-  const [selectedSeverities, setSelectedSeverities] = useState<LogSeverity[]>(() => {
-    try {
-      const stored = localStorage.getItem('headlamp.logs.severityFilter');
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          // Normalize and validate against ALL_SEVERITIES
-          const validSeverities = parsed.filter(s => ALL_SEVERITIES.includes(s as LogSeverity));
-          if (validSeverities.length > 0) {
-            return validSeverities as LogSeverity[];
-          }
-        }
+  const [storedSeverities, setStoredSeverities] = useLocalStorageState<LogSeverity[]>(
+    'headlamp.logs.severityFilter',
+    [...ALL_SEVERITIES]
+  );
+
+  const selectedSeverities = React.useMemo(() => {
+    if (Array.isArray(storedSeverities) && storedSeverities.length > 0) {
+      const validSeverities = storedSeverities.filter(s => ALL_SEVERITIES.includes(s));
+      if (validSeverities.length > 0) {
+        return validSeverities;
       }
-    } catch {
-      // ignore parse errors
     }
     return [...ALL_SEVERITIES];
-  });
+  }, [storedSeverities]);
 
   const xtermRef = React.useRef<XTerminal | null>(null);
   const processLogsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -576,8 +572,7 @@ export function WorkloadLogs({ item }: WorkloadLogsProps) {
           onChange={event => {
             const value = event.target.value as LogSeverity[];
             if (value.length > 0) {
-              setSelectedSeverities(value);
-              localStorage.setItem('headlamp.logs.severityFilter', JSON.stringify(value));
+              setStoredSeverities(value);
             }
           }}
           label={t('translation|Severity')}

--- a/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
@@ -133,6 +133,17 @@ describe('useLocalStorageState', () => {
       expect(JSON.parse(localStorage.getItem(storageKey) || '""')).toBe('updated');
     });
 
+    it('accepts a direct value instead of an updater function', () => {
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'initial'));
+
+      act(() => {
+        result.current[1]('direct-update');
+      });
+
+      expect(result.current[0]).toBe('direct-update');
+      expect(JSON.parse(localStorage.getItem(storageKey) || '""')).toBe('direct-update');
+    });
+
     it('composes consecutive updates using a retained setter', () => {
       const { result } = renderHook(() => useLocalStorageState(storageKey, 0));
       const set = result.current[1];
@@ -261,6 +272,74 @@ describe('useLocalStorageState', () => {
 
       expect(JSON.parse(localStorage.getItem(firstKey)!)).toBe('first');
       expect(JSON.parse(localStorage.getItem(secondKey)!)).toBe('updated');
+    });
+  });
+
+  describe('cross-tab synchronization', () => {
+    it('updates state when another tab modifies localStorage', () => {
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'initial'));
+
+      act(() => {
+        localStorage.setItem(storageKey, JSON.stringify('from-another-tab'));
+        const event = new Event('storage') as any;
+        event.key = storageKey;
+        event.newValue = JSON.stringify('from-another-tab');
+        event.storageArea = window.localStorage;
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current[0]).toBe('from-another-tab');
+    });
+
+    it('ignores sessionStorage events', () => {
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'initial'));
+
+      act(() => {
+        const event = new Event('storage') as any;
+        event.key = storageKey;
+        event.newValue = JSON.stringify('from-session-storage');
+        event.storageArea = window.sessionStorage;
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current[0]).toBe('initial');
+    });
+
+    it('falls back to default value on localStorage.clear()', () => {
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'initial'));
+
+      act(() => {
+        result.current[1]('changed');
+      });
+      expect(result.current[0]).toBe('changed');
+
+      act(() => {
+        const event = new Event('storage') as any;
+        event.key = null;
+        event.storageArea = window.localStorage;
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current[0]).toBe('initial');
+    });
+
+    it('falls back to default value on localStorage.removeItem()', () => {
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 'initial'));
+
+      act(() => {
+        result.current[1]('changed');
+      });
+      expect(result.current[0]).toBe('changed');
+
+      act(() => {
+        const event = new Event('storage') as any;
+        event.key = storageKey;
+        event.newValue = null;
+        event.storageArea = window.localStorage;
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current[0]).toBe('initial');
     });
   });
 });

--- a/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.test.tsx
@@ -263,4 +263,59 @@ describe('useLocalStorageState', () => {
       expect(JSON.parse(localStorage.getItem(secondKey)!)).toBe('updated');
     });
   });
+
+  describe('update', () => {
+    it('propagates updates via useLocalStorageState.update across hook instances', () => {
+      const { result: a } = renderHook(() => useLocalStorageState(storageKey, 0));
+      const { result: b } = renderHook(() => useLocalStorageState(storageKey, 0));
+
+      act(() => {
+        useLocalStorageState.update(storageKey, 42);
+      });
+
+      // Both hook instances must reflect the new value.
+      expect(a.current[0]).toBe(42);
+      expect(b.current[0]).toBe(42);
+      expect(JSON.parse(localStorage.getItem(storageKey)!)).toBe(42);
+    });
+
+    it('persists the value to localStorage', () => {
+      act(() => {
+        useLocalStorageState.update(storageKey, 'hello');
+      });
+
+      expect(JSON.parse(localStorage.getItem(storageKey)!)).toBe('hello');
+    });
+
+    it('does not notify listeners if update fails to persist', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('Storage write disabled');
+      });
+      const { result } = renderHook(() => useLocalStorageState(storageKey, 0));
+
+      act(() => {
+        useLocalStorageState.update(storageKey, 42);
+      });
+
+      expect(result.current[0]).toBe(0);
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    it('does not throw when update() is called after unmount', () => {
+      const { result, unmount } = renderHook(() => useLocalStorageState(storageKey, 0));
+
+      unmount();
+
+      // After unmount, update() should not throw even though there are no listeners.
+      expect(() => {
+        act(() => {
+          useLocalStorageState.update(storageKey, 99);
+        });
+      }).not.toThrow();
+
+      // The unmounted hook's last known value should be unchanged.
+      expect(result.current[0]).toBe(0);
+    });
+  });
 });

--- a/frontend/src/components/globalSearch/useLocalStorageState.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.tsx
@@ -52,11 +52,13 @@ function readStoredValue<T>(key: string, serializedDefaultValue: string): T {
   }
 }
 
-function writeStoredValue(key: string, value: unknown) {
+function writeStoredValue(key: string, value: unknown): boolean {
   try {
     localStorage.setItem(key, JSON.stringify(value));
+    return true;
   } catch (error) {
     console.error(`Error occurred while setting ${key} in local storage:`, error);
+    return false;
   }
 }
 
@@ -112,7 +114,7 @@ function updateEntry<T>(key: string, entry: StorageEntry, updater: (oldValue: T)
  * const [value, setValue] = useLocalStorageState<string>('myKey', 'default');
  * setValue(() => 'newValue');
  */
-export function useLocalStorageState<T>(key: string, defaultValue: T) {
+function useLocalStorageStateBase<T>(key: string, defaultValue: T) {
   // Serializing also gives each new entry its own deep clone of the default value.
   const serializedDefaultValue = JSON.stringify(defaultValue);
   const entry = useMemo(
@@ -133,3 +135,26 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
 
   return [state, setState] as const;
 }
+
+export const useLocalStorageState = Object.assign(useLocalStorageStateBase, {
+  /**
+   * Update the value in local storage and notify all `useLocalStorageState` hooks.
+   *
+   * @param key - local storage key
+   * @param value - local storage value
+   */
+  update(key: string, value: unknown): void {
+    const entry = storageEntries.get(key);
+    const persisted = writeStoredValue(key, value);
+    if (!persisted) {
+      return;
+    }
+
+    if (entry) {
+      entry.value = value;
+      for (const listener of entry.listeners) {
+        listener();
+      }
+    }
+  },
+});

--- a/frontend/src/components/globalSearch/useLocalStorageState.tsx
+++ b/frontend/src/components/globalSearch/useLocalStorageState.tsx
@@ -21,11 +21,46 @@ type Listener = () => void;
 interface StorageEntry {
   value: unknown;
   listeners: Set<Listener>;
+  serializedDefaultValue: string;
 }
 
 // localStorage does not notify listeners in the same window, so hook instances
 // using the same key share an in-memory entry.
 const storageEntries = new Map<string, StorageEntry>();
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event: StorageEvent) => {
+    if (event.storageArea !== window.localStorage) return;
+
+    if (event.key === null) {
+      // localStorage.clear() was called. Reset all entries to their default values.
+      for (const entry of storageEntries.values()) {
+        entry.value = JSON.parse(entry.serializedDefaultValue);
+        for (const listener of entry.listeners) {
+          listener();
+        }
+      }
+      return;
+    }
+    const entry = storageEntries.get(event.key);
+    if (entry) {
+      if (event.newValue === null) {
+        // localStorage.removeItem() was called for this key.
+        entry.value = JSON.parse(entry.serializedDefaultValue);
+      } else {
+        try {
+          entry.value = JSON.parse(event.newValue);
+        } catch (error) {
+          // Ignore parse errors from other tabs
+          return;
+        }
+      }
+      for (const listener of entry.listeners) {
+        listener();
+      }
+    }
+  });
+}
 
 function readStoredValue<T>(key: string, serializedDefaultValue: string): T {
   let serializedValue: string | null;
@@ -52,11 +87,13 @@ function readStoredValue<T>(key: string, serializedDefaultValue: string): T {
   }
 }
 
-function writeStoredValue(key: string, value: unknown) {
+function writeStoredValue(key: string, value: unknown): boolean {
   try {
     localStorage.setItem(key, JSON.stringify(value));
+    return true;
   } catch (error) {
     console.error(`Error occurred while setting ${key} in local storage:`, error);
+    return false;
   }
 }
 
@@ -69,6 +106,7 @@ function getStorageEntry<T>(key: string, serializedDefaultValue: string): Storag
   const newEntry: StorageEntry = {
     value: readStoredValue<T>(key, serializedDefaultValue),
     listeners: new Set(),
+    serializedDefaultValue,
   };
   storageEntries.set(key, newEntry);
 
@@ -85,8 +123,9 @@ function subscribe(key: string, entry: StorageEntry, listener: Listener) {
   };
 }
 
-function updateEntry<T>(key: string, entry: StorageEntry, updater: (oldValue: T) => T) {
-  const newValue = updater(entry.value as T);
+function updateEntry<T>(key: string, entry: StorageEntry, updater: T | ((oldValue: T) => T)) {
+  const isFunction = (val: any): val is (oldValue: T) => T => typeof val === 'function';
+  const newValue = isFunction(updater) ? updater(entry.value as T) : updater;
   entry.value = newValue;
 
   for (const listener of entry.listeners) {
@@ -127,7 +166,7 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
   const getSnapshot = useCallback(() => entry.value as T, [entry]);
   const state = useSyncExternalStore(subscribeToEntry, getSnapshot, getSnapshot);
   const setState = useCallback(
-    (updater: (oldValue: T) => T) => updateEntry(key, entry, updater),
+    (updater: T | ((oldValue: T) => T)) => updateEntry(key, entry, updater),
     [entry, key]
   );
 


### PR DESCRIPTION
### Summary
While the original stale-closure bug was resolved in main via `useSyncExternalStore` (commit 676ef52e7), that refactor unfortunately missed some critical features of standard local storage hooks. Since I've spent two months iterating on this PR, I decided to pivot this branch to add those missing features, drastically improving the hook and fixing a real bug!

### The Improvements
**1. Cross-Tab Synchronization (Missing in main)**
The current implementation in main only synchronizes state within the same window because it doesn't listen to the browser's storage event. I added a global `window.addEventListener('storage')` listener. Now, if a user has Headlamp open in two tabs and changes a setting (like log severity), all tabs immediately update in sync.

**2. Direct-Value Setters (Missing in main)**
Standard React `useState` accepts both updater functions and direct values. The implementation in main forced developers to use updater functions (e.g., `setZoomMode(() => '100%')`). I updated the signature to accept `T | ((oldValue: T) => T)` for a much better developer experience.

**3. Fixed LogsButton Synchronization Bug**
Previously, `LogsButton.tsx` updated `headlamp.logs.severityFilter` directly via `localStorage.setItem`. Because it bypassed the hook, other components (like Pod Details) did not re-render when it changed. I refactored `LogsButton` to fully consume the `useLocalStorageState` hook instead of raw local storage, instantly fixing this cross-component sync bug!

### Steps to Test
- **Cross-tab sync:** Open Headlamp in two tabs. Change the Log Severity filter in one tab, and observe it automatically update in the other tab.
- **LogsButton sync:** Open the Logs Viewer from a Pod Details view. Change the severity filter, and observe that the Pod Details background view immediately receives the updated state thanks to the new robust hook synchronization.
