### PR TITLE
frontend: GlobalSearchContent: Add Storybook stories

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { delay, http, HttpResponse } from 'msw';
+import type { Cluster } from '../../lib/k8s/cluster';
+import Pod from '../../lib/k8s/pod';
+import { initialState as configInitialState } from '../../redux/configSlice';
+import reducers from '../../redux/reducers/reducers';
+import { TestContext } from '../../test';
+import { generateK8sResourceList } from '../../test/mocker';
+import { podList } from '../pod/storyHelper';
+import { GlobalSearchContent } from './GlobalSearchContent';
+
+const phonyPods = generateK8sResourceList(
+  {
+    ...podList[5],
+    metadata: {
+      ...podList[5].metadata,
+      name: 'pod-{{i}}',
+    },
+  },
+  { instantiateAs: Pod }
+);
+
+const sampleCluster: Cluster = {
+  name: 'sample-cluster',
+  auth_type: '',
+};
+
+const store = configureStore({
+  reducer: reducers,
+  preloadedState: {
+    config: {
+      ...configInitialState,
+      clusters: {
+        [sampleCluster.name]: sampleCluster,
+      },
+      allClusters: {
+        [sampleCluster.name]: sampleCluster,
+      },
+    },
+  },
+});
+
+const queryClients = new Map<string, QueryClient>();
+const recentSearchItemsKey = 'search-recent-items';
+const sampleClusterApiBase = `http://localhost:4466/clusters/${sampleCluster.name}`;
+
+function getQueryClient(storyId: string) {
+  let queryClient = queryClients.get(storyId);
+  if (!queryClient) {
+    queryClient = new QueryClient();
+    queryClients.set(storyId, queryClient);
+  }
+
+  return queryClient;
+}
+
+function makeKubeList(apiVersion: string, kind: string, items: any[] = []) {
+  return {
+    apiVersion,
+    kind: `${kind}List`,
+    metadata: {
+      resourceVersion: '1',
+    },
+    items,
+  };
+}
+
+const meta: Meta<typeof GlobalSearchContent> = {
+  title: 'GlobalSearch/GlobalSearchContent',
+  component: GlobalSearchContent,
+  args: {
+    defaultValue: '',
+    maxWidth: 500,
+    onBlur: () => {},
+  },
+  parameters: {
+    msw: {
+      handlers: {
+        pod: [
+          http.get(`${sampleClusterApiBase}/api/v1/pods`, () =>
+            HttpResponse.json(
+              makeKubeList(
+                'v1',
+                'Pod',
+                phonyPods.map(pod => pod.jsonData)
+              )
+            )
+          ),
+        ],
+        resources: [
+          http.get(`${sampleClusterApiBase}/apis/apps/v1/deployments`, () =>
+            HttpResponse.json(makeKubeList('apps/v1', 'Deployment'))
+          ),
+          http.get(`${sampleClusterApiBase}/api/v1/services`, () =>
+            HttpResponse.json(makeKubeList('v1', 'Service'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/batch/v1/jobs`, () =>
+            HttpResponse.json(makeKubeList('batch/v1', 'Job'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/batch/v1/cronjobs`, () =>
+            HttpResponse.json(makeKubeList('batch/v1', 'CronJob'))
+          ),
+          http.get(`${sampleClusterApiBase}/api/v1/configmaps`, () =>
+            HttpResponse.json(makeKubeList('v1', 'ConfigMap'))
+          ),
+          http.get(`${sampleClusterApiBase}/api/v1/namespaces`, () =>
+            HttpResponse.json(makeKubeList('v1', 'Namespace'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/apps/v1/statefulsets`, () =>
+            HttpResponse.json(makeKubeList('apps/v1', 'StatefulSet'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/apps/v1/replicasets`, () =>
+            HttpResponse.json(makeKubeList('apps/v1', 'ReplicaSet'))
+          ),
+          http.get(`${sampleClusterApiBase}/api/v1/persistentvolumeclaims`, () =>
+            HttpResponse.json(makeKubeList('v1', 'PersistentVolumeClaim'))
+          ),
+          http.get(`${sampleClusterApiBase}/api/v1/endpoints`, () =>
+            HttpResponse.json(makeKubeList('v1', 'Endpoints'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/discovery.k8s.io/v1/endpointslices`, () =>
+            HttpResponse.json(makeKubeList('discovery.k8s.io/v1', 'EndpointSlice'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/networking.k8s.io/v1/ingresses`, () =>
+            HttpResponse.json(makeKubeList('networking.k8s.io/v1', 'Ingress'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/extensions/v1beta1/ingresses`, () =>
+            HttpResponse.json(makeKubeList('extensions/v1beta1', 'Ingress'))
+          ),
+          http.get(`${sampleClusterApiBase}/api/v1/serviceaccounts`, () =>
+            HttpResponse.json(makeKubeList('v1', 'ServiceAccount'))
+          ),
+          http.get(`${sampleClusterApiBase}/api/v1/nodes`, () =>
+            HttpResponse.json(makeKubeList('v1', 'Node'))
+          ),
+          http.get(`${sampleClusterApiBase}/apis/jobset.x-k8s.io/v1alpha2/jobsets`, () =>
+            HttpResponse.json(makeKubeList('jobset.x-k8s.io/v1alpha2', 'JobSet'))
+          ),
+        ],
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      localStorage.removeItem(recentSearchItemsKey);
+
+      const queryClient = getQueryClient(context.id);
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <TestContext store={store} routerMap={{ cluster: sampleCluster.name }} urlPrefix="/c">
+            <Story />
+          </TestContext>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GlobalSearchContent>;
+
+export const WithEmptyInput: Story = {};
+
+export const LoadingResources: Story = {
+  args: {
+    defaultValue: 'pod',
+  },
+  parameters: {
+    storyshots: {
+      disable: true,
+    },
+    msw: {
+      handlers: {
+        pod: [
+          http.get(`${sampleClusterApiBase}/api/v1/pods`, async () => {
+            await delay('infinite');
+            return HttpResponse.json(makeKubeList('v1', 'Pod'));
+          }),
+        ],
+      },
+    },
+  },
+};
+
+export const FoundSomeResults: Story = {
+  args: {
+    defaultValue: 'pod',
+  },
+};

--- a/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
@@ -43,21 +43,6 @@ const sampleCluster: Cluster = {
   auth_type: '',
 };
 
-const store = configureStore({
-  reducer: reducers,
-  preloadedState: {
-    config: {
-      ...configInitialState,
-      clusters: {
-        [sampleCluster.name]: sampleCluster,
-      },
-      allClusters: {
-        [sampleCluster.name]: sampleCluster,
-      },
-    },
-  },
-});
-
 const recentSearchItemsKey = 'search-recent-items';
 const sampleClusterApiBase = `http://localhost:4466/clusters/${sampleCluster.name}`;
 
@@ -150,6 +135,21 @@ const meta: Meta<typeof GlobalSearchContent> = {
   decorators: [
     Story => {
       localStorage.removeItem(recentSearchItemsKey);
+
+      const store = configureStore({
+        reducer: reducers,
+        preloadedState: {
+          config: {
+            ...configInitialState,
+            clusters: {
+              [sampleCluster.name]: sampleCluster,
+            },
+            allClusters: {
+              [sampleCluster.name]: sampleCluster,
+            },
+          },
+        },
+      });
 
       const queryClient = new QueryClient({
         defaultOptions: {

--- a/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
@@ -58,19 +58,8 @@ const store = configureStore({
   },
 });
 
-const queryClients = new Map<string, QueryClient>();
 const recentSearchItemsKey = 'search-recent-items';
 const sampleClusterApiBase = `http://localhost:4466/clusters/${sampleCluster.name}`;
-
-function getQueryClient(storyId: string) {
-  let queryClient = queryClients.get(storyId);
-  if (!queryClient) {
-    queryClient = new QueryClient();
-    queryClients.set(storyId, queryClient);
-  }
-
-  return queryClient;
-}
 
 function makeKubeList(apiVersion: string, kind: string, items: any[] = []) {
   return {
@@ -159,17 +148,24 @@ const meta: Meta<typeof GlobalSearchContent> = {
     },
   },
   decorators: [
-    (Story, context) => {
+    Story => {
       localStorage.removeItem(recentSearchItemsKey);
 
-      const queryClient = getQueryClient(context.id);
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            gcTime: 0,
+          },
+        },
+      });
 
       return (
-        <QueryClientProvider client={queryClient}>
-          <TestContext store={store} routerMap={{ cluster: sampleCluster.name }} urlPrefix="/c">
+        <TestContext store={store} routerMap={{ cluster: sampleCluster.name }} urlPrefix="/c">
+          <QueryClientProvider client={queryClient}>
             <Story />
-          </TestContext>
-        </QueryClientProvider>
+          </QueryClientProvider>
+        </TestContext>
       );
     },
   ],

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -155,13 +155,13 @@ function makeKubeObjectResults(
 }
 
 /**
- * Global search component
+ * The `GlobalSearchContent` component provides the search field and results list for global search.
+ * The default results include Kubernetes objects, clusters, app pages, namespace filters,
+ * theme switching, keyboard shortcut settings, and advanced search suggestions.
  *
- * Can search:
- *  - Kubernetes objects
- *  - Clusters
- *  - App Pages
- *  - Custom Actions
+ * @param props.maxWidth - The maximum width of the results list.
+ * @param props.defaultValue - The initial search query to display in the search field.
+ * @param props.onBlur - Callback called when the search field loses focus.
  */
 export function GlobalSearchContent({
   maxWidth,

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -159,9 +159,9 @@ function makeKubeObjectResults(
  * The default results include Kubernetes objects, clusters, app pages, namespace filters,
  * theme switching, keyboard shortcut settings, and advanced search suggestions.
  *
- * @param props.maxWidth - The maximum width of the results list.
- * @param props.defaultValue - The initial search query to display in the search field.
- * @param props.onBlur - Callback called when the search field loses focus.
+ * @param maxWidth - The maximum width of the results list.
+ * @param defaultValue - The initial search query to display in the search field.
+ * @param onBlur - Callback called when the search field loses focus.
  */
 export function GlobalSearchContent({
   maxWidth,

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -154,24 +154,24 @@ function makeKubeObjectResults(
   );
 }
 
+interface GlobalSearchContentProps {
+  /** The maximum width of the results list. */
+  maxWidth: number;
+  /** The initial search query to display in the search field. */
+  defaultValue: string;
+  /** Callback called when the search field loses focus. */
+  onBlur: () => void;
+}
+
 /**
  * The `GlobalSearchContent` component provides the search field and results list for global search.
  * The default results include Kubernetes objects, clusters, app pages, namespace filters,
  * theme switching, keyboard shortcut settings, and advanced search suggestions.
  *
- * @param maxWidth - The maximum width of the results list.
- * @param defaultValue - The initial search query to display in the search field.
- * @param onBlur - Callback called when the search field loses focus.
+ * @param props - The component props.
  */
-export function GlobalSearchContent({
-  maxWidth,
-  defaultValue,
-  onBlur,
-}: {
-  maxWidth: number;
-  defaultValue: string;
-  onBlur: () => void;
-}) {
+export function GlobalSearchContent(props: GlobalSearchContentProps) {
+  const { maxWidth, defaultValue, onBlur } = props;
   const { t } = useTranslation();
   const history = useHistory();
   const dispatch = useDispatch();

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
@@ -1,0 +1,1192 @@
+<body>
+  <div>
+    <div
+      aria-owns=":mock-test-id:"
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-controls=":mock-test-id:"
+          aria-expanded="true"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-activedescendant=":mock-test-id:"
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value="pod"
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1oql5kp-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-5vmmeo-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    >
+      <div
+        style="position: relative; height: 500px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
+      >
+        <div
+          style="height: 550px; width: 100%;"
+        >
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="0"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 0px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  pod
+                </span>
+                -0
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="1"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 50px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  pod
+                </span>
+                -1
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="2"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 100px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  pod
+                </span>
+                -2
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="3"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 150px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  pod
+                </span>
+                -3
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="4"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 200px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  pod
+                </span>
+                -4
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="5"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 250px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Page
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+                s
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="6"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 300px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Page
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+                 Disruption Budgets
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="7"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 350px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Page
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                Vertical 
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+                 Autoscalers
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="8"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 400px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Page
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                H
+                <span
+                  style="font-weight: bold;"
+                >
+                  o
+                </span>
+                riz
+                <span
+                  style="font-weight: bold;"
+                >
+                  o
+                </span>
+                ntal 
+                <span
+                  style="font-weight: bold;"
+                >
+                  Pod
+                </span>
+                 Autoscalers
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="9"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 450px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Advanced Search (Beta)
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                Search "
+                <span
+                  style="font-weight: bold;"
+                >
+                  pod
+                </span>
+                " with Advanced Search
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="10"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 500px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-wjpmq5"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="ns.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="23.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <rect
+                      height="6.6900792"
+                      id="rect8790"
+                      style="opacity: 1; fill: none; fill-opacity: 1; fill-rule: nonzero; stroke: currentcolor; stroke-width: 0.40000001; stroke-linecap: butt; stroke-linejoin: round; stroke-miterlimit: 10; stroke-dasharray: 0.80000001, 0.4; stroke-dashoffset: 3.44000006; stroke-opacity: 1;"
+                      width="7.6735892"
+                      x="6.1734986"
+                      y="6.5793304"
+                    />
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Current Namespace
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                Set names
+                <span
+                  style="font-weight: bold;"
+                >
+                  p
+                </span>
+                ace: 
+                <span
+                  style="font-weight: bold;"
+                >
+                  pod
+                </span>
+              </div>
+            </div>
+          </li>
+        </div>
+      </div>
+    </ul>
+  </div>
+</body>

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.WithEmptyInput.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.WithEmptyInput.stories.storyshot
@@ -1,0 +1,71 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-expanded="false"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value=""
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ppbyx2-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-5vmmeo-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    />
+  </div>
+</body>

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -90,7 +90,15 @@ window.matchMedia = () => ({
  * Recursively walks the tree and replaces any usage of useId
  */
 function replaceUseId(node: any) {
-  const attributesToReplace = ['id', 'for', 'aria-describedby', 'aria-labelledby', 'aria-controls'];
+  const attributesToReplace = [
+    'id',
+    'for',
+    'aria-describedby',
+    'aria-labelledby',
+    'aria-controls',
+    'aria-activedescendant',
+    'aria-owns',
+  ];
   if (node.nodeType === Node.ELEMENT_NODE) {
     for (const attr of node.attributes) {
       if (attributesToReplace.includes(attr.name)) {


### PR DESCRIPTION
## Summary

GlobalSearchContent component did not have Storybook coverage, so this PR adds stories and snapshots for the states that can currently be represented by the component:

- With Empty Input: renders the component with an empty query.
- Loading Resources: shows the loading spinner while resources are loading.
- Found Some Results: displays matching resources as search results.

Issue #931 also mentions that GlobalSearchContent component should have Storybook coverage, so it is included here as related context.

## Related Issue

Fixes #5878  

## Changes

`frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx`

- Added stories:
  - `WithEmptyInput`: renders the component with an empty query.
  - `LoadingResources`: keeps the pod request pending so the loading spinner is shown.
  - `FoundSomeResults`: renders matching pod results for the query.

- Added `QueryClientProvider` with a story-specific query client so pending requests from `delay('infinite')` do not leak into other stories after switching stories.
- Added `configureStore` to provide cluster state, allowing `GlobalSearchContent` to request resource lists from the mocked backend via MSW.
- Added `localStorage.removeItem` to clear recent search items before each story, preventing `WithEmptyInput` from showing search history.

`frontend/src/components/globalSearch/__snapshots__/`

- Added storyshot snapshots for:
  - With Empty Input
  - Found Some Results

- Did not add a storyshot snapshot for Loading Resources because it uses `delay('infinite')` to keep the resource request pending, so the story does not settle for snapshot generation.

`frontend/src/components/globalSearch/GlobalSearchContent.tsx`

- Updated the `GlobalSearchContent` component description comment to make it clearer in Storybook Docs.

## Steps to Test

1. `npm run frontend:install`
2. `npm run frontend:storybook`
3. Open `GlobalSearch > GlobalSearchContent` from the Storybook sidebar.
4. Verify that the following stories render correctly:
   - `WithEmptyInput`
   - `LoadingResources`
   - `FoundSomeResults`

## Screenshots
Docs
<img width="1296" height="798" src="https://github.com/user-attachments/assets/1c887695-821b-46b7-9d7d-7a6d10d97418" />

With Empty Input
<img width="1296" height="798" src="https://github.com/user-attachments/assets/861a2aa0-abe1-4f08-8691-8beb34fa38c9" />

Loading Resources
https://github.com/user-attachments/assets/ebec31ae-b187-4b4a-b665-e7366b0e968b

Found Some Results
<img width="1296" height="798" src="https://github.com/user-attachments/assets/2701ab67-8340-4df4-bf02-342cb3bd0994" />



## Notes for the Reviewer

Issue #931 mentions five expected states: empty search state, search loading spinner, search results list, no results found, and search error state.

This PR does not add stories for the no-results or search-error states because they do not currently appear to be directly represented by GlobalSearchContent component: 

- No results found: when a non-empty query is entered, the component appears to always provide at least a namespace action such as `Set namespace: <query>`, so there does not seem to be a true empty-results UI state for arbitrary non-empty queries.
- Search error state: failed resource loading does not currently appear to surface a user-facing error state in this component.

