### PR TITLE
backend: portforward: Reject duplicate IDs to prevent resource leaks

### DIFF
--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -57,6 +57,8 @@ const (
 	PortForwardReadinessTimeout = 30 * time.Second
 )
 
+var inFlightPortForwards sync.Map
+
 type portForwardRequest struct {
 	ID               string `json:"id"`
 	Namespace        string `json:"namespace"`
@@ -151,6 +153,38 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		p.ID = uuid.New().String()
 	}
 
+	userID := r.Header.Get("X-HEADLAMP-USER-ID")
+	requestClusterName := mux.Vars(r)["clusterName"]
+	clusterName := requestClusterName
+
+	if userID != "" {
+		clusterName += userID
+	}
+
+	// Ensure we don't orphan an existing port-forward by overwriting its cache entry.
+	// This check happens before any resource allocation or blocking code so duplicates short-circuit
+	// deterministically and avoid unnecessary listener churn.
+	if existingPF, err := getPortForwardByID(cache, clusterName, p.ID); err == nil && existingPF.Status == RUNNING {
+		//nolint:goconst
+		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
+			nil, "portforward ID already exists")
+		http.Error(w, "portforward with this ID is already running", http.StatusConflict)
+
+		return
+	}
+
+	// Reject duplicates before any resource-consuming work (port alloc, kubeconfig lookup).
+	inFlightKey := strings.Join([]string{requestClusterName, userID, p.ID}, "\x00")
+	if _, loaded := inFlightPortForwards.LoadOrStore(inFlightKey, struct{}{}); loaded {
+		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
+			nil, "portforward ID is already starting")
+		http.Error(w, "portforward with this ID is already starting", http.StatusConflict)
+
+		return
+	}
+
+	defer inFlightPortForwards.Delete(inFlightKey)
+
 	if err := p.Validate(); err != nil {
 		logger.Log(logger.LevelError, nil, err, "validating portforward payload")
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -170,27 +204,11 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		p.Port = strconv.Itoa(freePort)
 	}
 
-	userID := r.Header.Get("X-HEADLAMP-USER-ID")
-	requestClusterName := mux.Vars(r)["clusterName"]
-	clusterName := requestClusterName
-
-	if userID != "" {
-		clusterName += userID
-	}
-
-	// Ensure we don't orphan an existing port-forward by overwriting its cache entry
-	if existingPF, err := getPortForwardByID(cache, clusterName, p.ID); err == nil && existingPF.Status == RUNNING {
-		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
-			nil, "portforward ID already exists")
-		http.Error(w, "portforward with this ID is already running", http.StatusConflict)
-
-		return
-	}
-
 	kContext, err := kubeConfigStore.GetContext(clusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName},
 			err, "getting kubeconfig context")
+
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return
@@ -204,6 +222,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 	err = startPortForward(kContext, cache, p, token, clusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "starting portforward")
+
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -178,6 +178,15 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		clusterName += userID
 	}
 
+	// Ensure we don't orphan an existing port-forward by overwriting its cache entry
+	if existingPF, err := getPortForwardByID(cache, clusterName, p.ID); err == nil && existingPF.Status == RUNNING {
+		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
+			nil, "portforward ID already exists")
+		http.Error(w, "portforward with this ID is already running", http.StatusConflict)
+
+		return
+	}
+
 	kContext, err := kubeConfigStore.GetContext(clusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName},

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -25,7 +25,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
@@ -679,4 +681,109 @@ func TestStartPortForward_DuplicateIDConflict(t *testing.T) {
 	defer func() { _ = res.Body.Close() }()
 
 	assert.Equal(t, http.StatusConflict, res.StatusCode, "expected 409 Conflict for duplicate ID, but got something else")
+}
+
+// blockingContextStore makes GetContext block until released, and signals via
+// `entered` (closed once) that a caller is inside, meaning it holds the in-flight lock.
+type blockingContextStore struct {
+	kubeconfig.ContextStore
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingContextStore) GetContext(name string) (*kubeconfig.Context, error) {
+	b.once.Do(func() { close(b.entered) })
+	<-b.release
+
+	return nil, fmt.Errorf("context not found: %s", name)
+}
+
+// TestStartPortForward_ConcurrentRequests verifies the in-flight lock deterministically:
+// G1 acquires the lock and blocks in GetContext; only then is G2 started (guaranteed 409).
+// G2 completes, the test unblocks G1, which returns 500 on the missing context.
+//
+//nolint:funlen
+func TestStartPortForward_ConcurrentRequests(t *testing.T) {
+	c := cache.New[interface{}]()
+
+	store := &blockingContextStore{
+		ContextStore: kubeconfig.NewContextStore(),
+		entered:      make(chan struct{}),
+		release:      make(chan struct{}),
+	}
+
+	makeRequest := func() *httptest.ResponseRecorder {
+		payload := map[string]interface{}{
+			"id":         "concurrent-id",
+			"pod":        "some-pod",
+			"namespace":  "default",
+			"targetPort": "8080",
+		}
+
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/portforward", bytes.NewReader(body))
+		r = mux.SetURLVars(r, map[string]string{"clusterName": "test-cluster"})
+
+		StartPortForward(store, c, false, w, r)
+
+		return w
+	}
+
+	// Separate WaitGroups: wg2 lets us wait for G2 alone while G1 is still blocked.
+	var (
+		wg1, wg2 sync.WaitGroup
+		rec      [2]*httptest.ResponseRecorder
+	)
+
+	wg1.Add(1)
+
+	go func() {
+		defer wg1.Done()
+
+		rec[0] = makeRequest()
+	}()
+
+	// Wait (bounded) for G1 to enter GetContext (holding the lock); otherwise fail instead of hanging.
+	select {
+	case <-store.entered:
+		// G1 is now inside GetContext
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first request to enter GetContext")
+	}
+
+	wg2.Add(1)
+
+	go func() {
+		defer wg2.Done()
+
+		rec[1] = makeRequest()
+	}()
+
+	wg2.Wait()           // G2 short-circuits at 409; doesn't call GetContext.
+	close(store.release) // unblock G1.
+	wg1.Wait()
+
+	res0 := rec[0].Result()
+	defer func() { _ = res0.Body.Close() }()
+
+	res1 := rec[1].Result()
+	defer func() { _ = res1.Body.Close() }()
+
+	statusCodes := []int{res0.StatusCode, res1.StatusCode}
+
+	conflicts := 0
+
+	for _, sc := range statusCodes {
+		if sc == http.StatusConflict {
+			conflicts++
+		}
+	}
+
+	assert.Equal(t, 1, conflicts, "expected exactly one 409 Conflict from the in-flight lock")
+	assert.Contains(t, statusCodes, http.StatusInternalServerError,
+		"expected the winning request to return 500 for missing context")
 }

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
@@ -640,4 +641,42 @@ func TestStopOrDeletePortForwardHandler_UserIDKeyIsolation(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, res.StatusCode,
 		"stop request with user ID must not find entries stored under base cluster key")
