### PR TITLE
backend: Add configurable favicon support

### DIFF
--- a/backend/cmd/favicon_test.go
+++ b/backend/cmd/favicon_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Minimal fake favicons: the real PNG/ICO magic-byte signature (which the
+// handler validates) followed by arbitrary filler. The body content is never
+// decoded, so any bytes after the signature work.
+var (
+	pngBytes = append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, []byte("png-body")...)
+	icoBytes = append([]byte{0x00, 0x00, 0x01, 0x00}, []byte("ico-body")...)
+)
+
+func faviconTestConfig(favicon, faviconBase64 string) *HeadlampConfig {
+	return &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				Favicon:       favicon,
+				FaviconBase64: faviconBase64,
+			},
+		},
+	}
+}
+
+func writeTempFavicon(t *testing.T, name string, data []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	return path
+}
+
+func TestResolveFavicon_PNGFile(t *testing.T) {
+	path := writeTempFavicon(t, "favicon.png", pngBytes)
+
+	data, contentType, ok := resolveFavicon(faviconTestConfig(path, ""))
+	assert.True(t, ok)
+	assert.Equal(t, "image/png", contentType)
+	assert.Equal(t, pngBytes, data)
+}
+
+func TestResolveFavicon_ICOFile(t *testing.T) {
+	path := writeTempFavicon(t, "favicon.ico", icoBytes)
+
+	data, contentType, ok := resolveFavicon(faviconTestConfig(path, ""))
+	assert.True(t, ok)
+	assert.Equal(t, "image/x-icon", contentType)
+	assert.Equal(t, icoBytes, data)
+}
+
+func TestResolveFavicon_MagicMismatch(t *testing.T) {
+	// A .png file whose bytes are not actually a PNG must be rejected.
+	path := writeTempFavicon(t, "fake.png", []byte("<html>not a png</html>"))
+
+	_, _, ok := resolveFavicon(faviconTestConfig(path, ""))
+	assert.False(t, ok)
+}
+
+func TestResolveFavicon_UnsupportedExtension(t *testing.T) {
+	path := writeTempFavicon(t, "icon.svg", []byte("<svg></svg>"))
+
+	_, _, ok := resolveFavicon(faviconTestConfig(path, ""))
+	assert.False(t, ok)
+}
+
+func TestResolveFavicon_MissingFile(t *testing.T) {
+	_, _, ok := resolveFavicon(faviconTestConfig("/no/such/favicon.png", ""))
+	assert.False(t, ok)
+}
+
+func TestResolveFavicon_Base64PNG(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString(pngBytes)
+
+	data, contentType, ok := resolveFavicon(faviconTestConfig("", encoded))
+	assert.True(t, ok)
+	assert.Equal(t, "image/png", contentType)
+	assert.Equal(t, pngBytes, data)
+}
+
+func TestResolveFavicon_Base64NotPNG(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("not a png"))
+
+	_, _, ok := resolveFavicon(faviconTestConfig("", encoded))
+	assert.False(t, ok)
+}
+
+func TestResolveFavicon_Base64Invalid(t *testing.T) {
+	_, _, ok := resolveFavicon(faviconTestConfig("", "this is not base64!!!"))
+	assert.False(t, ok)
+}
+
+func TestResolveFavicon_FileWinsOverBase64(t *testing.T) {
+	path := writeTempFavicon(t, "favicon.ico", icoBytes)
+	encoded := base64.StdEncoding.EncodeToString(pngBytes)
+
+	data, contentType, ok := resolveFavicon(faviconTestConfig(path, encoded))
+	assert.True(t, ok)
+	assert.Equal(t, "image/x-icon", contentType)
+	assert.Equal(t, icoBytes, data)
+}
+
+func TestResolveFavicon_None(t *testing.T) {
+	_, _, ok := resolveFavicon(faviconTestConfig("", ""))
+	assert.False(t, ok)
+}
+
+func TestAddFaviconRoutes_ServesAllTabIcons(t *testing.T) {
+	path := writeTempFavicon(t, "favicon.png", pngBytes)
+
+	r := mux.NewRouter()
+	addFaviconRoutes(faviconTestConfig(path, ""), r)
+
+	for _, route := range []string{"/favicon.ico", "/favicon-16x16.png", "/favicon-32x32.png"} {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, route, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, route)
+		assert.Equal(t, "image/png", w.Header().Get("Content-Type"), route)
+		assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"), route)
+		assert.Equal(t, pngBytes, w.Body.Bytes(), route)
+	}
+}
+
+func TestAddFaviconRoutes_NotConfigured(t *testing.T) {
+	r := mux.NewRouter()
+	addFaviconRoutes(faviconTestConfig("", ""), r)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/favicon.ico", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// No override registered, so the bare router has no match.
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/backend/cmd/favicon_test.go
+++ b/backend/cmd/favicon_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -99,6 +100,15 @@ func TestResolveFavicon_Base64NotPNG(t *testing.T) {
 
 func TestResolveFavicon_Base64Invalid(t *testing.T) {
 	_, _, ok := resolveFavicon(faviconTestConfig("", "this is not base64!!!"))
+	assert.False(t, ok)
+}
+
+func TestResolveFavicon_Base64TooLarge(t *testing.T) {
+	// A base64 string whose decoded size exceeds the cap must be rejected before
+	// it is decoded into memory.
+	oversized := strings.Repeat("A", maxFaviconSize*2)
+
+	_, _, ok := resolveFavicon(faviconTestConfig("", oversized))
 	assert.False(t, ok)
 }
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -567,6 +567,145 @@ func setupInClusterContext(config *HeadlampConfig) {
 	}
 }
 
+// maxFaviconSize bounds how large a custom favicon may be (1 MiB).
+const maxFaviconSize = 1 << 20
+
+// faviconMagic maps a server-controlled content type to the leading magic bytes
+// the data must start with. We never trust a caller- or extension-supplied MIME
+// type: the content type is fixed here and the bytes are validated against it,
+// so a renamed/mislabelled file (e.g. HTML or SVG posing as an icon) is rejected
+// rather than served and sniffed by the browser.
+var faviconMagic = map[string][]byte{
+	"image/png":    {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, // \x89PNG\r\n\x1a\n
+	"image/x-icon": {0x00, 0x00, 0x01, 0x00},                         // ICONDIR header
+}
+
+// resolveFavicon turns the configured favicon (file path and/or base64 PNG) into
+// in-memory bytes plus a server-determined content type. It returns ok=false
+// when nothing is configured or the input is invalid, in which case the bundled
+// default icon is left in place.
+func resolveFavicon(config *HeadlampConfig) (data []byte, contentType string, ok bool) {
+	switch {
+	case config.Favicon != "" && config.FaviconBase64 != "":
+		logger.Log(logger.LevelWarn, nil, nil,
+			"both --favicon and --favicon-base64 are set; using --favicon and ignoring --favicon-base64")
+
+		data, contentType, ok = faviconFromFile(config.Favicon)
+	case config.Favicon != "":
+		data, contentType, ok = faviconFromFile(config.Favicon)
+	case config.FaviconBase64 != "":
+		data, contentType, ok = faviconFromBase64(config.FaviconBase64)
+	default:
+		return nil, "", false
+	}
+
+	return data, contentType, ok
+}
+
+// faviconFromFile reads an icon file, picking a fixed content type from the
+// extension (only .png and .ico are allowed) and validating the magic bytes.
+func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png":
+		contentType = "image/png"
+	case ".ico":
+		contentType = "image/x-icon"
+	default:
+		logger.Log(logger.LevelWarn, map[string]string{"path": path}, nil,
+			"unsupported favicon file type (only .png and .ico are allowed); serving default icon")
+
+		return nil, "", false
+	}
+
+	logFields := map[string]string{"path": path}
+
+	info, err := os.Stat(path) //nolint:gosec // path is admin-provided configuration
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "favicon file not accessible; serving default icon")
+		return nil, "", false
+	}
+
+	if info.Size() > maxFaviconSize {
+		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
+		return nil, "", false
+	}
+
+	data, err = os.ReadFile(path) //nolint:gosec // path is admin-provided configuration
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "reading favicon file; serving default icon")
+		return nil, "", false
+	}
+
+	if !hasFaviconMagic(data, contentType) {
+		logger.Log(logger.LevelWarn, logFields, nil,
+			"favicon file content does not match its extension; serving default icon")
+
+		return nil, "", false
+	}
+
+	return data, contentType, true
+}
+
+// faviconFromBase64 decodes a base64 PNG. The content type is fixed to
+// image/png and the decoded bytes are validated against the PNG signature.
+func faviconFromBase64(encoded string) (data []byte, contentType string, ok bool) {
+	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		logger.Log(logger.LevelWarn, nil, err, "decoding favicon-base64; serving default icon")
+		return nil, "", false
+	}
+
+	if len(data) > maxFaviconSize {
+		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 too large; serving default icon")
+		return nil, "", false
+	}
+
+	if !hasFaviconMagic(data, "image/png") {
+		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 is not a valid PNG; serving default icon")
+		return nil, "", false
+	}
+
+	return data, "image/png", true
+}
+
+// hasFaviconMagic reports whether data starts with the magic bytes registered
+// for the given content type.
+func hasFaviconMagic(data []byte, contentType string) bool {
+	magic, known := faviconMagic[contentType]
+	if !known {
+		return false
+	}
+
+	return bytes.HasPrefix(data, magic)
+}
+
+// addFaviconRoutes overrides the bundled tab-icon paths with an admin-configured
+// favicon. It is registered before the SPA/embedded catch-all so it wins in both
+// embedded-binary and --html-static-dir modes. Only the browser-tab icons are
+// overridden; apple-touch-icon keeps the default.
+func addFaviconRoutes(config *HeadlampConfig, r *mux.Router) {
+	data, contentType, ok := resolveFavicon(config)
+	if !ok {
+		return
+	}
+
+	for _, route := range []string{"/favicon.ico", "/favicon-16x16.png", "/favicon-32x32.png"} {
+		r.HandleFunc(route, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", contentType)
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Cache-Control", "public, max-age=86400")
+
+			// data is a validated PNG/ICO image (magic-byte checked, fixed
+			// content type, served with nosniff), not attacker-controlled markup.
+			if _, err := w.Write(data); err != nil { //nolint:gosec // validated image bytes, served with nosniff
+				logger.Log(logger.LevelError, nil, err, "writing favicon response")
+			}
+		})
+	}
+
+	logger.Log(logger.LevelInfo, nil, nil, "Serving custom favicon ("+contentType+")")
+}
+
 //nolint:gocognit,funlen,gocyclo
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
@@ -1122,6 +1261,10 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	})
+
+	// Override the bundled favicon with an admin-configured one, if any.
+	// Registered before the catch-all so it takes precedence.
+	addFaviconRoutes(config, r)
 
 	// Serve the frontend if needed
 	if spa.UseEmbeddedFiles {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -625,6 +625,11 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 		return nil, "", false
 	}
 
