### PR TITLE
Tests: add Tests for InitRequestMetrics and InitApplicationsMetrics

### DIFF
--- a/backend/pkg/telemetry/export_test.go
+++ b/backend/pkg/telemetry/export_test.go
@@ -1,0 +1,11 @@
+package telemetry
+
+import "go.opentelemetry.io/otel/metric"
+
+func InitRequestMetricsForTest(meter metric.Meter, metrics *Metrics) error {
+	return initRequestMetrics(meter, metrics)
+}
+
+func InitApplicationMetricsForTest(meter metric.Meter, metrics *Metrics) error {
+	return initApplicationMetrics(meter, metrics)
+}

--- a/backend/pkg/telemetry/metrics_test.go
+++ b/backend/pkg/telemetry/metrics_test.go
@@ -396,3 +396,38 @@ func sumDataPoints(data metricdata.Aggregation) int64 {
 
 	return 0
 }
+
+func TestInitRequestMetrics(t *testing.T) {
+	provider, _ := setupTestMeter(t)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+
+	meter := otel.Meter("headlamp-test")
+	metrics := &tel.Metrics{}
+
+	err := tel.InitRequestMetricsForTest(meter, metrics)
+	require.NoError(t, err)
+
+	require.NotNil(t, metrics.RequestCounter, "RequestCounter should be initialized")
+	require.NotNil(t, metrics.RequestDuration, "RequestDuration should be initialized")
+	require.NotNil(t, metrics.ActiveRequestsGauge, "ActiveRequestsGauge should be initialized")
+	require.NotNil(t, metrics.ClusterProxyRequests, "ClusterProxyRequests should be initialized")
+}
+
+func TestInitApplicationMetrics(t *testing.T) {
+	provider, _ := setupTestMeter(t)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+
+	meter := otel.Meter("headlamp-test")
+	metrics := &tel.Metrics{}
+
+	err := tel.InitApplicationMetricsForTest(meter, metrics)
+	require.NoError(t, err)
+
+	require.NotNil(t, metrics.PluginLoadCount, "PluginLoadCount should be initialized")
+	require.NotNil(t, metrics.PluginDeleteCount, "PluginDeleteCount should be initialized")
+	require.NotNil(t, metrics.ErrorCounter, "ErrorCounter should be initialized")
+}


### PR DESCRIPTION
### Description
This PR introduces unit tests for the OpenTelemetry metrics initialization logic in the backend telemetry package. It specifically targets `initRequestMetrics` and `initApplicationMetrics` to ensure that core metrics (such as `RequestCounter`, `RequestDuration`, `PluginLoadCount`, etc.) are correctly instantiated.

**Changes included:**
* Added `export_test.go` in the `telemetry` package to cleanly expose the private initialization functions (`initRequestMetrics` and `initApplicationMetrics`) for black-box testing.
* Added `TestInitRequestMetrics` and `TestInitApplicationMetrics` in the `telemetry_test` package to verify the successful creation of all metric instruments.

**A note on coverage:** These tests cover the successful initialization ("happy path"), bringing the statement coverage for these specific functions to ~72%. The remaining uncovered lines are standard `if err != nil` boilerplate for OpenTelemetry instrument creation. I opted to keep the tests clean and readable rather than heavily mocking the OpenTelemetry `Meter` interface just to trigger error returns, but I am entirely happy to add sad-path tests if the maintainers prefer!

### Related Issue
Fixes #5938 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Tech debt / Refactoring / Testing
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

###Screenshots of test passing on my local machine

- 
<img width="1029" height="186" alt="image" src="https://github.com/user-attachments/assets/ba74deeb-c7b0-4cc2-9259-b2c1c6a15517" />

- 
<img width="1029" height="186" alt="image" src="https://github.com/user-attachments/assets/4ebc01a1-07c0-45c6-9afd-239fef674a8e" />

- 
<img width="1217" height="199" alt="image" src="https://github.com/user-attachments/assets/93c0e42c-0f9c-48cd-a942-4de6df225972" />




