### PR TITLE
frontend: Highlight YAML syntax errors using Monaco editor markers

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -212,7 +212,7 @@ describe('EditorDialog', () => {
       vi.advanceTimersByTime(500);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /undo changes/i }));
+    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
     expect(mockSetModelMarkers).toHaveBeenLastCalledWith(
       expect.any(Object),
       'headlamp-yaml-parse',

--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -20,9 +20,11 @@ import React from 'react';
 import { TestContext } from '../../../test';
 import EditorDialog from './EditorDialog';
 
-const { mockTextarea, mockEditorInstance } = vi.hoisted(() => {
+const { mockSetModelMarkers, mockGetModel, mockTextarea, mockEditorInstance } = vi.hoisted(() => {
   const textarea = document.createElement('textarea');
   return {
+    mockSetModelMarkers: vi.fn(),
+    mockGetModel: vi.fn(() => ({})),
     mockTextarea: textarea,
     mockEditorInstance: {
       getDomNode: () => ({
@@ -37,27 +39,50 @@ const { mockTextarea, mockEditorInstance } = vi.hoisted(() => {
   };
 });
 
-vi.mock('js-yaml', () => ({
-  dump: vi.fn((value: unknown) => JSON.stringify(value, null, 2)),
-  loadAll: vi.fn((value: string) => {
-    if (value.includes('invalid')) {
-      throw new Error('Invalid YAML');
+vi.mock('js-yaml', () => {
+  class YAMLException extends Error {
+    reason: string;
+    mark: any;
+    constructor(reason: string, mark: any) {
+      super(reason);
+      this.name = 'YAMLException';
+      this.reason = reason;
+      this.mark = mark;
     }
+  }
 
-    return [{ apiVersion: 'v1', kind: 'Node', metadata: { name: 'node-1' } }];
-  }),
-}));
+  return {
+    YAMLException,
+    dump: vi.fn((value: unknown) => JSON.stringify(value, null, 2)),
+    loadAll: vi.fn((value: string) => {
+      if (value.includes('invalid')) {
+        throw new YAMLException('Invalid YAML', { line: 2, column: 5 });
+      }
+      return [{ apiVersion: 'v1', kind: 'Node', metadata: { name: 'node-1' } }];
+    }),
+  };
+});
 
-vi.mock('@monaco-editor/react', () => ({
-  Editor: ({ onMount }: any) => {
-    React.useEffect(() => {
-      onMount?.(mockEditorInstance, {});
-    }, [onMount]);
+vi.mock('@monaco-editor/react', () => {
+  return {
+    Monaco: {} as any,
+    Editor: ({ onChange, onMount }: any) => {
+      React.useEffect(() => {
+        onMount?.(
+          { ...mockEditorInstance, getModel: mockGetModel },
+          { editor: { setModelMarkers: mockSetModelMarkers }, MarkerSeverity: { Error: 8 } }
+        );
+      }, [onMount]);
 
-    return <div data-testid="mock-monaco-editor" />;
-  },
-  DiffEditor: () => null,
-}));
+      return (
+        <div data-testid="mock-monaco-editor">
+          <textarea aria-label="monaco-code" onChange={e => onChange?.(e.target.value)} />
+        </div>
+      );
+    },
+    DiffEditor: () => null,
+  };
+});
 
 vi.mock('./DocsViewer', () => ({
   default: () => null,
@@ -148,6 +173,47 @@ describe('EditorDialog', () => {
     });
 
     expect(screen.queryByText('Invalid YAML')).not.toBeInTheDocument();
+  });
+
+  it('sets model markers on invalid YAML and clears them on valid YAML in monaco editor', () => {
+    localStorage.setItem('useSimpleEditor', 'false'); // Use monaco
+    renderEditorDialog();
+
+    const editor = screen.getByRole('textbox', { name: /monaco-code/i });
+
+    // Simulate invalid yaml
+    fireEvent.change(editor, { target: { value: 'invalid' } });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockSetModelMarkers).toHaveBeenCalledWith(expect.any(Object), 'headlamp-yaml-parse', [
+      {
+        startLineNumber: 3,
+        startColumn: 6,
+        endLineNumber: 3,
+        endColumn: 7,
+        message: 'Invalid YAML',
+        severity: 8,
+      },
+    ]);
+
+    // Simulate valid yaml
+    fireEvent.change(editor, { target: { value: 'valid' } });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockSetModelMarkers).toHaveBeenCalledWith(expect.any(Object), 'headlamp-yaml-parse', []);
+
+    // Ensure Undo also clears markers
+    fireEvent.change(editor, { target: { value: 'invalid' } });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
+    expect(mockSetModelMarkers).toHaveBeenCalledWith(expect.any(Object), 'headlamp-yaml-parse', []);
   });
 
   it('renders the editor textarea and action buttons with correct id and aria-controls attributes', () => {

--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -212,8 +212,12 @@ describe('EditorDialog', () => {
       vi.advanceTimersByTime(500);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
-    expect(mockSetModelMarkers).toHaveBeenCalledWith(expect.any(Object), 'headlamp-yaml-parse', []);
+    fireEvent.click(screen.getByRole('button', { name: /undo changes/i }));
+    expect(mockSetModelMarkers).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      'headlamp-yaml-parse',
+      []
+    );
   });
 
   it('renders the editor textarea and action buttons with correct id and aria-controls attributes', () => {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -146,9 +146,12 @@ export default function EditorDialog(props: EditorDialogProps) {
   const monacoRef = React.useRef<Monaco | null>(null);
   const editorRef = React.useRef<editor.IStandaloneCodeEditor | null>(null);
 
-  function handleEditorDidMount(editor: any, monaco: any) {
-    editorRef.current = editor;
-    monacoRef.current = monaco;
+  function handleEditorDidMount(
+    editorInstance: editor.IStandaloneCodeEditor,
+    monacoInstance: Monaco
+  ) {
+    editorRef.current = editorInstance;
+    monacoRef.current = monacoInstance;
   }
 
   React.useEffect(() => {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -275,7 +275,7 @@ export default function EditorDialog(props: EditorDialogProps) {
                 ? model.getLineMaxColumn(safeLineNumber)
                 : mark.column + 2;
             const startColumn = Math.min(mark.column + 1, maxColumn);
-            const endColumn = Math.max(startColumn + 1, Math.min(mark.column + 2, maxColumn));
+            const endColumn = Math.min(Math.max(startColumn + 1, mark.column + 2), maxColumn);
 
             monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', [
               {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -507,14 +507,14 @@ export default function EditorDialog(props: EditorDialogProps) {
             value={code.code}
             options={editorOptions}
             onChange={onChange}
-            onMount={handleEditorDidMount}
-            height="100%"
-            onMount={editor => {
+            onMount={(editor, monaco) => {
+              handleEditorDidMount(editor, monaco);
               const textarea = editor.getDomNode()?.querySelector('textarea');
               if (textarea && editorId) {
                 textarea.id = editorId;
               }
             }}
+            height="100%"
           />
         )}
       </Box>

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -266,12 +266,17 @@ export default function EditorDialog(props: EditorDialogProps) {
           const reason = (err as any)?.reason;
 
           if (mark && typeof mark.line === 'number' && typeof mark.column === 'number') {
+            const lineNumber = mark.line + 1;
+            const maxColumn =
+              typeof model.getLineMaxColumn === 'function'
+                ? model.getLineMaxColumn(lineNumber)
+                : mark.column + 2;
             monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', [
               {
-                startLineNumber: mark.line + 1,
-                startColumn: mark.column + 1,
-                endLineNumber: mark.line + 1,
-                endColumn: mark.column + 2,
+                startLineNumber: lineNumber,
+                startColumn: Math.min(mark.column + 1, maxColumn),
+                endLineNumber: lineNumber,
+                endColumn: Math.min(mark.column + 2, maxColumn),
                 message: reason || err?.message || t('Invalid YAML'),
                 severity: monacoRef.current.MarkerSeverity.Error,
               },

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -267,16 +267,22 @@ export default function EditorDialog(props: EditorDialogProps) {
 
           if (mark && typeof mark.line === 'number' && typeof mark.column === 'number') {
             const lineNumber = mark.line + 1;
+            const lineCount =
+              typeof model.getLineCount === 'function' ? model.getLineCount() : lineNumber;
+            const safeLineNumber = Math.min(Math.max(lineNumber, 1), lineCount);
             const maxColumn =
               typeof model.getLineMaxColumn === 'function'
-                ? model.getLineMaxColumn(lineNumber)
+                ? model.getLineMaxColumn(safeLineNumber)
                 : mark.column + 2;
+            const startColumn = Math.min(mark.column + 1, maxColumn);
+            const endColumn = Math.max(startColumn + 1, Math.min(mark.column + 2, maxColumn));
+
             monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', [
               {
-                startLineNumber: lineNumber,
-                startColumn: Math.min(mark.column + 1, maxColumn),
-                endLineNumber: lineNumber,
-                endColumn: Math.min(mark.column + 2, maxColumn),
+                startLineNumber: safeLineNumber,
+                startColumn,
+                endLineNumber: safeLineNumber,
+                endColumn,
                 message: reason || err?.message || t('Invalid YAML'),
                 severity: monacoRef.current.MarkerSeverity.Error,
               },

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import '../../../i18n/config';
-import { DiffEditor, Editor } from '@monaco-editor/react';
+import { DiffEditor, Editor, Monaco } from '@monaco-editor/react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import DialogActions from '@mui/material/DialogActions';
@@ -27,6 +27,7 @@ import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import * as yaml from 'js-yaml';
 import _ from 'lodash';
+import type { editor } from 'monaco-editor';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -110,6 +111,7 @@ export default function EditorDialog(props: EditorDialogProps) {
     selectOnLineNumbers: true,
     readOnly: isReadOnly(),
     automaticLayout: true,
+    fixedOverflowWidgets: true,
   };
   const initialCode = typeof item === 'string' ? item : yaml.dump(item || {});
   const originalCodeRef = React.useRef({ code: initialCode, format: item ? 'yaml' : '' });
@@ -140,6 +142,28 @@ export default function EditorDialog(props: EditorDialogProps) {
 
   const dispatchCreateEvent = useEventCallback(HeadlampEventType.CREATE_RESOURCE);
   const dispatch: AppDispatch = useDispatch();
+
+  const monacoRef = React.useRef<Monaco | null>(null);
+  const editorRef = React.useRef<editor.IStandaloneCodeEditor | null>(null);
+
+  function handleEditorDidMount(editor: any, monaco: any) {
+    editorRef.current = editor;
+    monacoRef.current = monaco;
+  }
+
+  React.useEffect(() => {
+    // Avoid holding onto disposed Monaco instances when switching editors/unmounting.
+    if (useSimpleEditor) {
+      editorRef.current = null;
+      monacoRef.current = null;
+    }
+
+    return () => {
+      window.clearTimeout(lastCodeCheckHandler.current);
+      editorRef.current = null;
+      monacoRef.current = null;
+    };
+  }, [useSimpleEditor]);
 
   function isKubeObjectIsh(item: any): item is KubeObjectIsh {
     return item && typeof item === 'object' && !Array.isArray(item) && 'metadata' in item;
@@ -231,6 +255,29 @@ export default function EditorDialog(props: EditorDialogProps) {
       if (error !== (err?.message || '')) {
         setError(err?.message || '');
       }
+
+      if (!useSimpleEditor && monacoRef.current && editorRef.current) {
+        const model = editorRef.current.getModel?.();
+        if (model) {
+          const mark = (err as any)?.mark;
+          const reason = (err as any)?.reason;
+
+          if (mark && typeof mark.line === 'number' && typeof mark.column === 'number') {
+            monacoRef.current.editor.setModelMarkers(model, 'yaml', [
+              {
+                startLineNumber: mark.line + 1,
+                startColumn: mark.column + 1,
+                endLineNumber: mark.line + 1,
+                endColumn: mark.column + 2,
+                message: reason || err?.message || t('Invalid YAML'),
+                severity: monacoRef.current.MarkerSeverity.Error,
+              },
+            ]);
+          } else {
+            monacoRef.current.editor.setModelMarkers(model, 'yaml', []);
+          }
+        }
+      }
     }, 500); // ms
 
     setCode(currentCode => ({ code: value as string, format: currentCode.format }));
@@ -275,8 +322,13 @@ export default function EditorDialog(props: EditorDialogProps) {
         res.obj = yaml.loadAll(code) as KubeObjectInterface[];
         res.obj = res.obj.filter(obj => !!obj);
         return res;
-      } catch (e) {
-        res.error = new Error((e as Error).message || t('Invalid YAML'));
+      } catch (e: any) {
+        const err = new Error((e as Error).message || t('Invalid YAML')) as any;
+        if (e instanceof yaml.YAMLException && e.mark) {
+          err.mark = e.mark;
+          err.reason = e.reason;
+        }
+        res.error = err;
       }
     }
 
@@ -305,6 +357,13 @@ export default function EditorDialog(props: EditorDialogProps) {
     window.clearTimeout(lastCodeCheckHandler.current);
     setCode(originalCodeRef.current);
     setError('');
+    if (monacoRef.current && editorRef.current) {
+      const model =
+        typeof editorRef.current.getModel === 'function' ? editorRef.current.getModel() : null;
+      if (model) {
+        monacoRef.current.editor.setModelMarkers(model, 'yaml', []);
+      }
+    }
   }
 
   const applyFunc = async (
@@ -434,6 +493,7 @@ export default function EditorDialog(props: EditorDialogProps) {
             value={code.code}
             options={editorOptions}
             onChange={onChange}
+            onMount={handleEditorDidMount}
             height="100%"
             onMount={editor => {
               const textarea = editor.getDomNode()?.querySelector('textarea');

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -168,6 +168,17 @@ export default function EditorDialog(props: EditorDialogProps) {
     };
   }, [useSimpleEditor]);
 
+  React.useEffect(() => {
+    if (useSimpleEditor || error) {
+      return;
+    }
+
+    const model = editorRef.current?.getModel();
+    if (monacoRef.current && model) {
+      monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', []);
+    }
+  }, [error, useSimpleEditor]);
+
   function isKubeObjectIsh(item: any): item is KubeObjectIsh {
     return item && typeof item === 'object' && !Array.isArray(item) && 'metadata' in item;
   }
@@ -274,8 +285,12 @@ export default function EditorDialog(props: EditorDialogProps) {
               typeof model.getLineMaxColumn === 'function'
                 ? model.getLineMaxColumn(safeLineNumber)
                 : mark.column + 2;
-            const startColumn = Math.min(mark.column + 1, maxColumn);
-            const endColumn = Math.min(Math.max(startColumn + 1, mark.column + 2), maxColumn);
+            const safeMaxColumn = Math.max(maxColumn, 1);
+            const startColumn = Math.min(
+              Math.max(mark.column + 1, 1),
+              Math.max(safeMaxColumn - 1, 1)
+            );
+            const endColumn = Math.min(startColumn + 1, safeMaxColumn);
 
             monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', [
               {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -266,7 +266,7 @@ export default function EditorDialog(props: EditorDialogProps) {
           const reason = (err as any)?.reason;
 
           if (mark && typeof mark.line === 'number' && typeof mark.column === 'number') {
-            monacoRef.current.editor.setModelMarkers(model, 'yaml', [
+            monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', [
               {
                 startLineNumber: mark.line + 1,
                 startColumn: mark.column + 1,
@@ -277,7 +277,7 @@ export default function EditorDialog(props: EditorDialogProps) {
               },
             ]);
           } else {
-            monacoRef.current.editor.setModelMarkers(model, 'yaml', []);
+            monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', []);
           }
         }
       }
@@ -364,7 +364,7 @@ export default function EditorDialog(props: EditorDialogProps) {
       const model =
         typeof editorRef.current.getModel === 'function' ? editorRef.current.getModel() : null;
       if (model) {
-        monacoRef.current.editor.setModelMarkers(model, 'yaml', []);
+        monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', []);
       }
     }
   }


### PR DESCRIPTION
This extracts the exact line and column of js-yaml parse errors and passes them to monaco.editor.setModelMarkers, rendering a visual squiggly line under the invalid YAML in the EditorDialog.

Fixes #5932

## Summary

This PR adds visual validation for YAML syntax errors by leveraging Monaco editor's native marker capabilities to display a red squiggly line directly under invalid YAML in the EditorDialog.

## Related Issue

Fixes #5932  

## Changes

- Updated `EditorDialog.tsx` to extract the `line`, `column`, and `reason` properties from `js-yaml` parse exceptions.
- Added `monaco.editor.setModelMarkers` logic to accurately map syntax errors visually inside the editor.
- Ensured markers are properly cleared when the YAML becomes valid again or when the dialog state is reset.

## Steps to Test

1. Run Headlamp locally using `npm start`.
2. Open the Resource Creation or Editing dialog (using the `+` button in the top right).
3. Enter or paste invalid YAML into the editor (e.g., create a deliberate indentation error or bad mapping).
4. Observe that a red squiggly line immediately appears exactly where the syntax error occurred.
5. Hover over the squiggly line to see the exact parse error reason in a native Monaco tooltip.
6. Fix the YAML error and observe that the squiggly line disappears automatically.

## Screenshots (if applicable)

<img width="1601" height="727" alt="image" src="https://github.com/user-attachments/assets/b7f731f8-b5bd-41d0-ac98-3589a9e5caa7" />
## Notes for the Reviewer

- The original single-line error message at the bottom of the dialog is completely preserved as an additional fallback warning.
- The `EditorDialog.tsx` component was updated to safely handle exceptions that might not be from `js-yaml` without crashing.
