### PR TITLE
support oidc logout

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -291,13 +291,7 @@ func baseURLReplace(staticDir string, baseURL string) {
 	mustWriteFile(index, output)
 }
 
-func getOidcCallbackURL(r *http.Request, config *HeadlampConfig) string {
-	// If callback URL is configured, use it
-	if config.OidcCallbackURL != "" {
-		return config.OidcCallbackURL
-	}
-
-	// Otherwise, generate callback URL dynamically
+func getUrlScheme(r *http.Request) string {
 	urlScheme := r.URL.Scheme
 	if urlScheme == "" {
 		// check proxy headers first
@@ -312,6 +306,18 @@ func getOidcCallbackURL(r *http.Request, config *HeadlampConfig) string {
 			urlScheme = "https"
 		}
 	}
+
+	return urlScheme
+}
+
+func getOidcCallbackURL(r *http.Request, config *HeadlampConfig) string {
+	// If callback URL is configured, use it
+	if config.OidcCallbackURL != "" {
+		return config.OidcCallbackURL
+	}
+
+	// Otherwise, generate callback URL dynamically
+	urlScheme := getUrlScheme(r)
 
 	// Clean up + add the base URL to the redirect URL
 	hostWithBaseURL := strings.Trim(r.Host, "/")
@@ -711,6 +717,143 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			ProxyAuthEmailHeader:    config.ProxyAuthEmailHeader,
 		}),
 	).Methods("GET")
+
+	r.HandleFunc("/clusters/{clusterName}/oidc-logout", func(w http.ResponseWriter, r *http.Request) {
+		cluster := mux.Vars(r)["clusterName"]
+
+		if cluster == "" {
+			http.Error(w, "Cluster name is required", http.StatusBadRequest)
+			return
+		}
+
+		if config.OidcSkipLogout {
+			logger.Log(logger.LevelInfo, map[string]string{logFieldCluster: cluster},
+				nil, "oidc-logout: disabled, clearing cookie and redirecting")
+			auth.ClearTokenCookie(w, r, cluster, config.BaseURL)
+			auth.ClearIDTokenCookie(w, r, cluster, config.BaseURL)
+			baseURL := strings.TrimRight(config.BaseURL, "/")
+			http.Redirect(w, r, fmt.Sprintf("%s/c/%s/login", baseURL, url.PathEscape(cluster)), http.StatusFound)
+
+			return
+		}
+
+		kContext, err := config.KubeConfigStore.GetContext(cluster)
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{logFieldCluster: cluster},
+				err, "failed to get context for oidc logout")
+			http.NotFound(w, r)
+
+			return
+		}
+
+		oidcAuthConfig, err := kContext.OidcConfig()
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{logFieldCluster: cluster},
+				err, "failed to get oidc config for logout")
+			http.Error(w, "Failed to get OIDC config for logout", http.StatusInternalServerError)
+
+			return
+		}
+
+		ctx := r.Context()
+
+		if config.Insecure {
+			baseTransport, ok := http.DefaultTransport.(*http.Transport)
+			if ok {
+				tr := baseTransport.Clone()
+
+				tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+				if baseTransport.TLSClientConfig != nil {
+					tlsCfg = baseTransport.TLSClientConfig.Clone()
+					tlsCfg.InsecureSkipVerify = true
+				}
+
+				tr.TLSClientConfig = tlsCfg
+				InsecureClient := &http.Client{Transport: tr}
+				ctx = oidc.ClientContext(ctx, InsecureClient)
+			}
+		}
+
+		ctx = auth.ConfigureTLSContext(ctx, oidcAuthConfig.SkipTLSVerify, oidcAuthConfig.CACert)
+
+		provider, err := oidc.NewProvider(ctx, oidcAuthConfig.IdpIssuerURL)
+		if err != nil {
+			logger.Log(logger.LevelError,
+				map[string]string{logFieldCluster: cluster, "idpIssuerURL": oidcAuthConfig.IdpIssuerURL},
+				err, "failed to get provider for logout")
+			auth.ClearTokenCookie(w, r, cluster, config.BaseURL)
+			auth.ClearIDTokenCookie(w, r, cluster, config.BaseURL)
+			http.Redirect(w, r, strings.TrimRight(config.BaseURL, "/")+"/", http.StatusFound)
+
+			return
+		}
+
+		var providerClaims struct {
+			EndSessionEndpoint string `json:"end_session_endpoint"`
+		}
+
+		if err := provider.Claims(&providerClaims); err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to get provider claims")
+			auth.ClearTokenCookie(w, r, cluster, config.BaseURL)
+			auth.ClearIDTokenCookie(w, r, cluster, config.BaseURL)
+			http.Redirect(w, r, strings.TrimRight(config.BaseURL, "/")+"/", http.StatusFound)
+
+			return
+		}
+
+		idToken, idTokenErr := auth.GetIDTokenFromCookie(r, cluster)
+		if idTokenErr != nil && !errors.Is(idTokenErr, http.ErrNoCookie) {
+			logger.Log(logger.LevelError, nil, idTokenErr, "failed to get ID token from cookie")
+		} else if errors.Is(idTokenErr, http.ErrNoCookie) {
+			logger.Log(logger.LevelWarn,
+				map[string]string{logFieldCluster: cluster}, nil, "oidc-logout: no ID token cookie found")
+		}
+
+		auth.ClearTokenCookie(w, r, cluster, config.BaseURL)
+		auth.ClearIDTokenCookie(w, r, cluster, config.BaseURL)
+
+		if providerClaims.EndSessionEndpoint == "" {
+			logger.Log(logger.LevelWarn, map[string]string{logFieldCluster: cluster},
+				nil, "oidc-logout: no end_session_endpoint found, redirecting to home")
+			http.Redirect(w, r, strings.TrimRight(config.BaseURL, "/")+"/", http.StatusFound)
+
+			return
+		}
+
+		urlScheme := getUrlScheme(r)
+
+		hostWithBaseURL := strings.Trim(r.Host, "/")
+
+		baseURL := strings.Trim(config.BaseURL, "/")
+		if baseURL != "" {
+			hostWithBaseURL = hostWithBaseURL + "/" + baseURL
+		}
+
+		postLogoutRedirectURI := fmt.Sprintf("%s://%s/c/%s/login", urlScheme, hostWithBaseURL, url.PathEscape(cluster))
+
+		logoutURL, err := url.Parse(providerClaims.EndSessionEndpoint)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to parse end_session_endpoint")
+			http.Redirect(w, r, strings.TrimRight(config.BaseURL, "/")+"/", http.StatusFound)
+
+			return
+		}
+
+		query := logoutURL.Query()
+		query.Set("post_logout_redirect_uri", postLogoutRedirectURI)
+
+		if idToken == "" {
+			logger.Log(logger.LevelWarn, map[string]string{
+				logFieldCluster: cluster,
+			}, nil, "oidc-logout: no id_token_hint available")
+		} else {
+			query.Set("id_token_hint", idToken)
+		}
+
+		logoutURL.RawQuery = query.Encode()
+
+		http.Redirect(w, r, logoutURL.String(), http.StatusFound)
+	}).Methods("GET")
 
 	config.handleClusterRequests(r)
 
