### PR TITLE
frontend: node: Separate roles list with spaces

### DIFF
--- a/frontend/src/components/node/List.tsx
+++ b/frontend/src/components/node/List.tsx
@@ -109,7 +109,7 @@ export default function NodeList() {
               return Object.keys(node.metadata.labels ?? {})
                 .filter((t: String) => t.startsWith('node-role.kubernetes.io/'))
                 .map(t => t.replace('node-role.kubernetes.io/', ''))
-                .join(',');
+                .join(', ');
             },
           },
           ...(hasNodePools


### PR DESCRIPTION
This change updates the roles column in the node list to join entries with `", "` instead of `","`, matching the formatting used on the node details page for a consistent look across views.

### Screenshots

#### Before

<img width="192" height="146" alt="image" src="https://github.com/user-attachments/assets/f5767bcf-3299-4f17-bc9b-eb8f75653089" />

#### After

<img width="158" height="157" alt="image" src="https://github.com/user-attachments/assets/2d20e0ab-0426-404e-abf2-bd2836fe46a8" />

