### PR TITLE
backend: k8cache: Add unit tests for resource filtering

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -116,8 +116,8 @@ func SkipWebSocket(r *http.Request, next http.Handler, w http.ResponseWriter) bo
 	return false
 }
 
-// returnGVRList returns list+watch GroupVersionResources filtered to important kinds
-// used for cache invalidation watchers.
+// returnGVRList returns list+watch GroupVersionResources filtered to an allowlisted set of
+// API resource names (e.g. pods, deployments) used for cache invalidation watchers.
 func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
 	skipKinds := map[string]bool{
 		"Lease": true,

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -116,8 +116,8 @@ func SkipWebSocket(r *http.Request, next http.Handler, w http.ResponseWriter) bo
 	return false
 }
 
-// returnGVRList return gvrList which is group, version, resource which is all the supported resources
-// that are supported by the k8s server.
+// returnGVRList returns list+watch GroupVersionResources filtered to important kinds
+// used for cache invalidation watchers.
 func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
 	skipKinds := map[string]bool{
 		"Lease": true,
@@ -147,7 +147,37 @@ func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVer
 		}
 	}
 
-	return gvrList
+	filtered := filterImportantResources(gvrList)
+
+	return filtered
+}
+
+// filterImportantResources filters the provided list of GroupVersionResources to
+// include only those that are deemed important for caching and watching.
+func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.GroupVersionResource {
+	allowed := map[string]struct{}{
+		"pods":         {},
+		"services":     {},
+		"deployments":  {},
+		"replicasets":  {},
+		"statefulsets": {},
+		"daemonsets":   {},
+		"nodes":        {},
+		"configmaps":   {},
+		"secrets":      {},
+		"jobs":         {},
+		"cronjobs":     {},
+	}
+
+	filtered := make([]schema.GroupVersionResource, 0, len(allowed))
+
+	for _, gvr := range gvrList {
+		if _, ok := allowed[gvr.Resource]; ok {
+			filtered = append(filtered, gvr)
+		}
+	}
+
+	return filtered
 }
 
 // Corrected CheckForChanges.

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -713,6 +713,7 @@ func TestFilterImportantResources(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range filterImportantResourcesTests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -644,75 +644,75 @@ func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) 
 	assert.NotContains(t, cachedValue, "stale")
 }
 
