### PR TITLE
frontend: EditorDialog: Fix aria-controls to reference the actual editor textarea

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -20,6 +20,23 @@ import React from 'react';
 import { TestContext } from '../../../test';
 import EditorDialog from './EditorDialog';
 
+const { mockTextarea, mockEditorInstance } = vi.hoisted(() => {
+  const textarea = document.createElement('textarea');
+  return {
+    mockTextarea: textarea,
+    mockEditorInstance: {
+      getDomNode: () => ({
+        querySelector: (selector: string) => {
+          if (selector === 'textarea') {
+            return textarea;
+          }
+          return null;
+        },
+      }),
+    },
+  };
+});
+
 vi.mock('js-yaml', () => ({
   dump: vi.fn((value: unknown) => JSON.stringify(value, null, 2)),
   loadAll: vi.fn((value: string) => {
@@ -32,7 +49,13 @@ vi.mock('js-yaml', () => ({
 }));
 
 vi.mock('@monaco-editor/react', () => ({
-  Editor: () => null,
+  Editor: ({ onMount }: any) => {
+    React.useEffect(() => {
+      onMount?.(mockEditorInstance, {});
+    }, [onMount]);
+
+    return <div data-testid="mock-monaco-editor" />;
+  },
   DiffEditor: () => null,
 }));
 
@@ -45,16 +68,19 @@ vi.mock('../ConfirmButton', () => ({
     children,
     onConfirm,
     disabled,
-    ariaLabel,
+    'aria-label': ariaLabel,
+    'aria-controls': ariaControls,
   }: {
     children: React.ReactNode;
     onConfirm: () => void;
     disabled?: boolean;
-    ariaLabel?: string;
+    'aria-label'?: string;
+    'aria-controls'?: string;
   }) => (
     <Button
       aria-label={ariaLabel}
       disabled={disabled}
+      aria-controls={ariaControls}
       onClick={() => {
         if (!disabled) {
           onConfirm();
@@ -70,6 +96,7 @@ describe('EditorDialog', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     localStorage.setItem('useSimpleEditor', 'true');
+    mockTextarea.id = '';
   });
 
   afterEach(() => {
@@ -103,7 +130,7 @@ describe('EditorDialog', () => {
 
     expect(screen.getByText('Invalid YAML')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /undo changes/i }));
+    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
 
     expect(screen.queryByText('Invalid YAML')).not.toBeInTheDocument();
   });
@@ -114,12 +141,56 @@ describe('EditorDialog', () => {
     const editor = screen.getByRole('textbox', { name: /code$/i });
     fireEvent.change(editor, { target: { value: 'invalid' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /undo changes/i }));
+    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
 
     act(() => {
       vi.advanceTimersByTime(500);
     });
 
     expect(screen.queryByText('Invalid YAML')).not.toBeInTheDocument();
+  });
+
+  it('renders the editor textarea and action buttons with correct id and aria-controls attributes', () => {
+    renderEditorDialog();
+
+    const textarea = screen.getByRole('textbox', { name: /code/i });
+    expect(textarea.id).toMatch(/^editor-textarea-/);
+
+    const textareaId = textarea.id;
+
+    // Under test render, ConfirmButton has aria-label="Undo" which overrides "Undo Changes" as the accessible name
+    const undoButton = screen.getByRole('button', { name: /undo/i });
+    expect(undoButton).toHaveAttribute('aria-controls', textareaId);
+
+    const dryRunButton = screen.getByRole('button', { name: /dry run/i });
+    expect(dryRunButton).toHaveAttribute('aria-controls', textareaId);
+
+    const saveApplyButton = screen.getByRole('button', { name: /save & apply/i });
+    expect(saveApplyButton).toHaveAttribute('aria-controls', textareaId);
+  });
+
+  it('correctly sets textarea ID and aria-controls attributes when using Monaco editor onMount', () => {
+    localStorage.setItem('useSimpleEditor', 'false');
+
+    renderEditorDialog();
+
+    expect(mockTextarea.id).toMatch(/^editor-textarea-/);
+
+    const textareaId = mockTextarea.id;
+
+    expect(screen.getByRole('button', { name: /undo/i })).toHaveAttribute(
+      'aria-controls',
+      textareaId
+    );
+
+    expect(screen.getByRole('button', { name: /dry run/i })).toHaveAttribute(
+      'aria-controls',
+      textareaId
+    );
+
+    expect(screen.getByRole('button', { name: /save & apply/i })).toHaveAttribute(
+      'aria-controls',
+      textareaId
+    );
   });
 });

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -424,9 +424,9 @@ export default function EditorDialog(props: EditorDialogProps) {
   function makeEditor() {
     const language = originalCodeRef.current.format || 'yaml';
     return (
-      <Box height="100%" id={editorId}>
+      <Box height="100%">
         {useSimpleEditor ? (
-          <SimpleEditor language={language} value={code.code} onChange={onChange} />
+          <SimpleEditor id={editorId} language={language} value={code.code} onChange={onChange} />
         ) : (
           <Editor
             language={language}
@@ -435,6 +435,12 @@ export default function EditorDialog(props: EditorDialogProps) {
             options={editorOptions}
             onChange={onChange}
             height="100%"
+            onMount={editor => {
+              const textarea = editor.getDomNode()?.querySelector('textarea');
+              if (textarea && editorId) {
+                textarea.id = editorId;
+              }
+            }}
           />
         )}
       </Box>
@@ -606,7 +612,7 @@ export default function EditorDialog(props: EditorDialogProps) {
             color="secondary"
             variant="contained"
             disabled={originalCodeRef.current.code === code.code || !!error}
-            // @todo: aria-controls should point to the textarea id
+            aria-controls={editorId}
             sx={{ whiteSpace: 'nowrap' }}
           >
             {t('translation|Dry Run')}
@@ -619,7 +625,6 @@ export default function EditorDialog(props: EditorDialogProps) {
             variant="contained"
             disabled={originalCodeRef.current.code === code.code || !!error}
             aria-controls={editorId}
-            // @todo: aria-controls should point to the textarea id
             sx={{ whiteSpace: 'nowrap' }}
           >
             {saveLabel || t('translation|Save & Apply')}

--- a/frontend/src/components/common/Resource/SimpleEditor.tsx
+++ b/frontend/src/components/common/Resource/SimpleEditor.tsx
@@ -28,13 +28,16 @@ export interface SimpleEditorProps {
   value: string | undefined;
   /** When things in the editor change. */
   onChange(value: string | undefined, ev: any): void;
+  /** Optional id to set on the underlying textarea element. */
+  id?: string;
 }
 
 /** A very basic code editor. */
-function SimpleEditor({ language, value, onChange }: SimpleEditorProps) {
+function SimpleEditor({ language, value, onChange, id }: SimpleEditorProps) {
   // TextareaAutosize doesn't react well within a dialog/tab
   return (
     <SizedTextarea
+      id={id}
       aria-label={`${language} Code`}
       onChange={event => onChange(event.target.value, event)}
       value={value}

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -214,7 +214,6 @@
           >
             <div
               class="MuiBox-root css-10klw3m"
-              id="editor-textarea-id"
             >
               <div
                 class="mock-monaco-editor"
@@ -281,6 +280,7 @@
             />
           </button>
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-1uk0gch-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -250,7 +250,6 @@
           >
             <div
               class="MuiBox-root css-10klw3m"
-              id="editor-textarea-id"
             >
               <div
                 class="mock-monaco-editor"
@@ -317,6 +316,7 @@
             />
           </button>
           <button
+            aria-controls="editor-textarea-id"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-1uk0gch-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"


### PR DESCRIPTION
## Summary
Fix `aria-controls` on the Undo Changes, Dry Run, and Save & Apply buttons in EditorDialog to reference the actual editor `<textarea>` id instead of a wrapper `<Box>` container.

## Changes
- `SimpleEditor`: Added optional `id` prop forwarded to the underlying `<textarea>` element.
- `EditorDialog`: Restored `editorId` generation. For Monaco Editor, it uses `onMount` to find and assign the ID to the generated `<textarea>`. For SimpleEditor, it passes the `id` directly. All three action buttons now correctly point to the real textarea's ID.

## Steps to Test
1. Run Headlamp and open any resource.
2. Click the Edit button.
3. Inspect the Undo Changes, Dry Run, or Save & Apply buttons in your browser DevTools.
4. Verify that their `aria-controls` attributes match the ID of the underlying `<textarea>` element.

## Related
Resolves the two `@todo: aria-controls should point to the textarea id` comments.
