### PR TITLE
frontend: plugin: Fix main branch tests, add test that implementation detail is not exported

### DIFF
--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -537,9 +537,7 @@
       "default": [Function],
     },
   },
-  "Lodash": Function {
-    "default": [Function],
-  },
+  "Lodash": "Present",
   "MonacoEditor": "Present",
   "MuiCore": "Present",
   "MuiLab": "Present",
@@ -619,9 +617,6 @@
   "clusterAction": [Function],
   "default": [Function],
   "getHeadlampAPIHeaders": [Function],
-  "queryClient": {
-    "queryClient": QueryClient {},
-  },
   "registerAddClusterProvider": [Function],
   "registerAppBarAction": [Function],
   "registerAppLogo": [Function],

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -47,7 +47,6 @@ import * as K8s from '../lib/k8s';
 import * as ApiProxy from '../lib/k8s/apiProxy';
 import * as Crd from '../lib/k8s/crd';
 import * as Notification from '../lib/notification';
-import * as queryClient from '../lib/queryClient';
 import * as Router from '../lib/router';
 import * as Utils from '../lib/util';
 import { eventAction, HeadlampEventType } from '../redux/headlampEventSlice';
@@ -105,7 +104,6 @@ window.pluginLib = {
   ...registryToExport,
   Activity,
   stateless,
-  queryClient,
 };
 
 // backwards compat.

--- a/frontend/src/plugin/pluginLib.test.ts
+++ b/frontend/src/plugin/pluginLib.test.ts
@@ -21,6 +21,7 @@ describe('pluginLib variable', () => {
   it('should stay the same for plugin compatibility', async () => {
     const externalLibs = [
       'Iconify',
+      'Lodash',
       'MonacoEditor',
       'MuiCore',
       'MuiLab',
@@ -42,5 +43,13 @@ describe('pluginLib variable', () => {
     });
 
     await expect(window.pluginLib).toMatchFileSnapshot('__snapshots__/pluginLib.snapshot');
+  });
+
+  it('should not expose queryClient to plugins', () => {
+    // queryClient is an internal singleton that plugins must not access directly.
+    // Exposing it lets plugins invalidate or mutate queries belonging to other
+    // plugins or to Headlamp core, breaking isolation and causing subtle bugs.
+    // It's an implementation detail of our pluginLib that plugins must not rely on.
+    expect(window.pluginLib).not.toHaveProperty('queryClient');
   });
 });


### PR DESCRIPTION
## Summary

Fixes a pre-existing snapshot instability: `Lodash` serializes differently across environments (local macOS includes `module.exports`, CI Ubuntu does not), causing the `pluginLib.snapshot` test to fail on CI. Fixed by adding `Lodash` to the `externalLibs` list so it gets the same `"Present"/"Missing"` normalization as other bundled libraries.

Also stops exporting the internal `queryClient` singleton to plugins via `window.pluginLib`. Plugins that access the shared QueryClient can invalidate or mutate queries belonging to other plugins or Headlamp core, breaking isolation. A test is added to prevent re-exporting it in the future.

## Changes

- Added `Lodash` to the `externalLibs` normalization list to fix cross-platform snapshot instability
- Removed `queryClient` import and export from `frontend/src/plugin/index.ts`
- Added test in `pluginLib.test.ts`: `should not expose queryClient to plugins`
- Updated `pluginLib.snapshot` to reflect both changes

## Steps to Test

1. Run `cd frontend && npx vitest run src/plugin/pluginLib.test.ts`
2. Both tests should pass: the snapshot test and the new queryClient exclusion test
3. Verify no existing plugin in the repo imports `queryClient` from `pluginLib`

## Notes for the Reviewer

- No plugin in the repo uses `pluginLib.queryClient` — they all create their own `QueryClient` instances
- This is a breaking change only for third-party plugins that directly access `window.pluginLib.queryClient`, which is an undocumented internal
- The Lodash snapshot fix is independent of the queryClient change but included here since it affects the same snapshot file