+var filterImportantResourcesTests = []struct {
+	name  string
+	input []schema.GroupVersionResource
+	want  []schema.GroupVersionResource
+}{
+	{
+		name:  "empty input",
+		input: nil,
+		want:  []schema.GroupVersionResource{},
+	},
+	{
+		name: "keeps allowed resources and drops others",
+		input: []schema.GroupVersionResource{
+			{Group: "", Version: "v1", Resource: "pods"},
+			{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+			{Group: "apps", Version: "v1", Resource: "deployments"},
+			{Group: "", Version: "v1", Resource: "namespaces"},
+		},
+		want: []schema.GroupVersionResource{
+			{Group: "", Version: "v1", Resource: "pods"},
+			{Group: "apps", Version: "v1", Resource: "deployments"},
+		},
+	},
+	{
+		name: "preserves group and version fields",
+		input: []schema.GroupVersionResource{
+			{Group: "batch", Version: "v1", Resource: "jobs"},
+			{Group: "batch", Version: "v1", Resource: "cronjobs"},
+		},
+		want: []schema.GroupVersionResource{
+			{Group: "batch", Version: "v1", Resource: "jobs"},
+			{Group: "batch", Version: "v1", Resource: "cronjobs"},
+		},
+	},
+	{
+		name: "keeps all allowlisted resource kinds",
+		input: []schema.GroupVersionResource{
+			{Group: "", Version: "v1", Resource: "pods"},
+			{Group: "", Version: "v1", Resource: "services"},
+			{Group: "apps", Version: "v1", Resource: "deployments"},
+			{Group: "apps", Version: "v1", Resource: "replicasets"},
+			{Group: "apps", Version: "v1", Resource: "statefulsets"},
+			{Group: "apps", Version: "v1", Resource: "daemonsets"},
+			{Group: "", Version: "v1", Resource: "nodes"},
+			{Group: "", Version: "v1", Resource: "configmaps"},
+			{Group: "", Version: "v1", Resource: "secrets"},
+			{Group: "batch", Version: "v1", Resource: "jobs"},
+			{Group: "batch", Version: "v1", Resource: "cronjobs"},
+		},
+		want: []schema.GroupVersionResource{
+			{Group: "", Version: "v1", Resource: "pods"},
+			{Group: "", Version: "v1", Resource: "services"},
+			{Group: "apps", Version: "v1", Resource: "deployments"},
+			{Group: "apps", Version: "v1", Resource: "replicasets"},
+			{Group: "apps", Version: "v1", Resource: "statefulsets"},
+			{Group: "apps", Version: "v1", Resource: "daemonsets"},
+			{Group: "", Version: "v1", Resource: "nodes"},
+			{Group: "", Version: "v1", Resource: "configmaps"},
+			{Group: "", Version: "v1", Resource: "secrets"},
+			{Group: "batch", Version: "v1", Resource: "jobs"},
+			{Group: "batch", Version: "v1", Resource: "cronjobs"},
+		},
+	},
+}
+
 func TestFilterImportantResources(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name  string
-		input []schema.GroupVersionResource
-		want  []schema.GroupVersionResource
-	}{
-		{
-			name:  "empty input",
-			input: nil,
-			want:  []schema.GroupVersionResource{},
-		},
-		{
-			name: "keeps allowed resources and drops others",
-			input: []schema.GroupVersionResource{
-				{Group: "", Version: "v1", Resource: "pods"},
-				{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
-				{Group: "apps", Version: "v1", Resource: "deployments"},
-				{Group: "", Version: "v1", Resource: "namespaces"},
-			},
-			want: []schema.GroupVersionResource{
-				{Group: "", Version: "v1", Resource: "pods"},
-				{Group: "apps", Version: "v1", Resource: "deployments"},
-			},
-		},
-		{
-			name: "preserves group and version fields",
-			input: []schema.GroupVersionResource{
-				{Group: "batch", Version: "v1", Resource: "jobs"},
-				{Group: "batch", Version: "v1", Resource: "cronjobs"},
-			},
-			want: []schema.GroupVersionResource{
-				{Group: "batch", Version: "v1", Resource: "jobs"},
-				{Group: "batch", Version: "v1", Resource: "cronjobs"},
-			},
-		},
-		{
-			name: "keeps all allowlisted resource kinds",
-			input: []schema.GroupVersionResource{
-				{Group: "", Version: "v1", Resource: "pods"},
-				{Group: "", Version: "v1", Resource: "services"},
-				{Group: "apps", Version: "v1", Resource: "deployments"},
-				{Group: "apps", Version: "v1", Resource: "replicasets"},
-				{Group: "apps", Version: "v1", Resource: "statefulsets"},
-				{Group: "apps", Version: "v1", Resource: "daemonsets"},
-				{Group: "", Version: "v1", Resource: "nodes"},
-				{Group: "", Version: "v1", Resource: "configmaps"},
-				{Group: "", Version: "v1", Resource: "secrets"},
-				{Group: "batch", Version: "v1", Resource: "jobs"},
-				{Group: "batch", Version: "v1", Resource: "cronjobs"},
-			},
-			want: []schema.GroupVersionResource{
-				{Group: "", Version: "v1", Resource: "pods"},
-				{Group: "", Version: "v1", Resource: "services"},
-				{Group: "apps", Version: "v1", Resource: "deployments"},
-				{Group: "apps", Version: "v1", Resource: "replicasets"},
-				{Group: "apps", Version: "v1", Resource: "statefulsets"},
-				{Group: "apps", Version: "v1", Resource: "daemonsets"},
-				{Group: "", Version: "v1", Resource: "nodes"},
-				{Group: "", Version: "v1", Resource: "configmaps"},
-				{Group: "", Version: "v1", Resource: "secrets"},
-				{Group: "batch", Version: "v1", Resource: "jobs"},
-				{Group: "batch", Version: "v1", Resource: "cronjobs"},
-			},
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range filterImportantResourcesTests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -641,6 +642,120 @@ func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) 
 	require.NoError(t, err)
 	assert.Contains(t, cachedValue, "ConfigMap")
 	assert.NotContains(t, cachedValue, "stale")
+}
+
+func TestFilterImportantResources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []schema.GroupVersionResource
+		want  []schema.GroupVersionResource
+	}{
+		{
+			name:  "empty input",
+			input: nil,
+			want:  []schema.GroupVersionResource{},
+		},
+		{
+			name: "keeps allowed resources and drops others",
+			input: []schema.GroupVersionResource{
+				{Group: "", Version: "v1", Resource: "pods"},
+				{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+				{Group: "apps", Version: "v1", Resource: "deployments"},
+				{Group: "", Version: "v1", Resource: "namespaces"},
+			},
+			want: []schema.GroupVersionResource{
+				{Group: "", Version: "v1", Resource: "pods"},
+				{Group: "apps", Version: "v1", Resource: "deployments"},
+			},
+		},
+		{
+			name: "preserves group and version fields",
+			input: []schema.GroupVersionResource{
+				{Group: "batch", Version: "v1", Resource: "jobs"},
+				{Group: "batch", Version: "v1", Resource: "cronjobs"},
+			},
+			want: []schema.GroupVersionResource{
+				{Group: "batch", Version: "v1", Resource: "jobs"},
+				{Group: "batch", Version: "v1", Resource: "cronjobs"},
+			},
+		},
+		{
+			name: "keeps all allowlisted resource kinds",
+			input: []schema.GroupVersionResource{
+				{Group: "", Version: "v1", Resource: "pods"},
+				{Group: "", Version: "v1", Resource: "services"},
+				{Group: "apps", Version: "v1", Resource: "deployments"},
+				{Group: "apps", Version: "v1", Resource: "replicasets"},
+				{Group: "apps", Version: "v1", Resource: "statefulsets"},
+				{Group: "apps", Version: "v1", Resource: "daemonsets"},
+				{Group: "", Version: "v1", Resource: "nodes"},
+				{Group: "", Version: "v1", Resource: "configmaps"},
+				{Group: "", Version: "v1", Resource: "secrets"},
+				{Group: "batch", Version: "v1", Resource: "jobs"},
+				{Group: "batch", Version: "v1", Resource: "cronjobs"},
+			},
+			want: []schema.GroupVersionResource{
+				{Group: "", Version: "v1", Resource: "pods"},
+				{Group: "", Version: "v1", Resource: "services"},
+				{Group: "apps", Version: "v1", Resource: "deployments"},
+				{Group: "apps", Version: "v1", Resource: "replicasets"},
+				{Group: "apps", Version: "v1", Resource: "statefulsets"},
+				{Group: "apps", Version: "v1", Resource: "daemonsets"},
+				{Group: "", Version: "v1", Resource: "nodes"},
+				{Group: "", Version: "v1", Resource: "configmaps"},
+				{Group: "", Version: "v1", Resource: "secrets"},
+				{Group: "batch", Version: "v1", Resource: "jobs"},
+				{Group: "batch", Version: "v1", Resource: "cronjobs"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := k8cache.ExportedFilterImportantResources(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
+	t.Parallel()
+
+	apiResourceLists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Kind: "Pod", Verbs: []string{"list", "watch", "get"}},
+				{Name: "ingresses", Kind: "Ingress", Verbs: []string{"list", "watch", "get"}},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment", Verbs: []string{"list", "watch", "get"}},
+				{Name: "deployments/scale", Kind: "Scale", Verbs: []string{"get", "update"}},
+			},
+		},
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "events", Kind: "Event", Verbs: []string{"list", "watch"}},
+			},
+		},
+	}
+
+	got := k8cache.ExportedReturnGVRList(apiResourceLists)
+
+	want := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "pods"},
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+	}
+
+	assert.Equal(t, want, got)
 }
 
 func TestSyncWatchers(t *testing.T) {

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -139,4 +141,14 @@ func ExportedRedactContextKey(key string) string {
 // ExportedRedactCacheKey exposes redactCacheKey for testing.
 func ExportedRedactCacheKey(key string) string {
 	return redactCacheKey(key)
+}
+
+// ExportedFilterImportantResources exposes filterImportantResources for testing.
+func ExportedFilterImportantResources(gvrList []schema.GroupVersionResource) []schema.GroupVersionResource {
+	return filterImportantResources(gvrList)
+}
+
+// ExportedReturnGVRList exposes returnGVRList for testing.
+func ExportedReturnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
+	return returnGVRList(apiResourceLists)
 }


### PR DESCRIPTION
### Summary
Adds unit tests for filterImportantResources in the k8cache package, related to [#4670](https://github.com/kubernetes-sigs/headlamp/pull/4670).

Headlamp’s cache invalidation watches Kubernetes resources via informers. PR #4670 filters that list to ~11 common resource kinds to cut goroutine usage (~400 → ~100 per cluster context). That change lacked deterministic test coverage, and the proposed integration test using runtime.NumGoroutine() is flaky (expected 3 goroutines, got ~175).

This PR adds table-driven unit tests instead.

### Changes
Add filterImportantResources() and wire it into returnGVRList() (same logic as #4670)
Export ExportedFilterImportantResources and ExportedReturnGVRList for testing
Add TestFilterImportantResources — allowlist behavior, group/version preservation, all 11 kinds
Add TestReturnGVRList_FiltersImportantResources — end-to-end from API discovery input
Does not include the flaky goroutine integration test from #4670
Related
Related #3854
Related #4670

### Test plan

 go test ./pkg/k8cache/... -run "TestFilterImportantResources|TestReturnGVRList" -v