+	if !info.Mode().IsRegular() {
+		logger.Log(logger.LevelWarn, logFields, nil, "favicon path is not a regular file; serving default icon")
+		return nil, "", false
+	}
+
 	if info.Size() > maxFaviconSize {
 		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
 		return nil, "", false

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -619,7 +619,17 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 
 	logFields := map[string]string{"path": path}
 
-	info, err := os.Stat(path) //nolint:gosec // path is admin-provided configuration
+	file, err := os.Open(path) //nolint:gosec // path is admin-provided configuration
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "favicon file not accessible; serving default icon")
+		return nil, "", false
+	}
+
+	defer func() { _ = file.Close() }()
+
+	// Stat the open descriptor rather than the path so the regular-file check
+	// applies to exactly what we read.
+	info, err := file.Stat()
 	if err != nil {
 		logger.Log(logger.LevelWarn, logFields, err, "favicon file not accessible; serving default icon")
 		return nil, "", false
@@ -630,14 +640,16 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 		return nil, "", false
 	}
 
-	if info.Size() > maxFaviconSize {
-		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
+	// Read through a LimitReader so the size cap is enforced on the bytes we
+	// actually read, not on a possibly-stale stat size (avoids a TOCTOU bypass).
+	data, err = io.ReadAll(io.LimitReader(file, maxFaviconSize+1))
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "reading favicon file; serving default icon")
 		return nil, "", false
 	}
 
