### PR TITLE
frontend: Replace native title tooltips with styled tooltips

### DIFF
--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -18,7 +18,6 @@ import { Icon } from '@iconify/react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import { useTheme } from '@mui/material/styles';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import {
   MRT_ColumnFiltersState,
@@ -260,17 +259,13 @@ export default function ClusterTable({
           Cell: ({ row: { original } }) => {
             const appearance = getClusterAppearanceFromMeta(original.name);
             return (
-              <Tooltip title={original.name} arrow>
-                <span>
-                  <Link routeName="cluster" params={{ cluster: original.name }}>
-                    <ClusterBadge
-                      name={original.name}
-                      icon={appearance.icon}
-                      accentColor={appearance.accentColor}
-                    />
-                  </Link>
-                </span>
-              </Tooltip>
+              <Link routeName="cluster" params={{ cluster: original.name }}>
+                <ClusterBadge
+                  name={original.name}
+                  icon={appearance.icon}
+                  accentColor={appearance.accentColor}
+                />
+              </Link>
             );
           },
         },

--- a/frontend/src/components/App/Home/ClusterTable.tsx
+++ b/frontend/src/components/App/Home/ClusterTable.tsx
@@ -259,13 +259,17 @@ export default function ClusterTable({
           Cell: ({ row: { original } }) => {
             const appearance = getClusterAppearanceFromMeta(original.name);
             return (
-              <Link routeName="cluster" params={{ cluster: original.name }}>
-                <ClusterBadge
-                  name={original.name}
-                  icon={appearance.icon}
-                  accentColor={appearance.accentColor}
-                />
-              </Link>
+              <LightTooltip title={original.name}>
+                <span>
+                  <Link routeName="cluster" params={{ cluster: original.name }}>
+                    <ClusterBadge
+                      name={original.name}
+                      icon={appearance.icon}
+                      accentColor={appearance.accentColor}
+                    />
+                  </Link>
+                </span>
+              </LightTooltip>
             );
           },
         },

--- a/frontend/src/components/App/Home/SquareButton.tsx
+++ b/frontend/src/components/App/Home/SquareButton.tsx
@@ -21,6 +21,7 @@ import CardContent from '@mui/material/CardContent';
 import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import React from 'react';
+import { LightTooltip } from '../../common/Tooltip';
 
 export interface SquareButtonProps extends ButtonBaseProps {
   /** The icon to display for this button. */
@@ -62,24 +63,25 @@ const SquareButton = React.forwardRef<HTMLButtonElement, SquareButtonProps>((pro
                 : theme.palette.getContrastText(theme.palette.squareButton.background))
             }
           />
-          <Typography
-            color="textSecondary"
-            gutterBottom
-            title={label}
-            sx={{
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              display: 'block',
-              fontSize: '1rem',
-              paddingTop: '8px',
-              color: primary
-                ? theme.palette.getContrastText(theme.palette.text.primary)
-                : theme.palette.getContrastText(theme.palette.squareButton.background),
-            }}
-          >
-            {label}
-          </Typography>
+          <LightTooltip title={label}>
+            <Typography
+              color="textSecondary"
+              gutterBottom
+              sx={{
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                display: 'block',
+                fontSize: '1rem',
+                paddingTop: '8px',
+                color: primary
+                  ? theme.palette.getContrastText(theme.palette.text.primary)
+                  : theme.palette.getContrastText(theme.palette.squareButton.background),
+              }}
+            >
+              {label}
+            </Typography>
+          </LightTooltip>
         </CardContent>
       </Card>
     </ButtonBase>

--- a/frontend/src/components/App/Home/__snapshots__/RecentClusters.OneExistingCluster.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/RecentClusters.OneExistingCluster.stories.storyshot
@@ -20,8 +20,9 @@
               class="MuiCardContent-root css-d64700-MuiCardContent-root"
             >
               <p
+                aria-label="cluster0"
                 class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-qscjxq-MuiTypography-root"
-                title="cluster0"
+                data-mui-internal-clone-element="true"
               >
                 cluster0
               </p>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.Basic.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.Basic.stories.storyshot
@@ -12,8 +12,9 @@
           class="MuiCardContent-root css-d64700-MuiCardContent-root"
         >
           <p
+            aria-label="Some label"
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-qscjxq-MuiTypography-root"
-            title="Some label"
+            data-mui-internal-clone-element="true"
           >
             Some label
           </p>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconColor.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconColor.stories.storyshot
@@ -12,8 +12,9 @@
           class="MuiCardContent-root css-d64700-MuiCardContent-root"
         >
           <p
+            aria-label="Some label"
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-qscjxq-MuiTypography-root"
-            title="Some label"
+            data-mui-internal-clone-element="true"
           >
             Some label
           </p>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconSize.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.DifferentIconSize.stories.storyshot
@@ -12,8 +12,9 @@
           class="MuiCardContent-root css-d64700-MuiCardContent-root"
         >
           <p
+            aria-label="Some label"
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-qscjxq-MuiTypography-root"
-            title="Some label"
+            data-mui-internal-clone-element="true"
           >
             Some label
           </p>

--- a/frontend/src/components/App/Home/__snapshots__/SquareButton.Primary.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/SquareButton.Primary.stories.storyshot
@@ -12,8 +12,9 @@
           class="MuiCardContent-root css-d64700-MuiCardContent-root"
         >
           <p
+            aria-label="Some label"
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-11x8x5l-MuiTypography-root"
-            title="Some label"
+            data-mui-internal-clone-element="true"
           >
             Some label
           </p>

--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -619,26 +619,20 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <span
-                        aria-label="cluster0"
-                        class=""
-                        data-mui-internal-clone-element="true"
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                        href="/c/cluster0/"
                       >
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                          href="/c/cluster0/"
+                        <div
+                          class="MuiBox-root css-172hjuw"
                         >
-                          <div
-                            class="MuiBox-root css-172hjuw"
+                          <span
+                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
-                            >
-                              cluster0
-                            </span>
-                          </div>
-                        </a>
-                      </span>
+                            cluster0
+                          </span>
+                        </div>
+                      </a>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
@@ -729,26 +723,20 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <span
-                        aria-label="cluster1"
-                        class=""
-                        data-mui-internal-clone-element="true"
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                        href="/c/cluster1/"
                       >
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                          href="/c/cluster1/"
+                        <div
+                          class="MuiBox-root css-172hjuw"
                         >
-                          <div
-                            class="MuiBox-root css-172hjuw"
+                          <span
+                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
-                            >
-                              cluster1
-                            </span>
-                          </div>
-                        </a>
-                      </span>
+                            cluster1
+                          </span>
+                        </div>
+                      </a>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
@@ -839,26 +827,20 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <span
-                        aria-label="cluster2"
-                        class=""
-                        data-mui-internal-clone-element="true"
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                        href="/c/cluster2/"
                       >
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                          href="/c/cluster2/"
+                        <div
+                          class="MuiBox-root css-172hjuw"
                         >
-                          <div
-                            class="MuiBox-root css-172hjuw"
+                          <span
+                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
                           >
-                            <span
-                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
-                            >
-                              cluster2
-                            </span>
-                          </div>
-                        </a>
-                      </span>
+                            cluster2
+                          </span>
+                        </div>
+                      </a>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"

--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -619,20 +619,26 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                        href="/c/cluster0/"
+                      <span
+                        aria-label="cluster0"
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="MuiBox-root css-172hjuw"
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster0/"
                         >
-                          <span
-                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                          <div
+                            class="MuiBox-root css-172hjuw"
                           >
-                            cluster0
-                          </span>
-                        </div>
-                      </a>
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster0
+                            </span>
+                          </div>
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
@@ -723,20 +729,26 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                        href="/c/cluster1/"
+                      <span
+                        aria-label="cluster1"
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="MuiBox-root css-172hjuw"
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster1/"
                         >
-                          <span
-                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                          <div
+                            class="MuiBox-root css-172hjuw"
                           >
-                            cluster1
-                          </span>
-                        </div>
-                      </a>
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster1
+                            </span>
+                          </div>
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
@@ -827,20 +839,26 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
                     >
-                      <a
-                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
-                        href="/c/cluster2/"
+                      <span
+                        aria-label="cluster2"
+                        class=""
+                        data-mui-internal-clone-element="true"
                       >
-                        <div
-                          class="MuiBox-root css-172hjuw"
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster2/"
                         >
-                          <span
-                            class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                          <div
+                            class="MuiBox-root css-172hjuw"
                           >
-                            cluster2
-                          </span>
-                        </div>
-                      </a>
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster2
+                            </span>
+                          </div>
+                        </a>
+                      </span>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"

--- a/frontend/src/components/advancedSearch/SavedSearches.tsx
+++ b/frontend/src/components/advancedSearch/SavedSearches.tsx
@@ -33,6 +33,7 @@ import { useDispatch } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { setNamespaceFilter } from '../../redux/filterSlice';
 import { useTypedSelector } from '../../redux/hooks';
+import { LightTooltip } from '../common/Tooltip';
 import {
   addSavedAdvancedSearch,
   deleteSavedAdvancedSearch,
@@ -247,24 +248,27 @@ export function SavedSearches({
                     />
                   ) : (
                     <>
-                      <Typography variant="subtitle2" noWrap title={search.name}>
-                        {search.name}
-                      </Typography>
-                      <Typography
-                        component="pre"
-                        variant="caption"
-                        title={search.query}
-                        sx={{
-                          color: 'text.secondary',
-                          fontFamily: 'monospace',
-                          margin: 0,
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {search.query}
-                      </Typography>
+                      <LightTooltip title={search.name}>
+                        <Typography variant="subtitle2" noWrap>
+                          {search.name}
+                        </Typography>
+                      </LightTooltip>
+                      <LightTooltip title={search.query}>
+                        <Typography
+                          component="pre"
+                          variant="caption"
+                          sx={{
+                            color: 'text.secondary',
+                            fontFamily: 'monospace',
+                            margin: 0,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {search.query}
+                        </Typography>
+                      </LightTooltip>
                     </>
                   )}
                 </Box>

--- a/frontend/src/components/cluster/Chooser.tsx
+++ b/frontend/src/components/cluster/Chooser.tsx
@@ -53,6 +53,7 @@ import ActionButton from '../common/ActionButton';
 import { DialogTitle } from '../common/Dialog';
 import ErrorBoundary from '../common/ErrorBoundary';
 import Loader from '../common/Loader';
+import { LightTooltip } from '../common/Tooltip';
 import ClusterChooser from './ClusterChooser';
 import ClusterChooserPopup from './ClusterChooserPopup';
 
@@ -150,19 +151,20 @@ const ClusterButton = React.forwardRef<HTMLButtonElement, ClusterButtonProps>((p
           }}
         >
           <Icon icon={icon} width="50" height="50" color={iconColor} />
-          <Typography
-            color="textSecondary"
-            gutterBottom
-            sx={{
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              display: 'block',
-            }}
-            title={cluster.name}
-          >
-            {cluster.name}
-          </Typography>
+          <LightTooltip title={cluster.name}>
+            <Typography
+              color="textSecondary"
+              gutterBottom
+              sx={{
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                display: 'block',
+              }}
+            >
+              {cluster.name}
+            </Typography>
+          </LightTooltip>
         </CardContent>
       </Card>
     </ButtonBase>

--- a/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.ManyClusters.stories.storyshot
@@ -182,8 +182,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="cluster-1"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="cluster-1"
+                          data-mui-internal-clone-element="true"
                         >
                           cluster-1
                         </p>
@@ -218,8 +219,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="cluster-2"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="cluster-2"
+                          data-mui-internal-clone-element="true"
                         >
                           cluster-2
                         </p>
@@ -245,8 +247,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="cluster-3"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="cluster-3"
+                          data-mui-internal-clone-element="true"
                         >
                           cluster-3
                         </p>

--- a/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.Normal.stories.storyshot
@@ -182,8 +182,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="cluster1"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="cluster1"
+                          data-mui-internal-clone-element="true"
                         >
                           cluster1
                         </p>
@@ -218,8 +219,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="cluster2"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="cluster2"
+                          data-mui-internal-clone-element="true"
                         >
                           cluster2
                         </p>
@@ -245,8 +247,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="cluster3"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="cluster3"
+                          data-mui-internal-clone-element="true"
                         >
                           cluster3
                         </p>

--- a/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
+++ b/frontend/src/components/cluster/__snapshots__/Chooser.SingleCluster.stories.storyshot
@@ -171,8 +171,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="only-cluster"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="only-cluster"
+                          data-mui-internal-clone-element="true"
                         >
                           only-cluster
                         </p>
@@ -207,8 +208,9 @@
                         class="MuiCardContent-root css-d64700-MuiCardContent-root"
                       >
                         <p
+                          aria-label="only-cluster"
                           class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-18vfeyy-MuiTypography-root"
-                          title="only-cluster"
+                          data-mui-internal-clone-element="true"
                         >
                           only-cluster
                         </p>

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -87,7 +87,7 @@ export interface StatusLabelProps {
 }
 
 export const StatusLabel = forwardRef<HTMLSpanElement, StatusLabelProps>((props, ref) => {
-  const { status, sx, className = '', ...other } = props;
+  const { status, sx, className = '', title, ...other } = props;
   const theme = useTheme();
 
   const statuses = ['success', 'warning', 'error'];
@@ -120,7 +120,7 @@ export const StatusLabel = forwardRef<HTMLSpanElement, StatusLabelProps>((props,
     };
   }
 
-  return (
+  const label = (
     <Typography
       ref={ref}
       sx={{
@@ -143,6 +143,15 @@ export const StatusLabel = forwardRef<HTMLSpanElement, StatusLabelProps>((props,
       {...other}
     />
   );
+
+  // A `title` would otherwise be forwarded to the underlying span as a native
+  // HTML tooltip, which the browser renders unstyled (and out of place next to
+  // the rest of the UI). Route it through our styled tooltip instead.
+  if (title) {
+    return <LightTooltip title={title}>{label}</LightTooltip>;
+  }
+
+  return label;
 });
 
 export function makeStatusLabel(label: string, successStatusName: string) {

--- a/frontend/src/components/common/Label.tsx
+++ b/frontend/src/components/common/Label.tsx
@@ -83,6 +83,8 @@ export function ValueLabel(props: React.PropsWithChildren<{}>) {
 export interface StatusLabelProps {
   status: 'success' | 'warning' | 'error' | '';
   sx?: SxProps<Theme>;
+  /** When set, the label is wrapped in a tooltip instead of forwarding a native title to the span. */
+  title?: string;
   [otherProps: string]: any;
 }
 

--- a/frontend/src/components/deployments/List.tsx
+++ b/frontend/src/components/deployments/List.tsx
@@ -73,11 +73,9 @@ export default function DeploymentsList() {
       .map((condition: any) => {
         const { type, message } = condition;
         return (
-          <Box display="inline-block">
-            <StatusLabel status={renderStatus(condition)}>
-              <span title={message} key={type}>
-                {type}
-              </span>
+          <Box display="inline-block" key={type}>
+            <StatusLabel status={renderStatus(condition)} title={message}>
+              {type}
             </StatusLabel>
           </Box>
         );

--- a/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
+++ b/frontend/src/components/deployments/__snapshots__/List.Deployments.stories.storyshot
@@ -860,9 +860,7 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
                     >
-                      <span>
-                        Progressing
-                      </span>
+                      Progressing
                     </span>
                   </div>
                 </td>
@@ -988,9 +986,7 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
                     >
-                      <span>
-                        Available
-                      </span>
+                      Available
                     </span>
                   </div>
                 </td>

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -61,6 +61,7 @@ import { Activity } from '../activity/Activity';
 import { ADVANCED_SEARCH_QUERY_KEY } from '../advancedSearch/AdvancedSearch';
 import { ThemePreview } from '../App/Settings/ThemePreview';
 import { setTheme, useAppThemes } from '../App/themeSlice';
+import { LightTooltip } from '../common/Tooltip';
 import { KubeObjectDetails } from '../resourceMap/details/KubeNodeDetails';
 import { KubeIcon } from '../resourceMap/kubeIcon/KubeIcon';
 import { Delayed } from './Delayed';
@@ -616,29 +617,30 @@ function SearchRow({
         </Box>
       </Box>
       {option.k8sLabelsMatch && option.k8sLabelsMatch.value && (
-        <Typography
-          title={option.k8sLabelsMatch.value}
-          sx={theme => ({
-            color: theme.palette.text.primary,
-            borderRadius: theme.shape.borderRadius + 'px',
-            backgroundColor: theme.palette.background.muted,
-            border: '1px solid',
-            borderColor: theme.palette.divider,
-            fontSize: theme.typography.pxToRem(14),
-            wordBreak: 'break-word',
-            paddingTop: 0.25,
-            paddingBottom: 0.25,
-            paddingLeft: 0.5,
-            paddingRight: 0.5,
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            overflowWrap: 'anywhere',
-            textOverflow: 'ellipsis',
-            maxWidth: '220px',
-          })}
-        >
-          <HighlightText text={option.k8sLabelsMatch.value} match={option.k8sLabelsMatch} />
-        </Typography>
+        <LightTooltip title={option.k8sLabelsMatch.value}>
+          <Typography
+            sx={theme => ({
+              color: theme.palette.text.primary,
+              borderRadius: theme.shape.borderRadius + 'px',
+              backgroundColor: theme.palette.background.muted,
+              border: '1px solid',
+              borderColor: theme.palette.divider,
+              fontSize: theme.typography.pxToRem(14),
+              wordBreak: 'break-word',
+              paddingTop: 0.25,
+              paddingBottom: 0.25,
+              paddingLeft: 0.5,
+              paddingRight: 0.5,
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              overflowWrap: 'anywhere',
+              textOverflow: 'ellipsis',
+              maxWidth: '220px',
+            })}
+          >
+            <HighlightText text={option.k8sLabelsMatch.value} match={option.k8sLabelsMatch} />
+          </Typography>
+        </LightTooltip>
       )}
     </Box>
   );

--- a/frontend/src/components/resourceMap/KubeObjectGlance/KubeObjectGlance.tsx
+++ b/frontend/src/components/resourceMap/KubeObjectGlance/KubeObjectGlance.tsx
@@ -28,6 +28,7 @@ import ReplicaSet from '../../../lib/k8s/replicaSet';
 import Service from '../../../lib/k8s/service';
 import StatefulSet from '../../../lib/k8s/statefulSet';
 import { DateLabel } from '../../common/Label';
+import { LightTooltip } from '../../common/Tooltip';
 import { DeploymentGlance } from './DeploymentGlance';
 import { EndpointsGlance } from './EndpointsGlance';
 import { HorizontalPodAutoscalerGlance } from './HorizontalPodAutoscalerGlance';
@@ -90,16 +91,17 @@ export const KubeObjectGlance = memo(({ resource }: { resource: KubeObject }) =>
             width="100%"
             key={it.message + it.lastOccurrence}
           >
-            <Box
-              whiteSpace="nowrap"
-              overflow="hidden"
-              textOverflow="ellipsis"
-              mr="auto"
-              maxWidth="300px"
-              title={it.message}
-            >
-              {it.message}
-            </Box>
+            <LightTooltip title={it.message}>
+              <Box
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                mr="auto"
+                maxWidth="300px"
+              >
+                {it.message}
+              </Box>
+            </LightTooltip>
             <DateLabel date={it.lastOccurrence} format="mini" />
           </Box>
         ))}

--- a/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
+++ b/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
@@ -102,9 +102,13 @@ export function SelectionBreadcrumbs({
         const subtitle = it.subtitle ?? it?.kubeObject?.kind;
         const subtitleElement = subtitle ? <Box sx={{ opacity: 0.7 }}>{subtitle}</Box> : null;
         const label = getLabel(it);
+        // Include the subtitle so the tooltip (and the aria-label the tooltip
+        // sets on its child) announces both the subtitle and the label, rather
+        // than relabeling the child with the label alone.
+        const tooltipTitle = [subtitle, label].filter(Boolean).join(' ');
 
         return i === path.length - 1 ? (
-          <LightTooltip title={label} key={it.id}>
+          <LightTooltip title={tooltipTitle} key={it.id}>
             <Box
               sx={{
                 display: 'flex',
@@ -126,7 +130,7 @@ export function SelectionBreadcrumbs({
             </Box>
           </LightTooltip>
         ) : (
-          <LightTooltip title={label} key={it.id}>
+          <LightTooltip title={tooltipTitle} key={it.id}>
             <Link
               onClick={() => onNodeClick(it.id)}
               sx={{

--- a/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
+++ b/frontend/src/components/resourceMap/SelectionBreadcrumbs.tsx
@@ -18,6 +18,7 @@ import Box from '@mui/material/Box';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Link from '@mui/material/Link';
 import { useTranslation } from 'react-i18next';
+import { LightTooltip } from '../common/Tooltip';
 import { getMainNode } from './graph/graphGrouping';
 import { GraphNode } from './graph/graphModel';
 import { KubeIcon } from './kubeIcon/KubeIcon';
@@ -103,53 +104,53 @@ export function SelectionBreadcrumbs({
         const label = getLabel(it);
 
         return i === path.length - 1 ? (
-          <Box
-            key={it.id}
-            title={label}
-            sx={{
-              display: 'flex',
-              gap: 0.5,
-              maxWidth: '200px',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-            }}
-          >
-            {icon} {subtitleElement}{' '}
+          <LightTooltip title={label} key={it.id}>
             <Box
               sx={{
+                display: 'flex',
+                gap: 0.5,
+                maxWidth: '200px',
+                whiteSpace: 'nowrap',
                 overflow: 'hidden',
-                textOverflow: 'ellipsis',
               }}
             >
-              {label}
+              {icon} {subtitleElement}{' '}
+              <Box
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {label}
+              </Box>
             </Box>
-          </Box>
+          </LightTooltip>
         ) : (
-          <Link
-            key={it.id}
-            onClick={() => onNodeClick(it.id)}
-            title={label}
-            sx={{
-              display: 'flex',
-              gap: 0.5,
-              textTransform: 'unset',
-              maxWidth: '200px',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              cursor: 'pointer',
-            }}
-          >
-            {icon} {subtitleElement}{' '}
-            <Box
+          <LightTooltip title={label} key={it.id}>
+            <Link
+              onClick={() => onNodeClick(it.id)}
               sx={{
+                display: 'flex',
+                gap: 0.5,
+                textTransform: 'unset',
+                maxWidth: '200px',
+                whiteSpace: 'nowrap',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
+                cursor: 'pointer',
               }}
             >
-              {label}
-            </Box>
-          </Link>
+              {icon} {subtitleElement}{' '}
+              <Box
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {label}
+              </Box>
+            </Link>
+          </LightTooltip>
         );
       })}
     </Breadcrumbs>

--- a/frontend/src/components/resourceMap/nodes/GroupNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/GroupNode.tsx
@@ -18,6 +18,7 @@ import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import { alpha } from '@mui/system/colorManipulator';
 import { memo } from 'react';
+import { LightTooltip } from '../../common/Tooltip';
 import { useGraphView, useNode } from '../GraphView';
 import { KubeIcon } from '../kubeIcon/KubeIcon';
 
@@ -73,15 +74,22 @@ export const GroupNodeComponent = memo(({ id }: { id: string }) => {
       }}
     >
       {(node?.label || node?.subtitle) && (
-        <Label title={node?.label}>
-          {node?.kubeObject ? (
-            <KubeIcon kind={node.kubeObject.kind} apiGroup={apiGroup} width="24px" height="24px" />
-          ) : (
-            node?.icon ?? null
-          )}
-          <Box sx={{ opacity: 0.8 }}>{node?.subtitle}</Box>
-          <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{node?.label}</Box>
-        </Label>
+        <LightTooltip title={node?.label ?? ''}>
+          <Label>
+            {node?.kubeObject ? (
+              <KubeIcon
+                kind={node.kubeObject.kind}
+                apiGroup={apiGroup}
+                width="24px"
+                height="24px"
+              />
+            ) : (
+              node?.icon ?? null
+            )}
+            <Box sx={{ opacity: 0.8 }}>{node?.subtitle}</Box>
+            <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{node?.label}</Box>
+          </Label>
+        </LightTooltip>
       )}
     </Container>
   );

--- a/frontend/src/components/resourceMap/nodes/GroupNode.tsx
+++ b/frontend/src/components/resourceMap/nodes/GroupNode.tsx
@@ -73,24 +73,38 @@ export const GroupNodeComponent = memo(({ id }: { id: string }) => {
         }
       }}
     >
-      {(node?.label || node?.subtitle) && (
-        <LightTooltip title={node?.label ?? ''}>
-          <Label>
-            {node?.kubeObject ? (
-              <KubeIcon
-                kind={node.kubeObject.kind}
-                apiGroup={apiGroup}
-                width="24px"
-                height="24px"
-              />
-            ) : (
-              node?.icon ?? null
-            )}
-            <Box sx={{ opacity: 0.8 }}>{node?.subtitle}</Box>
-            <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{node?.label}</Box>
-          </Label>
-        </LightTooltip>
-      )}
+      {(node?.label || node?.subtitle) &&
+        (() => {
+          const labelContent = (
+            <Label>
+              {node?.kubeObject ? (
+                <KubeIcon
+                  kind={node.kubeObject.kind}
+                  apiGroup={apiGroup}
+                  width="24px"
+                  height="24px"
+                />
+              ) : (
+                node?.icon ?? null
+              )}
+              <Box sx={{ opacity: 0.8 }}>{node?.subtitle}</Box>
+              <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{node?.label}</Box>
+            </Label>
+          );
+
+          // Include the subtitle so the tooltip (and the aria-label the tooltip
+          // sets on its child) announces both the subtitle and the label, rather
+          // than dropping the subtitle from the accessible name.
+          const tooltipTitle = [node?.subtitle, node?.label].filter(Boolean).join(' ');
+
+          // Only wrap in a tooltip when there's something to show; otherwise an
+          // empty title would render an empty tooltip (and an empty aria-label).
+          return tooltipTitle ? (
+            <LightTooltip title={tooltipTitle}>{labelContent}</LightTooltip>
+          ) : (
+            labelContent
+          );
+        })()}
     </Container>
   );
 });

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -374,7 +374,7 @@ export function createMuiTheme(currentTheme: AppTheme) {
       MuiTooltip: {
         styleOverrides: {
           tooltip: {
-            fontSize: '1.3em',
+            fontSize: '0.875rem',
             color: '#fff',
             backgroundColor: '#000',
           },


### PR DESCRIPTION
## What this does

Across the UI, several text elements set the native HTML `title` attribute, which the browser/OS renders as an unstyled tooltip that looks out of place next to Headlamp's own styled tooltips. This PR replaces those native tooltips with the styled `LightTooltip`, fixes the root prop-forwarding that leaked them, and tidies up tooltip sizing.

Fixes #5960 

### Changes

- **Root fix in `StatusLabel`** — it spread `{...other}` (including any `title`) onto its underlying `<span>`, forwarding a native tooltip. Now a `title` is routed through `LightTooltip` instead. This is what surfaced unstyled tooltips on status badges (including plugin-sourced ones).
- **Replaced native `title` tooltips with `LightTooltip`** on text/DOM elements in: Home `SquareButton`, advanced-search `SavedSearches`, cluster `Chooser`, `GlobalSearchContent`, resource-map `KubeObjectGlance`, `SelectionBreadcrumbs`, and `GroupNode`; deployments `List` conditions now pass the message through `StatusLabel`.
- **Reduced the oversized global tooltip font** — the global `MuiTooltip` override set the font to `1.3em` (~double MUI's default), making every tooltip look bloated. Lowered to `0.875rem`.
- **Removed a redundant always-on tooltip** on the Home cluster-table Name column that merely repeated the cluster name already shown beside the icon.

### Testing

- `tsc --noEmit`, eslint, and prettier all clean
- All 548 storyshot snapshot tests pass (snapshots updated where markup legitimately changed)
- Verified visually against a running cluster

### Screenshots
<img width="213" height="97" alt="image" src="https://github.com/user-attachments/assets/674bbd9a-3c8f-40b2-b049-873f19156e20" />
<img width="480" height="270" alt="Screenshot From 2026-06-10 20-45-55" src="https://github.com/user-attachments/assets/60852d78-4e91-4272-95e2-44a24c8b51de" />
