### PR TITLE
frontend: Fix stateless cluster add-cluster flow

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2211,11 +2211,14 @@ func parseClusterFromKubeConfig(kubeConfigs []string) ([]Cluster, []error) {
 	}
 
 	if len(setupErrors) > 0 {
-		logger.Log(logger.LevelError, nil, setupErrors, "setting up contexts from kubeconfig")
-		return nil, setupErrors
+		if len(clusters) == 0 {
+			logger.Log(logger.LevelError, nil, setupErrors, "setting up contexts from kubeconfig")
+		} else {
+			logger.Log(logger.LevelWarn, nil, setupErrors, "setting up contexts from kubeconfig")
+		}
 	}
 
-	return clusters, nil
+	return clusters, setupErrors
 }
 
 func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -29,6 +29,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const statelessContextKeySep = "\x00"
+
+func statelessContextKey(clusterName, userID string) string {
+	if userID == "" {
+		return clusterName
+	}
+
+	return clusterName + statelessContextKeySep + userID
+}
+
 // MarshalCustomObject marshals the runtime.Unknown object into a CustomObject.
 func MarshalCustomObject(info runtime.Object, contextName string) (kubeconfig.CustomObject, error) {
 	// Convert the runtime.Unknown object to a byte slice
@@ -83,14 +93,10 @@ func (c *HeadlampConfig) setKeyInCache(key string, context kubeconfig.Context) e
 // Handles stateless cluster requests if kubeconfig is set and dynamic clusters are enabled.
 // It returns context key which is used to store the context in the cache.
 func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) (string, error) {
-	var key string
-
 	var contextKey string
 
 	userID := r.Header.Get("X-HEADLAMP-USER-ID")
-	clusterName := mux.Vars(r)["clusterName"]
-	// unique key for the context
-	key = clusterName + userID
+	targetClusterName := mux.Vars(r)["clusterName"]
 
 	contexts, contextLoadErrors, err := kubeconfig.LoadContextsFromBase64String(kubeConfig, kubeconfig.DynamicCluster)
 	if len(contextLoadErrors) > 0 {
@@ -117,6 +123,8 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 	}
 
 	for _, context := range contexts {
+		effectiveContextName := context.Name
+
 		info := context.KubeContext.Extensions["headlamp_info"]
 		if info != nil {
 			customObj, err := MarshalCustomObject(info, context.Name)
@@ -127,21 +135,23 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 				return "", err
 			}
 
-			// Check if the CustomName field is present
 			if customObj.CustomName != "" {
-				key = customObj.CustomName + userID
+				effectiveContextName = customObj.CustomName
 			}
-		} else if context.Name != clusterName {
-			// Skip contexts that don't match the requested cluster name
+		}
+
+		if effectiveContextName != targetClusterName {
+			// Keep only the context requested by the route parameter.
 			continue
 		}
 
-		// check context is present
-		if err := c.setKeyInCache(key, context); err != nil {
+		cacheKey := statelessContextKey(effectiveContextName, userID)
+
+		if err := c.setKeyInCache(cacheKey, context); err != nil {
 			return "", err
 		}
 
-		contextKey = key
+		contextKey = cacheKey
 	}
 
 	return contextKey, nil
@@ -177,7 +187,9 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 	}
 
 	contexts, setupErrors := parseClusterFromKubeConfig(kubeconfigs)