+}
+
+// TestStartPortForward_DuplicateIDConflict verifies that StartPortForward
+// returns a 409 Conflict if a port-forward with the same ID is already running.
+func TestStartPortForward_DuplicateIDConflict(t *testing.T) {
+	c := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	// Seed a running port-forward in the cache
+	pf := portForward{
+		ID:        "duplicate-id",
+		Cluster:   "test-cluster",
+		Pod:       "some-pod",
+		Namespace: "default",
+		Status:    RUNNING,
+	}
+	portforwardstore(c, pf)
+
+	reqPayload := map[string]interface{}{
+		"id":         "duplicate-id",
+		"pod":        "another-pod",
+		"namespace":  "default",
+		"targetPort": "8080",
+	}
+	jsonReq, err := json.Marshal(reqPayload)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/portforward", bytes.NewReader(jsonReq))
+	r = mux.SetURLVars(r, map[string]string{"clusterName": "test-cluster"})
+
+	StartPortForward(kubeConfigStore, c, false, w, r)
+
+	res := w.Result()
+
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusConflict, res.StatusCode, "expected 409 Conflict for duplicate ID, but got something else")
 }

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -62,6 +62,7 @@ func portforwardstore(cache cache.Cache[interface{}], p portForward) {
 func stopOrDeletePortForward(cache cache.Cache[interface{}], cluster string, id string, isStopRequest bool) error {
 	portforward, err := getPortForwardByID(cache, cluster, id)
 	if err != nil {
+		//nolint:goconst
 		logger.Log(logger.LevelError, map[string]string{"cluster": cluster, "id": id},
 			err, "getting portforward")
 


### PR DESCRIPTION
Prevents port and goroutine leaks by returning an HTTP 409 Conflict when a client attempts to start a port-forward using an ID that is already active in the cache.

## Summary

Fixes a resource leak in the `portforward` package where submitting a `POST /portforward` request with an ID already in use by a `RUNNING` port-forward would silently overwrite the cache entry. This made it impossible to stop or delete the original port-forward, leaving its goroutines and local port permanently orphaned.

This PR adds an early conflict check in `StartPortForward` that returns `HTTP 409 Conflict` if the provided `id` is already associated with a running port-forward or a port-forward already in process, enforcing proper state management and preventing the leak.

## Related Issue

Fixes #5984 

## Changes

- Added duplicate-ID check in `StartPortForward` (`backend/pkg/portforward/handler.go`) that returns 
`HTTP 409 Conflict` before any new resources are allocated
- Added `TestStartPortForward_DuplicateIDConflict` in `internal_test.go` to cover the regression and confirm the 409 response
- Added an in memory FlightLock to check for concurrent duplicate requests
- Added `TestStartPortForward_ConcurrentRequests` to test against concurrent duplicate requests bounded by time.

## Steps to Test

1. Run the Headlamp backend locally (`npm run backend:start`)
2. Send a `POST` request to start a port-forward with a specific `id` (e.g., `"id": "my-pf"`) targeting a valid pod
3. Send the exact same `POST` request again with the same `id`
4. Observe that the second request returns `HTTP 409 Conflict` instead of `HTTP 200`
5. Confirm via `GET /clusters/<cluster>/portforward/list` that only one port-forward entry exists and it is still functional
6. Run unit tests: `npm run backend:test` to check that the new test works

## Screenshots
Before the fix:
<img width="1917" height="905" alt="Image" src="https://github.com/user-attachments/assets/b6ec964d-1d1e-48b7-9b69-4e4f414f761d" />

After the fix:
<img width="1891" height="395" alt="image" src="https://github.com/user-attachments/assets/1a10d24c-ae2c-4a1d-b020-8efb4ca9a62f" />
the backend will reject the request

## Notes for the Reviewer
- The fix is minimal, just a single guard block before any Kubernetes client setup or port allocation occurs, so there is no
  performance impact on the path.
- The check uses the existing `getPortForwardByID` helper and only blocks on `Status == RUNNING`; a stopped or deleted entry with the same ID can still be reused, which preserves the existing UX.
