### PR TITLE
frontend: Added Storybook stories for Resource components

### DIFF
--- a/frontend/src/components/App/icons.ts
+++ b/frontend/src/components/App/icons.ts
@@ -525,6 +525,12 @@ const mdiIcons = {
     'timer-sand': {
       body: '<path fill="currentColor" d="M6 2h12v6l-4 4l4 4v6H6v-6l4-4l-4-4zm10 14.5l-4-4l-4 4V20h8zm-4-5l4-4V4H8v3.5zM10 6h4v.75l-2 2l-2-2z"/>',
     },
+    'radiobox-marked': {
+      body: '<path fill="currentColor" d="M12 20a8 8 0 0 1-8-8a8 8 0 0 1 8-8a8 8 0 0 1 8 8a8 8 0 0 1-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2m0 5a5 5 0 0 0-5 5a5 5 0 0 0 5 5a5 5 0 0 0 5-5a5 5 0 0 0-5-5"/>',
+    },
+    'radiobox-blank': {
+      body: '<path fill="currentColor" d="M12 20a8 8 0 0 1-8-8a8 8 0 0 1 8-8a8 8 0 0 1 8 8a8 8 0 0 1-8 8m0-18A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2"/>',
+    },
   },
   aliases: {
     'more-vert': {

--- a/frontend/src/components/common/Resource/A8RInfo.stories.tsx
+++ b/frontend/src/components/common/Resource/A8RInfo.stories.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Box from '@mui/material/Box';
+import { Meta, StoryFn } from '@storybook/react';
+import A8RInfo from './A8RInfo';
+
+export default {
+  title: 'Resource/A8RInfo',
+  component: A8RInfo,
+  decorators: [
+    Story => (
+      <Box sx={{ p: 2, maxWidth: 520 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    annotations: {
+      control: 'object',
+      description: 'Kubernetes annotations map. Only keys prefixed with "a8r.io/" are shown.',
+    },
+  },
+} as Meta;
+
+type A8RInfoProps = { annotations?: Record<string, string> };
+
+const Template: StoryFn<A8RInfoProps> = args => <A8RInfo {...args} />;
+
+export const FullMetadata = Template.bind({});
+FullMetadata.args = {
+  annotations: {
+    'a8r.io/description': 'Frontend service serving the public website.',
+    'a8r.io/owner': 'team-frontend',
+    'a8r.io/repository': 'https://github.com/example/frontend',
+    'a8r.io/documentation': 'https://docs.example.com/frontend',
+    'a8r.io/chat': 'https://example.slack.com/archives/frontend',
+    'a8r.io/bugs': 'https://github.com/example/frontend/issues',
+    'a8r.io/support': 'https://support.example.com',
+    'a8r.io/runbook': 'https://runbooks.example.com/frontend',
+    'a8r.io/incidents': 'https://status.example.com',
+    'a8r.io/uptime': 'https://status.example.com/uptime',
+    'a8r.io/performance': 'https://grafana.example.com/d/frontend',
+    'a8r.io/logs': 'https://kibana.example.com/app/logs',
+    'a8r.io/dependencies': 'database, redis, auth-service',
+  },
+};
+FullMetadata.storyName = 'Full metadata (all keys)';
+
+export const MinimalMetadata = Template.bind({});
+MinimalMetadata.args = {
+  annotations: {
+    'a8r.io/owner': 'team-platform',
+    'a8r.io/description': 'Internal API gateway.',
+  },
+};
+MinimalMetadata.storyName = 'Minimal metadata';
+
+export const LinksOnly = Template.bind({});
+LinksOnly.args = {
+  annotations: {
+    'a8r.io/repository': 'https://github.com/example/api',
+    'a8r.io/documentation': 'https://docs.example.com/api',
+    'a8r.io/logs': 'https://kibana.example.com/app/logs',
+  },
+};
+LinksOnly.storyName = 'Links only';
+
+export const MixedWithUnrelatedAnnotations = Template.bind({});
+MixedWithUnrelatedAnnotations.args = {
+  annotations: {
+    'kubectl.kubernetes.io/last-applied-configuration': '{...}',
+    'deployment.kubernetes.io/revision': '4',
+    'a8r.io/owner': 'team-data',
+    'a8r.io/description': 'ETL pipeline orchestrator.',
+  },
+};
+MixedWithUnrelatedAnnotations.storyName = 'Mixed with unrelated annotations';
+
+export const UnknownKeysIgnored = Template.bind({});
+UnknownKeysIgnored.args = {
+  annotations: {
+    'a8r.io/favourite-color': 'blue',
+    'a8r.io/owner': 'team-misc',
+  },
+};
+UnknownKeysIgnored.storyName = 'Unknown a8r.io keys are ignored';
+
+export const Empty = Template.bind({});
+Empty.args = {
+  annotations: {},
+};
+Empty.storyName = 'Empty (renders nothing)';

--- a/frontend/src/components/common/Resource/CircularChart.stories.tsx
+++ b/frontend/src/components/common/Resource/CircularChart.stories.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Box from '@mui/material/Box';
+import { Meta, StoryFn } from '@storybook/react';
+import type { KubeMetrics } from '../../../lib/k8s/cluster';
+import Node from '../../../lib/k8s/node';
+import type Pod from '../../../lib/k8s/pod';
+import { parseCpu, TO_ONE_CPU } from '../../../lib/units';
+import { TestContext } from '../../../test';
+import type { CircularChartProps } from './CircularChart';
+import { CircularChart } from './CircularChart';
+
+function makeNode(name: string, cpu: string): Node {
+  return new Node({
+    kind: 'Node',
+    apiVersion: 'v1',
+    metadata: {
+      name,
+      uid: `node-${name}`,
+      creationTimestamp: '2023-01-01T00:00:00Z',
+    },
+    status: {
+      capacity: { cpu, memory: '16Gi' },
+    },
+    spec: {
+      podCIDR: '10.0.0.0/24',
+      taints: [],
+    },
+  });
+}
+
+function makeMetric(name: string, cpu: string): KubeMetrics {
+  return {
+    metadata: {
+      name,
+      uid: `metric-${name}`,
+      creationTimestamp: '2023-01-01T00:00:00Z',
+    },
+    usage: { cpu, memory: '4Gi' },
+    status: { capacity: { cpu: '4', memory: '16Gi' } },
+  };
+}
+
+const nodes = [makeNode('node-1', '4'), makeNode('node-2', '4'), makeNode('node-3', '8')];
+
+const metrics = [
+  makeMetric('node-1', '1200m'),
+  makeMetric('node-2', '2600m'),
+  makeMetric('node-3', '3100m'),
+];
+
+const cpuUsedGetter = (item: KubeMetrics) => parseCpu(item.usage.cpu) / TO_ONE_CPU;
+const cpuAvailableGetter = (item: Node | Pod) =>
+  parseCpu(item.status?.capacity?.cpu ?? '0') / TO_ONE_CPU;
+const cpuLegend = (used: number, available: number) =>
+  used < 0 || available < 0 ? '…' : `${used.toFixed(1)} / ${available} cores`;
+
+export default {
+  title: 'Resource/CircularChart',
+  component: CircularChart,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Box sx={{ p: 2, width: 260 }}>
+          <Story />
+        </Box>
+      </TestContext>
+    ),
+  ],
+  argTypes: {
+    noMetrics: {
+      control: 'boolean',
+      description: 'Show the "install metrics-server" message instead of a chart.',
+    },
+  },
+} as Meta;
+
+const Template: StoryFn<CircularChartProps> = args => <CircularChart {...args} />;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  title: 'CPU usage',
+  items: nodes,
+  itemsMetrics: metrics,
+  resourceUsedGetter: cpuUsedGetter,
+  resourceAvailableGetter: cpuAvailableGetter,
+  getLegend: cpuLegend,
+};
+Basic.storyName = 'Basic (CPU across nodes)';
+
+export const HighUtilization = Template.bind({});
+HighUtilization.args = {
+  title: 'CPU usage',
+  items: nodes,
+  itemsMetrics: [
+    makeMetric('node-1', '3800m'),
+    makeMetric('node-2', '3900m'),
+    makeMetric('node-3', '7600m'),
+  ],
+  resourceUsedGetter: cpuUsedGetter,
+  resourceAvailableGetter: cpuAvailableGetter,
+  getLegend: cpuLegend,
+};
+HighUtilization.storyName = 'High utilization';
+
+export const Loading = Template.bind({});
+Loading.args = {
+  title: 'CPU usage',
+  items: null,
+  itemsMetrics: null,
+  resourceUsedGetter: cpuUsedGetter,
+  resourceAvailableGetter: cpuAvailableGetter,
+  getLegend: cpuLegend,
+};
+Loading.storyName = 'Loading (items not yet available)';
+
+export const NoMetrics = Template.bind({});
+NoMetrics.args = {
+  title: 'CPU usage',
+  items: nodes,
+  itemsMetrics: null,
+  noMetrics: true,
+  resourceUsedGetter: cpuUsedGetter,
+  resourceAvailableGetter: cpuAvailableGetter,
+  getLegend: cpuLegend,
+};
+NoMetrics.storyName = 'No metrics (metrics-server missing)';
+
+export const PartialMetrics = Template.bind({});
+PartialMetrics.args = {
+  title: 'CPU usage',
+  items: nodes,
+  itemsMetrics: [makeMetric('node-1', '1200m')],
+  resourceUsedGetter: cpuUsedGetter,
+  resourceAvailableGetter: cpuAvailableGetter,
+  getLegend: cpuLegend,
+};
+PartialMetrics.storyName = 'Partial metrics';

--- a/frontend/src/components/common/Resource/RevisionHistorySection.stories.tsx
+++ b/frontend/src/components/common/Resource/RevisionHistorySection.stories.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Box from '@mui/material/Box';
+import { Meta, StoryFn } from '@storybook/react';
+import type { KubeObject } from '../../../lib/k8s/KubeObject';
+import type { RevisionInfo } from '../../../lib/k8s/rollback';
+import { TestContext } from '../../../test';
+import RevisionHistorySection from './RevisionHistorySection';
+
+const sampleRevisions: RevisionInfo[] = [
+  {
+    revision: 3,
+    createdAt: '2023-01-03T09:30:00Z',
+    images: ['registry.k8s.io/nginx:1.25.3'],
+    isCurrent: true,
+  },
+  {
+    revision: 2,
+    createdAt: '2023-01-02T14:10:00Z',
+    images: ['registry.k8s.io/nginx:1.25.2'],
+    isCurrent: false,
+  },
+  {
+    revision: 1,
+    createdAt: '2023-01-01T08:00:00Z',
+    images: ['registry.k8s.io/nginx:1.25.1', 'registry.k8s.io/sidecar:0.4.0'],
+    isCurrent: false,
+  },
+];
+
+function makeResource(uid: string, getRevisionHistory: () => Promise<RevisionInfo[]>): KubeObject {
+  return {
+    metadata: {
+      name: 'my-deployment',
+      namespace: 'default',
+      uid,
+      resourceVersion: '1',
+    },
+    getRevisionHistory,
+  } as unknown as KubeObject;
+}
+
+export default {
+  title: 'Resource/RevisionHistorySection',
+  component: RevisionHistorySection,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Box sx={{ p: 2, maxWidth: 720 }}>
+          <Story />
+        </Box>
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<{ resource: KubeObject }> = args => <RevisionHistorySection {...args} />;
+
+export const WithHistory = Template.bind({});
+WithHistory.args = {
+  resource: makeResource('with-history', () => Promise.resolve(sampleRevisions)),
+};
+WithHistory.storyName = 'With revision history';
+
+export const SingleRevision = Template.bind({});
+SingleRevision.args = {
+  resource: makeResource('single-revision', () =>
+    Promise.resolve([
+      {
+        revision: 1,
+        createdAt: '2023-01-01T08:00:00Z',
+        images: ['registry.k8s.io/nginx:1.25.1'],
+        isCurrent: true,
+      },
+    ])
+  ),
+};
+SingleRevision.storyName = 'Single (current) revision';
+
+export const Empty = Template.bind({});
+Empty.args = {
+  resource: makeResource('empty', () => Promise.resolve([])),
+};
+Empty.storyName = 'No revisions';
+
+export const Loading = Template.bind({});
+Loading.args = {
+  resource: makeResource('loading', () => new Promise<RevisionInfo[]>(() => {})),
+};
+Loading.storyName = 'Loading';
+
+export const ErrorState = Template.bind({});
+ErrorState.args = {
+  resource: makeResource('error', () =>
+    Promise.reject(new Error('Forbidden: cannot list ReplicaSets in namespace "default"'))
+  ),
+};
+ErrorState.storyName = 'Error loading history';
+
+export const ManyRevisions = Template.bind({});
+ManyRevisions.args = {
+  resource: makeResource('many-revisions', () =>
+    Promise.resolve(
+      Array.from({ length: 8 }, (_, i) => {
+        const revision = 8 - i;
+        return {
+          revision,
+          createdAt: `2023-01-${String(revision).padStart(2, '0')}T08:00:00Z`,
+          images: [`registry.k8s.io/nginx:1.25.${revision}`],
+          isCurrent: i === 0,
+        };
+      })
+    )
+  ),
+};
+ManyRevisions.storyName = 'Many revisions';

--- a/frontend/src/components/common/Resource/RollbackDialog.stories.tsx
+++ b/frontend/src/components/common/Resource/RollbackDialog.stories.tsx
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { screen } from '@testing-library/react';
+import { expect, userEvent, waitFor } from 'storybook/test';
+import type { KubeObjectInterface } from '../../../lib/k8s/KubeObject';
+import type { RevisionInfo } from '../../../lib/k8s/rollback';
+import { TestContext } from '../../../test';
+import type { RollbackableResource } from './RollbackButton';
+import RollbackDialog from './RollbackDialog';
+
+const revisions: RevisionInfo[] = [
+  {
+    revision: 4,
+    createdAt: '2023-01-04T11:00:00Z',
+    images: ['registry.k8s.io/nginx:1.25.4'],
+    isCurrent: true,
+  },
+  {
+    revision: 3,
+    createdAt: '2023-01-03T09:30:00Z',
+    images: ['registry.k8s.io/nginx:1.25.3'],
+    isCurrent: false,
+  },
+  {
+    revision: 2,
+    createdAt: '2023-01-02T14:10:00Z',
+    images: ['registry.k8s.io/nginx:1.25.2', 'registry.k8s.io/sidecar:0.4.0'],
+    isCurrent: false,
+  },
+  {
+    revision: 1,
+    createdAt: '2023-01-01T08:00:00Z',
+    images: ['registry.k8s.io/nginx:1.25.1'],
+    isCurrent: false,
+  },
+];
+
+const dryRunResult: KubeObjectInterface = {
+  kind: 'Deployment',
+  apiVersion: 'apps/v1',
+  metadata: {
+    name: 'nginx-deployment',
+    namespace: 'default',
+    uid: 'd1e2f3a4-b5c6-7890-abcd-ef0123456789',
+    resourceVersion: '24680',
+    creationTimestamp: '2023-01-01T08:00:00Z',
+  },
+  spec: {
+    replicas: 3,
+    template: {
+      spec: {
+        containers: [{ name: 'nginx', image: 'registry.k8s.io/nginx:1.25.2' }],
+      },
+    },
+  },
+};
+
+function makeResource(rollbackImpl?: RollbackableResource['rollback']): RollbackableResource {
+  return {
+    rollback:
+      rollbackImpl ??
+      (async () => ({
+        success: true,
+        message: 'Dry-run succeeded',
+        dryRunResult,
+      })),
+  } as unknown as RollbackableResource;
+}
+
+interface RollbackDialogProps {
+  open: boolean;
+  resourceKind: string;
+  resourceName: string;
+  resource: RollbackableResource;
+  getRevisionHistory: () => Promise<RevisionInfo[]>;
+  onClose: () => void;
+  onConfirm: (toRevision?: number) => void;
+}
+
+export default {
+  title: 'Resource/RollbackDialog',
+  component: RollbackDialog,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+  argTypes: {
+    open: { control: 'boolean' },
+    resourceKind: { control: 'text' },
+    resourceName: { control: 'text' },
+  },
+} as Meta;
+
+const Template: StoryFn<RollbackDialogProps> = args => <RollbackDialog {...args} />;
+
+export const WithRevisions = Template.bind({});
+WithRevisions.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+WithRevisions.storyName = 'With revisions';
+
+export const OnlyCurrentRevision = Template.bind({});
+OnlyCurrentRevision.args = {
+  open: true,
+  resourceKind: 'StatefulSet',
+  resourceName: 'postgres',
+  resource: makeResource(),
+  getRevisionHistory: () =>
+    Promise.resolve([
+      {
+        revision: 1,
+        createdAt: '2023-01-01T08:00:00Z',
+        images: ['registry.k8s.io/postgres:16.1'],
+        isCurrent: true,
+      },
+    ]),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+OnlyCurrentRevision.storyName = 'Only current revision (nothing to roll back)';
+
+export const Loading = Template.bind({});
+Loading.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => new Promise<RevisionInfo[]>(() => {}),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+Loading.storyName = 'Loading revision history';
+
+export const HistoryError = Template.bind({});
+HistoryError.args = {
+  open: true,
+  resourceKind: 'DaemonSet',
+  resourceName: 'fluentd',
+  resource: makeResource(),
+  getRevisionHistory: () =>
+    Promise.reject(new Error('the server could not find the requested resource')),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+HistoryError.storyName = 'Failed to load history';
+
+export const PreviewSuccess = Template.bind({});
+PreviewSuccess.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+PreviewSuccess.storyName = 'Preview (dry-run) succeeds';
+PreviewSuccess.parameters = { storyshots: { disable: true } };
+PreviewSuccess.play = async () => {
+  const previewButton = await screen.findByRole('button', { name: 'preview-button' });
+  await waitFor(() => expect(previewButton).toBeEnabled());
+  await userEvent.click(previewButton);
+  await waitFor(() => expect(screen.getByText(/Dry-Run Preview/i)).toBeInTheDocument());
+};
+
+export const PreviewFails = Template.bind({});
+PreviewFails.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(async () => ({
+    success: false,
+    message: 'admission webhook denied the request',
+  })),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+PreviewFails.storyName = 'Preview (dry-run) fails';
+PreviewFails.parameters = { storyshots: { disable: true } };
+PreviewFails.play = async () => {
+  const previewButton = await screen.findByRole('button', { name: 'preview-button' });
+  await waitFor(() => expect(previewButton).toBeEnabled());
+  await userEvent.click(previewButton);
+  await waitFor(() => expect(screen.getByText(/Dry-run failed/i)).toBeInTheDocument());
+};
+
+export const Closed = Template.bind({});
+Closed.args = {
+  open: false,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+Closed.storyName = 'Closed';

--- a/frontend/src/components/common/Resource/RollbackDialog.stories.tsx
+++ b/frontend/src/components/common/Resource/RollbackDialog.stories.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { screen } from '@testing-library/react';
+import { expect, userEvent, waitFor } from 'storybook/test';
+import type { KubeObjectInterface } from '../../../lib/k8s/KubeObject';
+import type { RevisionInfo } from '../../../lib/k8s/rollback';
+import { TestContext } from '../../../test';
+import type { RollbackableResource } from './RollbackButton';
+import RollbackDialog from './RollbackDialog';
+
+const revisions: RevisionInfo[] = [
+  {
+    revision: 4,
+    createdAt: '2023-01-04T11:00:00Z',
+    images: ['registry.k8s.io/nginx:1.25.4'],
+    isCurrent: true,
+  },
+  {
+    revision: 3,
+    createdAt: '2023-01-03T09:30:00Z',
+    images: ['registry.k8s.io/nginx:1.25.3'],
+    isCurrent: false,
+  },
+  {
+    revision: 2,
+    createdAt: '2023-01-02T14:10:00Z',
+    images: ['registry.k8s.io/nginx:1.25.2', 'registry.k8s.io/sidecar:0.4.0'],
+    isCurrent: false,
+  },
+  {
+    revision: 1,
+    createdAt: '2023-01-01T08:00:00Z',
+    images: ['registry.k8s.io/nginx:1.25.1'],
+    isCurrent: false,
+  },
+];
+
+const dryRunResult: KubeObjectInterface = {
+  kind: 'Deployment',
+  apiVersion: 'apps/v1',
+  metadata: {
+    name: 'nginx-deployment',
+    namespace: 'default',
+    uid: 'd1e2f3a4-b5c6-7890-abcd-ef0123456789',
+    resourceVersion: '24680',
+    creationTimestamp: '2023-01-01T08:00:00Z',
+  },
+  spec: {
+    replicas: 3,
+    template: {
+      spec: {
+        containers: [{ name: 'nginx', image: 'registry.k8s.io/nginx:1.25.2' }],
+      },
+    },
+  },
+};
+
+function makeResource(rollbackImpl?: RollbackableResource['rollback']): RollbackableResource {
+  return {
+    rollback:
+      rollbackImpl ??
+      (async () => ({
+        success: true,
+        message: 'Dry-run succeeded',
+        dryRunResult,
+      })),
+  } as unknown as RollbackableResource;
+}
+
+export default {
+  title: 'Resource/RollbackDialog',
+  component: RollbackDialog,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+  argTypes: {
+    open: { control: 'boolean' },
+    resourceKind: { control: 'text' },
+    resourceName: { control: 'text' },
+  },
+} as Meta;
+
+const Template: StoryFn<typeof RollbackDialog> = args => <RollbackDialog {...args} />;
+
+export const WithRevisions = Template.bind({});
+WithRevisions.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+WithRevisions.storyName = 'With revisions';
+
+export const OnlyCurrentRevision = Template.bind({});
+OnlyCurrentRevision.args = {
+  open: true,
+  resourceKind: 'StatefulSet',
+  resourceName: 'postgres',
+  resource: makeResource(),
+  getRevisionHistory: () =>
+    Promise.resolve([
+      {
+        revision: 1,
+        createdAt: '2023-01-01T08:00:00Z',
+        images: ['registry.k8s.io/postgres:16.1'],
+        isCurrent: true,
+      },
+    ]),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+OnlyCurrentRevision.storyName = 'Only current revision (nothing to roll back)';
+
+export const Loading = Template.bind({});
+Loading.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => new Promise<RevisionInfo[]>(() => {}),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+Loading.storyName = 'Loading revision history';
+
+export const HistoryError = Template.bind({});
+HistoryError.args = {
+  open: true,
+  resourceKind: 'DaemonSet',
+  resourceName: 'fluentd',
+  resource: makeResource(),
+  getRevisionHistory: () =>
+    Promise.reject(new Error('the server could not find the requested resource')),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+HistoryError.storyName = 'Failed to load history';
+
+export const PreviewSuccess = Template.bind({});
+PreviewSuccess.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+PreviewSuccess.storyName = 'Preview (dry-run) succeeds';
+PreviewSuccess.parameters = { storyshots: { disable: true } };
+PreviewSuccess.play = async () => {
+  const previewButton = await screen.findByTestId('preview-button');
+  await waitFor(() => expect(previewButton).toBeEnabled());
+  await userEvent.click(previewButton);
+  await waitFor(() => expect(screen.getByText(/Dry-Run Preview/i)).toBeInTheDocument());
+};
+
+export const PreviewFails = Template.bind({});
+PreviewFails.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(async () => ({
+    success: false,
+    message: 'admission webhook denied the request',
+  })),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+PreviewFails.storyName = 'Preview (dry-run) fails';
+PreviewFails.parameters = { storyshots: { disable: true } };
+PreviewFails.play = async () => {
+  const previewButton = await screen.findByTestId('preview-button');
+  await waitFor(() => expect(previewButton).toBeEnabled());
+  await userEvent.click(previewButton);
+  await waitFor(() => expect(screen.getByText(/Dry-run failed/i)).toBeInTheDocument());
+};
+
+export const KeyboardSelection = Template.bind({});
+KeyboardSelection.args = {
+  open: true,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+KeyboardSelection.storyName = 'Keyboard selection';
+KeyboardSelection.parameters = { storyshots: { disable: true } };
+KeyboardSelection.play = async () => {
+  const radios = await screen.findAllByRole('radio');
+  const selectable = radios.filter(radio => !radio.hasAttribute('aria-disabled'));
+
+  await waitFor(() => expect(selectable[0]).toHaveAttribute('aria-checked', 'true'));
+
+  selectable[0].focus();
+  await userEvent.keyboard('{ArrowDown}');
+
+  // Focus has to travel with the selection, and the group keeps a single tab stop.
+  await waitFor(() => expect(selectable[1]).toHaveAttribute('aria-checked', 'true'));
+  await waitFor(() => expect(selectable[1]).toHaveFocus());
+  expect(selectable[1]).toHaveAttribute('tabindex', '0');
+  expect(selectable[0]).toHaveAttribute('aria-checked', 'false');
+  expect(selectable[0]).toHaveAttribute('tabindex', '-1');
+
+  await userEvent.keyboard('{ArrowUp}');
+
+  await waitFor(() => expect(selectable[0]).toHaveAttribute('aria-checked', 'true'));
+  await waitFor(() => expect(selectable[0]).toHaveFocus());
+};
+
+export const Closed = Template.bind({});
+Closed.args = {
+  open: false,
+  resourceKind: 'Deployment',
+  resourceName: 'nginx-deployment',
+  resource: makeResource(),
+  getRevisionHistory: () => Promise.resolve(revisions),
+  onClose: () => {},
+  onConfirm: () => {},
+};
+Closed.storyName = 'Closed';

--- a/frontend/src/components/common/Resource/RollbackDialog.test.tsx
+++ b/frontend/src/components/common/Resource/RollbackDialog.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { RevisionInfo } from '../../../lib/k8s/rollback';
+import { TestContext } from '../../../test';
+import type { RollbackableResource } from './RollbackButton';
+import RollbackDialog from './RollbackDialog';
+
+const revisions: RevisionInfo[] = [
+  { revision: 4, createdAt: '2023-01-04T11:00:00Z', images: ['nginx:1.25.4'], isCurrent: true },
+  { revision: 3, createdAt: '2023-01-03T09:30:00Z', images: ['nginx:1.25.3'], isCurrent: false },
+  { revision: 2, createdAt: '2023-01-02T14:10:00Z', images: ['nginx:1.25.2'], isCurrent: false },
+  { revision: 1, createdAt: '2023-01-01T08:00:00Z', images: ['nginx:1.25.1'], isCurrent: false },
+];
+
+const resource = {
+  rollback: vi.fn(async () => ({ success: true, message: 'ok' })),
+} as unknown as RollbackableResource;
+
+function renderDialog(history: RevisionInfo[] = revisions) {
+  return render(
+    <TestContext>
+      <RollbackDialog
+        open
+        resourceKind="Deployment"
+        resourceName="nginx-deployment"
+        resource={resource}
+        getRevisionHistory={() => Promise.resolve(history)}
+        onClose={() => {}}
+        onConfirm={() => {}}
+      />
+    </TestContext>
+  );
+}
+
+async function selectableRadios() {
+  const radios = await screen.findAllByRole('radio');
+  return radios.filter(radio => !radio.hasAttribute('aria-disabled'));
+}
+
+describe('RollbackDialog revision picker', () => {
+  it('exposes the revisions as a single-tab-stop radio group', async () => {
+    renderDialog();
+
+    const selectable = await selectableRadios();
+
+    await waitFor(() => expect(selectable[0]).toHaveAttribute('aria-checked', 'true'));
+
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    expect(selectable.filter(radio => radio.getAttribute('tabindex') === '0')).toHaveLength(1);
+  });
+
+  it('moves focus with the selection on ArrowDown and ArrowUp', async () => {
+    renderDialog();
+
+    const selectable = await selectableRadios();
+
+    await waitFor(() => expect(selectable[0]).toHaveAttribute('aria-checked', 'true'));
+
+    selectable[0].focus();
+    await userEvent.keyboard('{ArrowDown}');
+
+    await waitFor(() => expect(selectable[1]).toHaveAttribute('aria-checked', 'true'));
+    expect(selectable[1]).toHaveFocus();
+    expect(selectable[1]).toHaveAttribute('tabindex', '0');
+    expect(selectable[0]).toHaveAttribute('aria-checked', 'false');
+    expect(selectable[0]).toHaveAttribute('tabindex', '-1');
+
+    await userEvent.keyboard('{ArrowUp}');
+
+    await waitFor(() => expect(selectable[0]).toHaveAttribute('aria-checked', 'true'));
+    expect(selectable[0]).toHaveFocus();
+  });
+
+  it('does not steal focus later when there is only one selectable revision', async () => {
+    const onlyOneSelectable = [
+      { revision: 2, createdAt: '2023-01-02T14:10:00Z', images: ['nginx:1.25.2'], isCurrent: true },
+      {
+        revision: 1,
+        createdAt: '2023-01-01T08:00:00Z',
+        images: ['nginx:1.25.1'],
+        isCurrent: false,
+      },
+    ];
+    renderDialog(onlyOneSelectable);
+
+    const selectable = await selectableRadios();
+    expect(selectable).toHaveLength(1);
+
+    await waitFor(() => expect(selectable[0]).toHaveAttribute('aria-checked', 'true'));
+
+    // Every arrow lands back on the same revision, so nothing should be queued.
+    selectable[0].focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{ArrowUp}');
+
+    // Move on to another control, then cause an unrelated re-render.
+    const previewButton = screen.getByTestId('preview-button');
+    await waitFor(() => expect(previewButton).toBeEnabled());
+    previewButton.focus();
+    await userEvent.click(previewButton);
+
+    await waitFor(() => expect(resource.rollback).toHaveBeenCalled());
+
+    expect(selectable[0]).not.toHaveFocus();
+  });
+
+  it('wraps around at the ends of the group', async () => {
+    renderDialog();
+
+    const selectable = await selectableRadios();
+
+    await waitFor(() => expect(selectable[0]).toHaveAttribute('aria-checked', 'true'));
+
+    selectable[0].focus();
+    await userEvent.keyboard('{ArrowUp}');
+
+    const last = selectable[selectable.length - 1];
+
+    await waitFor(() => expect(last).toHaveAttribute('aria-checked', 'true'));
+    expect(last).toHaveFocus();
+  });
+});

--- a/frontend/src/components/common/Resource/RollbackDialog.tsx
+++ b/frontend/src/components/common/Resource/RollbackDialog.tsx
@@ -228,6 +228,8 @@ export default function RollbackDialog(props: RollbackDialogProps) {
                           sx={{ mr: 1 }}
                         />
                         <ListItemText
+                          primaryTypographyProps={{ component: 'div' }}
+                          secondaryTypographyProps={{ component: 'div' }}
                           primary={
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                               <Typography variant="body2" fontWeight="medium">

--- a/frontend/src/components/common/Resource/RollbackDialog.tsx
+++ b/frontend/src/components/common/Resource/RollbackDialog.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Icon } from '@iconify/react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -24,9 +25,9 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
-import Radio from '@mui/material/Radio';
 import Typography from '@mui/material/Typography';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -126,6 +127,62 @@ export default function RollbackDialog(props: RollbackDialogProps) {
     setPreviewOpen(false);
   }, [selectedRevision]);
 
+  const selectableRevisions = revisions.filter(rev => !rev.isCurrent);
+  const revisionRefs = useRef(new Map<number, HTMLElement>());
+  const pendingFocus = useRef<number | null>(null);
+
+  // In a radio group focus follows selection, so an arrow key has to move the focus too.
+  // Leaving it behind would strand assistive technology on an option that is no longer
+  // checked and no longer the group's tab stop. Only keyboard moves queue a focus change,
+  // so clicking an option or auto-selecting one on load does not pull focus into the list.
+  useEffect(() => {
+    if (pendingFocus.current === null) {
+      return;
+    }
+
+    revisionRefs.current.get(pendingFocus.current)?.focus();
+    pendingFocus.current = null;
+  });
+
+  function moveSelection(event: React.KeyboardEvent, step: number) {
+    if (selectableRevisions.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const current = selectableRevisions.findIndex(rev => rev.revision === selectedRevision);
+    const next =
+      current === -1
+        ? 0
+        : (current + step + selectableRevisions.length) % selectableRevisions.length;
+
+    const target = selectableRevisions[next].revision;
+
+    // With a single selectable revision every arrow lands back on it. React can skip the
+    // re-render for a same-value update, which would leave the queued focus to fire on some
+    // later unrelated render and pull focus out of whatever the user moved on to.
+    if (target === selectedRevision) {
+      return;
+    }
+
+    pendingFocus.current = target;
+    setSelectedRevision(target);
+  }
+
+  function handleRevisionKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+      moveSelection(event, 1);
+    } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+      moveSelection(event, -1);
+    }
+  }
+
+  // A radio group is one tab stop: the checked option, or the first selectable one when
+  // nothing is checked yet. Arrow keys move the selection within it.
+  const rovingTabStop =
+    selectableRevisions.find(rev => rev.revision === selectedRevision) ?? selectableRevisions[0];
+
   function handleConfirm() {
     previewRequestId.current++;
     onConfirm(selectedRevision);
@@ -202,72 +259,96 @@ export default function RollbackDialog(props: RollbackDialogProps) {
                 </Typography>
               ) : (
                 <>
-                  <List sx={{ maxHeight: 320, overflow: 'auto' }}>
+                  <List
+                    role="radiogroup"
+                    aria-label={t('translation|Revision History')}
+                    sx={{ maxHeight: 320, overflow: 'auto' }}
+                  >
                     {revisions.map(rev => (
-                      <ListItemButton
-                        key={rev.revision}
-                        selected={selectedRevision === rev.revision}
-                        onClick={() => {
-                          if (!rev.isCurrent) {
-                            setSelectedRevision(rev.revision);
-                          }
-                        }}
-                        disabled={rev.isCurrent}
-                        sx={{
-                          borderRadius: 1,
-                          mb: 0.5,
-                          border: '1px solid',
-                          borderColor:
-                            selectedRevision === rev.revision ? 'primary.main' : 'divider',
-                        }}
-                      >
-                        <Radio
-                          checked={selectedRevision === rev.revision}
+                      <ListItem key={rev.revision} role="none" disablePadding sx={{ mb: 0.5 }}>
+                        <ListItemButton
+                          role="radio"
+                          ref={(node: HTMLElement | null) => {
+                            if (node) {
+                              revisionRefs.current.set(rev.revision, node);
+                            } else {
+                              revisionRefs.current.delete(rev.revision);
+                            }
+                          }}
+                          aria-checked={selectedRevision === rev.revision}
+                          tabIndex={rovingTabStop?.revision === rev.revision ? 0 : -1}
+                          onKeyDown={handleRevisionKeyDown}
+                          selected={selectedRevision === rev.revision}
+                          onClick={() => {
+                            if (!rev.isCurrent) {
+                              setSelectedRevision(rev.revision);
+                            }
+                          }}
                           disabled={rev.isCurrent}
-                          size="small"
-                          sx={{ mr: 1 }}
-                        />
-                        <ListItemText
-                          primary={
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                              <Typography variant="body2" fontWeight="medium">
-                                {t('translation|Revision {{ revision }}', {
-                                  revision: rev.revision,
-                                })}
-                              </Typography>
-                              {rev.isCurrent && (
-                                <Chip
-                                  label={t('translation|Current')}
-                                  size="small"
-                                  color="primary"
-                                  variant="outlined"
-                                />
-                              )}
-                            </Box>
-                          }
-                          secondary={
-                            <Box component="span">
-                              <Typography variant="caption" color="text.secondary" component="span">
-                                <DateLabel date={rev.createdAt} />
-                              </Typography>
-                              {rev.images.length > 0 && (
+                          sx={{
+                            borderRadius: 1,
+                            border: '1px solid',
+                            borderColor:
+                              selectedRevision === rev.revision ? 'primary.main' : 'divider',
+                          }}
+                        >
+                          <Icon
+                            icon={
+                              selectedRevision === rev.revision
+                                ? 'mdi:radiobox-marked'
+                                : 'mdi:radiobox-blank'
+                            }
+                            width="20"
+                            style={{ marginRight: 8, flexShrink: 0 }}
+                            aria-hidden
+                          />
+                          <ListItemText
+                            primaryTypographyProps={{ component: 'div' }}
+                            secondaryTypographyProps={{ component: 'div' }}
+                            primary={
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                <Typography variant="body2" fontWeight="medium">
+                                  {t('translation|Revision {{ revision }}', {
+                                    revision: rev.revision,
+                                  })}
+                                </Typography>
+                                {rev.isCurrent && (
+                                  <Chip
+                                    label={t('translation|Current')}
+                                    size="small"
+                                    color="primary"
+                                    variant="outlined"
+                                  />
+                                )}
+                              </Box>
+                            }
+                            secondary={
+                              <Box>
                                 <Typography
                                   variant="caption"
                                   color="text.secondary"
-                                  component="span"
-                                  sx={{ display: 'block' }}
+                                  component="div"
                                 >
-                                  {rev.images.map((img, i) => (
-                                    <Box key={i} component="span" sx={{ display: 'block' }}>
-                                      {img}
-                                    </Box>
-                                  ))}
+                                  <DateLabel date={rev.createdAt} />
                                 </Typography>
-                              )}
-                            </Box>
-                          }
-                        />
-                      </ListItemButton>
+                                {rev.images.length > 0 && (
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    component="div"
+                                  >
+                                    {rev.images.map((img, i) => (
+                                      <Box key={i} sx={{ display: 'block' }}>
+                                        {img}
+                                      </Box>
+                                    ))}
+                                  </Typography>
+                                )}
+                              </Box>
+                            }
+                          />
+                        </ListItemButton>
+                      </ListItem>
                     ))}
                   </List>
 

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.Empty.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.Empty.stories.storyshot
@@ -1,0 +1,7 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1fvfakn"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.FullMetadata.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.FullMetadata.stories.storyshot
@@ -1,0 +1,264 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1fvfakn"
+    >
+      <div
+        class="MuiBox-root css-1hdbc19"
+      >
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Description
+              :
+            </strong>
+             
+            Frontend service serving the public website.
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Owner
+              :
+            </strong>
+             
+            team-frontend
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Dependencies
+              :
+            </strong>
+             
+            database, redis, auth-service
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Chat
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://example.slack.com/archives/frontend"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://example.slack.com/archives/frontend
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Documentation
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://docs.example.com/frontend"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://docs.example.com/frontend
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Repository
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://github.com/example/frontend"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://github.com/example/frontend
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Logs
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://kibana.example.com/app/logs"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://kibana.example.com/app/logs
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Bugs
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://github.com/example/frontend/issues"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://github.com/example/frontend/issues
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Support
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://support.example.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://support.example.com
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Runbook
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://runbooks.example.com/frontend"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://runbooks.example.com/frontend
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Incidents
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://status.example.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://status.example.com
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Uptime
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://status.example.com/uptime"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://status.example.com/uptime
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Performance
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://grafana.example.com/d/frontend"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://grafana.example.com/d/frontend
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.LinksOnly.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.LinksOnly.stories.storyshot
@@ -1,0 +1,75 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1fvfakn"
+    >
+      <div
+        class="MuiBox-root css-1hdbc19"
+      >
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Documentation
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://docs.example.com/api"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://docs.example.com/api
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Repository
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://github.com/example/api"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://github.com/example/api
+            </a>
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Logs
+              :
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+              href="https://kibana.example.com/app/logs"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              https://kibana.example.com/app/logs
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.MinimalMetadata.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.MinimalMetadata.stories.storyshot
@@ -1,0 +1,40 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1fvfakn"
+    >
+      <div
+        class="MuiBox-root css-1hdbc19"
+      >
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Description
+              :
+            </strong>
+             
+            Internal API gateway.
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Owner
+              :
+            </strong>
+             
+            team-platform
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.MixedWithUnrelatedAnnotations.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.MixedWithUnrelatedAnnotations.stories.storyshot
@@ -1,0 +1,40 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1fvfakn"
+    >
+      <div
+        class="MuiBox-root css-1hdbc19"
+      >
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Description
+              :
+            </strong>
+             
+            ETL pipeline orchestrator.
+          </p>
+        </div>
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Owner
+              :
+            </strong>
+             
+            team-data
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.UnknownKeysIgnored.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.UnknownKeysIgnored.stories.storyshot
@@ -1,0 +1,26 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1fvfakn"
+    >
+      <div
+        class="MuiBox-root css-1hdbc19"
+      >
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+          >
+            <strong>
+              Owner
+              :
+            </strong>
+             
+            team-misc
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/CircularChart.Basic.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/CircularChart.Basic.stories.storyshot
@@ -1,0 +1,142 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-18rvz4b"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-qrw4x1"
+        >
+          <div
+            class="MuiBox-root css-1sl8dhm"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+              >
+                CPU usage
+              </p>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+            >
+              6.9 / 16 cores
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <div
+              aria-busy="false"
+              aria-live="polite"
+              class="MuiBox-root css-2esbmj"
+            >
+              <div
+                class="recharts-wrapper"
+                style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+              >
+                <svg
+                  class="recharts-surface"
+                  cx="70"
+                  cy="70"
+                  height="112"
+                  style="width: 100%; height: 100%;"
+                  viewBox="0 0 112 112"
+                  width="112"
+                >
+                  <title />
+                  <desc />
+                  <defs>
+                    <clippath
+                      id="recharts-id"
+                    >
+                      <rect
+                        height="102"
+                        width="102"
+                        x="5"
+                        y="5"
+                      />
+                    </clippath>
+                  </defs>
+                  <g
+                    class="recharts-layer recharts-pie"
+                    tabindex="0"
+                  >
+                    <g
+                      class="recharts-layer recharts-pie-sector"
+                      tabindex="-1"
+                    >
+                      <path
+                        aria-label="43.1 %"
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    0,1,
+    79.75595624167678,101.68481418736364
+  L 75.15069912876507,91.69523927528775
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            61,27.199999999999996 Z"
+                        fill="#000"
+                        name="used"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
+                    <g
+                      class="recharts-layer recharts-pie-sector"
+                      tabindex="-1"
+                    >
+                      <path
+                        aria-label="43.1 %"
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 79.75595624167678,101.68481418736364
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99999999999999,16.199999999999996
+  L 60.99999999999999,27.199999999999996
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            75.15069912876507,91.69523927528775 Z"
+                        fill="#e0e0e0"
+                        name="total"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
+                    <text
+                      class="recharts-text recharts-label"
+                      fill="#808080"
+                      offset="5"
+                      style="font-size: 16.8px; fill: #000;"
+                      text-anchor="middle"
+                      x="61"
+                      y="61"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="61"
+                      >
+                        43.1 %
+                      </tspan>
+                    </text>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/CircularChart.HighUtilization.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/CircularChart.HighUtilization.stories.storyshot
@@ -1,0 +1,142 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-18rvz4b"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-qrw4x1"
+        >
+          <div
+            class="MuiBox-root css-1sl8dhm"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+              >
+                CPU usage
+              </p>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+            >
+              15.3 / 16 cores
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <div
+              aria-busy="false"
+              aria-live="polite"
+              class="MuiBox-root css-2esbmj"
+            >
+              <div
+                class="recharts-wrapper"
+                style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+              >
+                <svg
+                  class="recharts-surface"
+                  cx="70"
+                  cy="70"
+                  height="112"
+                  style="width: 100%; height: 100%;"
+                  viewBox="0 0 112 112"
+                  width="112"
+                >
+                  <title />
+                  <desc />
+                  <defs>
+                    <clippath
+                      id="recharts-id"
+                    >
+                      <rect
+                        height="102"
+                        width="102"
+                        x="5"
+                        y="5"
+                      />
+                    </clippath>
+                  </defs>
+                  <g
+                    class="recharts-layer recharts-pie"
+                    tabindex="0"
+                  >
+                    <g
+                      class="recharts-layer recharts-pie-sector"
+                      tabindex="-1"
+                    >
+                      <path
+                        aria-label="95.6 %"
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    48.83946784604468,17.8820054068766
+  L 51.82531279456049,28.46901300786672
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            61,27.199999999999996 Z"
+                        fill="#000"
+                        name="used"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
+                    <g
+                      class="recharts-layer recharts-pie-sector"
+                      tabindex="-1"
+                    >
+                      <path
+                        aria-label="95.6 %"
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 48.83946784604468,17.8820054068766
+    A 44.800000000000004,44.800000000000004,0,
+    0,1,
+    60.99999999999999,16.199999999999996
+  L 60.99999999999999,27.199999999999996
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            51.82531279456049,28.46901300786672 Z"
+                        fill="#e0e0e0"
+                        name="total"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
+                    <text
+                      class="recharts-text recharts-label"
+                      fill="#808080"
+                      offset="5"
+                      style="font-size: 16.8px; fill: #000;"
+                      text-anchor="middle"
+                      x="61"
+                      y="61"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="61"
+                      >
+                        95.6 %
+                      </tspan>
+                    </text>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/CircularChart.Loading.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/CircularChart.Loading.stories.storyshot
@@ -1,0 +1,69 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-18rvz4b"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-qrw4x1"
+        >
+          <div
+            class="MuiBox-root css-1sl8dhm"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+              >
+                CPU usage
+              </p>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+            >
+              …
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <div
+              aria-busy="true"
+              aria-live="polite"
+              class="MuiBox-root css-2esbmj"
+            >
+              <div
+                class="MuiBox-root css-5cned0"
+              >
+                <span
+                  aria-label="Loading data for "
+                  class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1g0vz9s-MuiCircularProgress-root"
+                  role="progressbar"
+                  style="width: 40px; height: 40px;"
+                  title="Loading data for "
+                >
+                  <svg
+                    class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                    viewBox="22 22 44 44"
+                  >
+                    <circle
+                      class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                      cx="44"
+                      cy="44"
+                      fill="none"
+                      r="20.2"
+                      stroke-width="3.6"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/CircularChart.NoMetrics.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/CircularChart.NoMetrics.stories.storyshot
@@ -1,0 +1,40 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-18rvz4b"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-qrw4x1"
+        >
+          <div
+            class="MuiBox-root css-1sl8dhm"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+              >
+                CPU usage
+              </p>
+              <div
+                class="MuiContainer-root MuiContainer-maxWidthLg css-64uahr-MuiContainer-root"
+              />
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+            >
+              0.0 / 16 cores
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/CircularChart.PartialMetrics.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/CircularChart.PartialMetrics.stories.storyshot
@@ -1,0 +1,142 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-18rvz4b"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-u96y7l-MuiPaper-root"
+      >
+        <div
+          class="MuiBox-root css-qrw4x1"
+        >
+          <div
+            class="MuiBox-root css-1sl8dhm"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-16da70x-MuiTypography-root"
+              >
+                CPU usage
+              </p>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
+            >
+              1.2 / 16 cores
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <div
+              aria-busy="false"
+              aria-live="polite"
+              class="MuiBox-root css-2esbmj"
+            >
+              <div
+                class="recharts-wrapper"
+                style="position: relative; cursor: default; width: 112px; height: 112px; margin-left: auto; margin-right: auto;"
+              >
+                <svg
+                  class="recharts-surface"
+                  cx="70"
+                  cy="70"
+                  height="112"
+                  style="width: 100%; height: 100%;"
+                  viewBox="0 0 112 112"
+                  width="112"
+                >
+                  <title />
+                  <desc />
+                  <defs>
+                    <clippath
+                      id="recharts-id"
+                    >
+                      <rect
+                        height="102"
+                        width="102"
+                        x="5"
+                        y="5"
+                      />
+                    </clippath>
+                  </defs>
+                  <g
+                    class="recharts-layer recharts-pie"
+                    tabindex="0"
+                  >
+                    <g
+                      class="recharts-layer recharts-pie-sector"
+                      tabindex="-1"
+                    >
+                      <path
+                        aria-label="7.5 %"
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    0,1,
+    81.3387743883317,21.08290771636112
+  L 76.34487889119669,30.883979482433165
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            61,27.199999999999996 Z"
+                        fill="#000"
+                        name="used"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
+                    <g
+                      class="recharts-layer recharts-pie-sector"
+                      tabindex="-1"
+                    >
+                      <path
+                        aria-label="7.5 %"
+                        class="recharts-sector"
+                        cx="61"
+                        cy="61"
+                        d="M 81.3387743883317,21.08290771636112
+    A 44.800000000000004,44.800000000000004,0,
+    1,1,
+    60.99999999999999,16.199999999999996
+  L 60.99999999999999,27.199999999999996
+            A 33.800000000000004,33.800000000000004,0,
+            1,0,
+            76.34487889119669,30.883979482433165 Z"
+                        fill="#e0e0e0"
+                        name="total"
+                        role="img"
+                        stroke="#e0e0e0"
+                        tabindex="-1"
+                      />
+                    </g>
+                    <text
+                      class="recharts-text recharts-label"
+                      fill="#808080"
+                      offset="5"
+                      style="font-size: 16.8px; fill: #000;"
+                      text-anchor="middle"
+                      x="61"
+                      y="61"
+                    >
+                      <tspan
+                        dy="0.355em"
+                        x="61"
+                      >
+                        7.5 %
+                      </tspan>
+                    </text>
+                  </g>
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.Empty.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.Empty.stories.storyshot
@@ -1,0 +1,41 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-113m2lz"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h2
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+              >
+                Revision History
+              </h2>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-7oje3w-MuiTypography-root"
+          >
+            No revision history available.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.ErrorState.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.ErrorState.stories.storyshot
@@ -1,0 +1,41 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-113m2lz"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h2
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+              >
+                Revision History
+              </h2>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-lf1pl8-MuiTypography-root"
+          >
+            Failed to load revision history: Forbidden: cannot list ReplicaSets in namespace "default"
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.Loading.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.Loading.stories.storyshot
@@ -1,0 +1,41 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-113m2lz"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h2
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+              >
+                Revision History
+              </h2>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-7oje3w-MuiTypography-root"
+          >
+            Loading revision history…
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.ManyRevisions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.ManyRevisions.stories.storyshot
@@ -1,0 +1,452 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-113m2lz"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h2
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+              >
+                Revision History
+              </h2>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <div
+            class="MuiTableContainer-root css-rorn0c-MuiTableContainer-root"
+          >
+            <table
+              class="MuiTable-root css-vzt8dn-MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Revision
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Created
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Images
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      8
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-08T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.8
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-outlinedPrimary css-t4xq4n-MuiChip-root"
+                    >
+                      <span
+                        class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+                      >
+                        Current
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      7
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-07T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.7
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      6
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-06T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.6
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      5
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-05T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.5
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      4
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-04T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.4
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      3
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-03T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.3
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      2
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-02T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.2
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      1
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-01T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.1
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.SingleRevision.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.SingleRevision.stories.storyshot
@@ -1,0 +1,130 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-113m2lz"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h2
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+              >
+                Revision History
+              </h2>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <div
+            class="MuiTableContainer-root css-rorn0c-MuiTableContainer-root"
+          >
+            <table
+              class="MuiTable-root css-vzt8dn-MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Revision
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Created
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Images
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      1
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-01T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.1
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-outlinedPrimary css-t4xq4n-MuiChip-root"
+                    >
+                      <span
+                        class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+                      >
+                        Current
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.WithHistory.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RevisionHistorySection.WithHistory.stories.storyshot
@@ -1,0 +1,227 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-113m2lz"
+    >
+      <div
+        class="MuiBox-root css-j1fy4m"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+          >
+            <div
+              class="MuiBox-root css-70qvj9"
+            >
+              <h2
+                class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+              >
+                Revision History
+              </h2>
+              <div
+                class="MuiBox-root css-ldp2l3"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1txv3mw"
+        >
+          <div
+            class="MuiTableContainer-root css-rorn0c-MuiTableContainer-root"
+          >
+            <table
+              class="MuiTable-root css-vzt8dn-MuiTable-root"
+            >
+              <thead
+                class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+              >
+                <tr
+                  class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                >
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Revision
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Created
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Images
+                  </th>
+                  <th
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1e49d97-MuiTableCell-root"
+                    scope="col"
+                  >
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+              >
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      3
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-03T09:30:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.3
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-outlinedPrimary css-t4xq4n-MuiChip-root"
+                    >
+                      <span
+                        class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+                      >
+                        Current
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      2
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-02T14:10:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.2
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                    >
+                      1
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      aria-label="2023-01-01T08:00:00.000Z"
+                      class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      90d
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root css-1kkt86i"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/nginx:1.25.1
+                      </p>
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-3czxqc-MuiTypography-root"
+                      >
+                        registry.k8s.io/sidecar:0.4.0
+                      </p>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+                    >
+                      Previous
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.Closed.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.Closed.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.HistoryError.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.HistoryError.stories.storyshot
@@ -1,0 +1,84 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback DaemonSet
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-lf1pl8-MuiTypography-root"
+          >
+            Failed to load revision history: the server could not find the requested resource
+          </p>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            aria-label="cancel-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="preview-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Preview
+          </button>
+          <button
+            aria-label="confirm-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Rollback
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.HistoryError.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.HistoryError.stories.storyshot
@@ -1,0 +1,84 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback DaemonSet
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-lf1pl8-MuiTypography-root"
+          >
+            Failed to load revision history: the server could not find the requested resource
+          </p>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            data-testid="cancel-button"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            data-testid="preview-button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Preview
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            data-testid="confirm-button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Rollback
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.Loading.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.Loading.stories.storyshot
@@ -1,0 +1,84 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback Deployment
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-7oje3w-MuiTypography-root"
+          >
+            Loading revision history…
+          </p>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            aria-label="cancel-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="preview-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Preview
+          </button>
+          <button
+            aria-label="confirm-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Rollback
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.Loading.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.Loading.stories.storyshot
@@ -1,0 +1,84 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback Deployment
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-7oje3w-MuiTypography-root"
+          >
+            Loading revision history…
+          </p>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            data-testid="cancel-button"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            data-testid="preview-button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Preview
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            data-testid="confirm-button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Rollback
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.OnlyCurrentRevision.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.OnlyCurrentRevision.stories.storyshot
@@ -1,0 +1,89 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback StatefulSet
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-i6y5kq-MuiTypography-root"
+          >
+            Select a revision to rollback "postgres" to. This will replace the current pod template with the one from the selected revision.
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+          >
+            No previous revisions available to rollback to.
+          </p>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            aria-label="cancel-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="preview-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Preview
+          </button>
+          <button
+            aria-label="confirm-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Rollback
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.OnlyCurrentRevision.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.OnlyCurrentRevision.stories.storyshot
@@ -1,0 +1,89 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback StatefulSet
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-i6y5kq-MuiTypography-root"
+          >
+            Select a revision to rollback "postgres" to. This will replace the current pod template with the one from the selected revision.
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-11zj6ou-MuiTypography-root"
+          >
+            No previous revisions available to rollback to.
+          </p>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            data-testid="cancel-button"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            data-testid="preview-button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Preview
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            data-testid="confirm-button"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Rollback
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.WithRevisions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.WithRevisions.stories.storyshot
@@ -1,0 +1,473 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback Deployment
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-i6y5kq-MuiTypography-root"
+          >
+            Select a revision to rollback "nginx-deployment" to. This will replace the current pod template with the one from the selected revision.
+          </p>
+          <ul
+            class="MuiList-root MuiList-padding css-1tmg5zb-MuiList-root"
+          >
+            <div
+              aria-disabled="true"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-disabled Mui-disabled MuiListItemButton-root MuiListItemButton-gutters Mui-disabled css-jvjlif-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="-1"
+            >
+              <span
+                aria-disabled="true"
+                class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-disabled MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1inluhi-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+                tabindex="-1"
+              >
+                <input
+                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  disabled=""
+                  type="radio"
+                  value=""
+                />
+                <span
+                  class="css-19y5vkv-MuiRadioButtonIcon-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-q6smfc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonUncheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-145qo40-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonCheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+              >
+                <div
+                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                >
+                  <div
+                    class="MuiBox-root css-axw7ok"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                    >
+                      Revision 4
+                    </p>
+                    <div
+                      class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-outlinedPrimary css-t4xq4n-MuiChip-root"
+                    >
+                      <span
+                        class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+                      >
+                        Current
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                    >
+                      <p
+                        aria-label="2023-01-04T11:00:00.000Z"
+                        class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        90d
+                      </p>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1imddaz-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-13o7eu2"
+                      >
+                        registry.k8s.io/nginx:1.25.4
+                      </span>
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-et6oqk-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall Mui-checked MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1inluhi-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+              >
+                <input
+                  checked=""
+                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  type="radio"
+                  value=""
+                />
+                <span
+                  class="css-19y5vkv-MuiRadioButtonIcon-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-q6smfc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonUncheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-majg0n-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonCheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+              >
+                <div
+                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                >
+                  <div
+                    class="MuiBox-root css-axw7ok"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                    >
+                      Revision 3
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                    >
+                      <p
+                        aria-label="2023-01-03T09:30:00.000Z"
+                        class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        90d
+                      </p>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1imddaz-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-13o7eu2"
+                      >
+                        registry.k8s.io/nginx:1.25.3
+                      </span>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-jvjlif-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1inluhi-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+              >
+                <input
+                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  type="radio"
+                  value=""
+                />
+                <span
+                  class="css-19y5vkv-MuiRadioButtonIcon-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-q6smfc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonUncheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-145qo40-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonCheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+              >
+                <div
+                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                >
+                  <div
+                    class="MuiBox-root css-axw7ok"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                    >
+                      Revision 2
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                    >
+                      <p
+                        aria-label="2023-01-02T14:10:00.000Z"
+                        class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        90d
+                      </p>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1imddaz-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-13o7eu2"
+                      >
+                        registry.k8s.io/nginx:1.25.2
+                      </span>
+                      <span
+                        class="MuiBox-root css-13o7eu2"
+                      >
+                        registry.k8s.io/sidecar:0.4.0
+                      </span>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-jvjlif-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall MuiRadio-root MuiRadio-colorPrimary MuiRadio-sizeSmall css-1inluhi-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+              >
+                <input
+                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  type="radio"
+                  value=""
+                />
+                <span
+                  class="css-19y5vkv-MuiRadioButtonIcon-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-q6smfc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonUncheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-145qo40-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                    data-testid="RadioButtonCheckedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </span>
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+              >
+                <div
+                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                >
+                  <div
+                    class="MuiBox-root css-axw7ok"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                    >
+                      Revision 1
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                    >
+                      <p
+                        aria-label="2023-01-01T08:00:00.000Z"
+                        class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        90d
+                      </p>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1imddaz-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiBox-root css-13o7eu2"
+                      >
+                        registry.k8s.io/nginx:1.25.1
+                      </span>
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </ul>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            aria-label="cancel-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="preview-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Preview
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-label="confirm-button"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Rollback
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.WithRevisions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/RollbackDialog.WithRevisions.stories.storyshot
@@ -1,0 +1,346 @@
+<body>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+    role="presentation"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-testid="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+      role="presentation"
+      style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby=":mock-test-id:"
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthMd MuiDialog-paperFullWidth css-1uqdd3t-MuiPaper-root-MuiDialog-paper"
+        role="dialog"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-8yphvn-MuiTypography-root-MuiDialogTitle-root"
+          id=":mock-test-id:"
+        >
+          Rollback Deployment
+        </h2>
+        <div
+          class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-i6y5kq-MuiTypography-root"
+          >
+            Select a revision to rollback "nginx-deployment" to. This will replace the current pod template with the one from the selected revision.
+          </p>
+          <ul
+            aria-label="Revision History"
+            class="MuiList-root MuiList-padding css-1tmg5zb-MuiList-root"
+            role="radiogroup"
+          >
+            <li
+              class="MuiListItem-root MuiListItem-gutters css-x18396-MuiListItem-root"
+              role="none"
+            >
+              <div
+                aria-checked="false"
+                aria-disabled="true"
+                class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-disabled Mui-disabled MuiListItemButton-root MuiListItemButton-gutters Mui-disabled css-3hi4xs-MuiButtonBase-root-MuiListItemButton-root"
+                role="radio"
+                tabindex="-1"
+              >
+                <div
+                  class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-axw7ok"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                      >
+                        Revision 4
+                      </p>
+                      <div
+                        class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorPrimary MuiChip-outlinedPrimary css-t4xq4n-MuiChip-root"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+                        >
+                          Current
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <p
+                          aria-label="2023-01-04T11:00:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </div>
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <div
+                          class="MuiBox-root css-13o7eu2"
+                        >
+                          registry.k8s.io/nginx:1.25.4
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li
+              class="MuiListItem-root MuiListItem-gutters css-x18396-MuiListItem-root"
+              role="none"
+            >
+              <div
+                aria-checked="true"
+                class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-4ohgg6-MuiButtonBase-root-MuiListItemButton-root"
+                role="radio"
+                tabindex="0"
+              >
+                <div
+                  class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-axw7ok"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                      >
+                        Revision 3
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <p
+                          aria-label="2023-01-03T09:30:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </div>
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <div
+                          class="MuiBox-root css-13o7eu2"
+                        >
+                          registry.k8s.io/nginx:1.25.3
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </div>
+            </li>
+            <li
+              class="MuiListItem-root MuiListItem-gutters css-x18396-MuiListItem-root"
+              role="none"
+            >
+              <div
+                aria-checked="false"
+                class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-3hi4xs-MuiButtonBase-root-MuiListItemButton-root"
+                role="radio"
+                tabindex="-1"
+              >
+                <div
+                  class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-axw7ok"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                      >
+                        Revision 2
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <p
+                          aria-label="2023-01-02T14:10:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </div>
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <div
+                          class="MuiBox-root css-13o7eu2"
+                        >
+                          registry.k8s.io/nginx:1.25.2
+                        </div>
+                        <div
+                          class="MuiBox-root css-13o7eu2"
+                        >
+                          registry.k8s.io/sidecar:0.4.0
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </div>
+            </li>
+            <li
+              class="MuiListItem-root MuiListItem-gutters css-x18396-MuiListItem-root"
+              role="none"
+            >
+              <div
+                aria-checked="false"
+                class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-3hi4xs-MuiButtonBase-root-MuiListItemButton-root"
+                role="radio"
+                tabindex="-1"
+              >
+                <div
+                  class="MuiListItemText-root MuiListItemText-multiline css-konndc-MuiListItemText-root"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-axw7ok"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-18k2gby-MuiTypography-root"
+                      >
+                        Revision 1
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiTypography-root MuiTypography-body2 MuiListItemText-secondary css-pglae5-MuiTypography-root"
+                  >
+                    <div
+                      class="MuiBox-root css-0"
+                    >
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <p
+                          aria-label="2023-01-01T08:00:00.000Z"
+                          class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                          data-mui-internal-clone-element="true"
+                        >
+                          90d
+                        </p>
+                      </div>
+                      <div
+                        class="MuiTypography-root MuiTypography-caption css-70yeff-MuiTypography-root"
+                      >
+                        <div
+                          class="MuiBox-root css-13o7eu2"
+                        >
+                          registry.k8s.io/nginx:1.25.1
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div
+          class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSecondary MuiButton-disableElevation css-14f6w6s-MuiButtonBase-root-MuiButton-root"
+            data-testid="cancel-button"
+            tabindex="0"
+            type="button"
+          >
+            Cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1ftyvt9-MuiButtonBase-root-MuiButton-root"
+            data-testid="preview-button"
+            tabindex="0"
+            type="button"
+          >
+            Preview
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gn8fa3-MuiButtonBase-root-MuiButton-root"
+            data-testid="confirm-button"
+            tabindex="0"
+            type="button"
+          >
+            Rollback
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-testid="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>


### PR DESCRIPTION
## Summary

This PR adds Storybook stories for five `common/Resource/` components that previously had no coverage, and fixes a small DOM nesting issue surfaced while writing them.

## Related Issue

Fixes #5958

## Changes

- Added stories for `CircularChart`, `A8RInfo`, `RevisionHistorySection` and `RollbackDialog`
- Added `RollbackDialog` interaction stories (`play`) for the dry-run preview success and failure paths
- Fixed invalid DOM nesting in `RollbackDialog`, which the new story surfaced, and reworked the revision picker it sits in (see below)

## Steps to Test

1. Run `npm run storybook` in `frontend/`
2. Open `Resource/CircularChart`, `Resource/A8RInfo`, `Resource/RevisionHistorySection` and `Resource/RollbackDialog`
3. Check each story variant renders correctly (loading, empty, error and edge cases)
4. Run `npx vitest run src/storybook.test.tsx` to confirm the snapshot tests pass

## Screenshots (if applicable)


## The RollbackDialog change, and why it grew

The story surfaced a `validateDOMNesting` warning, and fixing it properly turned out to require more than the two lines this description originally claimed. Recording the reasoning here rather than leaving it implicit in the diff.

**The nesting.** `ListItemText` renders its `primary` and `secondary` slots as `<p>` by default, and `DateLabel` renders a `<p>` too, so the tree was `<p><p>`. Switching only the inner wrappers to `<span>` would have replaced it with `<span><span><p>`, which is equally invalid — a `<p>` cannot be a descendant of a phrasing-content element. Both slots are now `component: 'div'` and the two wrappers inside `secondary` are block elements, so the chain is `<div><div><div><p>`.

**The revision picker.** The list rendered an MUI `Radio` inside a `ListItemButton`. That is a control inside a control, and the axe gate flags it: reverting to it reproduces three violations on `With revisions` and `Preview (dry-run) fails` — `nested-interactive`, `label` (the radio has no accessible name of its own) and `list` (`List` containing `ListItemButton` directly). So the radio could not simply stay.

The picker is now a real radio group: `List` carries `role="radiogroup"` with a label, each revision is a `ListItem role="none"` wrapping a `ListItemButton role="radio"` with `aria-checked`, and the radio glyph is a decorative `aria-hidden` icon rather than a second focusable control. Keyboard behaviour follows the APG radio-group pattern — a single tab stop (the checked option, or the first selectable one when nothing is checked) with Arrow keys moving the selection, so users tab past the group instead of through every revision.

`npm run test:a11y` reports 0 new violations with this in place.

## Notes for the Reviewer

- The two `RollbackDialog` `play` stories use `storyshots: { disable: true }`, matching the existing interaction story pattern (for example `ResourceTableMultiActions`), so they run in the browser test-storybook runner rather than the snapshot suite