-	data, err = os.ReadFile(path) //nolint:gosec // path is admin-provided configuration
-	if err != nil {
-		logger.Log(logger.LevelWarn, logFields, err, "reading favicon file; serving default icon")
+	if len(data) > maxFaviconSize {
+		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
 		return nil, "", false
 	}
 
@@ -654,14 +666,19 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 // faviconFromBase64 decodes a base64 PNG. The content type is fixed to
 // image/png and the decoded bytes are validated against the PNG signature.
 func faviconFromBase64(encoded string) (data []byte, contentType string, ok bool) {
-	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
-	if err != nil {
-		logger.Log(logger.LevelWarn, nil, err, "decoding favicon-base64; serving default icon")
+	trimmed := strings.TrimSpace(encoded)
+
+	// Reject oversized input before decoding it. DecodedLen is an upper bound on
+	// the decoded size, so this caps the allocation instead of decoding a huge
+	// string into memory first.
+	if base64.StdEncoding.DecodedLen(len(trimmed)) > maxFaviconSize {
+		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 too large; serving default icon")
 		return nil, "", false
 	}
 
-	if len(data) > maxFaviconSize {
-		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 too large; serving default icon")
+	data, err := base64.StdEncoding.DecodeString(trimmed)
+	if err != nil {
+		logger.Log(logger.LevelWarn, nil, err, "decoding favicon-base64; serving default icon")
 		return nil, "", false
 	}
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -626,6 +626,145 @@ func loadDynamicClusters(config *HeadlampConfig, path string, skipFunc func(kube
 	}
 }
 
+// maxFaviconSize bounds how large a custom favicon may be (1 MiB).
+const maxFaviconSize = 1 << 20
+
+// faviconMagic maps a server-controlled content type to the leading magic bytes
+// the data must start with. We never trust a caller- or extension-supplied MIME
+// type: the content type is fixed here and the bytes are validated against it,
+// so a renamed/mislabelled file (e.g. HTML or SVG posing as an icon) is rejected
+// rather than served and sniffed by the browser.
+var faviconMagic = map[string][]byte{
+	"image/png":    {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, // \x89PNG\r\n\x1a\n
+	"image/x-icon": {0x00, 0x00, 0x01, 0x00},                         // ICONDIR header
+}
+
+// resolveFavicon turns the configured favicon (file path and/or base64 PNG) into
+// in-memory bytes plus a server-determined content type. It returns ok=false
+// when nothing is configured or the input is invalid, in which case the bundled
+// default icon is left in place.
+func resolveFavicon(config *HeadlampConfig) (data []byte, contentType string, ok bool) {
+	switch {
+	case config.Favicon != "" && config.FaviconBase64 != "":
+		logger.Log(logger.LevelWarn, nil, nil,
+			"both --favicon and --favicon-base64 are set; using --favicon and ignoring --favicon-base64")
+
+		data, contentType, ok = faviconFromFile(config.Favicon)
+	case config.Favicon != "":
+		data, contentType, ok = faviconFromFile(config.Favicon)
+	case config.FaviconBase64 != "":
+		data, contentType, ok = faviconFromBase64(config.FaviconBase64)
+	default:
+		return nil, "", false
+	}
+
+	return data, contentType, ok
+}
+
+// faviconFromFile reads an icon file, picking a fixed content type from the
+// extension (only .png and .ico are allowed) and validating the magic bytes.
+func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png":
+		contentType = "image/png"
+	case ".ico":
+		contentType = "image/x-icon"
+	default:
+		logger.Log(logger.LevelWarn, map[string]string{"path": path}, nil,
+			"unsupported favicon file type (only .png and .ico are allowed); serving default icon")
+
+		return nil, "", false
+	}
+
+	logFields := map[string]string{"path": path}
+
+	info, err := os.Stat(path) //nolint:gosec // path is admin-provided configuration
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "favicon file not accessible; serving default icon")
+		return nil, "", false
+	}
+
+	if info.Size() > maxFaviconSize {
+		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
+		return nil, "", false
+	}
+
+	data, err = os.ReadFile(path) //nolint:gosec // path is admin-provided configuration
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "reading favicon file; serving default icon")
+		return nil, "", false
+	}
+
+	if !hasFaviconMagic(data, contentType) {
+		logger.Log(logger.LevelWarn, logFields, nil,
+			"favicon file content does not match its extension; serving default icon")
+
+		return nil, "", false
+	}
+
+	return data, contentType, true
+}
+
+// faviconFromBase64 decodes a base64 PNG. The content type is fixed to
+// image/png and the decoded bytes are validated against the PNG signature.
+func faviconFromBase64(encoded string) (data []byte, contentType string, ok bool) {
+	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		logger.Log(logger.LevelWarn, nil, err, "decoding favicon-base64; serving default icon")
+		return nil, "", false
+	}
+
+	if len(data) > maxFaviconSize {
+		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 too large; serving default icon")
+		return nil, "", false
+	}
+
+	if !hasFaviconMagic(data, "image/png") {
+		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 is not a valid PNG; serving default icon")
+		return nil, "", false
+	}
+
+	return data, "image/png", true
+}
+
+// hasFaviconMagic reports whether data starts with the magic bytes registered
+// for the given content type.
+func hasFaviconMagic(data []byte, contentType string) bool {
+	magic, known := faviconMagic[contentType]
+	if !known {
+		return false
+	}
+
+	return bytes.HasPrefix(data, magic)
+}
+
+// addFaviconRoutes overrides the bundled tab-icon paths with an admin-configured
+// favicon. It is registered before the SPA/embedded catch-all so it wins in both
+// embedded-binary and --html-static-dir modes. Only the browser-tab icons are
+// overridden; apple-touch-icon keeps the default.
+func addFaviconRoutes(config *HeadlampConfig, r *mux.Router) {
+	data, contentType, ok := resolveFavicon(config)
+	if !ok {
+		return
+	}
+
+	for _, route := range []string{"/favicon.ico", "/favicon-16x16.png", "/favicon-32x32.png"} {
+		r.HandleFunc(route, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", contentType)
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Cache-Control", "public, max-age=86400")
+
+			// data is a validated PNG/ICO image (magic-byte checked, fixed
+			// content type, served with nosniff), not attacker-controlled markup.
+			if _, err := w.Write(data); err != nil { //nolint:gosec // validated image bytes, served with nosniff
+				logger.Log(logger.LevelError, nil, err, "writing favicon response")
+			}
+		})
+	}
+
+	logger.Log(logger.LevelInfo, nil, nil, "Serving custom favicon ("+contentType+")")
+}
+
 //nolint:gocognit,funlen,gocyclo
 func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Handler {
 	kubeConfigPath := config.KubeConfigPath
@@ -1172,6 +1311,10 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	})
+
+	// Override the bundled favicon with an admin-configured one, if any.
+	// Registered before the catch-all so it takes precedence.
+	addFaviconRoutes(config, r)
 
 	// Serve the frontend if needed
 	if spa.UseEmbeddedFiles {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -684,6 +684,11 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 		return nil, "", false
 	}
 
