### PR TITLE
frontend: Gateway: Fix crash when spec.listeners is undefined

### DIFF
--- a/frontend/src/components/gateway/GatewayDetails.tsx
+++ b/frontend/src/components/gateway/GatewayDetails.tsx
@@ -138,7 +138,7 @@ export default function GatewayDetails(props: { name?: string; namespace?: strin
                     .map((listener: GatewayListener) => (
                       <GatewayListenerTable
                         listener={listener}
-                        status={item.getListernerStatusByName(listener.name)}
+                        status={item.getListenerStatusByName(listener.name)}
                       />
                     ))
                 )}

--- a/frontend/src/components/gateway/GatewayDetails.tsx
+++ b/frontend/src/components/gateway/GatewayDetails.tsx
@@ -69,7 +69,7 @@ function GatewayListenerTable(props: {
     },
     {
       name: t('translation|Conditions'),
-      value: status?.conditions.map(c => makeStatusLabel(c)),
+      value: status?.conditions?.map(c => makeStatusLabel(c)),
     },
   ];
   return <NameValueTable rows={mainRows} />;

--- a/frontend/src/components/gateway/GatewayList.stories.tsx
+++ b/frontend/src/components/gateway/GatewayList.stories.tsx
@@ -71,8 +71,7 @@ BrokenSpec.parameters = {
           HttpResponse.json({
             kind: 'GatewayList',
             metadata: {},
-            // apiVersion overridden to match the v1 endpoint this handler serves.
-            items: [{ ...BROKEN_GATEWAY, apiVersion: 'gateway.networking.k8s.io/v1' }],
+            items: [BROKEN_GATEWAY],
           })
         ),
         http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways', () =>

--- a/frontend/src/components/gateway/GatewayList.stories.tsx
+++ b/frontend/src/components/gateway/GatewayList.stories.tsx
@@ -18,7 +18,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { TestContext } from '../../test';
 import ListView from './GatewayList';
-import { DEFAULT_GATEWAY } from './storyHelper';
+import { BROKEN_GATEWAY, DEFAULT_GATEWAY } from './storyHelper';
 
 export default {
   title: 'Gateway/ListView',
@@ -59,3 +59,25 @@ const Template: StoryFn = () => {
 };
 
 export const Items = Template.bind({});
+
+// Repro for issue #5987: a Gateway without spec.listeners crashes the list view.
+export const BrokenSpec = Template.bind({});
+BrokenSpec.parameters = {
+  msw: {
+    handlers: {
+      storyBase: [],
+      story: [
+        http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/gateways', () =>
+          HttpResponse.json({
+            kind: 'GatewayList',
+            metadata: {},
+            items: [BROKEN_GATEWAY],
+          })
+        ),
+        http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways', () =>
+          HttpResponse.error()
+        ),
+      ],
+    },
+  },
+};

--- a/frontend/src/components/gateway/GatewayList.stories.tsx
+++ b/frontend/src/components/gateway/GatewayList.stories.tsx
@@ -75,7 +75,7 @@ BrokenSpec.parameters = {
           })
         ),
         http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways', () =>
-          HttpResponse.error()
+          HttpResponse.json({ message: 'Not Found' }, { status: 404 })
         ),
       ],
     },

--- a/frontend/src/components/gateway/GatewayList.stories.tsx
+++ b/frontend/src/components/gateway/GatewayList.stories.tsx
@@ -71,7 +71,8 @@ BrokenSpec.parameters = {
           HttpResponse.json({
             kind: 'GatewayList',
             metadata: {},
-            items: [BROKEN_GATEWAY],
+            // apiVersion overridden to match the v1 endpoint this handler serves.
+            items: [{ ...BROKEN_GATEWAY, apiVersion: 'gateway.networking.k8s.io/v1' }],
           })
         ),
         http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways', () =>

