### PR TITLE
frontend: logs: persist follow and showTimestamps to localStorage

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -47,6 +47,7 @@ import {
   useEventCallback,
 } from '../../../redux/headlampEventSlice';
 import { Activity } from '../../activity/Activity';
+import { useLocalStorageState } from '../../globalSearch/useLocalStorageState';
 import ActionButton from '../ActionButton';
 import { LogViewer } from '../LogViewer';
 import { LightTooltip } from '../Tooltip';
@@ -100,8 +101,11 @@ function LogsButtonContent({ item }: LogsButtonProps) {
   });
   const [allPodLogs, setAllPodLogs] = useState<{ [podName: string]: string[] }>({});
 
-  const [showTimestamps, setShowTimestamps] = useState<boolean>(true);
-  const [follow, setFollow] = useState<boolean>(true);
+  const [showTimestamps, setShowTimestamps] = useLocalStorageState<boolean>(
+    'headlamp.logs.showTimestamps',
+    true
+  );
+  const [follow, setFollow] = useLocalStorageState<boolean>('headlamp.logs.follow', true);
   const [lines, setLines] = useState<number>(100);
   const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
   const [showReconnectButton, setShowReconnectButton] = useState(false);

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -84,7 +84,7 @@ export function PodLogViewer(props: PodLogViewerProps) {
     'headlamp.logs.showTimestamps',
     true
   );
-  const [follow, setFollow] = React.useState<boolean>(true);
+  const [follow, setFollow] = useLocalStorageState<boolean>('headlamp.logs.follow', true);
   const [prettifyLogs, setPrettifyLogs] = useLocalStorageState<boolean>(
     'headlamp.logs.prettifyLogs',
     false


### PR DESCRIPTION
## Summary
This PR fixes the logs viewer not preserving the follow (auto-scroll) and showTimestamps preferences between sessions by migrating those state values to localStorage.

## Related Issue
Fixes #5705

## Changes
- Migrated `follow` in `PodLogViewer` from `React.useState` to `useLocalStorageState` with key `headlamp.logs.follow`
- Migrated `follow` and `showTimestamps` in `LogsButtonContent` from `useState` to `useLocalStorageState` with keys `headlamp.logs.follow` and `headlamp.logs.showTimestamps`

## Steps to Test
1. Open any pod and launch the logs view
2. Toggle the Follow switch off
3. Navigate away to another resource and come back to the logs view
4. Observe that the Follow toggle is still off
5. Hard reload the page, reopen logs and confirm the preference persists

## Notes for the Reviewer
- `useLocalStorageState` was already imported in `pod/Details.tsx` for `showTimestamps` and `prettifyLogs`, so no new dependency is added
- The key `headlamp.logs.showTimestamps` already existed in `PodLogViewer`, `LogsButtonContent` now uses the same key so both viewers share one consistent stored value
- Default value is `true` in both cases, preserving existing behaviour for new users and on first load