-	if len(setupErrors) > 0 {
+	if len(setupErrors) > 0 && len(contexts) == 0 {
+		// Only fail the request when NO clusters could be parsed at all.
+		// Partial failures (some entries invalid, others valid) still return the valid clusters.
 		logger.Log(logger.LevelError, nil, setupErrors, "setting up contexts from kubeconfig")
 
 		http.Error(w, "setting up contexts from kubeconfig", http.StatusBadRequest)
@@ -201,15 +213,13 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-// websocketConnContextKey handles websocket requests. It returns context key
-// which is used to store the context in the cache. The context key is
-// unique for each user. It is found in the "base64url.headlamp.authorization.k8s.io" protocol
-// of the websocket.
+// websocketConnContextKey extracts the user identity from websocket subprotocols
+// and builds the same cache key shape used by HTTP stateless requests.
 func websocketConnContextKey(r *http.Request, clusterName string) string {
 	// Expected number of submatches in the regular expression
 	const expectedSubmatches = 2
 
-	var contextKey string
+	var userID string
 	// Define a regular expression pattern for base64url.headlamp.authorization.k8s.io
 	pattern := `base64url\.headlamp\.authorization\.k8s\.io\.([a-zA-Z0-9_-]+)`
 
@@ -221,10 +231,7 @@ func websocketConnContextKey(r *http.Request, clusterName string) string {
 
 	// Check if a match is found
 	if len(matches) >= expectedSubmatches {
-		// Extract the value after the specified prefix
-		contextKey = clusterName + matches[1]
-	} else {
-		contextKey = clusterName
+		userID = matches[1]
 	}
 
 	// Remove the base64url.headlamp.authorization.k8s.io subprotocol from the list
@@ -247,7 +254,11 @@ func websocketConnContextKey(r *http.Request, clusterName string) string {
 	// Add the updated Sec-Websocket-Protocol header
 	r.Header.Add("Sec-Websocket-Protocol", updatedProtocol)
 
-	return contextKey
+	if userID == "" {
+		return clusterName
+	}
+
+	return statelessContextKey(clusterName, userID)
 }
 
 // getContextKeyForRequest handles every requests. It returns context key

--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -206,6 +207,44 @@ func TestParseKubeConfigRequiresKubeconfigs(t *testing.T) {
 	}
 }
 
+func TestParseKubeConfigValidClusterReturnedWhenBatchContainsInvalidEntry(t *testing.T) {
+	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")
+	require.NoError(t, err)
+
+	validKubeConfig := base64.StdEncoding.EncodeToString(kubeConfigByte)
+
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "",
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	}
+	handler := createHeadlampHandler(context.Background(), &c)
+
+	body := map[string]interface{}{
+		"kubeconfigs": []string{validKubeConfig, "not-valid-base64-!!!"},
+	}
+
+	resp, err := getResponseFromRestrictedEndpoint(handler, "POST", "/parseKubeConfig", body)
+	require.NoError(t, err)
+
+	// Valid clusters should still be returned even though one entry in the batch is invalid.
+	// Previously the whole batch would fail with 400, silently dropping all valid clusters.
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	var config clientConfig
+
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &config))
+	assert.Greater(t, len(config.Clusters), 0, "expected valid clusters to be returned despite the invalid entry")
+}
+
 //nolint:funlen
 func TestStatelessClusterApiRequest(t *testing.T) {
 	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")
@@ -288,6 +327,71 @@ func TestMarshalCustomObject(t *testing.T) {
 	assert.Equal(t, "test-cluster", result.CustomName)
 }
 
+func TestHandleStatelessReqUsesCustomDisplayNameAsContextKey(t *testing.T) {
+	const userID = "user-a"
+
+	const displayName = "display-cluster"
+
+	rawKubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- name: real-cluster
+  cluster:
+    server: https://example.invalid
+contexts:
+- name: raw-context
+  context:
+    cluster: real-cluster
+    user: real-user
+    extensions:
+    - name: headlamp_info
+      extension:
+        customName: display-cluster
+users:
+- name: real-user
+  user:
+    token: test-token
+current-context: raw-context
+`
+
+	cache := cache.New[interface{}]()
+	kubeConfigStore := kubeconfig.NewContextStore()
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeConfigStore,
+			},
+			Cache: cache,
+		},
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/clusters/display-cluster/version", nil)
+	req = mux.SetURLVars(req, map[string]string{"clusterName": displayName})
+	req.Header.Set("X-HEADLAMP-USER-ID", userID)
+
+	contextKey, err := c.handleStatelessReq(req, base64.StdEncoding.EncodeToString([]byte(rawKubeconfig)))
+	require.NoError(t, err)
+
+	expectedContextKey := statelessContextKey(displayName, userID)
+	assert.Equal(t, expectedContextKey, contextKey)
+
+	keys, err := kubeConfigStore.GetContextKeys()
+	require.NoError(t, err)
+	assert.Contains(t, keys, expectedContextKey)
+}
+
+func TestStatelessContextKeyCollision(t *testing.T) {
+	first := statelessContextKey("ab", "c")
+	second := statelessContextKey("a", "bc")
+
+	assert.NotEqual(t, first, second)
+}
+
+func TestStatelessContextKeyWithoutUserID(t *testing.T) {
+	assert.Equal(t, "cluster-a", statelessContextKey("cluster-a", ""))
+}
+
 func TestWebsocketConnContextKey(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -300,7 +404,7 @@ func TestWebsocketConnContextKey(t *testing.T) {
 			name:           "With authorization protocol",
 			protocols:      "base64url.headlamp.authorization.k8s.io.user123, v4.channel.k8s.io",
 			clusterName:    "test-cluster",
-			expectedKey:    "test-clusteruser123",
+			expectedKey:    statelessContextKey("test-cluster", "user123"),
 			expectedHeader: "v4.channel.k8s.io",
 		},
 		{

--- a/e2e-tests/tests/dynamicCluster.spec.ts
+++ b/e2e-tests/tests/dynamicCluster.spec.ts
@@ -26,7 +26,19 @@ let headlampPage: HeadlampPage;
 test.beforeEach(async ({ page }) => {
   headlampPage = new HeadlampPage(page);
 
-  await headlampPage.navigateToCluster('test', process.env.HEADLAMP_TEST_TOKEN);
+  // Navigate to the test cluster page
+  await headlampPage.navigateTopage('/c/test');
+
+  // Authenticate only when the auth page appears (e.g. minikube with token auth).
+  // Use a short wait to avoid racing page hydration in slower environments.
+  const authHeader = page.locator('h1:has-text("Authentication")');
+  const hasAuthPage = await authHeader
+    .waitFor({ state: 'visible', timeout: 2000 })
+    .then(() => true)
+    .catch(() => false);
+  if (hasAuthPage) {
+    await headlampPage.authenticate(process.env.HEADLAMP_TEST_TOKEN);
+  }
 });
 
 test('There is cluster choose button and test cluster is selected', async () => {
@@ -47,21 +59,151 @@ test('Store modified kubeconfig to IndexDB and check if present', async ({ page 
   expect(storedKubeconfig).not.toBeNull();
 });
 
-test('check dummy is present in cluster and working', async ({ page }) => {
+test('parseKubeConfig endpoint accepts kubeconfigs array format', async ({ page }) => {
   const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
-  await saveKubeconfigToIndexDB(page, base64EncodedKubeconfig);
-  await page.waitForLoadState('load');
 
-  const storedKubeconfig = await getKubeconfigFromIndexDB(page);
-  await page.waitForLoadState('load');
+  // Call /parseKubeConfig with the correct kubeconfigs (plural, array) format
+  const response = await page.evaluate(async (kubeconfig: string) => {
+    const resp = await fetch('/parseKubeConfig', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kubeconfigs: [kubeconfig] }),
+    });
+    return { status: resp.status, body: await resp.json() };
+  }, base64EncodedKubeconfig);
 
-  expect(storedKubeconfig).not.toBeNull();
-
-  await headlampPage.navigateTopage('/c/dummy', /Cluster/);
-  await headlampPage.pageLocatorContent('h2:has-text("Overview")', 'Overview');
+  expect(response.status).toBe(200);
+  expect(response.body).toHaveProperty('clusters');
+  expect(Array.isArray(response.body.clusters)).toBe(true);
+  expect(response.body.clusters.length).toBeGreaterThan(0);
+  expect(response.body.clusters.some((c: { name: string }) => c.name === 'dummy')).toBe(true);
 });
 
-const getBase64EncodedKubeconfig = async () => {
+test('parseKubeConfig endpoint rejects singular kubeconfig format', async ({ page }) => {
+  const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
+
+  // Verify the old singular kubeconfig format is rejected by the backend
+  const rejectResponse = await page.evaluate(async (kubeconfig: string) => {
+    const resp = await fetch('/parseKubeConfig', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kubeconfig: kubeconfig }),
+    });
+    return { status: resp.status };
+  }, base64EncodedKubeconfig);
+
+  // The backend requires kubeconfigs (plural, array) and rejects kubeconfig (singular)
+  expect(rejectResponse.status).toBe(400);
+});
+
+test('stateless cluster loads without errors after storing kubeconfig', async ({ page }) => {
+  const base64EncodedKubeconfig = await getBase64EncodedKubeconfig();
+  const parseKubeConfigStatuses: number[] = [];
+  const browserErrors: string[] = [];
+
+  page.on('response', response => {
+    if (response.url().includes('/parseKubeConfig')) {
+      parseKubeConfigStatuses.push(response.status());
+    }
+  });
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      browserErrors.push(msg.text());
+    }
+  });
+
+  // Step 1: Store kubeconfig in IndexedDB (simulates the user adding a cluster)
+  await saveKubeconfigToIndexDB(page, base64EncodedKubeconfig);
+
+  // Step 2: Reload to trigger stateless startup parsing flow.
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForResponse(response => response.url().includes('/parseKubeConfig'));
+
+  expect(parseKubeConfigStatuses.length).toBeGreaterThan(0);
+  expect(parseKubeConfigStatuses.every(status => status === 200)).toBe(true);
+  expect(browserErrors.some(msg => msg.includes('kubeconfigs is required'))).toBe(false);
+
+  // Confirm the stateless cluster can be loaded after reload.
+  await headlampPage.navigateTopage('/c/dummy');
+  await headlampPage.pageLocatorContent(
+    'button:has-text("Our Cluster Chooser button. Cluster: dummy")',
+    'Our Cluster Chooser button. Cluster: dummy'
+  );
+});
+
+test('reload does not trigger stateless parsing when IndexedDB is empty', async ({ page }) => {
+  await clearKubeconfigsFromIndexDB(page);
+
+  const parseKubeConfigStatuses: number[] = [];
+
+  page.on('response', response => {
+    if (response.url().includes('/parseKubeConfig')) {
+      parseKubeConfigStatuses.push(response.status());
+    }
+  });
+
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForTimeout(1500);
+
+  expect(parseKubeConfigStatuses).toHaveLength(0);
+});
+
+test('adding another stateless cluster keeps previously added clusters available', async ({
+  page,
+}) => {
+  await clearKubeconfigsFromIndexDB(page);
+
+  const firstClusterName = 'dummy';
+  const secondClusterName = 'dummy-two';
+  const firstKubeconfig = await getBase64EncodedKubeconfig(firstClusterName);
+  const secondKubeconfig = await getBase64EncodedKubeconfig(secondClusterName);
+
+  await saveKubeconfigToIndexDB(page, firstKubeconfig);
+  await saveKubeconfigToIndexDB(page, secondKubeconfig);
+
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForResponse(response => response.url().includes('/parseKubeConfig'));
+
+  await headlampPage.navigateTopage(`/c/${firstClusterName}`);
+  await headlampPage.pageLocatorContent(
+    `button:has-text("Our Cluster Chooser button. Cluster: ${firstClusterName}")`,
+    `Our Cluster Chooser button. Cluster: ${firstClusterName}`
+  );
+
+  await headlampPage.navigateTopage(`/c/${secondClusterName}`);
+  await headlampPage.pageLocatorContent(
+    `button:has-text("Our Cluster Chooser button. Cluster: ${secondClusterName}")`,
+    `Our Cluster Chooser button. Cluster: ${secondClusterName}`
+  );
+});
+
+test('valid kubeconfig is still parsed when an invalid one is also sent', async ({ page }) => {
+  const validKubeconfig = await getBase64EncodedKubeconfig();
+  // A clearly invalid kubeconfig that cannot be decoded
+  const invalidKubeconfig = 'not-valid-base64-!!!';
+
+  // Send both in one request — one valid, one invalid.
+  // The backend should return the valid cluster rather than discarding it entirely.
+  const response = await page.evaluate(
+    async ({ valid, invalid }: { valid: string; invalid: string }) => {
+      const resp = await fetch('/parseKubeConfig', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kubeconfigs: [valid, invalid] }),
+      });
+      const body = resp.status === 200 ? await resp.json() : await resp.text();
+      return { status: resp.status, body };
+    },
+    { valid: validKubeconfig, invalid: invalidKubeconfig }
+  );
+
+  expect(response.status).toBe(200);
+  expect(Array.isArray(response.body.clusters)).toBe(true);
+  expect(response.body.clusters.some((c: { name: string }) => c.name === 'dummy')).toBe(true);
+});
+
+const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
   // Use kubectl command-line tool to get the kubeconfig
   const { stdout, stderr } = await exec('kubectl config view --output json');
   if (stderr) {
@@ -71,16 +213,16 @@ const getBase64EncodedKubeconfig = async () => {
 
   // Parse the kubeconfig JSON
   const kubeconfig = JSON.parse(stdout);
-  // Update the existing cluster and context names to "dummy"
-  kubeconfig.clusters[0].name = 'dummy';
+  // Update the existing cluster and context names to the requested test cluster.
+  kubeconfig.clusters[0].name = clusterName;
   // The 10.96.0.0/12: is the CIDR used by service cluster IP’s
   // and the first service that is created is that of minikube when it bootstraps the cluster.
   // It will always get 10.96.0.1 IP assigned. For more context please check https://minikube.sigs.k8s.io/docs/handbook/vpn_and_proxy/.
   kubeconfig.clusters[0].cluster.server = 'https://10.96.0.1:443';
-  kubeconfig.contexts[0].name = 'dummy';
-  kubeconfig.users[0].name = 'dummy';
-  kubeconfig.contexts[0].context.user = 'dummy';
-  kubeconfig.contexts[0].context.cluster = 'dummy';
+  kubeconfig.contexts[0].name = clusterName;
+  kubeconfig.users[0].name = clusterName;
+  kubeconfig.contexts[0].context.user = clusterName;
+  kubeconfig.contexts[0].context.cluster = clusterName;
 
   // Get the contents of certificate-authority file and convert to base64
   const caFilePath = kubeconfig.clusters[0].cluster['certificate-authority'];
@@ -105,8 +247,8 @@ const getBase64EncodedKubeconfig = async () => {
   delete kubeconfig.users[0].user['client-certificate'];
   delete kubeconfig.clusters[0].cluster['certificate-authority'];
 
-  // Set the current context to "minikubedummy"
-  kubeconfig['current-context'] = 'dummy';
+  // Set the current context to the generated cluster name.
+  kubeconfig['current-context'] = clusterName;
 
   // Convert JSON back to YAML
   const kubeconfigYaml = yaml.stringify(kubeconfig);
@@ -116,48 +258,57 @@ const getBase64EncodedKubeconfig = async () => {
 
 const saveKubeconfigToIndexDB = async (page, base64EncodedKubeconfig) => {
   await page.evaluate(base64EncodedKubeconfig => {
-    // Open or create an IndexDB database
-    const request = indexedDB.open('kubeconfigs', 1);
+    return new Promise<void>((resolve, reject) => {
+      // Open or create an IndexDB database
+      const request = indexedDB.open('kubeconfigs', 1);
 
-    // Handle database creation or upgrade
-    request.onupgradeneeded = function (event: any) {
-      const db = event.target ? event.target.result : null;
-      // Create the object store if it doesn't exist
-      if (!db.objectStoreNames.contains('kubeconfigStore')) {
-        db.createObjectStore('kubeconfigStore', {
-          keyPath: 'id',
-          autoIncrement: true,
-        });
-      }
-    };
-
-    request.onsuccess = (event: any) => {
-      const db = event.target.result;
-      const transaction = db.transaction(['kubeconfigStore'], 'readwrite');
-      const store = transaction.objectStore('kubeconfigStore');
-
-      // Add the base64 encoded kubeconfig to the IndexDB store
-      const addRequest = store.add({ kubeconfig: base64EncodedKubeconfig });
-
-      // Handle the success or failure of the add operation
-      addRequest.onsuccess = () => {
-        console.log('Kubeconfig added to IndexDB');
+      // Handle database creation or upgrade
+      request.onupgradeneeded = function (event: any) {
+        const db = event.target ? event.target.result : null;
+        // Create the object store if it doesn't exist
+        if (!db.objectStoreNames.contains('kubeconfigStore')) {
+          db.createObjectStore('kubeconfigStore', {
+            keyPath: 'id',
+            autoIncrement: true,
+          });
+        }
       };
 
-      addRequest.onerror = () => {
-        console.error('Error adding kubeconfig to IndexDB');
+      request.onsuccess = (event: any) => {
+        const db = event.target.result;
+        const transaction = db.transaction(['kubeconfigStore'], 'readwrite');
+        const store = transaction.objectStore('kubeconfigStore');
+
+        // Add the base64 encoded kubeconfig to the IndexDB store
+        const addRequest = store.add({ kubeconfig: base64EncodedKubeconfig });
+
+        transaction.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+
+        transaction.onerror = () => {
+          db.close();
+          reject(new Error('Error committing kubeconfig transaction'));
+        };
+
+        transaction.onabort = () => {
+          db.close();
+          reject(new Error('Kubeconfig transaction aborted'));
+        };
+
+        addRequest.onerror = () => {
+          console.error('Error adding kubeconfig to IndexDB');
+          db.close();
+          reject(new Error('Error adding kubeconfig to IndexDB'));
+        };
       };
 
-      // Close the database when done
-      transaction.oncomplete = () => {
-        db.close();
+      request.onerror = function (event: any) {
+        console.error('Error opening the database:', event.target.error);
+        reject(event.target.error);
       };
-    };
-
-    request.onerror = function (event: any) {
-      console.error('Error opening the database:', event.target.error);
-      return event.target.error;
-    };
+    });
   }, base64EncodedKubeconfig);
 };
 
@@ -198,4 +349,48 @@ const getKubeconfigFromIndexDB = async page => {
   });
 
   return storedKubeconfig;
+};
+
+const clearKubeconfigsFromIndexDB = async page => {
+  await page.evaluate(() => {
+    return new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open('kubeconfigs', 1);
+
+      request.onupgradeneeded = (event: any) => {
+        const db = event.target.result;
+        if (!db.objectStoreNames.contains('kubeconfigStore')) {
+          db.createObjectStore('kubeconfigStore', {
+            keyPath: 'id',
+            autoIncrement: true,
+          });
+        }
+      };
+
+      request.onsuccess = (event: any) => {
+        const db = event.target.result;
+        const transaction = db.transaction(['kubeconfigStore'], 'readwrite');
+        const store = transaction.objectStore('kubeconfigStore');
+        store.clear();
+
+        transaction.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+
+        transaction.onerror = () => {
+          db.close();
+          reject(new Error('Error clearing kubeconfig store'));
+        };
+
+        transaction.onabort = () => {
+          db.close();
+          reject(new Error('Aborted clearing kubeconfig store'));
+        };
+      };
+
+      request.onerror = (event: any) => {
+        reject(event.target.error);
+      };
+    });
+  });
 };

--- a/frontend/src/components/App/Settings/ClusterNameEditor.tsx
+++ b/frontend/src/components/App/Settings/ClusterNameEditor.tsx
@@ -23,6 +23,8 @@ import { ClusterSettings } from '../../../helpers/clusterSettings';
 import { parseKubeConfig, renameCluster } from '../../../lib/k8s/api/v1/clusterApi';
 import { Cluster } from '../../../lib/k8s/cluster';
 import { setConfig, setStatelessConfig } from '../../../redux/configSlice';
+import store from '../../../redux/stores/store';
+import { mergeStatelessConfigState } from '../../../stateless';
 import { findKubeconfigByClusterName } from '../../../stateless/findKubeconfigByClusterName';
 import { updateStatelessClusterKubeconfig } from '../../../stateless/updateStatelessClusterKubeconfig';
 import { ConfirmButton, ConfirmDialog, NameValueTable } from '../../common';
@@ -123,9 +125,14 @@ export function ClusterNameEditor({
               const updatedKubeconfig = await findKubeconfigByClusterName(cluster, clusterID);
               if (updatedKubeconfig !== null) {
                 parseKubeConfig({ kubeconfig: updatedKubeconfig })
-                  .then((config: any) => {
+                  .then((parsedConfig: any) => {
                     storeNewClusterName(newClusterName);
-                    dispatch(setStatelessConfig(config));
+                    const currentStatelessClusters = store.getState().config.statelessClusters;
+                    dispatch(
+                      setStatelessConfig(
+                        mergeStatelessConfigState(currentStatelessClusters, parsedConfig)
+                      )
+                    );
                   })
                   .catch((err: Error) => {
                     console.error('Error updating cluster name:', err.message);

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -33,6 +33,8 @@ import { useHistory } from 'react-router-dom';
 import { useClustersConf } from '../../lib/k8s';
 import { setCluster } from '../../lib/k8s/api/v1/clusterApi';
 import { setStatelessConfig } from '../../redux/configSlice';
+import store from '../../redux/stores/store';
+import { mergeStatelessConfigState } from '../../stateless';
 import { DialogTitle } from '../common/Dialog';
 import { DropZoneBox } from '../common/DropZoneBox';
 import Loader from '../common/Loader';
@@ -372,9 +374,14 @@ function KubeConfigLoader() {
       function loadClusters() {
         const selectedClusterConfig = configWithSelectedClusters(fileContent, selectedClusters);
         setCluster({ kubeconfig: btoa(yaml.dump(selectedClusterConfig)) })
-          .then(res => {
-            if (res?.clusters?.length > 0) {
-              dispatch(setStatelessConfig(res));
+          .then(parsedConfig => {
+            if (parsedConfig?.clusters?.length > 0) {
+              const currentStatelessClusters = store.getState().config.statelessClusters;
+              dispatch(
+                setStatelessConfig(
+                  mergeStatelessConfigState(currentStatelessClusters, parsedConfig)
+                )
+              );
             }
             setState(Step.Success);
           })

--- a/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addBackstageAuthHeaders } from '../../../../helpers/addBackstageAuthHeaders';
+import { getHeadlampAPIHeaders } from '../../../../helpers/getHeadlampAPIHeaders';
+import { storeStatelessClusterKubeconfig } from '../../../../stateless';
+import { setCluster } from './clusterApi';
+import { request } from './clusterRequests';
+
+vi.mock('../../../../helpers/addBackstageAuthHeaders', () => ({
+  addBackstageAuthHeaders: vi.fn((headers: Record<string, string>) => headers),
+}));
+
+vi.mock('../../../../helpers/getHeadlampAPIHeaders', () => ({
+  getHeadlampAPIHeaders: vi.fn(() => ({
+    'X-HEADLAMP_BACKEND-TOKEN': 'backend-token',
+  })),
+}));
+
+vi.mock('../../../../stateless', () => ({
+  storeStatelessClusterKubeconfig: vi.fn(),
+}));
+
+vi.mock('../../../../stateless/deleteClusterKubeconfig', () => ({
+  deleteClusterKubeconfig: vi.fn(),
+}));
+
+vi.mock('../../../../stateless/findKubeconfigByClusterName', () => ({
+  findKubeconfigByClusterName: vi.fn(),
+}));
+
+vi.mock('../../../cluster', () => ({
+  getCluster: vi.fn(),
+  getSelectedClusters: vi.fn(() => []),
+}));
+
+vi.mock('./clusterRequests', () => ({
+  clusterRequest: vi.fn(),
+  post: vi.fn(),
+  request: vi.fn(),
+}));
+
+describe('setCluster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('includes backend auth headers for stateless parseKubeConfig request', async () => {
+    const kubeconfig = 'base64-kubeconfig';
+    const requestMock = vi.mocked(request);
+
+    requestMock.mockResolvedValue({ clusters: [] });
+
+    await setCluster({ kubeconfig });
+
+    expect(storeStatelessClusterKubeconfig).toHaveBeenCalledWith(kubeconfig);
+    expect(addBackstageAuthHeaders).toHaveBeenCalled();
+    expect(getHeadlampAPIHeaders).toHaveBeenCalled();
+    expect(requestMock).toHaveBeenCalledWith(
+      '/parseKubeConfig',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ kubeconfigs: [kubeconfig] }),
+        headers: expect.objectContaining({
+          'X-HEADLAMP_BACKEND-TOKEN': 'backend-token',
+        }),
+      }),
+      false,
+      false
+    );
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -140,14 +140,14 @@ export async function setCluster(clusterReq: ClusterRequest) {
 
   if (kubeconfig) {
     await storeStatelessClusterKubeconfig(kubeconfig);
-    // We just send parsed kubeconfig from the backend to the frontend.
     return request(
       '/parseKubeConfig',
       {
         method: 'POST',
-        body: JSON.stringify(clusterReq),
+        body: JSON.stringify({ kubeconfigs: [kubeconfig] }),
         headers: {
           ...headers,
+          ...getHeadlampAPIHeaders(),
         },
       },
       false,
@@ -306,8 +306,8 @@ export async function renameCluster(
 }
 
 /**
- * parseKubeConfig sends call to backend to parse kubeconfig and send back
- * the parsed clusters and contexts.
+ * parseKubeConfig sends a kubeconfig to the backend to parse and returns
+ * the resulting clusters.
  * @param clusterReq - The cluster request object.
  */
 export async function parseKubeConfig(clusterReq: ClusterRequest) {
@@ -319,7 +319,7 @@ export async function parseKubeConfig(clusterReq: ClusterRequest) {
       '/parseKubeConfig',
       {
         method: 'POST',
-        body: JSON.stringify(clusterReq),
+        body: JSON.stringify({ kubeconfigs: [kubeconfig] }),
         headers: {
           ...headers,
           ...getHeadlampAPIHeaders(),

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -670,7 +670,9 @@
     "handleDataBaseError": [Function],
     "handleDatabaseUpgrade": [Function],
     "isEqualClusterConfigs": [Function],
+    "mergeStatelessConfigState": [Function],
     "storeStatelessClusterKubeconfig": [Function],
+    "toStatelessConfigState": [Function],
   },
   "useTranslation": [Function],
 }

--- a/frontend/src/stateless/index.test.ts
+++ b/frontend/src/stateless/index.test.ts
@@ -14,12 +14,23 @@
  * limitations under the License.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setStatelessConfig } from '../redux/configSlice';
+import store from '../redux/stores/store';
 import {
+  fetchStatelessClusterKubeConfigs,
   findAndReplaceKubeconfig,
   getStatelessClusterKubeConfigs,
+  mergeStatelessConfigState,
   storeStatelessClusterKubeconfig,
+  toStatelessConfigState,
 } from './index';
+
+vi.mock('../lib/k8s/api/v1/clusterRequests', async importOriginal => {
+  const actual = (await importOriginal()) as any;
+  return { ...actual, request: vi.fn() };
+});
+import { request } from '../lib/k8s/api/v1/clusterRequests';
 
 describe('findAndReplaceKubeconfig', () => {
   beforeEach(() => {
@@ -288,5 +299,326 @@ extensions:
     expect(configs).toContain(kubeconfig1);
     expect(configs).toContain(kubeconfig2);
     expect(configs).toContain(kubeconfig3);
+  });
+});
+
+describe('fetchStatelessClusterKubeConfigs', () => {
+  const clearIndexedDB = () =>
+    new Promise<void>(resolve => {
+      const request = indexedDB.open('kubeconfigs', 1);
+      request.onupgradeneeded = (event: any) => {
+        const db = event.target.result as IDBDatabase;
+        if (!db.objectStoreNames.contains('kubeconfigStore')) {
+          db.createObjectStore('kubeconfigStore', { keyPath: 'id', autoIncrement: true });
+        }
+      };
+      request.onsuccess = (event: any) => {
+        const db = event.target.result as IDBDatabase;
+        const tx = db.transaction(['kubeconfigStore'], 'readwrite');
+        const clearReq = tx.objectStore('kubeconfigStore').clear();
+
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+
+        tx.onerror = () => {
+          db.close();
+          resolve();
+        };
+
+        tx.onabort = () => {
+          db.close();
+          resolve();
+        };
+
+        clearReq.onerror = () => {
+          // The transaction handlers above finalize the promise.
+        };
+      };
+      request.onerror = () => resolve();
+    });
+
+  beforeEach(async () => {
+    await clearIndexedDB();
+    store.dispatch(setStatelessConfig({ statelessClusters: null }));
+  });
+
+  afterEach(async () => {
+    await clearIndexedDB();
+    store.dispatch(setStatelessConfig({ statelessClusters: null }));
+  });
+
+  it('dispatches setStatelessConfig({}) when IndexedDB is empty and stale state exists', async () => {
+    // Seed stale redux state (simulates a previous session leaving clusters behind)
+    store.dispatch(
+      setStatelessConfig({
+        statelessClusters: { 'stale-cluster': { name: 'stale-cluster' } as any },
+      })
+    );
+    expect(store.getState().config.statelessClusters).not.toBeNull();
+
+    const dispatch = vi.fn();
+    // IndexedDB is empty — fetchStatelessClusterKubeConfigs should clear stale state
+    await fetchStatelessClusterKubeConfigs(dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(setStatelessConfig({ statelessClusters: {} }));
+  });
+
+  it('does not dispatch when IndexedDB is empty and state is already clear', async () => {
+    // statelessClusters is null in the store (already clean)
+    expect(store.getState().config.statelessClusters).toBeNull();
+
+    const dispatch = vi.fn();
+    await fetchStatelessClusterKubeConfigs(dispatch);
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('toStatelessConfigState', () => {
+  it('maps parsed clusters by name for redux state', () => {
+    const parsedConfig = {
+      clusters: [
+        { name: 'alpha', meta_data: {} },
+        { name: 'beta', meta_data: {} },
+      ],
+    } as any;
+
+    const nextState = toStatelessConfigState(parsedConfig);
+
+    expect(Object.keys(nextState.statelessClusters)).toEqual(['alpha', 'beta']);
+    expect(nextState.statelessClusters.alpha.name).toBe('alpha');
+    expect(nextState.statelessClusters.beta.name).toBe('beta');
+  });
+
+  it('returns an empty statelessClusters map for missing clusters', () => {
+    expect(toStatelessConfigState(undefined)).toEqual({ statelessClusters: {} });
+    expect(toStatelessConfigState({} as any)).toEqual({ statelessClusters: {} });
+  });
+});
+
+describe('mergeStatelessConfigState', () => {
+  it('preserves existing clusters while adding parsed clusters', () => {
+    const currentState = {
+      alpha: { name: 'alpha', meta_data: {} },
+    } as any;
+
+    const parsedConfig = {
+      clusters: [{ name: 'beta', meta_data: {} }],
+    } as any;
+
+    const nextState = mergeStatelessConfigState(currentState, parsedConfig);
+
+    expect(Object.keys(nextState.statelessClusters)).toEqual(['alpha', 'beta']);
+  });
+
+  it('updates existing cluster entries when parsed data has same key', () => {
+    const currentState = {
+      alpha: { name: 'alpha', meta_data: { old: true } },
+    } as any;
+
+    const parsedConfig = {
+      clusters: [{ name: 'alpha', meta_data: { old: false, fresh: true } }],
+    } as any;
+
+    const nextState = mergeStatelessConfigState(currentState, parsedConfig);
+
+    expect(nextState.statelessClusters.alpha.meta_data).toEqual({ old: false, fresh: true });
+  });
+
+  it('does not drop pre-existing clusters when a renamed cluster is re-parsed', () => {
+    // Simulates the ClusterNameEditor bug: after renaming "alpha", parseKubeConfig
+    // returns only the renamed cluster's config. Without merging, all other stateless
+    // clusters are wiped from the UI until the next periodic refresh.
+    const sessionClusters = {
+      alpha: { name: 'alpha', meta_data: {} },
+      beta: { name: 'beta', meta_data: {} },
+      gamma: { name: 'gamma', meta_data: {} },
+    } as any;
+
+    // Only "alpha" (now renamed to "alpha-new") comes back from the rename parse
+    const parsedConfig = {
+      clusters: [{ name: 'alpha-new', meta_data: {} }],
+    } as any;
+
+    const nextState = mergeStatelessConfigState(sessionClusters, parsedConfig);
+
+    // All three original clusters must still be present
+    expect(nextState.statelessClusters).toHaveProperty('beta');
+    expect(nextState.statelessClusters).toHaveProperty('gamma');
+    // The newly renamed cluster should also be present
+    expect(nextState.statelessClusters).toHaveProperty('alpha-new');
+  });
+});
+
+describe('fetchStatelessClusterKubeConfigs corner cases', () => {
+  const clearIndexedDB = () =>
+    new Promise<void>(resolve => {
+      const req = indexedDB.open('kubeconfigs', 1);
+      req.onupgradeneeded = (event: any) => {
+        const db = event.target.result as IDBDatabase;
+        if (!db.objectStoreNames.contains('kubeconfigStore')) {
+          db.createObjectStore('kubeconfigStore', { keyPath: 'id', autoIncrement: true });
+        }
+      };
+      req.onsuccess = (event: any) => {
+        const db = event.target.result as IDBDatabase;
+        const tx = db.transaction(['kubeconfigStore'], 'readwrite');
+        tx.objectStore('kubeconfigStore').clear();
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => {
+          db.close();
+          resolve();
+        };
+        tx.onabort = () => {
+          db.close();
+          resolve();
+        };
+      };
+      req.onerror = () => resolve();
+    });
+
+  beforeEach(async () => {
+    await clearIndexedDB();
+    store.dispatch(setStatelessConfig({ statelessClusters: null }));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await clearIndexedDB();
+    store.dispatch(setStatelessConfig({ statelessClusters: null }));
+  });
+
+  it('dispatches update when cluster names change even if count is the same', async () => {
+    await storeStatelessClusterKubeconfig('dummy-kubeconfig');
+
+    store.dispatch(
+      setStatelessConfig({
+        statelessClusters: {
+          alpha: { name: 'alpha', meta_data: {} } as any,
+          beta: { name: 'beta', meta_data: {} } as any,
+        },
+      })
+    );
+
+    vi.mocked(request).mockResolvedValue({
+      clusters: [
+        { name: 'alpha', meta_data: {} },
+        { name: 'gamma', meta_data: {} }, // 'beta' replaced by 'gamma'
+      ],
+    });
+
+    const dispatch = vi.fn();
+    await fetchStatelessClusterKubeConfigs(dispatch);
+
+    expect(dispatch).toHaveBeenCalled();
+  });
+
+  it('uses latest redux statelessClusters when parse response resolves', async () => {
+    await storeStatelessClusterKubeconfig('dummy-kubeconfig');
+
+    // Initial state before request starts.
+    store.dispatch(
+      setStatelessConfig({
+        statelessClusters: {
+          alpha: { name: 'alpha', meta_data: {} } as any,
+        },
+      })
+    );
+
+    let resolveRequest: (value: any) => void;
+    const pendingRequest = new Promise(resolve => {
+      resolveRequest = resolve;
+    });
+
+    vi.mocked(request).mockReturnValue(pendingRequest as any);
+
+    const dispatch = vi.fn();
+    const inFlight = fetchStatelessClusterKubeConfigs(dispatch);
+
+    // State changes while /parseKubeConfig is still in-flight.
+    // The decision must use this latest value, not a stale captured value.
+    store.dispatch(
+      setStatelessConfig({
+        statelessClusters: {
+          alpha: { name: 'alpha', meta_data: {} } as any,
+          beta: { name: 'beta', meta_data: {} } as any,
+        },
+      })
+    );
+
+    resolveRequest!({
+      clusters: [
+        { name: 'alpha', meta_data: {} },
+        { name: 'beta', meta_data: {} },
+      ],
+    });
+
+    await inFlight;
+
+    // No dispatch expected because latest store state already matches response.
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatches update when cluster payload changes but keys stay the same', async () => {
+    await storeStatelessClusterKubeconfig('dummy-kubeconfig');
+
+    store.dispatch(
+      setStatelessConfig({
+        statelessClusters: {
+          alpha: {
+            name: 'alpha',
+            meta_data: { project: 'old' },
+            cluster: { server: 'https://old.example.com' },
+          } as any,
+        },
+      })
+    );
+
+    vi.mocked(request).mockResolvedValue({
+      clusters: [
+        {
+          name: 'alpha',
+          meta_data: { project: 'new' },
+          cluster: { server: 'https://new.example.com' },
+        },
+      ],
+    });
+
+    const dispatch = vi.fn();
+    await fetchStatelessClusterKubeConfigs(dispatch);
+
+    // Same key set, but payload differs, so redux state must still update.
+    expect(dispatch).toHaveBeenCalled();
+  });
+
+  it('does not resolve before parse request settles', async () => {
+    await storeStatelessClusterKubeconfig('dummy-kubeconfig');
+
+    let resolveRequest: (value: any) => void;
+    const pendingRequest = new Promise(resolve => {
+      resolveRequest = resolve;
+    });
+
+    vi.mocked(request).mockReturnValue(pendingRequest as any);
+
+    const dispatch = vi.fn();
+    const settled = vi.fn();
+    const inFlight = fetchStatelessClusterKubeConfigs(dispatch).then(settled);
+
+    // Flush microtasks and verify the function is still waiting for request.
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+
+    resolveRequest!({
+      clusters: [],
+    });
+
+    await inFlight;
+    expect(settled).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/stateless/index.ts
+++ b/frontend/src/stateless/index.ts
@@ -16,6 +16,7 @@
 
 import _ from 'lodash';
 import { addBackstageAuthHeaders } from '../helpers/addBackstageAuthHeaders';
+import { getHeadlampAPIHeaders } from '../helpers/getHeadlampAPIHeaders';
 import { request } from '../lib/k8s/api/v1/clusterRequests';
 import { JSON_HEADERS } from '../lib/k8s/api/v1/constants';
 import { Cluster } from '../lib/k8s/cluster';
@@ -29,12 +30,55 @@ import { updateStatelessClusterKubeconfig } from './updateStatelessClusterKubeco
 
 /**
  * ParsedConfig is the object that is fetched from the backend.
- * It has cluster information as keys. The values are the same as the KubeconfigObject.
+ * It contains a list of parsed cluster entries under the `clusters` field.
+ * Each item corresponds to a parsed cluster object used by stateless config state.
  * @see KubeconfigObject
  * @see fetchStatelessClusterKubeConfigs
  */
 interface ParsedConfig {
-  [prop: string]: Cluster[];
+  clusters?: Cluster[];
+}
+
+/**
+ * Converts parsed `/parseKubeConfig` response data into the redux stateless state shape.
+ *
+ * @param parsedConfig Parsed backend response that may include a `clusters` array.
+ * @returns Object with `statelessClusters` indexed by cluster name.
+ */
+export function toStatelessConfigState(parsedConfig: ParsedConfig | null | undefined) {
+  const statelessClusters: NonNullable<ConfigState['statelessClusters']> = {};
+
+  if (parsedConfig?.clusters && Array.isArray(parsedConfig.clusters)) {
+    parsedConfig.clusters.forEach((cluster: Cluster) => {
+      statelessClusters[cluster.name] = cluster;
+    });
+  }
+
+  return { statelessClusters };
+}
+
+/**
+ * Merges freshly parsed stateless clusters into the currently loaded stateless map.
+ *
+ * Existing clusters are preserved, and clusters with matching names are overwritten
+ * by the latest parsed values.
+ *
+ * @param currentStatelessClusters Current stateless cluster map from redux state.
+ * @param parsedConfig Newly parsed backend response.
+ * @returns Merged `statelessClusters` payload suitable for `setStatelessConfig`.
+ */
+export function mergeStatelessConfigState(
+  currentStatelessClusters: ConfigState['statelessClusters'],
+  parsedConfig: ParsedConfig | null | undefined
+) {
+  const nextState = toStatelessConfigState(parsedConfig);
+
+  return {
+    statelessClusters: {
+      ...(currentStatelessClusters || {}),
+      ...nextState.statelessClusters,
+    },
+  };
 }
 
 /**
@@ -373,40 +417,39 @@ export function isEqualClusterConfigs(
  */
 export async function fetchStatelessClusterKubeConfigs(dispatch: any) {
   const config = await getStatelessClusterKubeConfigs();
-  const statelessClusters = store.getState().config.statelessClusters;
+
+  if (!config || config.length === 0) {
+    const statelessClusters = store.getState().config.statelessClusters;
+    if (statelessClusters && Object.keys(statelessClusters).length > 0) {
+      dispatch(setStatelessConfig({ statelessClusters: {} }));
+    }
+    return;
+  }
+
   const headers = addBackstageAuthHeaders(JSON_HEADERS);
   const clusterReq = {
     kubeconfigs: config,
   };
 
-  // Parses statelessCluster config
-  request(
+  return request(
     '/parseKubeConfig',
     {
       method: 'POST',
       body: JSON.stringify(clusterReq),
       headers: {
         ...headers,
+        ...getHeadlampAPIHeaders(),
       },
     },
     false,
     false
   )
     .then((config: ParsedConfig) => {
-      const clustersToConfig: ConfigState['statelessClusters'] = {};
-      if (config?.clusters && Array.isArray(config.clusters)) {
-        config?.clusters.forEach((cluster: Cluster) => {
-          clustersToConfig[cluster.name] = cluster;
-        });
-      }
+      const nextState = toStatelessConfigState(config);
+      const statelessClusters = store.getState().config.statelessClusters;
 
-      const configToStore = {
-        statelessClusters: clustersToConfig,
-      };
-      if (statelessClusters === null) {
-        dispatch(setStatelessConfig({ ...configToStore }));
-      } else if (Object.keys(clustersToConfig).length !== Object.keys(statelessClusters).length) {
-        dispatch(setStatelessConfig({ ...configToStore }));
+      if (isEqualClusterConfigs(statelessClusters, nextState.statelessClusters)) {
+        dispatch(setStatelessConfig(nextState));
       }
     })
     .catch((err: Error) => {


### PR DESCRIPTION
## Summary

This PR fixes stateless cluster parsing, state refresh, context key generation, and regression coverage across frontend, backend, and e2e flows.

## Changes

### frontend: clusterApi request format
- Updated setCluster and parseKubeConfig to send kubeconfigs as an array payload: { kubeconfigs: [kubeconfig] }.
- This fixes parseKubeConfig request validation failures caused by the old singular kubeconfig field.

### frontend: stateless fetch behavior and headers
- In fetchStatelessClusterKubeConfigs, clear stale statelessClusters Redux state when IndexedDB has no kubeconfigs.
- Added getHeadlampAPIHeaders to parseKubeConfig requests so X-HEADLAMP-BACKEND-TOKEN is sent in app mode.
- Added frontend unit coverage for the empty-IndexedDB branches:
  - stale state present: dispatch clears state
  - state already clear: no dispatch
- clearIndexedDB helper now creates kubeconfigStore on upgrade to avoid NotFoundError in isolated runs.

### backend: stateless context keying and parse handling
- Added statelessContextKey helper and used it in stateless request handling.
- Updated handleStatelessReq to respect headlamp_info custom display names while matching the requested route cluster.
- Updated websocketConnContextKey to preserve cluster-only fallback when no websocket user id subprotocol is present.
- Updated parseKubeConfig flow to return valid clusters for mixed valid/invalid kubeconfig batches and return 400 only when all provided entries fail.
- Added/updated backend tests covering:
  - mixed valid+invalid kubeconfig batch returns 200 with parsed clusters
  - custom display name keying and collision behavior
  - websocket context key fallback and key shape expectations

### e2e-tests: dynamic cluster regression coverage
- Extended stateless kubeconfig e2e coverage in e2e-tests/tests/dynamicCluster.spec.ts:
  - parse requests triggered only when kubeconfig content changes
  - reload behavior for parse and no-parse paths
  - multiple stateless clusters persist across refresh/update flows
  - mixed valid+invalid kubeconfig batches still surface valid clusters

## Testing

### Frontend unit tests
- stateless fetch behavior tests in frontend/src/stateless/index.test.ts

### Backend tests
- stateless parsing/keying coverage in backend/cmd/stateless_test.go

### E2E tests
- dynamic stateless cluster scenarios in e2e-tests/tests/dynamicCluster.spec.ts

### Manual testing
- Add a stateless cluster from kubeconfig in UI; verify no parse validation error.
- Reload the app; verify previously added stateless clusters are still listed and selectable.
- Update one kubeconfig with changed cluster content; verify cluster state refreshes without duplicates.
- Submit a mixed valid+invalid kubeconfig batch; verify valid clusters still appear.
