### PR TITLE
frontend: ResourceTable: Stable row id when metadata.uid is missing

### DIFF
--- a/frontend/src/components/common/Resource/ResourceTable.tsx
+++ b/frontend/src/components/common/Resource/ResourceTable.tsx
@@ -59,6 +59,7 @@ import { getA8RMetadata } from './A8RInfo';
 import DeleteButton from './DeleteButton';
 import DownloadButton from './DownloadButton';
 import EditButton from './EditButton';
+import { getResourceRowId } from './getResourceRowId';
 import ResourceTableMultiActions from './ResourceTableMultiActions';
 import { RestartButton } from './RestartButton';
 import ScaleButton from './ScaleButton';
@@ -718,7 +719,7 @@ function ResourceTableContent<RowItem extends KubeObject>(props: ResourceTablePr
         }}
         globalFilterFn="kubeObjectSearch"
         filterFunction={filterFunc}
-        getRowId={item => item?.metadata?.uid}
+        getRowId={getResourceRowId}
       />
     </>
   );

--- a/frontend/src/components/common/Resource/getResourceRowId.test.ts
+++ b/frontend/src/components/common/Resource/getResourceRowId.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getResourceRowId } from './getResourceRowId';
+
+describe('getResourceRowId', () => {
+  it('returns metadata.uid when present', () => {
+    const id = getResourceRowId(
+      {
+        cluster: 'staging',
+        metadata: { uid: 'abc-123', namespace: 'default', name: 'pod-a' },
+      },
+      0
+    );
+    expect(id).toBe('abc-123');
+  });
+
+  it('falls back to cluster/namespace/name when uid is missing (#5707)', () => {
+    const id = getResourceRowId(
+      {
+        cluster: 'staging',
+        metadata: { namespace: 'default', name: 'pod-a' },
+      },
+      0
+    );
+    expect(id).toBe('staging/default/pod-a');
+  });
+
+  it('falls back to the composite when metadata.uid is an empty string', () => {
+    // An empty-string uid is semantically "no uid": treat the same as
+    // missing rather than emitting a degenerate row id of `''`.
+    const id = getResourceRowId(
+      {
+        cluster: 'staging',
+        metadata: { uid: '', namespace: 'default', name: 'pod-a' },
+      },
+      0
+    );
+    expect(id).toBe('staging/default/pod-a');
+  });
+
+  it('keeps fallback ids distinct across clusters for same-name resources', () => {
+    const a = getResourceRowId(
+      { cluster: 'prod', metadata: { namespace: 'default', name: 'pod-a' } },
+      0
+    );
+    const b = getResourceRowId(
+      { cluster: 'staging', metadata: { namespace: 'default', name: 'pod-a' } },
+      0
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('returns the same id for the same resource across calls (selection stability)', () => {
+    const item = {
+      cluster: 'prod',
+      metadata: { namespace: 'kube-system', name: 'coredns-789' },
+    };
+    expect(getResourceRowId(item, 0)).toBe(getResourceRowId(item, 0));
+  });
+
+  it('falls back to the row index when no identifying metadata is present', () => {
+    expect(getResourceRowId({}, 5)).toBe('row-5');
+  });
+
+  it('falls back to the row index for null and undefined inputs without throwing', () => {
+    // Material React Table's documented contract passes a non-null row, but
+    // the previous `item?.metadata?.uid` implementation tolerated sparse
+    // data arrays and programmer errors; preserve that safety contract.
+    expect(getResourceRowId(null, 0)).toBe('row-0');
+    expect(getResourceRowId(undefined, 3)).toBe('row-3');
+  });
+
+  it('falls back to the row index when every identifying field is the empty string', () => {
+    // Mirrors the "no metadata" case but exercises the empty-string branch
+    // when the fields are present-but-empty rather than undefined; both
+    // shapes must produce the index fallback.
+    expect(getResourceRowId({ cluster: '', metadata: { namespace: '', name: '' } }, 7)).toBe(
+      'row-7'
+    );
+  });
+
+  it('falls back to the row index when name is missing even if cluster is set', () => {
+    // The composite is meaningful only when `name` is present; without it,
+    // every row from the same cluster would collapse to `cluster//` and
+    // collide. The index fallback keeps such rows distinct.
+    const a = getResourceRowId({ cluster: 'prod' }, 0);
+    const b = getResourceRowId({ cluster: 'prod' }, 1);
+    const c = getResourceRowId({ cluster: 'prod', metadata: { namespace: 'default' } }, 2);
+    expect(a).toBe('row-0');
+    expect(b).toBe('row-1');
+    expect(c).toBe('row-2');
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it('keeps anonymous rows distinct via index (no id collisions)', () => {
+    const a = getResourceRowId({}, 0);
+    const b = getResourceRowId({}, 1);
+    const c = getResourceRowId({ metadata: {} }, 2);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it('handles cluster-scoped resources (no namespace)', () => {
+    const id = getResourceRowId({ cluster: 'prod', metadata: { name: 'node-1' } }, 0);
+    expect(id).toBe('prod//node-1');
+  });
+
+  it('collides on the composite when two uid-less rows share cluster/namespace/name', () => {
+    // Documents the helper's known limitation: K8s name+namespace uniqueness
+    // makes this impossible for real persisted objects, but a synthetic /
+    // virtual row caller is on the hook for disambiguating.
+    const a = getResourceRowId(
+      { cluster: 'prod', metadata: { namespace: 'default', name: 'pod-a' } },
+      0
+    );
+    const b = getResourceRowId(
+      { cluster: 'prod', metadata: { namespace: 'default', name: 'pod-a' } },
+      1
+    );
+    expect(a).toBe(b);
+  });
+});

--- a/frontend/src/components/common/Resource/getResourceRowId.ts
+++ b/frontend/src/components/common/Resource/getResourceRowId.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Minimal shape `getResourceRowId` needs from a row. `KubeObject` (and any
+ * test fixture mimicking it) satisfies this structurally, so the helper can
+ * stand in for Material React Table's `getRowId` without the table data
+ * type being narrowed to a Kubernetes-specific class.
+ */
+export interface IdentifiableResource {
+  cluster?: string;
+  metadata?: {
+    uid?: string;
+    namespace?: string;
+    name?: string;
+  };
+}
+
+/**
+ * Returns a stable row identifier for a resource list table. Prefers
+ * `metadata.uid` (set by the API server for any persisted Kubernetes object)
+ * and falls back to a `cluster/namespace/name` composite so rows backed by
+ * resources without a uid (events, virtual rows, synthetic items) still have
+ * a key that is stable across polling refreshes (#5707).
+ *
+ * `index` is the row index passed by Material React Table, used as a
+ * last-resort unique tiebreaker so anonymous rows (items with no identifying
+ * metadata) don't collapse onto a single id.
+ *
+ * Although Material React Table's documented contract passes a non-null row,
+ * the previous implementation used optional chaining on `item?.metadata?.uid`
+ * and therefore tolerated a sparse data array (e.g. `[item1, null, item3]`)
+ * or a programmer error without crashing. We preserve that safety by
+ * accepting `null | undefined` and falling back to the index in that case.
+ *
+ * Known limitation: if `metadata.uid` is absent in one fetch and arrives in
+ * a later one, the id transitions from the composite to the uid and the row
+ * will be re-created by MRT. This is a narrower window than the original
+ * bug (where every refresh of a uid-less row reset selection) but still
+ * loses selection during that specific transition; the broader fix would
+ * be to pin a single id basis per row lifetime, which is out of scope here.
+ *
+ * Known limitation: two rows that share `cluster/namespace/name` but lack a
+ * uid will collide on the composite key. Kubernetes' own uniqueness rules
+ * make this impossible for real persisted objects (name is unique within a
+ * namespace, and namespace is part of the composite), so the collision can
+ * only occur for synthetic/virtual rows that the caller must disambiguate.
+ */
+export function getResourceRowId(
+  item: IdentifiableResource | null | undefined,
+  index: number
+): string {
+  if (!item) return `row-${index}`;
+  const uid = item.metadata?.uid;
+  if (uid) return uid;
+  const name = item.metadata?.name ?? '';
+  // `name` is the only field that uniquely identifies a row in the
+  // composite: cluster alone is a many-to-one bucket and namespace alone
+  // is meaningless without a name. Without `name`, the composite would
+  // collapse into a single id (`prod//`, `/default/`, etc.) and every
+  // such row in the table would collide. Fall back to the row index in
+  // that case so anonymous rows stay distinct.
+  if (!name) return `row-${index}`;
+  const cluster = item.cluster ?? '';
+  const namespace = item.metadata?.namespace ?? '';
+  return `${cluster}/${namespace}/${name}`;
+}

--- a/frontend/src/components/common/Resource/index.test.ts
+++ b/frontend/src/components/common/Resource/index.test.ts
@@ -27,6 +27,9 @@ const avoidCheck = [
   'AlertNotification',
   'ErrorBoundary',
   'logSeverityFilter',
+  // Internal helper exported only so `ResourceTable` and its co-located
+  // tests can import it; deliberately kept out of the barrel.
+  'getResourceRowId',
 ];
 
 const checkExports = [


### PR DESCRIPTION
## Summary

Fixes #5707. Row selections in resource tables vanish after every polling refresh whenever any visible row lacks a `metadata.uid`.

`getRowId` was `item => item?.metadata?.uid`. When that returns `undefined`, Material React Table falls back to the row index for identity. After the throttled refetch hands a new `data` array down (different order or length), index-based ids no longer point at the same rows and the selection map effectively resets. Rows without a uid (events, virtual rows, synthetic items) also collapse onto a single `undefined` id, which causes duplicate-key warnings on top of broken selection.

## Approach

Extract the id logic into a leaf module `getResourceRowId(item)` with no `lib/k8s` dependency:

- Use `metadata.uid` when present (the common path, unchanged behaviour).
- Fall back to `cluster/namespace/name` so resources without a uid still get a stable, distinct identifier across polling refreshes.
- Include `cluster` so identically-named resources from different clusters stay distinct in multi-cluster views.

`ResourceTable` now points `getRowId` at the helper directly, which also gives the prop a stable function identity across renders.

## Test plan

- [x] New unit test `getResourceRowId.test.ts` covers: uid present, uid missing (composite fallback), cross-cluster distinctness, idempotent calls (selection stability), `null`/`undefined`/empty inputs, missing-metadata path, and cluster-scoped resources. 7/7 pass.
- [x] Full `src/components/common/Resource` suite: 95/95 pass (including the export-tracking `index.test.ts`, where the new private helper is added to `avoidCheck`).
- [x] `npm run tsc` clean.
- [x] `npx eslint -c .eslintrc.ci.cjs --max-warnings 0` clean over the touched files and the whole `Resource` directory.
- [ ] Manual: select rows in any resource table, wait for the auto-refresh interval, confirm the same rows stay selected.

## Notes for the reviewer

- Scope is intentionally narrow. Two sibling reports (#5701 scroll position, #5702 search input focus) describe the same "resets on auto-refresh" pattern but their likely root causes (pagination toggle remounting the body, focus loss on rerender) are independent and would need their own investigation in a running cluster.