### PR TITLE
frontend: node: Add Storybook stories for Details and Charts

### DIFF
--- a/frontend/src/components/node/Charts.stories.tsx
+++ b/frontend/src/components/node/Charts.stories.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import Node from '../../lib/k8s/node';
+import { TestContext } from '../../test';
+import { UsageBarChart } from './Charts';
+import { NODE_DETAILED_DATA, NODE_METRICS_DATA } from './storyHelper';
+
+const node = new Node(NODE_DETAILED_DATA);
+
+export default {
+  title: 'node/Charts',
+  component: UsageBarChart,
+  argTypes: {},
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<typeof UsageBarChart> = args => <UsageBarChart {...args} />;
+
+export const CpuUsage = Template.bind({});
+CpuUsage.args = {
+  node,
+  nodeMetrics: NODE_METRICS_DATA,
+  resourceType: 'cpu',
+};
+
+export const MemoryUsage = Template.bind({});
+MemoryUsage.args = {
+  node,
+  nodeMetrics: NODE_METRICS_DATA,
+  resourceType: 'memory',
+};
+
+export const NoMetrics = Template.bind({});
+NoMetrics.args = {
+  node,
+  nodeMetrics: null,
+  resourceType: 'cpu',
+  noMetrics: true,
+};

--- a/frontend/src/components/node/Details.stories.tsx
+++ b/frontend/src/components/node/Details.stories.tsx
@@ -20,7 +20,12 @@ import { TestContext } from '../../test';
 import Details from './Details';
 import { NODE_DETAILED_DATA, NODE_METRICS_DATA } from './storyHelper';
 
-const emptyList = { kind: 'List', apiVersion: 'v1', metadata: {}, items: [] };
+const emptyList = {
+  kind: 'List',
+  apiVersion: 'v1',
+  metadata: { resourceVersion: '1' },
+  items: [],
+};
 
 const podMetricsList = {
   kind: 'PodMetricsList',

--- a/frontend/src/components/node/Details.stories.tsx
+++ b/frontend/src/components/node/Details.stories.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { TestContext } from '../../test';
+import Details from './Details';
+import { NODE_DETAILED_DATA, NODE_METRICS_DATA } from './storyHelper';
+
+const emptyList = { kind: 'List', apiVersion: 'v1', metadata: {}, items: [] };
+
+const podMetricsList = {
+  kind: 'PodMetricsList',
+  apiVersion: 'metrics.k8s.io/v1beta1',
+  metadata: {},
+  items: [],
+};
+
+// Node is cluster-scoped, so the pods and events it pulls in are queried
+// cluster-wide (no namespace path segment). The kubelet summary stats are
+// served by the node itself and are independent of metrics-server, so they
+// belong here too.
+const commonHandlers = [
+  http.get('http://localhost:4466/api/v1/nodes/node', () => HttpResponse.json(NODE_DETAILED_DATA)),
+  http.get('http://localhost:4466/api/v1/pods', () => HttpResponse.json(emptyList)),
+  http.get('http://localhost:4466/api/v1/events', () => HttpResponse.json(emptyList)),
+  http.get('http://localhost:4466/api/v1/nodes/node/proxy/stats/summary', () =>
+    HttpResponse.json({
+      node: {
+        fs: {
+          capacityBytes: 50000000000,
+          usedBytes: 10000000000,
+        },
+      },
+    })
+  ),
+];
+
+const metricsHandlers = [
+  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
+    HttpResponse.json({
+      kind: 'NodeMetricsList',
+      apiVersion: 'metrics.k8s.io/v1beta1',
+      metadata: {},
+      items: NODE_METRICS_DATA,
+    })
+  ),
+  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/pods', () =>
+    HttpResponse.json(podMetricsList)
+  ),
+];
+
+const notFound = () =>
+  HttpResponse.json({ kind: 'Status', status: 'Failure', code: 404 }, { status: 404 });
+
+// metrics-server unavailable: both the node and pod metrics APIs 404. The
+// kubelet summary (ephemeral storage) still works, as it does on a real cluster.
+const noMetricsHandlers = [
+  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', notFound),
+  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/pods', notFound),
+];
+
+export default {
+  title: 'node/DetailsView',
+  component: Details,
+  argTypes: {},
+  decorators: [
+    Story => (
+      <TestContext routerMap={{ name: 'node' }}>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn = () => <Details />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: {
+    handlers: {
+      story: [...commonHandlers, ...metricsHandlers],
+    },
+  },
+};
+
+export const NoMetrics = Template.bind({});
+NoMetrics.parameters = {
+  msw: {
+    handlers: {
+      story: [...commonHandlers, ...noMetricsHandlers],
+    },
+  },
+};

--- a/frontend/src/components/node/__snapshots__/Charts.CpuUsage.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Charts.CpuUsage.stories.storyshot
@@ -1,0 +1,8 @@
+<body>
+  <div>
+    <div
+      class="recharts-responsive-container css-a9n7s9"
+      style="width: 95%; height: 20px; min-width: 0;"
+    />
+  </div>
+</body>

--- a/frontend/src/components/node/__snapshots__/Charts.MemoryUsage.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Charts.MemoryUsage.stories.storyshot
@@ -1,0 +1,8 @@
+<body>
+  <div>
+    <div
+      class="recharts-responsive-container css-a9n7s9"
+      style="width: 95%; height: 20px; min-width: 0;"
+    />
+  </div>
+</body>

--- a/frontend/src/components/node/__snapshots__/Charts.NoMetrics.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Charts.NoMetrics.stories.storyshot
@@ -1,0 +1,12 @@
+<body>
+  <div>
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-1os2m0i-MuiTypography-root"
+    >
+      4000m
+    </p>
+    <div
+      class="MuiContainer-root MuiContainer-maxWidthLg css-64uahr-MuiContainer-root"
+    />
+  </div>
+</body>

--- a/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.Default.stories.storyshot
@@ -1,0 +1,1625 @@
+<body>
+  <div>
+    <div />
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+            />
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              style="padding-top: 3px;"
+            >
+              Back
+            </p>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-70qvj9"
+              >
+                <h1
+                  class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                >
+                  Node: node
+                </h1>
+                <div
+                  class="MuiBox-root css-ldp2l3"
+                >
+                  <button
+                    aria-label="Copy to clipboard"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Cordon"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Drain"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Edit"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Delete"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                  <div />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              aria-busy="false"
+              aria-live="polite"
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1sf3xto"
+              >
+                <div
+                  class="MuiBox-root css-13qwqa5"
+                >
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-t0zib5-MuiGrid-root"
+                      >
+                        <div
+                          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 css-1vtvfmb-MuiTypography-root"
+                          >
+                            Uptime
+                          </p>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-container MuiGrid-item css-dcx4qa-MuiGrid-root"
+                        >
+                          <div
+                            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 css-l0k1rq-MuiTypography-root"
+                            >
+                              90d
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              CPU Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            0.00 / 4 units
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="0.0 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99921809249515,16.20000000682343
+  L 60.999410078712856,27.200000005148027
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      0.0 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              Memory Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            0.00 / 7.63 GB
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="0.0 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99921809249515,16.20000000682343
+  L 60.999410078712856,27.200000005148027
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      0.0 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              Pod Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            0 / 110 Pods
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="0.0 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99921809249515,16.20000000682343
+  L 60.999410078712856,27.200000005148027
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      0.0 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              Ephemeral Storage Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            9.31 / 47.68 GB
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="19.5 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    0,1,
+    103.18117412019933,45.90733456802854
+  L 92.82418940318611,49.61312295534296
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            61,27.199999999999996 Z"
+                                      fill="#000"
+                                      name="used"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="19.5 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 103.18117412019933,45.90733456802854
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99999999999999,16.199999999999996
+  L 60.99999999999999,27.199999999999996
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            92.82418940318611,49.61312295534296 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      19.5 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-0"
+              >
+                <dl
+                  class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+                >
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Name
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      node
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Creation
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      2022-01-01T00:00:00.000Z
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Labels
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yi3mkw"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          node-role.kubernetes.io/control-plane: 
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          kubernetes.io/arch: amd64
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          kubernetes.io/os: linux
+                        </p>
+                      </div>
+                    </div>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Roles
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      control-plane
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Taints
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-15e19qo"
+                    />
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Ready
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                    >
+                      Yes
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Conditions
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                    >
+                      Scheduling Enabled
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Pod CIDR
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      10.244.0.0/24
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    InternalIP
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      172.18.0.2
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Hostname
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      node
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Capacity
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yi3mkw"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          cpu: 4
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          memory: 8000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          pods: 110
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                      </div>
+                    </div>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                  >
+                    Allocatable
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yi3mkw"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          cpu: 4
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          memory: 8000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          pods: 110
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                      </div>
+                    </div>
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Resource Allocation
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1qm1lh"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                >
+                  Total limits may be over 100 percent, i.e., overcommitted.
+                </p>
+              </div>
+              <dl
+                class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+              >
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  CPU Requests
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 m
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  CPU Limits
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 m
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Memory Requests
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 Bi
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                >
+                  Memory Limits
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 Bi
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    System Info
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <dl
+                class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+              >
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Architecture
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    amd64
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Boot ID
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    boot-id
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  System UUID
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    system-uuid
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  OS
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    linux
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Image
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    Ubuntu 22.04 LTS
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Kernel Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    5.15.0
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Machine ID
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    machine-id
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Kube Proxy Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    v1.25.3
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Kubelet Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    v1.25.3
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                >
+                  Container Runtime Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    containerd://1.6.9
+                  </span>
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Conditions
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Condition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Status
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Transition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Update
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Reason
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+                        >
+                          Ready
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        True
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="2022-01-01T00:00:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        -
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="kubelet is posting ready status"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          KubeletReady
+                        </p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Pods
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+                >
+                  <div
+                    class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+                    >
+                      <div
+                        class="MuiBox-root css-1dipl1t"
+                      >
+                        <div
+                          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                          style="margin-top: 0px;"
+                        >
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                            data-shrink="true"
+                            for="namespaces-filter"
+                            id="namespaces-filter-label"
+                          >
+                            Namespaces
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1xjtaff-MuiInputBase-root-MuiOutlinedInput-root"
+                          >
+                            <input
+                              aria-autocomplete="both"
+                              aria-expanded="false"
+                              aria-invalid="false"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                              id="namespaces-filter"
+                              placeholder="Filter"
+                              role="combobox"
+                              spellcheck="false"
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                            >
+                              <button
+                                aria-label="Open"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1aav1nn-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                                tabindex="-1"
+                                title="Open"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                                  data-testid="ArrowDropDownIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                                <span
+                                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                            <fieldset
+                              aria-hidden="true"
+                              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                            >
+                              <legend
+                                class="css-sl37lx-MuiNotchedOutlined-root"
+                              >
+                                <span>
+                                  Namespaces
+                                </span>
+                              </legend>
+                            </fieldset>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No data to be shown.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No data to be shown.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Events
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No data to be shown.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No data to be shown.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/Details.NoMetrics.stories.storyshot
@@ -1,0 +1,1625 @@
+<body>
+  <div>
+    <div />
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-bsyb48-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-1j11y9k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+            />
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+              style="padding-top: 3px;"
+            >
+              Back
+            </p>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-70qvj9"
+              >
+                <h1
+                  class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                >
+                  Node: node
+                </h1>
+                <div
+                  class="MuiBox-root css-ldp2l3"
+                >
+                  <button
+                    aria-label="Copy to clipboard"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Cordon"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Drain"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                />
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Edit"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                >
+                  <button
+                    aria-label="Delete"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                  <div />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              aria-busy="false"
+              aria-live="polite"
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1sf3xto"
+              >
+                <div
+                  class="MuiBox-root css-13qwqa5"
+                >
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1oobngp-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-t0zib5-MuiGrid-root"
+                      >
+                        <div
+                          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 css-1vtvfmb-MuiTypography-root"
+                          >
+                            Uptime
+                          </p>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-container MuiGrid-item css-dcx4qa-MuiGrid-root"
+                        >
+                          <div
+                            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 css-l0k1rq-MuiTypography-root"
+                            >
+                              90d
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              CPU Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            0.00 / 4 units
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="0.0 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99921809249515,16.20000000682343
+  L 60.999410078712856,27.200000005148027
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      0.0 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              Memory Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            0.00 / 7.63 GB
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="0.0 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99921809249515,16.20000000682343
+  L 60.999410078712856,27.200000005148027
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      0.0 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              Pod Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            0 / 110 Pods
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="0.0 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99921809249515,16.20000000682343
+  L 60.999410078712856,27.200000005148027
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      0.0 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+                    >
+                      <div
+                        class="MuiBox-root css-qrw4x1"
+                      >
+                        <div
+                          class="MuiBox-root css-1sl8dhm"
+                        >
+                          <div
+                            class="MuiBox-root css-0"
+                          >
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+                            >
+                              Ephemeral Storage Usage
+                            </p>
+                          </div>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+                          >
+                            9.31 / 47.68 GB
+                          </p>
+                        </div>
+                        <div
+                          class="MuiBox-root css-0"
+                        >
+                          <div
+                            aria-busy="false"
+                            aria-live="polite"
+                            class="MuiBox-root css-2esbmj"
+                          >
+                            <div
+                              class="recharts-wrapper"
+                              style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+                            >
+                              <svg
+                                class="recharts-surface"
+                                cx="70"
+                                cy="70"
+                                height="112"
+                                style="width: 100%; height: 100%;"
+                                viewBox="0 0 112 112"
+                                width="112"
+                              >
+                                <title />
+                                <desc />
+                                <defs>
+                                  <clippath
+                                    id="recharts-id"
+                                  >
+                                    <rect
+                                      height="102"
+                                      width="102"
+                                      x="5"
+                                      y="5"
+                                    />
+                                  </clippath>
+                                </defs>
+                                <g
+                                  class="recharts-layer recharts-pie"
+                                  tabindex="0"
+                                >
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="19.5 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    0,1,
+    103.18117412019933,45.90733456802854
+  L 92.82418940318611,49.61312295534296
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            61,27.199999999999996 Z"
+                                      fill="#000"
+                                      name="used"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="19.5 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 103.18117412019933,45.90733456802854
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99999999999999,16.199999999999996
+  L 60.99999999999999,27.199999999999996
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            92.82418940318611,49.61312295534296 Z"
+                                      fill="#e0e0e0"
+                                      name="total"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <text
+                                    class="recharts-text recharts-label"
+                                    fill="#808080"
+                                    offset="5"
+                                    style="font-size: 16.8px; fill: #000;"
+                                    text-anchor="middle"
+                                    x="61"
+                                    y="61"
+                                  >
+                                    <tspan
+                                      dy="0.355em"
+                                      x="61"
+                                    >
+                                      19.5 %
+                                    </tspan>
+                                  </text>
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-0"
+              >
+                <dl
+                  class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+                >
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Name
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      node
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Creation
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      2022-01-01T00:00:00.000Z
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Labels
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yi3mkw"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          node-role.kubernetes.io/control-plane: 
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          kubernetes.io/arch: amd64
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          kubernetes.io/os: linux
+                        </p>
+                      </div>
+                    </div>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Roles
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      control-plane
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Taints
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-15e19qo"
+                    />
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Ready
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                    >
+                      Yes
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Conditions
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                    >
+                      Scheduling Enabled
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Pod CIDR
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      10.244.0.0/24
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    InternalIP
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      172.18.0.2
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Hostname
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      node
+                    </span>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                  >
+                    Capacity
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yi3mkw"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          cpu: 4
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          memory: 8000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          pods: 110
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                      </div>
+                    </div>
+                  </dd>
+                  <dt
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                  >
+                    Allocatable
+                  </dt>
+                  <dd
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiBox-root css-yi3mkw"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          cpu: 4
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          memory: 8000000Ki
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          pods: 110
+                        </p>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                        >
+                          ephemeral-storage: 50000000Ki
+                        </p>
+                      </div>
+                    </div>
+                  </dd>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Resource Allocation
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1qm1lh"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                >
+                  Total limits may be over 100 percent, i.e., overcommitted.
+                </p>
+              </div>
+              <dl
+                class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+              >
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  CPU Requests
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 m
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  CPU Limits
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 m
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Memory Requests
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 Bi
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                >
+                  Memory Limits
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-70qvj9"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                    >
+                      0 Bi
+                    </span>
+                    <div
+                      class="MuiBox-root css-d0uhtl"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+                      >
+                        0.0
+                         %
+                      </span>
+                    </div>
+                  </div>
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    System Info
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <dl
+                class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+              >
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Architecture
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    amd64
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Boot ID
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    boot-id
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  System UUID
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    system-uuid
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  OS
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    linux
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Image
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    Ubuntu 22.04 LTS
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Kernel Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    5.15.0
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Machine ID
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    machine-id
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Kube Proxy Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    v1.25.3
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+                >
+                  Kubelet Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    v1.25.3
+                  </span>
+                </dd>
+                <dt
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+                >
+                  Container Runtime Version
+                </dt>
+                <dd
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+                  >
+                    containerd://1.6.9
+                  </span>
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Conditions
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
+              >
+                <table
+                  class="MuiTable-root css-r7i92b-MuiTable-root"
+                >
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Condition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Status
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Transition
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Last Update
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Reason
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+                        >
+                          Ready
+                        </span>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        True
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="2022-01-01T00:00:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        -
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <p
+                          aria-label="kubelet is posting ready status"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          KubeletReady
+                        </p>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Pods
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+                >
+                  <div
+                    class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+                    >
+                      <div
+                        class="MuiBox-root css-1dipl1t"
+                      >
+                        <div
+                          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                          style="margin-top: 0px;"
+                        >
+                          <label
+                            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                            data-shrink="true"
+                            for="namespaces-filter"
+                            id="namespaces-filter-label"
+                          >
+                            Namespaces
+                          </label>
+                          <div
+                            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1xjtaff-MuiInputBase-root-MuiOutlinedInput-root"
+                          >
+                            <input
+                              aria-autocomplete="both"
+                              aria-expanded="false"
+                              aria-invalid="false"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                              id="namespaces-filter"
+                              placeholder="Filter"
+                              role="combobox"
+                              spellcheck="false"
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                            >
+                              <button
+                                aria-label="Open"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1aav1nn-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                                tabindex="-1"
+                                title="Open"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                                  data-testid="ArrowDropDownIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7 10l5 5 5-5z"
+                                  />
+                                </svg>
+                                <span
+                                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                            <fieldset
+                              aria-hidden="true"
+                              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                            >
+                              <legend
+                                class="css-sl37lx-MuiNotchedOutlined-root"
+                              >
+                                <span>
+                                  Namespaces
+                                </span>
+                              </legend>
+                            </fieldset>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No data to be shown.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No data to be shown.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
+                    Events
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No data to be shown.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No data to be shown.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/node/storyHelper.ts
+++ b/frontend/src/components/node/storyHelper.ts
@@ -14,9 +14,107 @@
  * limitations under the License.
  */
 
+import { KubeMetrics } from '../../lib/k8s/cluster';
 import { KubeNode, NODE_POOL_LABEL_KEYS } from '../../lib/k8s/node';
 
 const creationTimestamp = new Date('2022-01-01').toISOString();
+
+/**
+ * A fully-populated node with capacity, allocatable, conditions and system info.
+ * Useful for Details and Charts stories that need realistic resource data.
+ */
+export const NODE_DETAILED_DATA: KubeNode = {
+  kind: 'Node',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'node',
+    creationTimestamp,
+    uid: 'detailed-node-uid',
+    labels: {
+      'node-role.kubernetes.io/control-plane': '',
+      'kubernetes.io/arch': 'amd64',
+      'kubernetes.io/os': 'linux',
+    },
+  },
+  spec: {
+    podCIDR: '10.244.0.0/24',
+    podCIDRs: ['10.244.0.0/24'],
+    providerID: 'kind://docker/headlamp/node',
+    taints: [],
+    unschedulable: false,
+  },
+  status: {
+    addresses: [
+      { type: 'InternalIP', address: '172.18.0.2' },
+      { type: 'Hostname', address: 'node' },
+    ],
+    allocatable: {
+      cpu: '4',
+      'ephemeral-storage': '50000000Ki',
+      'hugepages-1Gi': '0',
+      'hugepages-2Mi': '0',
+      memory: '8000000Ki',
+      pods: '110',
+    },
+    capacity: {
+      cpu: '4',
+      'ephemeral-storage': '50000000Ki',
+      'hugepages-1Gi': '0',
+      'hugepages-2Mi': '0',
+      memory: '8000000Ki',
+      pods: '110',
+    },
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastHeartbeatTime: creationTimestamp,
+        lastTransitionTime: creationTimestamp,
+        reason: 'KubeletReady',
+        message: 'kubelet is posting ready status',
+      },
+    ],
+    nodeInfo: {
+      architecture: 'amd64',
+      bootID: 'boot-id',
+      containerRuntimeVersion: 'containerd://1.6.9',
+      kernelVersion: '5.15.0',
+      kubeProxyVersion: 'v1.25.3',
+      kubeletVersion: 'v1.25.3',
+      machineID: 'machine-id',
+      operatingSystem: 'linux',
+      osImage: 'Ubuntu 22.04 LTS',
+      systemUUID: 'system-uuid',
+    },
+  },
+};
+
+/**
+ * Node metrics matching {@link NODE_DETAILED_DATA}: usage is half of the node's
+ * capacity, so the interactive Storybook view renders ~50% CPU/memory usage.
+ *
+ * Note: the storyshot snapshot shows 0% usage because metric polling resolves
+ * after the snapshot is captured (same as the cluster/Overview stories).
+ */
+export const NODE_METRICS_DATA: KubeMetrics[] = [
+  {
+    metadata: {
+      name: 'node',
+      creationTimestamp,
+      uid: 'node-metrics-uid',
+    },
+    usage: {
+      cpu: '2',
+      memory: '4000000Ki',
+    },
+    status: {
+      capacity: {
+        cpu: '4',
+        memory: '8000000Ki',
+      },
+    },
+  },
+];
 
 export const NODE_DUMMY_DATA: KubeNode[] = [
   {


### PR DESCRIPTION
## Description

Adds Storybook stories for two node components that previously had none:
`node/Details.tsx` and `node/Charts.tsx`. In this codebase stories double
as snapshot tests (`src/storybook.test.tsx` runs every story through
`toMatchFileSnapshot`), so this also adds regression coverage for both.

- **`Charts.stories.tsx`** — `UsageBarChart` in CPU usage, memory usage,
  and no-metrics fallback states.
- **`Details.stories.tsx`** — `NodeDetails` in a default loaded view and a
  no-metrics view (metrics-server unavailable).
- **`storyHelper.ts`** — adds `NODE_DETAILED_DATA` (capacity, allocatable,
  conditions, system info) and matching `NODE_METRICS_DATA` so the stories
  render realistic data. Existing `NODE_DUMMY_DATA` is untouched.

Part of an effort to close gaps in components lacking stories/tests; this
is the Node piece.  Closes #5941.

## Note on diff size

The large line count is almost entirely generated `.storyshot` snapshot
files committed alongside the stories (standard for this repo). The
hand-written change is ~270 lines across the three `.tsx`/`.ts` files.

## Testing

`npx vitest run src/storybook.test.tsx -t "node/"` → 6 passed, no drift.