--- a/frontend/src/components/gateway/GatewayList.tsx
+++ b/frontend/src/components/gateway/GatewayList.tsx
@@ -58,7 +58,7 @@ export default function GatewayList() {
         {
           id: 'listeners',
           label: t('translation|Listeners'),
-          getValue: (gateway: Gateway) => gateway.spec.listeners.length,
+          getValue: (gateway: Gateway) => gateway.spec?.listeners?.length ?? 0,
         },
         'labels',
         'age',

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
@@ -19,7 +19,19 @@
             </h1>
             <div
               class="MuiBox-root css-ldp2l3"
-            />
+            >
+              <button
+                aria-label="Create Gateway"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
         </div>
         <div

--- a/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
+++ b/frontend/src/components/gateway/__snapshots__/GatewayList.BrokenSpec.stories.storyshot
@@ -1,0 +1,774 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-j1fy4m"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiBox-root css-70qvj9"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+            >
+              Gateways
+            </h1>
+            <div
+              class="MuiBox-root css-ldp2l3"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item css-ztq4zc-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <div
+                class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1x6bjyf-MuiAutocomplete-root"
+              >
+                <div
+                  class="MuiBox-root css-1dipl1t"
+                >
+                  <div
+                    class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+                    style="margin-top: 0px;"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                      data-shrink="true"
+                      for="namespaces-filter"
+                      id="namespaces-filter-label"
+                    >
+                      Namespaces
+                    </label>
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1xjtaff-MuiInputBase-root-MuiOutlinedInput-root"
+                    >
+                      <input
+                        aria-autocomplete="both"
+                        aria-expanded="false"
+                        aria-invalid="false"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+                        id="namespaces-filter"
+                        placeholder="Filter"
+                        role="combobox"
+                        spellcheck="false"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        class="MuiAutocomplete-endAdornment css-p1olib-MuiAutocomplete-endAdornment"
+                      >
+                        <button
+                          aria-label="Open"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-1aav1nn-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                          tabindex="-1"
+                          title="Open"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                            data-testid="ArrowDropDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7 10l5 5 5-5z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                      >
+                        <legend
+                          class="css-sl37lx-MuiNotchedOutlined-root"
+                        >
+                          <span>
+                            Namespaces
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1txv3mw"
+      >
+        <div
+          aria-atomic="true"
+          aria-live="polite"
+          class="MuiBox-root css-ty8jgw"
+          role="status"
+        />
+        <div
+          class="MuiBox-root css-1ipmh7v"
+        >
+          <div
+            class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+            style="min-height: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+            >
+              <div
+                class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-s0ueq2-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                >
+                  <div
+                    class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                  >
+                    <div
+                      class="MuiStack-root css-5kul5x-MuiStack-root"
+                    >
+                      <div
+                        class="MuiBox-root css-k008qs"
+                      >
+                         
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+            style="opacity: 0; visibility: hidden;"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+            >
+              Drop to group by 
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-zrlv9q"
+          >
+            <span />
+            <div
+              class="MuiBox-root css-1p0wbhh"
+            >
+              <div
+                class="MuiBox-root css-di3982"
+              >
+                <button
+                  aria-label="Show/Hide search"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Show/Hide filters"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="FilterListIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  aria-label="Show/Hide columns"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="ViewColumnIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <table
+          class="MuiTable-root css-13kw56n-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+          >
+            <tr
+              class="css-1lqh5un"
+            >
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-199xzek-MuiTableCell-root"
+                colspan="1"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-4ng264"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-bbxzxe"
+                    >
+                      <span
+                        aria-label="Toggle select all"
+                        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                        data-mui-internal-clone-element="true"
+                      >
+                        <input
+                          aria-label="Toggle select all"
+                          class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                          data-indeterminate="false"
+                          type="checkbox"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="CheckBoxOutlineBlankIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pksupb-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Name
+                    </div>
+                    <span
+                      aria-label="Sort by Name ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Name ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1r8sxpv-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Namespace
+                    </div>
+                    <span
+                      aria-label="Sort by Namespace ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Namespace ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-wo5zl7-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Class Name
+                    </div>
+                    <span
+                      aria-label="Sort by Class Name ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Class Name ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-8t6h3-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Conditions
+                    </div>
+                    <span
+                      aria-label="Sort by Conditions ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Conditions ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-n0lalj-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                    >
+                      Listeners
+                    </div>
+                    <span
+                      aria-label="Sort by Listeners descending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sort by Listeners descending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="SyncAltIcon"
+                          focusable="false"
+                          style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="ascending"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-7mz8xn-MuiTableCell-root"
+                colspan="1"
+                data-can-sort="true"
+                data-index="-1"
+                data-sort="asc"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-chb057"
+                    >
+                      Age
+                    </div>
+                    <span
+                      aria-label="Sorted by Age ascending"
+                      class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <span
+                        aria-label="Sorted by Age ascending"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-kfi25q-MuiButtonBase-root-MuiTableSortLabel-root"
+                        role="button"
+                        tabindex="0"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          data-testid="ArrowDownwardIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8z"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                      >
+                        0
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+              <th
+                aria-sort="none"
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-nv4ey6-MuiTableCell-root"
+                colspan="1"
+                data-index="-1"
+                scope="col"
+              >
+                <div
+                  class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                >
+                  <div
+                    class="Mui-TableHeadCell-Content-Labels MuiBox-root css-4ng264"
+                  >
+                    <div
+                      class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-bbxzxe"
+                    >
+                      Actions
+                    </div>
+                  </div>
+                  <div
+                    class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                  />
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="css-1obf64m"
+          >
+            <tr
+              class="css-1ospngb"
+              data-selected="false"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+              >
+                <span
+                  aria-label="Toggle select row"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  <input
+                    aria-label="Toggle select row"
+                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    data-indeterminate="false"
+                    type="checkbox"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="CheckBoxOutlineBlankIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  broken-gateway
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-2bq9ry-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  default
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-sfl6yz-MuiTableCell-root"
+              />
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-s67dbz-MuiTableCell-root"
+              />
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ryv7xy-MuiTableCell-root"
+              >
+                0
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+              >
+                <p
+                  aria-label="2023-07-19T09:48:42.000Z"
+                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  90d
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+              >
+                <button
+                  aria-label="Row Actions"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div
+          class="MuiBox-root css-1bxknjp"
+        >
+          <div
+            class="MuiBox-root css-1llu0od"
+          >
+            <span />
+            <div
+              class="MuiBox-root css-qpxlqp"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/gateway/storyHelper.ts
+++ b/frontend/src/components/gateway/storyHelper.ts
@@ -50,7 +50,7 @@ export const DEFAULT_GATEWAY: KubeGateway = {
   },
 };
 
