### PR TITLE
frontend: GlobalSearchContent: Add Storybook stories

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { lazy, Suspense } from 'react';
+import type { KubeObject } from '../../lib/k8s/KubeObject';
+import Pod from '../../lib/k8s/pod';
+import { TestContext } from '../../test';
+import { generateK8sResourceList } from '../../test/mocker';
+import { podList } from '../pod/storyHelper';
+import { GlobalSearchContent, type SearchResultItem } from './GlobalSearchContent';
+
+const LazyKubeIcon = lazy(() =>
+  import('../resourceMap/kubeIcon/KubeIcon').then(it => ({ default: it.KubeIcon }))
+);
+
+const phonyPods = generateK8sResourceList(
+  {
+    ...podList[5],
+    metadata: {
+      ...podList[5].metadata,
+      name: 'pod-{{i}}',
+    },
+  },
+  { instantiateAs: Pod }
+);
+
+function makeSearchResult(item: KubeObject): SearchResultItem {
+  return {
+    id: item.metadata.uid,
+    label: item.metadata.name,
+    subLabel: item.kind,
+    k8sLabels: item.metadata.labels
+      ? Object.entries(item.metadata.labels).map(([key, value]) => key + '=' + value)
+      : [],
+    icon: (
+      <Suspense fallback={null}>
+        <LazyKubeIcon kind={item.kind} width="24px" height="24px" />
+      </Suspense>
+    ),
+    onClick: () => {},
+  };
+}
+
+const meta: Meta<typeof GlobalSearchContent> = {
+  title: 'GlobalSearch/GlobalSearchContent',
+  component: GlobalSearchContent,
+  args: {
+    defaultValue: '',
+    maxWidth: 500,
+    onBlur: () => {},
+  },
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GlobalSearchContent>;
+
+export const WithEmptyInput: Story = {
+  args: {
+    defaultValue: '',
+  },
+};
+
+export const LoadingResources: Story = {
+  args: {
+    defaultValue: 'pod',
+    providedSearchResults: {
+      isLoadingResources: true,
+      items: [],
+    },
+  },
+};
+
+export const FoundSomeResults: Story = {
+  args: {
+    defaultValue: 'pod',
+    providedSearchResults: {
+      isLoadingResources: false,
+      items: phonyPods.map(makeSearchResult),
+    },
+  },
+};
+
+export const FoundNoResults: Story = {
+  args: {
+    defaultValue: 'pod',
+    providedSearchResults: {
+      isLoadingResources: false,
+      items: [],
+    },
+  },
+};

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -74,7 +74,7 @@ const LazyKubeIcon = lazy(() =>
 /**
  * Object representing a single search result
  */
-interface SearchResult {
+export interface SearchResultItem {
   id: string;
   label: string;
   icon?: JSX.Element;
@@ -84,6 +84,11 @@ interface SearchResult {
   labelMatch?: FuseResultMatch;
   subLabelMatch?: FuseResultMatch;
   k8sLabelsMatch?: FuseResultMatch;
+}
+
+export interface SearchResults {
+  isLoadingResources: boolean;
+  items: SearchResultItem[];
 }
 
 /**
@@ -167,10 +172,12 @@ export function GlobalSearchContent({
   maxWidth,
   defaultValue,
   onBlur,
+  providedSearchResults,
 }: {
   maxWidth: number;
   defaultValue: string;
   onBlur: () => void;
+  providedSearchResults?: SearchResults;
 }) {
   const { t } = useTranslation();
   const history = useHistory();
@@ -184,7 +191,7 @@ export function GlobalSearchContent({
 
   // Resource search items
   const resources = useSearchResources();
-  const loading = resources.filter(it => it.isLoading).map(it => it.kind);
+  const isLoadingResources = resources.filter(it => it.isLoading).length > 0;
   const namespaceItems = useMemo(() => {
     const namespaceResource = resources.find(resource => resource.kind === Namespace.kind);
     return (namespaceResource?.items as Namespace[]) ?? [];
@@ -197,7 +204,7 @@ export function GlobalSearchContent({
       ].filter(Boolean)
     );
 
-    const options: SearchResult[] = [];
+    const options: SearchResultItem[] = [];
 
     const addOption = (namespaceValue: string) => {
       if (!namespaceValue) {
@@ -263,7 +270,7 @@ export function GlobalSearchContent({
   );
 
   // Cluster items
-  const clusterItems: SearchResult[] = useMemo(
+  const clusterItems: SearchResultItem[] = useMemo(
     () =>
       Object.keys(clusters).map(cluster => ({
         id: cluster,
@@ -294,7 +301,7 @@ export function GlobalSearchContent({
           routeFilters.filter(f => f(route)).length !== routeFilters.length
         ) && !route.disabled
     );
-  const routes: SearchResult[] = useMemo(
+  const routes: SearchResultItem[] = useMemo(
     () =>
       filteredRoutes
         .filter(([, route]) => route.name && !route.path.includes(':'))
@@ -349,7 +356,7 @@ export function GlobalSearchContent({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, selectedClusters]);
-  const configureShortcutsAction: SearchResult = useMemo(
+  const configureShortcutsAction: SearchResultItem = useMemo(
     () => ({
       id: 'configure-shortcuts',
       subLabel: t('Settings'),
@@ -373,7 +380,7 @@ export function GlobalSearchContent({
         ...namespaceOptions,
         ...items,
         advancedSearchSuggestion,
-      ].filter(Boolean) as SearchResult[],
+      ].filter(Boolean) as SearchResultItem[],
     [
       configureShortcutsAction,
       themeActions,
@@ -402,47 +409,66 @@ export function GlobalSearchContent({
     [allOptions]
   );
 
-  const results: SearchResult[] = useMemo(() => {
-    if (!query) return [];
-    return fuse
-      .search(
-        {
-          // Construct logical query https://www.fusejs.io/api/query.html
-          // Improves search for space separated terms
-          $and: query
-            .split(' ')
-            .filter(Boolean)
-            .map(it => ({
-              $or: [
-                { label: it },
-                // Only search labels if there's an "=" character in the query
-                it.includes('=') ? { k8sLabels: it } : undefined,
-                { subLabel: it },
-              ].filter(Boolean) as Expression[],
-            })),
-        },
-        { limit: 100 }
-      )
-      .map(
-        ({ item, matches }) =>
-          ({
-            ...item,
-            labelMatch: matches?.find(it => it.key === 'label'),
-            subLabelMatch: matches?.find(it => it.key === 'subLabel'),
-            k8sLabelsMatch: matches?.find(it => it.key === 'k8sLabels'),
-          } satisfies SearchResult)
-      );
-  }, [query, fuse]);
+  const results: SearchResults = useMemo(() => {
+    if (!query) {
+      return {
+        isLoadingResources,
+        items: [],
+      };
+    }
 
-  const recentItems = useMemo(() => {
-    if (query) return [];
+    return {
+      isLoadingResources,
+      items: fuse
+        .search(
+          {
+            // Construct logical query https://www.fusejs.io/api/query.html
+            // Improves search for space separated terms
+            $and: query
+              .split(' ')
+              .filter(Boolean)
+              .map(it => ({
+                $or: [
+                  { label: it },
+                  // Only search labels if there's an "=" character in the query
+                  it.includes('=') ? { k8sLabels: it } : undefined,
+                  { subLabel: it },
+                ].filter(Boolean) as Expression[],
+              })),
+          },
+          { limit: 100 }
+        )
+        .map(
+          ({ item, matches }) =>
+            ({
+              ...item,
+              labelMatch: matches?.find(it => it.key === 'label'),
+              subLabelMatch: matches?.find(it => it.key === 'subLabel'),
+              k8sLabelsMatch: matches?.find(it => it.key === 'k8sLabels'),
+            } satisfies SearchResultItem)
+        ),
+    };
+  }, [query, fuse, isLoadingResources]);
 
-    return allOptions.filter(it => recent[it.id]).sort((a, b) => recent[b.id] - recent[a.id]);
+  const recents: SearchResults = useMemo(() => {
+    if (query) {
+      return {
+        isLoadingResources,
+        items: [],
+      };
+    }
+
+    return {
+      isLoadingResources,
+      items: allOptions.filter(it => recent[it.id]).sort((a, b) => recent[b.id] - recent[a.id]),
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recent, results, query]);
+  }, [recent, results, query, isLoadingResources]);
 
-  const autocomplete = useAutocomplete<SearchResult, false, false, true>({
-    options: !query ? recentItems : results,
+  const displayedSearchResults = providedSearchResults ?? (query ? results : recents);
+
+  const autocomplete = useAutocomplete<SearchResultItem, false, false, true>({
+    options: displayedSearchResults.items,
     freeSolo: true, // free user input, not just autocomplete options
     autoHighlight: true, // highlight first option on open
     openOnFocus: true,
@@ -450,7 +476,7 @@ export function GlobalSearchContent({
     filterOptions: options => options, // we handle filtering ourself
     onHighlightChange(_, option, reason) {
       if (reason === 'keyboard' && option) {
-        const index = results.indexOf(option);
+        const index = displayedSearchResults.items.indexOf(option);
         const list = listRef.current;
         list?.scrollToItem(index);
       }
@@ -502,7 +528,7 @@ export function GlobalSearchContent({
                     <Icon icon="mdi:close" />
                   </IconButton>
                 </Tooltip>
-                {loading.length > 0 && (
+                {displayedSearchResults.isLoadingResources && (
                   <Delayed display="flex" mr={1}>
                     <CircularProgress size="16px" />
                   </Delayed>
@@ -571,12 +597,12 @@ function SearchRow({
   style,
   index,
 }: {
-  data: UseAutocompleteReturnValue<SearchResult, false, false, true>;
+  data: UseAutocompleteReturnValue<SearchResultItem, false, false, true>;
   style: any;
   index: number;
 }) {
   const autocomplete = data;
-  const option = autocomplete.groupedOptions[index] as SearchResult;
+  const option = autocomplete.groupedOptions[index] as SearchResultItem;
 
   return (
     <Box

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.LoadingResources.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.LoadingResources.stories.storyshot
@@ -1,0 +1,94 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-expanded="false"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value="pod"
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1oql5kp-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiBox-root css-lvik6n"
+          >
+            <span
+              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1g0vz9s-MuiCircularProgress-root"
+              role="progressbar"
+              style="width: 16px; height: 16px;"
+            >
+              <svg
+                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                viewBox="22 22 44 44"
+              >
+                <circle
+                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                  cx="44"
+                  cy="44"
+                  fill="none"
+                  r="20.2"
+                  stroke-width="3.6"
+                />
+              </svg>
+            </span>
+          </div>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-1d9w0d4-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    />
+  </div>
+</body>

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.ShowsNoResults.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.ShowsNoResults.stories.storyshot
@@ -1,0 +1,71 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-expanded="false"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value="pod"
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1oql5kp-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-1d9w0d4-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    />
+  </div>
+</body>

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.ShowsSomeResults.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.ShowsSomeResults.stories.storyshot
@@ -1,0 +1,828 @@
+<body>
+  <div>
+    <div
+      aria-owns=":mock-test-id:"
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-controls=":mock-test-id:"
+          aria-expanded="true"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-activedescendant=":mock-test-id:"
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value="pod"
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1oql5kp-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-1d9w0d4-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    >
+      <div
+        style="position: relative; height: 250px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
+      >
+        <div
+          style="height: 250px; width: 100%;"
+        >
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6 Mui-focused"
+            data-option-index="0"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 0px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Pod
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                pod-0
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="1"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 50px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Pod
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                pod-1
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="2"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 100px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Pod
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                pod-2
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="3"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 150px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Pod
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                pod-3
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="4"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 200px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Pod
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                pod-4
+              </div>
+            </div>
+          </li>
+        </div>
+      </div>
+    </ul>
+  </div>
+</body>

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.WithEmptyInput.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.WithEmptyInput.stories.storyshot
@@ -1,0 +1,71 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-expanded="false"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value=""
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ppbyx2-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-1d9w0d4-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    />
+  </div>
+</body>


### PR DESCRIPTION
## Summary

GlobalSearchContent did not have Storybook coverage, so this PR adds stories and snapshots for the following visual states:

- With Empty Input: renders the component with an empty query.
- Loading Resources: shows the loading spinner while resources are loading.
- Found Some Results: displays matching resources as search results.
- Found No Results: renders the empty results state when no resources match the query.

To make these states reproducible in Storybook, GlobalSearchContent now accepts search results through props. This allows stories to render arbitrary results and loading states without depending on live resource loading.

Issue #931 also mentions that GlobalSearchContent should have Storybook coverage, so please refer to that issue as related context.

## Related Issue

Fixes #5878

## Changes

`frontend/src/components/globalSearch/GlobalSearchContent.tsx`
- Added a `providedSearchResults` prop so stories can pass the search results to display.
- When `providedSearchResults` is undefined, the component keeps the existing behavior and uses the regular search results or recent items.
- Exported `SearchResultItem` and `SearchResults` so Storybook stories can provide typed search result data.
- Included the resource loading state in `SearchResults` so the loading spinner can be rendered in isolation.

`frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx`

- Added four stories for GlobalSearchContent:
  - WithEmptyInput: renders the component with an empty query.
  - LoadingResources: passes `isLoadingResources: true` so the spinner is shown.
  - FoundSomeResults: passes mocked pod results through `providedSearchResults.items`.
  - FoundNoResults: passes an empty results list to reproduce the no-results state.

`frontend/src/components/globalSearch/__snapshots__/`

- Added storyshot snapshots for WithEmptyInput, LoadingResources, FoundSomeResults and FoundNoResults.

## Steps to Test

1. `npm run frontend:install`
1. `npm run frontend:storybook`
1. Open GlobalSearch > GlobalSearchContent from the left sidebar.
1. Verify that all four stories render correctly:
   - With Empty Input
   - Loading Resources
   - Found Some Results
   - Found No Results
   
## Screenshots
WIP

## Notes for the Reviewer

Issue #931 mentions five expected states: empty search state, search loading spinner, search results list, no results found, and search error state.

This PR does not include a search error state because GlobalSearchContent does not currently appear to expose a user-facing error state for failed resource loading.