@@ -1118,6 +1261,39 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		// Set auth cookie
 		auth.SetTokenCookie(w, r, oauthConfig.Cluster, rawUserToken, config.BaseURL, config.SessionTTL)
+
+		// Also save the ID token in a separate cookie for OIDC logout (id_token_hint)
+		// Try to get id_token from oauth2 token extras first
+		rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+		logger.Log(logger.LevelInfo, map[string]string{
+			logFieldCluster:   oauthConfig.Cluster,
+			"idTokenExtraOk":  fmt.Sprintf("%v", ok),
+			"tokenType":       tokenType,
+			"rawUserTokenLen": fmt.Sprintf("%d", len(rawUserToken)),
+		}, nil, "oidc-callback: attempting to save ID token cookie")
+
+		if !ok || rawIDToken == "" {
+			// Fallback: if tokenType is id_token, rawUserToken itself is the ID token
+			if tokenType == "id_token" {
+				rawIDToken = rawUserToken
+
+				logger.Log(logger.LevelInfo, map[string]string{
+					logFieldCluster: oauthConfig.Cluster,
+				}, nil, "oidc-callback: using rawUserToken as ID token fallback")
+			}
+		}
+
+		if rawIDToken != "" {
+			auth.SetIDTokenCookie(w, r, oauthConfig.Cluster, rawIDToken, config.BaseURL, config.SessionTTL)
+			logger.Log(logger.LevelInfo, map[string]string{
+				logFieldCluster: oauthConfig.Cluster,
+				"rawIDTokenLen": fmt.Sprintf("%d", len(rawIDToken)),
+			}, nil, "oidc-callback: ID token cookie saved")
+		} else {
+			logger.Log(logger.LevelWarn, map[string]string{
+				logFieldCluster: oauthConfig.Cluster,
+			}, nil, "oidc-callback: no ID token available to save")
+		}
 
 		redirectURL += fmt.Sprintf("auth?cluster=%1s", oauthConfig.Cluster)
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3999,3 +3999,218 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func TestOIDCLogoutEndpoint(t *testing.T) {
+	setupTestEnv(t)
+
+	testCluster := "test-cluster"
+
+	tests := getOIDCLogoutTestCases(t, testCluster)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := runOIDCLogoutTest(t, testCluster, tc)
+			assertOIDCLogoutResponse(t, rr, tc, testCluster)
+		})
+	}
+}
+
+func setupTestEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("APPDATA", t.TempDir())
+}
+
+func getOIDCLogoutTestCases(t *testing.T, testCluster string) []oidcLogoutTestCase {
+	return []oidcLogoutTestCase{
+		{
+			name:                       "OidcSkipLogout=true clears cookies and redirects to login",
+			oidcSkipLogout:             true,
+			setIDTokenCookie:           true,
+			expectedStatusCode:         http.StatusFound,
+			expectedRedirectContains:   "/c/" + testCluster + "/login",
+			expectTokenCookieCleared:   true,
+			expectIDTokenCookieCleared: true,
+		},
+		{
+			name: "provider discovery failure clears cookies and redirects to home",
+			setupOIDCProvider: func(t *testing.T) string {
+				return "http://invalid-provider.example.com"
+			},
+			setIDTokenCookie:           true,
+			expectedStatusCode:         http.StatusFound,
+			expectedRedirectContains:   "/",
+			expectTokenCookieCleared:   true,
+			expectIDTokenCookieCleared: true,
+		},
+		{
+			name:                       "missing end_session_endpoint clears cookies",
+			setupOIDCProvider:          setupOIDCProviderWithoutEndSessionEndpoint(t),
+			setIDTokenCookie:           true,
+			expectedStatusCode:         http.StatusFound,
+			expectedRedirectContains:   "/",
+			expectTokenCookieCleared:   true,
+			expectIDTokenCookieCleared: true,
+		},
+		{
+			name:                       "successful logout with id_token_hint",
+			setupOIDCProvider:          setupOIDCProviderWithEndSessionEndpoint(t),
+			setIDTokenCookie:           true,
+			expectedStatusCode:         http.StatusFound,
+			expectedRedirectContains:   "/logout",
+			expectTokenCookieCleared:   true,
+			expectIDTokenCookieCleared: true,
+		},
+		{
+			name:                       "successful logout without id_token_hint",
+			setupOIDCProvider:          setupOIDCProviderWithEndSessionEndpoint(t),
+			setIDTokenCookie:           false,
+			expectedStatusCode:         http.StatusFound,
+			expectedRedirectContains:   "/logout",
+			expectTokenCookieCleared:   false,
+			expectIDTokenCookieCleared: false,
+		},
+	}
+}
+
+type oidcLogoutTestCase struct {
+	name                       string
+	oidcSkipLogout             bool
+	setupOIDCProvider          func(t *testing.T) string
+	setIDTokenCookie           bool
+	expectedStatusCode         int
+	expectedRedirectContains   string
+	expectTokenCookieCleared   bool
+	expectIDTokenCookieCleared bool
+}
+
+func setupOIDCProviderWithEndSessionEndpoint(t *testing.T) func(t *testing.T) string {
+	return func(t *testing.T) string {
+		providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/.well-known/openid-configuration" {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"issuer":                 "http://" + r.Host,
+					"authorization_endpoint": "http://" + r.Host + "/auth",
+					"token_endpoint":         "http://" + r.Host + "/token",
+					"end_session_endpoint":   "http://" + r.Host + "/logout",
+				})
+
+				return
+			}
+
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(providerServer.Close)
+
+		return providerServer.URL
+	}
+}
+
+func setupOIDCProviderWithoutEndSessionEndpoint(t *testing.T) func(t *testing.T) string {
+	return func(t *testing.T) string {
+		providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/.well-known/openid-configuration" {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"issuer":                 "http://" + r.Host,
+					"authorization_endpoint": "http://" + r.Host + "/auth",
+					"token_endpoint":         "http://" + r.Host + "/token",
+				})
+
+				return
+			}
+
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(providerServer.Close)
+
+		return providerServer.URL
+	}
+}
+
+func runOIDCLogoutTest(t *testing.T, cluster string, tc oidcLogoutTestCase) *httptest.ResponseRecorder {
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	var issuerURL string
+	if tc.setupOIDCProvider != nil {
+		issuerURL = tc.setupOIDCProvider(t)
+	}
+
+	cfg := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeConfigStore,
+			},
+			OidcSkipLogout:   tc.oidcSkipLogout,
+			Cache:            cache.New[interface{}](),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	if issuerURL != "" {
+		err := kubeConfigStore.AddContext(&kubeconfig.Context{
+			Name: cluster,
+			OidcConf: &kubeconfig.OidcConfig{
+				ClientID:     "test-client",
+				ClientSecret: "test-secret",
+				IdpIssuerURL: issuerURL,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	handler := createHeadlampHandler(context.Background(), cfg)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/clusters/"+url.PathEscape(cluster)+"/oidc-logout", nil)
+	require.NoError(t, err)
+
+	if tc.setIDTokenCookie {
+		//nolint:gosec
+		req.AddCookie(&http.Cookie{
+			Name:  "headlamp-id-token-" + cluster + ".0",
+			Value: "test-id-token",
+			Path:  "/clusters/" + cluster,
+		})
+		//nolint:gosec
+		req.AddCookie(&http.Cookie{
+			Name:  "headlamp-auth-" + cluster + ".0",
+			Value: "test-auth-token",
+			Path:  "/clusters/" + cluster,
+		})
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	return rr
+}
+
+func assertOIDCLogoutResponse(t *testing.T, rr *httptest.ResponseRecorder, tc oidcLogoutTestCase, cluster string) {
+	assert.Equal(t, tc.expectedStatusCode, rr.Code, "Unexpected status code")
+	assert.Contains(t, rr.Header().Get("Location"), tc.expectedRedirectContains,
+		"Unexpected redirect location")
+
+	if tc.expectTokenCookieCleared {
+		assertCookieCleared(t, rr, "headlamp-auth-"+cluster)
+	}
+
+	if tc.expectIDTokenCookieCleared {
+		assertCookieCleared(t, rr, "headlamp-id-token-"+cluster)
+	}
+}
+
+func assertCookieCleared(t *testing.T, rr *httptest.ResponseRecorder, cookiePrefix string) {
+	var foundCookie bool
+
+	for _, cookie := range rr.Result().Cookies() {
+		if strings.HasPrefix(cookie.Name, cookiePrefix) {
+			assert.Equal(t, "", cookie.Value, "Cookie should be cleared")
+			assert.Equal(t, -1, cookie.MaxAge, "Cookie MaxAge should be -1")
+
+			foundCookie = true
+		}
+	}
+
+	assert.True(t, foundCookie, "Expected cookie with prefix %q to be cleared", cookiePrefix)
+}

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -212,6 +212,7 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		OidcValidatorIdpIssuerURL: conf.OidcValidatorIdpIssuerURL,
 		OidcScopes:                strings.Split(conf.OidcScopes, ","),
 		OidcSkipTLSVerify:         conf.OidcSkipTLSVerify,
+		OidcSkipLogout:            conf.OidcSkipLogout,
 		OidcUseAccessToken:        conf.OidcUseAccessToken,
 		OidcUsePKCE:               conf.OidcUsePKCE,
 		MeUsernamePaths:           conf.MeUsernamePath,

--- a/backend/pkg/auth/auth_test.go
+++ b/backend/pkg/auth/auth_test.go
@@ -825,6 +825,7 @@ func TestRefreshAndCacheNewToken_Success(t *testing.T) {
 
 	fc := &fakeCache{store: map[string]interface{}{oldKey: "REFRESH_OLD"}}
 	srv := newOIDCProviderServer(t, "", func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1024*1024)
 		require.NoError(t, r.ParseForm())
 		require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
 		require.Equal(t, "REFRESH_OLD", r.PostForm.Get("refresh_token"))
@@ -862,6 +863,7 @@ func TestRefreshAndCacheNewToken_ValidatorIssuerOverride(t *testing.T) {
 
 	fc := &fakeCache{store: map[string]interface{}{oldKey: refreshToken}}
 	srv := newOIDCProviderServer(t, issuerURL, func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1024*1024)
 		require.NoError(t, r.ParseForm())
 		require.Equal(t, "refresh_token", r.PostForm.Get("grant_type"))
 		require.Equal(t, refreshToken, r.PostForm.Get("refresh_token"))

--- a/backend/pkg/auth/cookies.go
+++ b/backend/pkg/auth/cookies.go
@@ -170,6 +170,123 @@ func ClearTokenCookie(w http.ResponseWriter, r *http.Request, cluster, baseURL s
 	}
 }
 
+// SetIDTokenCookie sets an ID token cookie for a specific cluster.
+// This is used for OIDC RP-initiated logout (id_token_hint parameter).
+// The cookie path is set to the cluster path ("/clusters/{clusterName}" or e.g. "/headlamp/clusters/{clusterName}"),
+// so it's available on the /clusters/{clusterName}/oidc-logout endpoint.
+// Large ID tokens are split into chunks to avoid exceeding per-cookie size limits (~4KB).
+func SetIDTokenCookie(w http.ResponseWriter, r *http.Request, cluster, idToken, baseURL string, sessionTTL int) {
+	if cluster == "" || idToken == "" {
+		return
+	}
+
+	sanitizedCluster := SanitizeClusterName(cluster)
+	if sanitizedCluster == "" {
+		return
+	}
+
+	secure := IsSecureContext(r)
+
+	cookiePath := GetCookiePath(baseURL, cluster)
+
+	// Split large ID tokens into chunks to avoid exceeding cookie size limits
+	chunks := splitToken(idToken, chunkSize)
+	for i, chunk := range chunks {
+		// G124: Secure is set from IsSecureContext so localhost development still works;
+		// HttpOnly and SameSite are set unconditionally.
+		cookie := &http.Cookie{ //nolint:gosec
+			Name:     fmt.Sprintf("headlamp-id-token-%s.%d", sanitizedCluster, i),
+			Value:    chunk,
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteStrictMode,
+			Path:     cookiePath,
+			MaxAge:   sessionTTL,
+		}
+
+		http.SetCookie(w, cookie)
+	}
+
+	// Clear the first cookie after the last chunk index so GetIDTokenFromCookie
+	// won't append stale higher-index chunks from a previous login.
+	// G124: Secure is set from IsSecureContext so localhost development still works;
+	// HttpOnly and SameSite are set unconditionally.
+	cleanupCookie := &http.Cookie{ //nolint:gosec
+		Name:     fmt.Sprintf("headlamp-id-token-%s.%d", sanitizedCluster, len(chunks)),
+		Value:    "",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteStrictMode,
+		Path:     cookiePath,
+		MaxAge:   -1,
+	}
+	http.SetCookie(w, cleanupCookie)
+}
+
+// GetIDTokenFromCookie retrieves the ID token cookie for a specific cluster.
+// Supports chunked cookies for large ID tokens.
+func GetIDTokenFromCookie(r *http.Request, cluster string) (string, error) {
+	sanitizedCluster := SanitizeClusterName(cluster)
+	if sanitizedCluster == "" {
+		return "", errors.New("invalid cluster name")
+	}
+
+	// Check for chunked cookies
+	var idToken strings.Builder
+
+	for i := 0; ; i++ {
+		cookie, err := r.Cookie(fmt.Sprintf("headlamp-id-token-%s.%d", sanitizedCluster, i))
+		if err != nil {
+			break
+		}
+
+		idToken.WriteString(cookie.Value)
+	}
+
+	if idToken.Len() > 0 {
+		return idToken.String(), nil
+	}
+
+	return "", http.ErrNoCookie
+}
+
+// ClearIDTokenCookie clears the ID token cookie for a specific cluster.
+// Supports chunked cookies for large ID tokens.
+func ClearIDTokenCookie(w http.ResponseWriter, r *http.Request, cluster, baseURL string) {
+	sanitizedCluster := SanitizeClusterName(cluster)
+	if sanitizedCluster == "" {
+		return
+	}
+
+	secure := IsSecureContext(r)
+
+	cookiePath := GetCookiePath(baseURL, cluster)
+
+	// Clear chunked cookies
+	for i := 0; ; i++ {
+		cookieName := fmt.Sprintf("headlamp-id-token-%s.%d", sanitizedCluster, i)
+
+		_, err := r.Cookie(cookieName)
+		if err != nil {
+			// No more cookies for this cluster
+			break
+		}
+
+		// G124: Secure is set from IsSecureContext so localhost development still works;
+		// HttpOnly and SameSite are set unconditionally.
+		cookie := &http.Cookie{ //nolint:gosec
+			Name:     cookieName,
+			Value:    "",
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteStrictMode,
+			Path:     cookiePath,
+			MaxAge:   -1,
+		}
+		http.SetCookie(w, cookie)
+	}
+}
+
 // splitToken splits a token into chunks of a given size.
 func splitToken(token string, size int) []string {
 	var chunks []string

--- a/backend/pkg/auth/cookies_test.go
+++ b/backend/pkg/auth/cookies_test.go
@@ -294,3 +294,163 @@ func TestClearAuthCookie(t *testing.T) {
 		t.Errorf("Expected MaxAge to be -1, got %d", cookie.MaxAge)
 	}
 }
+
+func TestSetAndGetIDTokenCookie(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), "GET", localhost, nil)
+	req.Host = localhost
+	w := httptest.NewRecorder()
+
+	testTTL := 100
+	auth.SetIDTokenCookie(w, req, "test-cluster", "test-id-token", "", testTTL)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 1 {
+		t.Fatalf("Expected at least 1 cookie, got %d", len(cookies))
+	}
+
+	cookie := cookies[0]
+	if cookie.Name != "headlamp-id-token-test-cluster.0" {
+		t.Errorf("Expected cookie name 'headlamp-id-token-test-cluster.0', got %q", cookie.Name)
+	}
+
+	if cookie.Value != "test-id-token" {
+		t.Errorf("Expected cookie value 'test-id-token', got %q", cookie.Value)
+	}
+
+	if !cookie.HttpOnly {
+		t.Error("Expected HttpOnly to be true")
+	}
+
+	if cookie.MaxAge != testTTL {
+		t.Errorf("Expected MaxAge to be %d, got %d", testTTL, cookie.MaxAge)
+	}
+
+	if cookie.Path != "/clusters/test-cluster" {
+		t.Errorf("Expected cookie path '/clusters/test-cluster', got %q", cookie.Path)
+	}
+
+	req.AddCookie(cookie)
+
+	idToken, err := auth.GetIDTokenFromCookie(req, "test-cluster")
+	if err != nil {
+		t.Fatalf("GetIDTokenFromCookie failed: %v", err)
+	}
+
+	if idToken != "test-id-token" {
+		t.Errorf("Expected ID token 'test-id-token', got %q", idToken)
+	}
+}
+
+func TestGetIDTokenCookieChunked(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	req.Host = localhost
+	w := httptest.NewRecorder()
+
+	longIDToken := strings.Repeat("a", 5000)
+
+	auth.SetIDTokenCookie(w, req, "test-cluster", longIDToken, "", 86400)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) < 2 {
+		t.Fatalf("Expected at least 2 cookies for a chunked ID token, got %d", len(cookies))
+	}
+
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+
+	idToken, err := auth.GetIDTokenFromCookie(req, "test-cluster")
+	if err != nil {
+		t.Fatalf("GetIDTokenFromCookie failed: %v", err)
+	}
+
+	if idToken != longIDToken {
+		t.Errorf("Expected ID token to be %d characters, got %d", len(longIDToken), len(idToken))
+	}
+}
+
+func TestClearIDTokenCookie(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	req.Host = localhost
+	w := httptest.NewRecorder()
+
+	req.AddCookie(&http.Cookie{
+		Name:     "headlamp-id-token-test-cluster.0",
+		Value:    "test-id-token",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/clusters/test-cluster",
+		MaxAge:   86400,
+	})
+
+	auth.ClearIDTokenCookie(w, req, "test-cluster", "")
+
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("Expected 1 cookie, got %d", len(cookies))
+	}
+
+	cookie := cookies[0]
+	if cookie.Name != "headlamp-id-token-test-cluster.0" {
+		t.Errorf("Expected cookie name 'headlamp-id-token-test-cluster.0', got %q", cookie.Name)
+	}
+
+	if cookie.Value != "" {
+		t.Errorf("Expected cookie value to be empty, got %q", cookie.Value)
+	}
+
+	if cookie.MaxAge != -1 {
+		t.Errorf("Expected MaxAge to be -1, got %d", cookie.MaxAge)
+	}
+
+	if cookie.Path != "/clusters/test-cluster" {
+		t.Errorf("Expected cookie path '/clusters/test-cluster', got %q", cookie.Path)
+	}
+}
+
+func TestClearIDTokenCookieChunked(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), "GET", localhostOrigin, nil)
+	req.Host = localhost
+	w := httptest.NewRecorder()
+
+	//nolint:gosec
+	req.AddCookie(&http.Cookie{
+		Name:     "headlamp-id-token-test-cluster.0",
+		Value:    "chunk0",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/clusters/test-cluster",
+		MaxAge:   86400,
+	})
+	//nolint:gosec
+	req.AddCookie(&http.Cookie{
+		Name:     "headlamp-id-token-test-cluster.1",
+		Value:    "chunk1",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/clusters/test-cluster",
+		MaxAge:   86400,
+	})
+
+	auth.ClearIDTokenCookie(w, req, "test-cluster", "")
+
+	cookies := w.Result().Cookies()
+	if len(cookies) != 2 {
+		t.Fatalf("Expected 2 cookies, got %d", len(cookies))
+	}
+
+	for _, cookie := range cookies {
+		if cookie.Value != "" {
+			t.Errorf("Expected cookie value to be empty, got %q", cookie.Value)
+		}
+
+		if cookie.MaxAge != -1 {
+			t.Errorf("Expected MaxAge to be -1, got %d", cookie.MaxAge)
+		}
+
+		if cookie.Path != "/clusters/test-cluster" {
+			t.Errorf("Expected cookie path '/clusters/test-cluster', got %q", cookie.Path)
+		}
+	}
+}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	OidcUseAccessToken           bool   `koanf:"oidc-use-access-token"`
 	OidcUseCookie                bool   `koanf:"oidc-use-cookie"`
 	OidcSkipTLSVerify            bool   `koanf:"oidc-skip-tls-verify"`
