### PR TITLE
frontend: 404: Add Storybook story for NotFoundComponent

### DIFF
--- a/frontend/src/components/404/NotFoundComponent.stories.tsx
+++ b/frontend/src/components/404/NotFoundComponent.stories.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import NotFoundComponent from '.';
+
+export default {
+  title: '404/NotFoundComponent',
+  component: NotFoundComponent,
+} as Meta;
+
+const Template: StoryFn = () => <NotFoundComponent />;
+
+export const Default = Template.bind({});

--- a/frontend/src/components/404/__snapshots__/NotFoundComponent.Default.stories.storyshot
+++ b/frontend/src/components/404/__snapshots__/NotFoundComponent.Default.stories.storyshot
@@ -1,0 +1,34 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column css-1b95sop-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <img
+          alt=""
+          class="css-8atqhb"
+          src="/src/assets/headlamp-404.svg"
+        />
+        <h1
+          class="MuiTypography-root MuiTypography-h1 css-5ewpze-MuiTypography-root"
+        >
+          Whoops! This page doesn't exist
+        </h1>
+        <h2
+          class="MuiTypography-root MuiTypography-h2 css-15otqr2-MuiTypography-root"
+        >
+          Head back 
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+            href="/"
+          >
+            home
+          </a>
+          .
+        </h2>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Description

`frontend/src/components/404/index.tsx` (`NotFoundComponent`) had no Storybook story. In this repo stories double as snapshot tests (`frontend/src/storybook.test.tsx` runs every story through `toMatchFileSnapshot`), so the component had no story-based regression coverage.

This adds a `Default` story that renders the "Whoops! This page doesn't exist" error page (via `ErrorComponent`), following the pattern used by the sibling `common/ErrorPage` stories.

The component is purely presentational and takes no props, so no MSW handlers or fixtures are needed.

## Changes
- `NotFoundComponent.stories.tsx` — hand-written (~25 lines)
- `__snapshots__/NotFoundComponent.Default.stories.storyshot` — generated

Closes #5963
Related: #931

## Testing
- `npx vitest run src/storybook.test.tsx` — all 549 storybook snapshot tests pass, no drift.