-// Regression fixture for issue #5987: the API can return a Gateway with no `spec`,
+// Regression fixture : the API can return a Gateway with no `spec`,
 // which previously crashed the list view. `spec` is optional on KubeGateway, so this
 // reproduces that case without a cast.
 export const BROKEN_GATEWAY: KubeGateway = {

--- a/frontend/src/components/gateway/storyHelper.ts
+++ b/frontend/src/components/gateway/storyHelper.ts
@@ -52,9 +52,10 @@ export const DEFAULT_GATEWAY: KubeGateway = {
 
 // Regression fixture: the API can return a Gateway with no `spec`,
 // which previously crashed the list view. `spec` is optional on KubeGateway, so this
-// reproduces that case without a cast.
+// reproduces that case without a cast. apiVersion is v1 to match the endpoint that
+// serves this fixture in the BrokenSpec story.
 export const BROKEN_GATEWAY: KubeGateway = {
-  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  apiVersion: 'gateway.networking.k8s.io/v1',
   kind: 'Gateway',
   metadata: {
     creationTimestamp: '2023-07-19T09:48:42Z',

--- a/frontend/src/components/gateway/storyHelper.ts
+++ b/frontend/src/components/gateway/storyHelper.ts
@@ -50,8 +50,9 @@ export const DEFAULT_GATEWAY: KubeGateway = {
   },
 };
 
-// Simulates the crash from issue #5987: a Gateway whose spec/listeners is missing.
-// The API can return such an object even though KubeGateway types spec/listeners as required.
+// Regression fixture for issue #5987: the API can return a Gateway with no `spec`,
+// which previously crashed the list view. `spec` is optional on KubeGateway, so this
+// reproduces that case without a cast.
 export const BROKEN_GATEWAY: KubeGateway = {
   apiVersion: 'gateway.networking.k8s.io/v1beta1',
   kind: 'Gateway',
@@ -63,9 +64,9 @@ export const BROKEN_GATEWAY: KubeGateway = {
     resourceVersion: '12346',
     uid: 'abc999',
   },
-  // no `spec` at all — this is the condition that triggers the crash at GatewayList.tsx:61
+  // no `spec` at all — the list view must handle this gracefully
   status: {},
-} as KubeGateway;
+};
 
 export const DEFAULT_GATEWAY_CLASS: KubeGatewayClass = {
   apiVersion: 'gateway.networking.k8s.io/v1beta1',

--- a/frontend/src/components/gateway/storyHelper.ts
+++ b/frontend/src/components/gateway/storyHelper.ts
@@ -50,7 +50,7 @@ export const DEFAULT_GATEWAY: KubeGateway = {
   },
 };
 
-// Regression fixture : the API can return a Gateway with no `spec`,
+// Regression fixture: the API can return a Gateway with no `spec`,
 // which previously crashed the list view. `spec` is optional on KubeGateway, so this
 // reproduces that case without a cast.
 export const BROKEN_GATEWAY: KubeGateway = {

--- a/frontend/src/components/gateway/storyHelper.ts
+++ b/frontend/src/components/gateway/storyHelper.ts
@@ -50,6 +50,23 @@ export const DEFAULT_GATEWAY: KubeGateway = {
   },
 };
 
+// Simulates the crash from issue #5987: a Gateway whose spec/listeners is missing.
+// The API can return such an object even though KubeGateway types spec/listeners as required.
+export const BROKEN_GATEWAY: KubeGateway = {
+  apiVersion: 'gateway.networking.k8s.io/v1beta1',
+  kind: 'Gateway',
+  metadata: {
+    creationTimestamp: '2023-07-19T09:48:42Z',
+    generation: 1,
+    name: 'broken-gateway',
+    namespace: 'default',
+    resourceVersion: '12346',
+    uid: 'abc999',
+  },
+  // no `spec` at all — this is the condition that triggers the crash at GatewayList.tsx:61
+  status: {},
+} as KubeGateway;
+
 export const DEFAULT_GATEWAY_CLASS: KubeGatewayClass = {
   apiVersion: 'gateway.networking.k8s.io/v1beta1',
   kind: 'GatewayClass',

--- a/frontend/src/components/resourceMap/sources/definitions/relations.tsx
+++ b/frontend/src/components/resourceMap/sources/definitions/relations.tsx
@@ -251,7 +251,7 @@ const jobToJobSet = makeRelation(Job, JobSet, (job, jobSet) =>
 const gatewayToGatewayClass = makeRelation(
   Gateway,
   GatewayClass,
-  (gateway, gatewayClass) => gateway.spec.gatewayClassName === gatewayClass.metadata.name
+  (gateway, gatewayClass) => gateway.spec?.gatewayClassName === gatewayClass.metadata.name
 );
 
 const httpRouteToGateway = makeRelation(HTTPRoute, Gateway, (httpRoute, gateway) =>

--- a/frontend/src/lib/k8s/gateway.ts
+++ b/frontend/src/lib/k8s/gateway.ts
@@ -74,12 +74,12 @@ export interface GatewayStatusAddress {
  * @see {@link https://gateway-api.sigs.k8s.io/api-types/gateway/} Gateway API definition for Gateway
  */
 export interface KubeGateway extends KubeObjectInterface {
-  spec: {
+  spec?: {
     gatewayClassName?: string;
-    listeners: GatewayListener[];
+    listeners?: GatewayListener[];
     [key: string]: any;
   };
-  status: {
+  status?: {
     addresses?: GatewayStatusAddress[];
     listeners?: GatewayListenerStatus[];
     conditions?: KubeCondition[];
@@ -102,15 +102,15 @@ class Gateway extends KubeObject<KubeGateway> {
   }
 
   getListeners(): GatewayListener[] {
-    return this.jsonData.spec.listeners;
+    return this.jsonData.spec?.listeners ?? [];
   }
 
   getAddresses(): GatewayStatusAddress[] {
-    return this.jsonData.status.addresses || [];
+    return this.jsonData.status?.addresses ?? [];
   }
 
   getListernerStatusByName(name: string): GatewayListenerStatus | null {
-    return this.jsonData.status.listeners?.find(t => t.name === name) || null;
+    return this.jsonData.status?.listeners?.find(t => t.name === name) ?? null;
   }
 
   static get pluralName() {

--- a/frontend/src/lib/k8s/gateway.ts
+++ b/frontend/src/lib/k8s/gateway.ts
@@ -109,7 +109,7 @@ class Gateway extends KubeObject<KubeGateway> {
     return this.jsonData.status?.addresses ?? [];
   }
 
-  getListernerStatusByName(name: string): GatewayListenerStatus | null {
+  getListenerStatusByName(name: string): GatewayListenerStatus | null {
     return this.jsonData.status?.listeners?.find(t => t.name === name) ?? null;
   }
 


### PR DESCRIPTION
 
## Summary

This PR fixes a crash in the Gateway list view where opening the Gateways page threw `TypeError: Cannot read properties of undefined (reading 'listeners')` and blanked the whole view. It happened whenever the cluster returned a Gateway without a `spec` (or without `spec.listeners`), because the "Listeners" column read `gateway.spec.listeners.length` with no guard. The underlying cause was the `KubeGateway` type declaring `spec`, `status` and `listeners` as required, so TypeScript never caught the unsafe access.

## Related Issue

Fixes #5987

## Changes

- Fixed the crashing "Listeners" column accessor in `GatewayList` to use optional chaining (`gateway.spec?.listeners?.length ?? 0`).
- Updated the `KubeGateway` type to mark `spec`, `status` and `listeners` as optional so the compiler enforces safe access.
- Hardened the Gateway model helpers (`getListeners`, `getAddresses`, `getListernerStatusByName`) and the details "Conditions" cell.
- Fixed a latent unguarded `gateway.spec` access in the resource-map `gatewayToGatewayClass` relation that the stricter types revealed.
- Added a `BrokenSpec` Storybook story (a Gateway with no `spec`) as a regression test for the crash.

## Steps to Test

1. Check out this branch and run `npm run frontend:test`.
2. Confirm the new `Gateway/ListView > BrokenSpec` story passes — before the fix this story threw the `listeners` TypeError.
3. Optionally run `npm run storybook`, open **Gateway → ListView → BrokenSpec**, and verify the list renders with `0` listeners instead of crashing.

## Screenshots

### Before


<img width="1238" height="720" alt="Screenshot 2026-06-11 171726" src="https://github.com/user-attachments/assets/698af55f-cc2c-49f3-bb98-eb9a5cae0a67" />

### After


<img width="1227" height="607" alt="Screenshot 2026-06-11 181643" src="https://github.com/user-attachments/assets/8e560359-483e-4649-a6e9-f25b54924bfb" />

## Notes for the Reviewer

- The real fix is one line in `GatewayList.tsx`; the rest hardens the `KubeGateway` model and its consumers so this class of undefined access can't recur.
- Making the type fields optional surfaced one pre-existing latent bug in `relations.tsx` (resource-map), which is fixed in the same commit since it's the same root cause.
- No new i18n strings were added (the "Listeners"/"Conditions" keys already existed), so translations are unaffected.