+	OidcSkipLogout               bool   `koanf:"oidc-skip-logout"`
 	OidcCAFile                   string `koanf:"oidc-ca-file"`
 	MeUsernamePath               string `koanf:"me-username-path"`
 	MeEmailPath                  string `koanf:"me-email-path"`
@@ -597,6 +598,7 @@ func addOIDCFlags(f *flag.FlagSet) {
 	f.String("oidc-validator-idp-issuer-url", "", "Override Identity provider issuer URL for OIDC during validation")
 	f.String("oidc-scopes", "profile,email", "A comma separated list of scopes needed from the OIDC provider")
 	f.Bool("oidc-skip-tls-verify", false, "Skip TLS verification for OIDC")
+	f.Bool("oidc-skip-logout", false, "Skip logout from OIDC provider")
 	f.String("oidc-ca-file", "", "CA file for OIDC")
 	f.Bool("oidc-use-access-token", false, "Setup oidc to pass through the access_token instead of the default id_token")
 	f.Bool("oidc-use-cookie", false, "Enable OIDC cookie usage even when not running in-cluster")

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -29,6 +29,7 @@ type HeadlampConfig struct {
 	OidcSkipTLSVerify         bool
 	OidcCACert                string
 	OidcUsePKCE               bool
+	OidcSkipLogout            bool
 	OidcScopes                []string
 	Cache                     cache.Cache[interface{}]
 	Multiplexer               WebSocketMultiplexer

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -33,6 +33,7 @@ import React, { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { getAppUrl } from '../../helpers/getAppUrl';
 import { getProductName, getVersion } from '../../helpers/getProductInfo';
 import { logout } from '../../lib/auth';
 import { useCluster, useClustersConf, useSelectedClusters } from '../../lib/k8s';
@@ -118,23 +119,38 @@ export default function TopBar({}: TopBarProps) {
   // The logout callback
   const logoutCallback = useCallback(
     async (clusterToLogout?: string) => {
+      let oidcClusterToRedirect: string | null = null;
+
       if (clusterToLogout) {
-        await logout(clusterToLogout);
+        const isOIDC = await logout(clusterToLogout, true);
+        if (isOIDC) {
+          oidcClusterToRedirect = clusterToLogout;
+        }
       } else {
         if (selectedClusters.length > 0) {
-          await Promise.all(
-            selectedClusters.map(async c => {
-              await logout(c);
-            })
-          );
+          for (const c of selectedClusters) {
+            const isOIDC = await logout(c, true);
+            if (isOIDC && oidcClusterToRedirect === null) {
+              oidcClusterToRedirect = c;
+            }
+          }
         } else if (cluster) {
-          await logout(cluster);
+          const isOIDC = await logout(cluster, true);
+          if (isOIDC) {
+            oidcClusterToRedirect = cluster;
+          }
         }
       }
 
       handleLogoutPathUpdate(clusterToLogout, history.location.pathname, (path: string) =>
         history.push(path)
       );
+
+      if (oidcClusterToRedirect) {
+        window.location.href = `${getAppUrl()}clusters/${encodeURIComponent(
+          oidcClusterToRedirect
+        )}/oidc-logout`;
+      }
     },
     [cluster, selectedClusters, history]
   );
@@ -252,7 +268,7 @@ export const PureTopBar = memo(
   ({
     appBarActions,
     appBarActionsProcessors = [],
-    logout,
+    logout: onLogout,
     cluster,
     selectedClusters,
     clusters,
@@ -334,7 +350,7 @@ export const PureTopBar = memo(
       >
         <MenuItem
           onClick={async () => {
-            await logout();
+            await onLogout();
             handleMenuClose();
           }}
         >

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -16,9 +16,12 @@
 
 import { Base64 } from 'js-base64';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAppUrl } from '../helpers/getAppUrl';
 import store from '../redux/stores/store';
-import { getUserInfo, setToken } from './auth';
+import { deleteTokens, getUserInfo, logout, setToken } from './auth';
 import { backendFetch } from './k8s/api/v2/fetch';
+import { getClusterAuthType } from './k8s/clusterAuthType';
+import { queryClient } from './queryClient';
 
 // Mock the dependencies
 vi.mock('./k8s/api/v2/fetch');
@@ -28,9 +31,20 @@ vi.mock('../redux/stores/store', () => ({
     getState: vi.fn(),
   },
 }));
+vi.mock('./k8s/clusterAuthType');
+vi.mock('../helpers/getAppUrl');
+vi.mock('./queryClient', () => ({
+  queryClient: {
+    removeQueries: vi.fn(),
+    invalidateQueries: vi.fn(),
+  },
+}));
 
 const mockBackendFetch = vi.mocked(backendFetch);
 const mockStore = vi.mocked(store);
+const mockGetClusterAuthType = vi.mocked(getClusterAuthType);
+const mockGetAppUrl = vi.mocked(getAppUrl);
+const mockQueryClient = vi.mocked(queryClient);
 
 describe('auth', () => {
   beforeEach(() => {
@@ -39,6 +53,8 @@ describe('auth', () => {
       ui: { functionsToOverride: {} },
       config: { allClusters: {} },
     } as any);
+    mockGetClusterAuthType.mockReturnValue('');
+    mockGetAppUrl.mockReturnValue('http://localhost:4466/');
   });
 
   describe('setToken', () => {
@@ -161,6 +177,249 @@ describe('auth', () => {
       expect(spy).toHaveBeenCalled();
 
       spy.mockRestore();
+    });
+  });
+
+  describe('logout', () => {
+    it('should redirect to oidc-logout endpoint for OIDC cluster when skipRedirect is false', async () => {
+      const cluster = 'test-cluster';
+      mockGetClusterAuthType.mockReturnValue('oidc');
+
+      const mockResponse: Partial<Response> = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      const mockLocation = { href: '' };
+      vi.stubGlobal('location', mockLocation);
+
+      const result = await logout(cluster);
+
+      expect(result).toBe(false);
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['auth'],
+        exact: false,
+      });
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['clusterMe', cluster],
+        exact: true,
+      });
+      expect(mockBackendFetch).toHaveBeenCalledWith(
+        `/clusters/${cluster}/set-token`,
+        expect.objectContaining({
+          body: JSON.stringify({ token: null }),
+        })
+      );
+      expect(mockLocation.href).toBe(
+        `http://localhost:4466/clusters/${encodeURIComponent(cluster)}/oidc-logout`
+      );
+    });
+
+    it('should return true for OIDC cluster when skipRedirect is true', async () => {
+      const cluster = 'test-cluster';
+      mockGetClusterAuthType.mockReturnValue('oidc');
+
+      const mockResponse: Partial<Response> = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      const mockLocation = { href: '' };
+      vi.stubGlobal('location', mockLocation);
+
+      const result = await logout(cluster, true);
+
+      expect(result).toBe(true);
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['auth'],
+        exact: false,
+      });
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['clusterMe', cluster],
+        exact: true,
+      });
+      expect(mockBackendFetch).toHaveBeenCalledWith(
+        `/clusters/${cluster}/set-token`,
+        expect.objectContaining({
+          body: JSON.stringify({ token: null }),
+        })
+      );
+      expect(mockLocation.href).toBe('');
+    });
+
+    it('should still redirect to oidc-logout when setToken fails for OIDC cluster', async () => {
+      const cluster = 'test-cluster';
+      mockGetClusterAuthType.mockReturnValue('oidc');
+
+      const mockResponse: Partial<Response> = {
+        ok: false,
+        status: 500,
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      const mockLocation = { href: '' };
+      vi.stubGlobal('location', mockLocation);
+
+      const result = await logout(cluster);
+
+      expect(result).toBe(false);
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['auth'],
+        exact: false,
+      });
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['clusterMe', cluster],
+        exact: true,
+      });
+      expect(mockLocation.href).toBe(
+        `http://localhost:4466/clusters/${encodeURIComponent(cluster)}/oidc-logout`
+      );
+    });
+
+    it('should clear token and queries for non-OIDC cluster', async () => {
+      const cluster = 'test-cluster';
+      mockGetClusterAuthType.mockReturnValue('');
+
+      const mockResponse: Partial<Response> = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      const mockLocation = { href: '' };
+      vi.stubGlobal('location', mockLocation);
+
+      const result = await logout(cluster);
+
+      expect(result).toBe(false);
+      expect(mockBackendFetch).toHaveBeenCalledWith(
+        `/clusters/${cluster}/set-token`,
+        expect.objectContaining({
+          body: JSON.stringify({ token: null }),
+        })
+      );
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['auth'],
+        exact: false,
+      });
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['clusterMe', cluster],
+        exact: true,
+      });
+      expect(mockLocation.href).toBe('');
+    });
+  });
+
+  describe('deleteTokens', () => {
+    it('should redirect to oidc-logout when there is one OIDC cluster', async () => {
+      mockStore.getState.mockReturnValue({
+        ui: { functionsToOverride: {} },
+        config: { allClusters: { 'oidc-cluster': {} } },
+      } as any);
+      mockGetClusterAuthType.mockReturnValue('oidc');
+
+      const mockResponse: Partial<Response> = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      const mockLocation = { href: '' };
+      vi.stubGlobal('location', mockLocation);
+
+      await deleteTokens();
+
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['auth'],
+        exact: false,
+      });
+      expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+        queryKey: ['clusterMe', 'oidc-cluster'],
+        exact: true,
+      });
+      expect(mockBackendFetch).toHaveBeenCalledWith(
+        '/clusters/oidc-cluster/set-token',
+        expect.objectContaining({
+          body: JSON.stringify({ token: null }),
+        })
+      );
+      expect(mockLocation.href).toBe(
+        `http://localhost:4466/clusters/${encodeURIComponent('oidc-cluster')}/oidc-logout`
+      );
+    });
+
+    it('should redirect to the OIDC cluster logout when there are mixed clusters', async () => {
+      mockStore.getState.mockReturnValue({
+        ui: { functionsToOverride: {} },
+        config: { allClusters: { 'oidc-cluster': {}, 'non-oidc-cluster': {} } },
+      } as any);
+
+      mockGetClusterAuthType.mockImplementation((cluster: string) => {
+        return cluster === 'oidc-cluster' ? 'oidc' : '';
+      });
+
+      const mockResponse: Partial<Response> = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      const mockLocation = { href: '' };
+      vi.stubGlobal('location', mockLocation);
+
+      await deleteTokens();
+
+      expect(mockBackendFetch).toHaveBeenCalledTimes(2);
+      expect(mockBackendFetch).toHaveBeenCalledWith(
+        '/clusters/oidc-cluster/set-token',
+        expect.objectContaining({
+          body: JSON.stringify({ token: null }),
+        })
+      );
+      expect(mockBackendFetch).toHaveBeenCalledWith(
+        '/clusters/non-oidc-cluster/set-token',
+        expect.objectContaining({
+          body: JSON.stringify({ token: null }),
+        })
+      );
+      expect(mockLocation.href).toBe(
+        `http://localhost:4466/clusters/${encodeURIComponent('oidc-cluster')}/oidc-logout`
+      );
+    });
+
+    it('should not redirect when there are no OIDC clusters', async () => {
+      mockStore.getState.mockReturnValue({
+        ui: { functionsToOverride: {} },
+        config: { allClusters: { 'non-oidc-cluster': {} } },
+      } as any);
+      mockGetClusterAuthType.mockReturnValue('');
+
+      const mockResponse: Partial<Response> = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      mockBackendFetch.mockResolvedValue(mockResponse as Response);
+
+      const mockLocation = { href: '' };
+      vi.stubGlobal('location', mockLocation);
+
+      await deleteTokens();
+
+      expect(mockBackendFetch).toHaveBeenCalledWith(
+        '/clusters/non-oidc-cluster/set-token',
+        expect.objectContaining({
+          body: JSON.stringify({ token: null }),
+        })
+      );
+      expect(mockLocation.href).toBe('');
     });
   });
 });

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -19,9 +19,11 @@
  */
 
 import { Base64 } from 'js-base64';
