### PR TITLE
frontend: add 100 to table rows-per-page options

### DIFF
--- a/frontend/src/components/common/SimpleTable.stories.tsx
+++ b/frontend/src/components/common/SimpleTable.stories.tsx
@@ -55,7 +55,7 @@ const Template: StoryFn<SimpleTableProps> = args => (
 );
 
 const fixtureData = {
-  rowsPerPage: [15, 25, 50],
+  rowsPerPage: [15, 25, 50, 100],
   errorMessage: null,
   columns: [
     {
@@ -283,7 +283,7 @@ const TemplateWithFilter: StoryFn<{
 };
 
 const podData = {
-  rowsPerPage: [15, 25, 50],
+  rowsPerPage: [15, 25, 50, 100],
   errorMessage: null,
   columns: [
     {

--- a/frontend/src/components/common/Table/Table.stories.tsx
+++ b/frontend/src/components/common/Table/Table.stories.tsx
@@ -61,7 +61,7 @@ const Template: StoryFn<TableProps<any>> = args => (
 );
 
 const fixtureData = {
-  rowsPerPage: [15, 25, 50],
+  rowsPerPage: [15, 25, 50, 100],
   errorMessage: null,
   columns: [
     {
@@ -291,7 +291,7 @@ const TemplateWithFilter: StoryFn<{
 };
 
 const podData: TableProps<any> = {
-  rowsPerPage: [15, 25, 50],
+  rowsPerPage: [15, 25, 50, 100],
   errorMessage: null,
   columns: [
     {

--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -111,7 +111,7 @@ export type TableProps<RowItem extends Record<string, any>> = Omit<
   initialPage?: number;
   /**
    * List of options for the rows per page selector
-   * @example [15, 25, 50]
+   * @example [15, 25, 50, 100]
    */
   rowsPerPage?: number[];
   /**

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -82,7 +82,7 @@ export interface ConfigState {
   };
 }
 
-export const defaultTableRowsPerPageOptions = [15, 25, 50];
+export const defaultTableRowsPerPageOptions = [15, 25, 50, 100];
 
 function defaultTimezone() {
   return import.meta.env.UNDER_TEST ? 'UTC' : Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
## What

Adds `100` to the default `rowsPerPage` options for resource tables. The options are now `15 / 25 / 50 / 100` (previously `15 / 25 / 50`).

The change is purely additive: existing values are untouched, the default page size is unchanged, and no existing user preferences are invalidated.

## Why

Namespaces with more than 50 resources force multiple paginations at the current max of 50. A 100-row option lets an operator view a full namespace at a glance.

100 is deliberately the ceiling rather than a higher value or "All":
- Headlamp tables currently render client-side without virtualization, so a much higher limit risks UI jank on large clusters.
- 100 matches the conventional `10 / 25 / 50 / 100` ladder used across the MUI ecosystem the project is built on.

## Changes

- `frontend/src/redux/configSlice.ts` — `defaultTableRowsPerPageOptions` updated (single source of truth; all tables and the Settings rows-per-page dropdown pick it up automatically)
- `frontend/src/components/common/Table/Table.tsx` — `@example` JSDoc updated
- `frontend/src/components/common/Table/Table.stories.tsx` — story fixture data updated
- `frontend/src/components/common/SimpleTable.stories.tsx` — story fixture data updated

## Testing

- `npm run lint` — clean
- `npm run tsc` — clean
- `npm test --run` — 1624/1626 pass (2 pre-existing flaky timeouts unrelated to this change)

Fixes #5967