+	if !info.Mode().IsRegular() {
+		logger.Log(logger.LevelWarn, logFields, nil, "favicon path is not a regular file; serving default icon")
+		return nil, "", false
+	}
+
 	if info.Size() > maxFaviconSize {
 		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
 		return nil, "", false

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -678,7 +678,17 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 
 	logFields := map[string]string{"path": path}
 
-	info, err := os.Stat(path) //nolint:gosec // path is admin-provided configuration
+	file, err := os.Open(path) //nolint:gosec // path is admin-provided configuration
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "favicon file not accessible; serving default icon")
+		return nil, "", false
+	}
+
+	defer func() { _ = file.Close() }()
+
+	// Stat the open descriptor rather than the path so the regular-file check
+	// applies to exactly what we read.
+	info, err := file.Stat()
 	if err != nil {
 		logger.Log(logger.LevelWarn, logFields, err, "favicon file not accessible; serving default icon")
 		return nil, "", false
@@ -689,14 +699,16 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 		return nil, "", false
 	}
 
-	if info.Size() > maxFaviconSize {
-		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
+	// Read through a LimitReader so the size cap is enforced on the bytes we
+	// actually read, not on a possibly-stale stat size (avoids a TOCTOU bypass).
+	data, err = io.ReadAll(io.LimitReader(file, maxFaviconSize+1))
+	if err != nil {
+		logger.Log(logger.LevelWarn, logFields, err, "reading favicon file; serving default icon")
 		return nil, "", false
 	}
 
-	data, err = os.ReadFile(path) //nolint:gosec // path is admin-provided configuration
-	if err != nil {
-		logger.Log(logger.LevelWarn, logFields, err, "reading favicon file; serving default icon")
+	if len(data) > maxFaviconSize {
+		logger.Log(logger.LevelWarn, logFields, nil, "favicon file too large; serving default icon")
 		return nil, "", false
 	}
 
@@ -713,14 +725,19 @@ func faviconFromFile(path string) (data []byte, contentType string, ok bool) {
 // faviconFromBase64 decodes a base64 PNG. The content type is fixed to
 // image/png and the decoded bytes are validated against the PNG signature.
 func faviconFromBase64(encoded string) (data []byte, contentType string, ok bool) {
-	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
-	if err != nil {
-		logger.Log(logger.LevelWarn, nil, err, "decoding favicon-base64; serving default icon")
+	trimmed := strings.TrimSpace(encoded)
+
+	// Reject oversized input before decoding it. DecodedLen is an upper bound on
+	// the decoded size, so this caps the allocation instead of decoding a huge
+	// string into memory first.
+	if base64.StdEncoding.DecodedLen(len(trimmed)) > maxFaviconSize {
+		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 too large; serving default icon")
 		return nil, "", false
 	}
 
-	if len(data) > maxFaviconSize {
-		logger.Log(logger.LevelWarn, nil, nil, "favicon-base64 too large; serving default icon")
+	data, err := base64.StdEncoding.DecodeString(trimmed)
+	if err != nil {
+		logger.Log(logger.LevelWarn, nil, err, "decoding favicon-base64; serving default icon")
 		return nil, "", false
 	}
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -121,6 +121,8 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		DefaultLightTheme:                     conf.DefaultLightTheme,
 		DefaultDarkTheme:                      conf.DefaultDarkTheme,
 		ForceTheme:                            conf.ForceTheme,
+		Favicon:                               conf.Favicon,
+		FaviconBase64:                         conf.FaviconBase64,
 		UnsafeUseServiceAccountToken:          conf.UnsafeUseServiceAccountToken,
 		ServiceAccountTokenPath:               conf.ServiceAccountTokenPath,
 	}

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -122,6 +122,8 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		DefaultLightTheme:                     conf.DefaultLightTheme,
 		DefaultDarkTheme:                      conf.DefaultDarkTheme,
 		ForceTheme:                            conf.ForceTheme,
+		Favicon:                               conf.Favicon,
+		FaviconBase64:                         conf.FaviconBase64,
 		UnsafeUseServiceAccountToken:          conf.UnsafeUseServiceAccountToken,
 		ServiceAccountTokenPath:               conf.ServiceAccountTokenPath,
 	}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -111,6 +111,9 @@ type Config struct {
 	DefaultLightTheme string `koanf:"default-light-theme"`
 	DefaultDarkTheme  string `koanf:"default-dark-theme"`
 	ForceTheme        string `koanf:"force-theme"`
+	// Favicon config
+	Favicon       string `koanf:"favicon"`
+	FaviconBase64 string `koanf:"favicon-base64"`
 }
 
 func (c *Config) warnRedundantThemeDefaults() {
@@ -580,6 +583,9 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.String("default-light-theme", "", "Default theme to use when user prefers light mode")
 	f.String("default-dark-theme", "", "Default theme to use when user prefers dark mode")
 	f.String("force-theme", "", "Force a specific theme, overriding user preferences")
+	f.String("favicon", "", "Path to a custom favicon file (.png or .ico) replacing the bundled tab icon")
+	f.String("favicon-base64", "",
+		"Base64-encoded PNG to use as the custom favicon; useful for containers without mounting files")
 	f.Bool("unsafe-use-service-account-token", false,
 		"UNSAFE: use the pod's service account token to authenticate all users in-cluster. "+
 			"Disables per-user auth; only safe behind an auth proxy")

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -112,6 +112,9 @@ type Config struct {
 	DefaultLightTheme string `koanf:"default-light-theme"`
 	DefaultDarkTheme  string `koanf:"default-dark-theme"`
 	ForceTheme        string `koanf:"force-theme"`
+	// Favicon config
+	Favicon       string `koanf:"favicon"`
+	FaviconBase64 string `koanf:"favicon-base64"`
 }
 
 func (c *Config) warnRedundantThemeDefaults() {
@@ -612,6 +615,9 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.String("default-light-theme", "", "Default theme to use when user prefers light mode")
 	f.String("default-dark-theme", "", "Default theme to use when user prefers dark mode")
 	f.String("force-theme", "", "Force a specific theme, overriding user preferences")
+	f.String("favicon", "", "Path to a custom favicon file (.png or .ico) replacing the bundled tab icon")
+	f.String("favicon-base64", "",
+		"Base64-encoded PNG to use as the custom favicon; useful for containers without mounting files")
 	f.Bool("unsafe-use-service-account-token", false,
 		"UNSAFE: use the pod's service account token to authenticate all users in-cluster. "+
 			"Disables per-user auth; only safe behind an auth proxy")

--- a/backend/pkg/config/config_favicon_test.go
+++ b/backend/pkg/config/config_favicon_test.go
@@ -1,0 +1,79 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFaviconConfiguration_File(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd", "--favicon=/branding/favicon.ico"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "/branding/favicon.ico", conf.Favicon)
+	assert.Equal(t, "", conf.FaviconBase64)
+}
+
+func TestParseFaviconConfiguration_Base64(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd", "--favicon-base64=aGVsbG8="})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "", conf.Favicon)
+	assert.Equal(t, "aGVsbG8=", conf.FaviconBase64)
+}
+
+func TestParseFaviconConfiguration_Both(t *testing.T) {
+	conf, err := config.Parse([]string{
+		"go run ./cmd",
+		"--favicon=/branding/favicon.png",
+		"--favicon-base64=aGVsbG8=",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "/branding/favicon.png", conf.Favicon)
+	assert.Equal(t, "aGVsbG8=", conf.FaviconBase64)
+}
+
+func TestParseFaviconConfiguration_FromEnv(t *testing.T) {
+	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_FAVICON", "/env/favicon.ico"))
+	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_FAVICON_BASE64", "ZW52"))
+
+	defer func() {
+		require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_FAVICON"))
+		require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_FAVICON_BASE64"))
+	}()
+
+	conf, err := config.Parse([]string{"go run ./cmd"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "/env/favicon.ico", conf.Favicon)
+	assert.Equal(t, "ZW52", conf.FaviconBase64)
+}
+
+func TestParseFaviconConfiguration_ArgsOverrideEnv(t *testing.T) {
+	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_FAVICON", "/env/favicon.ico"))
+
+	defer func() { require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_FAVICON")) }()
+
+	conf, err := config.Parse([]string{"go run ./cmd", "--favicon=/cli/favicon.ico"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "/cli/favicon.ico", conf.Favicon)
+}
+
+func TestParseFaviconConfiguration_NoConfig(t *testing.T) {
+	conf, err := config.Parse([]string{"go run ./cmd"})
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	assert.Equal(t, "", conf.Favicon)
+	assert.Equal(t, "", conf.FaviconBase64)
+}

--- a/backend/pkg/config/config_favicon_test.go
+++ b/backend/pkg/config/config_favicon_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
@@ -41,13 +40,9 @@ func TestParseFaviconConfiguration_Both(t *testing.T) {
 }
 
 func TestParseFaviconConfiguration_FromEnv(t *testing.T) {
-	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_FAVICON", "/env/favicon.ico"))
-	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_FAVICON_BASE64", "ZW52"))
-
-	defer func() {
-		require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_FAVICON"))
-		require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_FAVICON_BASE64"))
-	}()
+	// t.Setenv restores any prior value (or unsets) at test end, keeping the test isolated.
+	t.Setenv("HEADLAMP_CONFIG_FAVICON", "/env/favicon.ico")
+	t.Setenv("HEADLAMP_CONFIG_FAVICON_BASE64", "ZW52")
 
 	conf, err := config.Parse([]string{"go run ./cmd"})
 	require.NoError(t, err)
@@ -58,9 +53,7 @@ func TestParseFaviconConfiguration_FromEnv(t *testing.T) {
 }
 
 func TestParseFaviconConfiguration_ArgsOverrideEnv(t *testing.T) {
-	require.NoError(t, os.Setenv("HEADLAMP_CONFIG_FAVICON", "/env/favicon.ico"))
-
-	defer func() { require.NoError(t, os.Unsetenv("HEADLAMP_CONFIG_FAVICON")) }()
+	t.Setenv("HEADLAMP_CONFIG_FAVICON", "/env/favicon.ico")
 
 	conf, err := config.Parse([]string{"go run ./cmd", "--favicon=/cli/favicon.ico"})
 	require.NoError(t, err)

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -80,6 +80,8 @@ type HeadlampCFG struct {
 	DefaultLightTheme            string
 	DefaultDarkTheme             string
 	ForceTheme                   string
+	Favicon                      string
+	FaviconBase64                string
 	UnsafeUseServiceAccountToken bool
 	ServiceAccountTokenPath      string
 

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -81,6 +81,8 @@ type HeadlampCFG struct {
 	DefaultLightTheme            string
 	DefaultDarkTheme             string
 	ForceTheme                   string
+	Favicon                      string
+	FaviconBase64                string
 	UnsafeUseServiceAccountToken bool
 	ServiceAccountTokenPath      string
 

--- a/docs/installation/custom-favicon.md
+++ b/docs/installation/custom-favicon.md
@@ -1,0 +1,148 @@
+---
+title: Custom Favicon
+sidebar_label: Custom Favicon
+sidebar_position: 5
+---
+
+Headlamp can serve a custom favicon (the browser-tab icon) at runtime, for
+branding purposes, without rebuilding the frontend. The icon is provided to the
+backend either as a file path or as a base64-encoded PNG, which makes it easy to
+set in container and Kubernetes environments.
+
+Only the browser-tab icons are replaced:
+
+- `/favicon.ico`
+- `/favicon-16x16.png`
+- `/favicon-32x32.png`
+
+The same image is served for all three. The Apple touch icon
+(`/apple-touch-icon.png`, used for the iOS "Add to Home Screen" icon) is left
+unchanged.
+
+## Options
+
+| Flag               | Environment variable             | Description                                              |
+| ------------------ | -------------------------------- | -------------------------------------------------------- |
+| `-favicon`         | `HEADLAMP_CONFIG_FAVICON`        | Path to a custom favicon file (`.png` or `.ico`).        |
+| `-favicon-base64`  | `HEADLAMP_CONFIG_FAVICON_BASE64` | Base64-encoded PNG to use as the favicon.                |
+
+As with all Headlamp options, a command-line flag takes precedence over the
+matching environment variable. If both `-favicon` and `-favicon-base64` are set,
+`-favicon` (the file) is used and the base64 value is ignored (a warning is
+logged).
+
+## Requirements and behavior
+
+- **Accepted formats:** PNG (`.png`) and ICO (`.ico`) for `-favicon`; PNG only
+  for `-favicon-base64`.
+- **Validation:** The file extension determines the served `Content-Type`, and
+  the file contents are validated against it (the leading "magic bytes" must
+  match). Files larger than 1 MiB are rejected.
+- **Safe fallback:** If the configured icon is missing, too large, of an
+  unsupported type, or does not match its declared format, Headlamp logs a
+  warning and serves its **default** icon instead — it does not fail to start.
+- **A single image is enough.** Browsers scale the icon, so a single 32×32 (or
+  larger) image works for every tab-icon size.
+- **Caching:** The favicon is served with `Cache-Control: public, max-age=86400`.
+  After changing it, do a hard refresh (or use a private window) to bypass the
+  browser cache.
+
+## Examples
+
+### Local / static build
+
+```bash
+npm run frontend:build
+./backend/headlamp-server -html-static-dir frontend/build -favicon /branding/favicon.ico
+```
+
+Then open <http://localhost:4466/> — the tab shows your custom icon.
+
+### Environment variable
+
+```bash
+export HEADLAMP_CONFIG_FAVICON=/branding/favicon.png
+./backend/headlamp-server -html-static-dir frontend/build
+```
+
+### Base64 (no file needed)
+
+Useful in containers where mounting a file is inconvenient:
+
+```bash
+export HEADLAMP_CONFIG_FAVICON_BASE64="$(base64 -w0 favicon.png)"
+./backend/headlamp-server -html-static-dir frontend/build
+```
+
+### Docker
+
+Mount the icon and point the flag at it:
+
+```bash
+docker run -p 127.0.0.1:4466:4466 \
+  -v "$(pwd)/branding:/branding:ro" \
+  ghcr.io/headlamp-k8s/headlamp:latest \
+  -in-cluster -favicon /branding/favicon.ico
+```
+
+Or pass it inline as base64, with no volume:
+
+```bash
+docker run -p 127.0.0.1:4466:4466 \
+  -e HEADLAMP_CONFIG_FAVICON_BASE64="$(base64 -w0 favicon.png)" \
+  ghcr.io/headlamp-k8s/headlamp:latest -in-cluster
+```
+
+### Kubernetes
+
+The base64 form is the simplest in-cluster, because no volume is required:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+spec:
+  template:
+    spec:
+      containers:
+        - name: headlamp
+          image: ghcr.io/headlamp-k8s/headlamp:latest
+          args:
+            - "-in-cluster"
+          env:
+            - name: HEADLAMP_CONFIG_FAVICON_BASE64
+              valueFrom:
+                secretKeyRef:
+                  name: headlamp-branding
+                  key: favicon-base64
+```
+
+where the `headlamp-branding` Secret (or ConfigMap) holds the base64 string:
+
+```bash
+kubectl create secret generic headlamp-branding \
+  --from-literal=favicon-base64="$(base64 -w0 favicon.png)"
+```
+
+Alternatively, mount the icon file from a ConfigMap and use `-favicon`:
+
+```yaml
+args:
+  - "-in-cluster"
+  - "-favicon=/branding/favicon.png"
+volumeMounts:
+  - name: branding
+    mountPath: /branding
+    readOnly: true
+volumes:
+  - name: branding
+    configMap:
+      name: headlamp-branding
+```
+
+Create that ConfigMap from a binary file with:
+
+```bash
+kubectl create configmap headlamp-branding --from-file=favicon.png=favicon.png
+```

--- a/docs/installation/custom-favicon.md
+++ b/docs/installation/custom-favicon.md
@@ -70,7 +70,7 @@ export HEADLAMP_CONFIG_FAVICON=/branding/favicon.png
 Useful in containers where mounting a file is inconvenient:
 
 ```bash
-export HEADLAMP_CONFIG_FAVICON_BASE64="$(base64 -w0 favicon.png)"
+export HEADLAMP_CONFIG_FAVICON_BASE64="$(base64 < favicon.png | tr -d '\n')"
 ./backend/headlamp-server -html-static-dir frontend/build
 ```
 
@@ -89,7 +89,7 @@ Or pass it inline as base64, with no volume:
 
 ```bash
 docker run -p 127.0.0.1:4466:4466 \
-  -e HEADLAMP_CONFIG_FAVICON_BASE64="$(base64 -w0 favicon.png)" \
+  -e HEADLAMP_CONFIG_FAVICON_BASE64="$(base64 < favicon.png | tr -d '\n')" \
   ghcr.io/headlamp-k8s/headlamp:latest -in-cluster
 ```
 
@@ -122,7 +122,7 @@ where the `headlamp-branding` Secret (or ConfigMap) holds the base64 string:
 
 ```bash
 kubectl create secret generic headlamp-branding \
-  --from-literal=favicon-base64="$(base64 -w0 favicon.png)"
+  --from-literal=favicon-base64="$(base64 < favicon.png | tr -d '\n')"
 ```
 
 Alternatively, mount the icon file from a ConfigMap and use `-favicon`:


### PR DESCRIPTION
## Summary

This PR adds a **configurable favicon** by letting administrators replace Headlamp's browser-tab icon at runtime, either from a file or from a base64-encoded PNG. It works as CLI args and as env vars. Base64 as an env var is convenient in Kubernetes.

In my company Headlamp is self-hosted in each Kubernetes cluster. Each team has several clusters (dev, QA, preprod, prod). Users typically open several Headlamp tabs at once on different clusters, and the identical favicon makes it hard to tell them apart. With this change each Headlamp can ship a distinct icon, so the right tab is obvious at a glance.

## Changes

- **Added** `--favicon` (path to a `.png`/`.ico` file) and `--favicon-base64`   (base64-encoded PNG) backend flags, with matching `HEADLAMP_CONFIG_FAVICON`   and `HEADLAMP_CONFIG_FAVICON_BASE64` environment variables for convenience in Kubernetes.
- **Added** favicon resolution and serving in the backend HTTP handler. The   custom icon overrides the three browser-tab paths: `/favicon.ico`,  `/favicon-16x16.png`, `/favicon-32x32.png`. The server sets a fixed content type  (`image/png` or `image/x-icon`), validates the bytes against the expected   PNG/ICO magic bytes, caps the size at 1 MiB, and serves the response with   `X-Content-Type-Options: nosniff`. Invalid or missing input logs a warning and  falls back to the default icon instead of failing startup.
- **Added** unit tests for config parsing and for the resolver/handler behavior.
- **Added** documentation 

## Steps to Test

Use the new CLI args or env vars to load a custom favicon. 

**Precedence:** if both `--favicon` and `--favicon-base64` are set, `--favicon`  wins and a warning is logged.

If you want to test with the red headlamp, here it is in base64:

```base64
iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZiS0dEAPcA+wD+4MN0GAAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAAd0SU1FB+oGChMXJcsRyngAAAJESURBVFjD7Ze7axRBGMB/+5jlsnvhLhqEaHGm0RQ+YiSIGMRHkSYEF9KY7kCwEP8HGyv/hUAaG+2sIj7SKnYaxE4URBAxXjQLyR17kyKzgsvOzm7uzmv8YGB2d5jvN99jvm+hnNwHZM7YAi6U2dBmyDJ0AKfgujFgDlgGJnPWWcBP4KtyR7cXuED58x7wGogM/k9GVwE8Am4CxxRYKbcsAy/UaWQPow18AB4AR4oCeMDTHhWnxy9ddvzPAleTGW5u6thw1vX+PG/EbTpxrh5Lt2eWBa4C07pdQiFYdAQNKVn3fRpSsmALQiGw9bFeBRaKWHwKeJsVSBbIUAjZqte1Y8bzpGNrA/E7cN1kgTvAmSyyc57HahDk0q/7PouO0H0eB26nXWGn5pm56jrQkLJwYI1WtJ8O5QFoZW68eLKsBgEXJ5z+puHYpmM0/193+Bd7uPfAzkS3vwBrVodmFBXasBlFvPoR9xdgp1389J8ti1bEgQAksKtb+CQ2W6EZRWzEubS7ph4hBLZ1Vc2x9y+j9IWUvPMcY2m+ZbJIBXhoKq/Vyj7IjeOuDIWQ9aBQSV4DakXcsgR0+twPSOBu0SA8baqGB5TpLH3pF6PAlQGV/kvAURPASeDUgAAmgVkTwKxqwQchHnDZ9F+wCXxS8xrgl22pM2QLeAOsAI+Bb+kmJ0tGgBPANWAeOA8cLgHTAt4Bz1V7/x74reuyTDKiYiOBmdHAJEqfAS/zlJYFSMNMqb5xXs0/qpMmSrf/VUddVZap9bLJHvpZ+bqKh74mAAAAAElFTkSuQmCC
```

I also added unit tests:

```bash
cd backend
go test ./pkg/config/ -run TestParseFavicon -v
go test ./cmd/ -run "Favicon" -v
```

## Screenshots (if applicable)

<img width="352" height="82" alt="image" src="https://github.com/user-attachments/assets/9bbf5eb8-9000-4527-8ba2-b8eb3d5224ac" />

