### PR TITLE
backend: Add unit test for marshalToString in auth package

### DIFF
--- a/backend/pkg/auth/marshal_test.go
+++ b/backend/pkg/auth/marshal_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage // tests cover unexported marshalToString helper.
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+		ok       bool
+	}{
+		{
+			name:     "valid map",
+			input:    map[string]string{"foo": "bar"},
+			expected: `{"foo":"bar"}`,
+			ok:       true,
+		},
+		{
+			name:     "valid string",
+			input:    "hello",
+			expected: `"hello"`,
+			ok:       true,
+		},
+		{
+			name:     "invalid non-marshalable type",
+			input:    make(chan int), // channels cannot be marshaled
+			expected: "",
+			ok:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := marshalToString(tt.input)
+			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}


### PR DESCRIPTION
**Summary:** Adds a unit test to verify the `marshalToString` helper function.
**Issue** #5969 
**Changes:**
- Created `backend/pkg/auth/marshal_test.go`
- Added tests for valid maps, strings, and invalid types (e.g. channels) to ensure proper error logging and return values.
**Steps to Test:**
1. Run `npm run backend:test`

**Screenshots**
<img width="1033" height="342" alt="image" src="https://github.com/user-attachments/assets/3e73b934-1f30-426f-8698-db9c8fb834fe" />