+import { getAppUrl } from '../helpers/getAppUrl';
 import { getHeadlampAPIHeaders } from '../helpers/getHeadlampAPIHeaders';
 import store from '../redux/stores/store';
 import { backendFetch } from './k8s/api/v2/fetch';
+import { getClusterAuthType } from './k8s/clusterAuthType';
 import { queryClient } from './queryClient';
 
 /**
@@ -133,15 +135,44 @@ export function setToken(cluster: string, token: string | null) {
 
 /**
  * Logs out the user by clearing the authentication token for the specified cluster.
+ * For OIDC clusters, redirects to the IdP logout endpoint to properly end the session.
  *
  * @param cluster - The name of the cluster to log out from.
+ * @param skipRedirect - If true, skip the OIDC logout redirect (caller handles navigation).
+ * @returns True if an OIDC redirect was skipped (caller should handle navigation), false otherwise.
  * @throws {Error} When logout request fails
  */
-export async function logout(cluster: string) {
-  return setToken(cluster, null).then(() => {
+export async function logout(cluster: string, skipRedirect = false): Promise<boolean> {
+  const authType = getClusterAuthType(cluster);
+
+  // For OIDC auth, redirect to the backend OIDC logout endpoint which will
+  // redirect to the IdP's end_session_endpoint to properly terminate the session.
+  if (authType === 'oidc') {
+    // Clear local state first
     queryClient.removeQueries({ queryKey: ['auth'], exact: false });
     queryClient.removeQueries({ queryKey: ['clusterMe', cluster], exact: true });
-  });
+
+    // Clear the cluster auth cookie before redirecting (cookie path is cluster-scoped).
+    try {
+      await setToken(cluster, null);
+    } catch {
+      // Continue with logout redirect even if cookie clearing fails.
+    }
+
+    if (skipRedirect) {
+      return true;
+    }
+
+    // Redirect to the OIDC logout endpoint
+    // The backend will clear cookies and redirect to the IdP logout endpoint
+    window.location.href = `${getAppUrl()}clusters/${encodeURIComponent(cluster)}/oidc-logout`;
+    return false;
+  }
+
+  await setToken(cluster, null);
+  queryClient.removeQueries({ queryKey: ['auth'], exact: false });
+  queryClient.removeQueries({ queryKey: ['clusterMe', cluster], exact: true });
+  return false;
 }
 
 /**
@@ -149,7 +180,25 @@ export async function logout(cluster: string) {
  *
  * @returns {void}
  */
-export function deleteTokens() {
+export async function deleteTokens() {
   const clusters = Object.keys(store.getState().config.allClusters ?? {});
-  return Promise.all(clusters.map(cluster => logout(cluster)));
+
+  let oidcClusterToRedirect: string | null = null;
+  for (const cluster of clusters) {
+    if (getClusterAuthType(cluster) === 'oidc') {
+      oidcClusterToRedirect = cluster;
+    }
+  }
+
+  await Promise.all(
+    clusters.map(async cluster => {
+      await logout(cluster, true);
+    })
+  );
+
+  if (oidcClusterToRedirect) {
+    window.location.href = `${getAppUrl()}clusters/${encodeURIComponent(
+      oidcClusterToRedirect
+    )}/oidc-logout`;
+  }
 }

--- a/frontend/src/lib/k8s/api/v1/clusterRequests.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterRequests.ts
@@ -21,7 +21,6 @@ import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHea
 import { isDebugVerbose } from '../../../../helpers/debugVerbose';
 import { getAppUrl } from '../../../../helpers/getAppUrl';
 import { isBackstage } from '../../../../helpers/isBackstage';
-import store from '../../../../redux/stores/store';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
 import { logout } from '../../../auth';
@@ -65,18 +64,6 @@ export interface ClusterRequest {
 export interface ClusterRequestParams extends RequestParams {
   cluster?: string | null;
   autoLogoutOnAuthError?: boolean;
-}
-
-/**
- * @returns Auth type of the cluster, or an empty string if the cluster is not found.
- * It could return 'oidc' or '' for example.
- *
- * @param cluster - Name of the cluster.
- */
-export function getClusterAuthType(cluster: string): string {
-  const state = store.getState();
-  const authType: string = state.config?.clusters?.[cluster]?.['auth_type'] || '';
-  return authType;
 }
 
 /**
@@ -192,7 +179,9 @@ export async function clusterRequest(
     const { status, statusText } = response;
     if (autoLogoutOnAuthError && status === 401 && opts.headers.Authorization) {
       console.error('Logging out due to auth error', { status, statusText, path });
-      logout(cluster);
+      logout(cluster, true).catch(err => {
+        console.error('Auto-logout failed after auth error:', err);
+      });
     }
 
     let message = statusText;

--- a/frontend/src/lib/k8s/api/v2/fetch.test.ts
+++ b/frontend/src/lib/k8s/api/v2/fetch.test.ts
@@ -18,7 +18,7 @@ import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { findKubeconfigByClusterName } from '../../../../stateless/findKubeconfigByClusterName';
 import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
-import { getClusterAuthType } from '../v1/clusterRequests';
+import { getClusterAuthType } from '../../clusterAuthType';
 import { BASE_HTTP_URL, clusterFetch } from './fetch';
 
 vi.mock('../../../auth', () => ({
@@ -34,7 +34,7 @@ vi.mock('../../../../stateless/getUserIdFromLocalStorage', () => ({
   getUserIdFromLocalStorage: vi.fn(),
 }));
 
-vi.mock('../v1/clusterRequests', () => ({
+vi.mock('../../clusterAuthType', () => ({
   getClusterAuthType: vi.fn(),
 }));
 

--- a/frontend/src/lib/k8s/clusterAuthType.ts
+++ b/frontend/src/lib/k8s/clusterAuthType.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import store from '../../redux/stores/store';
+
+/**
+ * @returns Auth type of the cluster, or an empty string if the cluster is not found.
+ * It could return 'oidc' or '' for example.
+ *
+ * @param cluster - Name of the cluster.
+ */
+export function getClusterAuthType(cluster: string): string {
+  const state = store.getState();
+  const authType: string = state.config?.clusters?.[cluster]?.['auth_type'] || '';
+  return authType;
+}


### PR DESCRIPTION
## Summary

This PR fixes oidc logout issue by adding logout process in backend and frontend

## Related Issue

Fixes #2287  

## Changes

- Add the oidc id_token to cookie when login, which is used when logout oidc
- Add /clusters/<cluster_name>/oidc-logout endpoint to process the logout logic.
- Add a flag --oidc-skip-logout to bypass this feature if oidc provider does not support logout

## Steps to Test

1. [Step 1: e.g., Navigate to ...]
2. [Step 2: Click on ...]
3. [Step 3: Observe behavior or check logs/output]

## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
