### PR TITLE
backend: Use %w for error wrapping

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -389,7 +389,7 @@ func (m *Multiplexer) establishClusterConnection(
 
 	config, err := clusterContext.RESTConfig()
 	if err != nil {
-		return nil, fmt.Errorf("getting REST config: %v", err)
+		return nil, fmt.Errorf("getting REST config: %w", err)
 	}
 
 	authToken, err := m.clusterConnectionToken(clusterContext, token)
@@ -408,7 +408,7 @@ func (m *Multiplexer) establishClusterConnection(
 	if err != nil {
 		connection.updateStatus(StateError, err)
 
-		return nil, fmt.Errorf("failed to get TLS config: %v", err)
+		return nil, fmt.Errorf("failed to get TLS config: %w", err)
 	}
 
 	conn, err := m.dialWebSocket(wsURL, tlsConfig, config.Host, authToken)
@@ -441,7 +441,7 @@ func (m *Multiplexer) getClusterConfigWithFallback(clusterID, userID string) (*r
 
 	config, err := clusterContext.RESTConfig()
 	if err != nil {
-		return nil, fmt.Errorf("getting REST config: %v", err)
+		return nil, fmt.Errorf("getting REST config: %w", err)
 	}
 
 	return config, nil
@@ -456,7 +456,7 @@ func (m *Multiplexer) getClusterContextWithFallback(clusterID, userID string) (*
 
 		clusterContext, err = m.getClusterContext(combinedKey)
 		if err != nil {
-			return nil, fmt.Errorf("getting cluster config: %v", err)
+			return nil, fmt.Errorf("getting cluster config: %w", err)
 		}
 	}
 
@@ -547,7 +547,7 @@ func (m *Multiplexer) dialWebSocket(
 			defer func() { _ = resp.Body.Close() }()
 		}
 
-		return nil, fmt.Errorf("dialing WebSocket: %v", err)
+		return nil, fmt.Errorf("dialing WebSocket: %w", err)
 	}
 
 	return conn, nil
@@ -566,7 +566,7 @@ func (m *Multiplexer) monitorConnection(conn *Connection) {
 			return
 		case <-heartbeat.C:
 			if err := conn.WSConn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				conn.updateStatus(StateError, fmt.Errorf("heartbeat failed: %v", err))
+				conn.updateStatus(StateError, fmt.Errorf("heartbeat failed: %w", err))
 
 				if newConn, err := m.reconnect(conn); err != nil {
 					logger.Log(logger.LevelError, map[string]string{logFieldClusterID: conn.ClusterID}, err, "reconnecting to cluster")
@@ -1080,7 +1080,7 @@ func (m *Multiplexer) cleanupConnections() {
 func (m *Multiplexer) getClusterContext(clusterID string) (*kubeconfig.Context, error) {
 	ctxtProxy, err := m.kubeConfigStore.GetContext(clusterID)
 	if err != nil {
-		return nil, fmt.Errorf("getting context: %v", err)
+		return nil, fmt.Errorf("getting context: %w", err)
 	}
 
 	return ctxtProxy, nil

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -192,7 +192,7 @@ func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 	// get refresh token
 	refreshToken, err := cache.Get(ctx, oidcKeyPrefix+token)
 	if err != nil {
-		return nil, fmt.Errorf("getting refresh token: %v", err)
+		return nil, fmt.Errorf("getting refresh token: %w", err)
 	}
 
 	rToken, ok := refreshToken.(string)
@@ -217,7 +217,7 @@ func GetNewToken(clientID, clientSecret string, cache cache.Cache[interface{}],
 
 	// update the refresh token in the cache
 	if err := CacheRefreshedToken(newToken, tokenType, token, rToken, cache); err != nil {
-		return nil, fmt.Errorf("caching refreshed token: %v", err)
+		return nil, fmt.Errorf("caching refreshed token: %w", err)
 	}
 
 	return newToken, nil

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -493,7 +493,7 @@ func MakeHeadlampKubeConfigsDir() (string, error) {
 		return filepath.Dir(ex), nil
 	}
 
-	return "", fmt.Errorf("failed to get default kubeconfig persistence directory: %v", err)
+	return "", fmt.Errorf("failed to get default kubeconfig persistence directory: %w", err)
 }
 
 func DefaultHeadlampKubeConfigFile() (string, error) {

--- a/backend/pkg/exec/exec.go
+++ b/backend/pkg/exec/exec.go
@@ -350,7 +350,7 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	creds, err := r.a.getCreds()
 	if err != nil {
-		return nil, fmt.Errorf("getting credentials: %v", err)
+		return nil, fmt.Errorf("getting credentials: %w", err)
 	}
 	if creds.token != "" {
 		req.Header.Set("Authorization", "Bearer "+creds.token)
@@ -434,7 +434,7 @@ func (a *Authenticator) refreshCredsLocked() error {
 	env := append(a.environ(), a.env...)
 	data, err := runtime.Encode(codecs.LegacyCodec(a.group), cred)
 	if err != nil {
-		return fmt.Errorf("encode ExecCredentials: %v", err)
+		return fmt.Errorf("encode ExecCredentials: %w", err)
 	}
 	env = append(env, fmt.Sprintf("%s=%s", execInfoEnv, data))
 
@@ -460,7 +460,7 @@ func (a *Authenticator) refreshCredsLocked() error {
 
 	_, gvk, err := codecs.UniversalDecoder(a.group).Decode(stdout.Bytes(), nil, cred)
 	if err != nil {
-		return fmt.Errorf("decoding stdout: %v", err)
+		return fmt.Errorf("decoding stdout: %w", err)
 	}
 	if gvk.Group != a.group.Group || gvk.Version != a.group.Version {
 		return fmt.Errorf("exec plugin is configured to use API version %s, plugin returned version %s",
@@ -489,7 +489,7 @@ func (a *Authenticator) refreshCredsLocked() error {
 	if cred.Status.ClientKeyData != "" && cred.Status.ClientCertificateData != "" {
 		cert, err := tls.X509KeyPair([]byte(cred.Status.ClientCertificateData), []byte(cred.Status.ClientKeyData))
 		if err != nil {
-			return fmt.Errorf("failed parsing client key/certificate: %v", err)
+			return fmt.Errorf("failed parsing client key/certificate: %w", err)
 		}
 
 		// Leaf is initialized to be nil:
@@ -500,7 +500,7 @@ func (a *Authenticator) refreshCredsLocked() error {
 		// certificate values.
 		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
 		if err != nil {
-			return fmt.Errorf("failed parsing client leaf certificate: %v", err)
+			return fmt.Errorf("failed parsing client leaf certificate: %w", err)
 		}
 		newCreds.cert = &cert
 	}
@@ -552,6 +552,6 @@ func (a *Authenticator) wrapCmdRunErrorLocked(err error) error {
 		)
 
 	default:
-		return fmt.Errorf("exec: %v", err)
+		return fmt.Errorf("exec: %w", err)
 	}
 }

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -478,14 +478,14 @@ type ContextLoadError struct {
 func LoadContextsFromFile(kubeConfigPath string, source int) ([]Context, []ContextLoadError, error) {
 	data, err := os.ReadFile(kubeConfigPath) //nolint:gosec
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading kubeconfig file: %v", err)
+		return nil, nil, fmt.Errorf("error reading kubeconfig file: %w", err)
 	}
 
 	skipProxySetup := source != KubeConfig
 
 	contexts, contextErrors, err := loadContextsFromData(data, source, skipProxySetup)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error loading contexts from file: %v", err)
+		return nil, nil, fmt.Errorf("error loading contexts from file: %w", err)
 	}
 
 	// add the KubeConfigPath to each context
@@ -505,7 +505,7 @@ func LoadContextsFromFile(kubeConfigPath string, source int) ([]Context, []Conte
 func LoadContextsFromBase64String(kubeConfig string, source int) ([]Context, []ContextLoadError, error) {
 	kubeConfigByte, err := base64.StdEncoding.DecodeString(kubeConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error decoding base64 kubeconfig: %v", err)
+		return nil, nil, fmt.Errorf("error decoding base64 kubeconfig: %w", err)
 	}
 
 	skipProxySetup := source != KubeConfig
@@ -1184,7 +1184,7 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 
 	kubeConfigContexts, contextErrors, err := LoadContextsFromMultipleFiles(kubeConfigs, source)
 	if err != nil {
-		return fmt.Errorf("error loading kubeconfig files: %v", err)
+		return fmt.Errorf("error loading kubeconfig files: %w", err)
 	}
 
 	// if pass the shouldBeSkippedFunc=nil, it works like before
@@ -1207,7 +1207,7 @@ func LoadAndStoreKubeConfigs(kubeConfigStore ContextStore, kubeConfigs string, s
 	}
 
 	for _, contextError := range contextErrors {
-		errs = append(errs, fmt.Errorf("error in context %s: %v", contextError.ContextName, contextError.Error))
+		errs = append(errs, fmt.Errorf("error in context %s: %w", contextError.ContextName, contextError.Error))
 	}
 
 	return errors.Join(errs...)

--- a/backend/pkg/kubeconfig/watcher.go
+++ b/backend/pkg/kubeconfig/watcher.go
@@ -126,13 +126,13 @@ func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignore
 	// First read all kubeconfig files to get new contexts
 	newContexts, _, err := LoadContextsFromMultipleFiles(paths, source)
 	if err != nil {
-		return fmt.Errorf("error reading kubeconfig files: %v", err)
+		return fmt.Errorf("error reading kubeconfig files: %w", err)
 	}
 
 	// Get existing contexts from store
 	existingContexts, err := kubeConfigStore.GetContexts()
 	if err != nil {
-		return fmt.Errorf("error getting existing contexts: %v", err)
+		return fmt.Errorf("error getting existing contexts: %w", err)
 	}
 
 	// Find and remove contexts that no longer exist in the kubeconfig
@@ -164,7 +164,7 @@ func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignore
 	// Now load and store the new configurations
 	err = LoadAndStoreKubeConfigs(kubeConfigStore, paths, source, ignoreFunc)
 	if err != nil {
-		return fmt.Errorf("error loading kubeconfig files: %v", err)
+		return fmt.Errorf("error loading kubeconfig files: %w", err)
 	}
 
 	return nil

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -112,7 +112,7 @@ func getPortForwardList(cache cache.Cache[interface{}], cluster string) []portFo
 func getPortForwardByID(cache cache.Cache[interface{}], cluster string, id string) (portForward, error) {
 	cacheValue, err := cache.Get(context.Background(), storeKeyPrefix+cluster+id)
 	if err != nil {
-		return portForward{}, fmt.Errorf("failed to get portforward from cache: %v", err)
+		return portForward{}, fmt.Errorf("failed to get portforward from cache: %w", err)
 	}
 
 	pf, ok := cacheValue.(portForward)

--- a/backend/pkg/serviceproxy/http.go
+++ b/backend/pkg/serviceproxy/http.go
@@ -20,12 +20,12 @@ func HTTPGetStream(ctx context.Context, uri string, w io.Writer) error {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil) //nolint:gosec
 	if err != nil {
-		return fmt.Errorf("creating request: %v", err)
+		return fmt.Errorf("creating request: %w", err)
 	}
 
 	resp, err := cli.Do(req) //nolint:gosec
 	if err != nil {
-		return fmt.Errorf("failed HTTP GET: %v", err)
+		return fmt.Errorf("failed HTTP GET: %w", err)
 	}
 
 	defer func() { _ = resp.Body.Close() }()
@@ -35,7 +35,7 @@ func HTTPGetStream(ctx context.Context, uri string, w io.Writer) error {
 	}
 
 	if _, err := io.Copy(w, resp.Body); err != nil {
-		return fmt.Errorf("streaming response: %v", err)
+		return fmt.Errorf("streaming response: %w", err)
 	}
 
 	return nil

--- a/backend/pkg/telemetry/telemetry.go
+++ b/backend/pkg/telemetry/telemetry.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -297,7 +298,7 @@ func setupShutdownFunction(t *Telemetry) {
 
 		// Return both errors if both occur
 		if err1 != nil && err2 != nil {
-			return fmt.Errorf("multiple shutdown errors: tracer: %w; meter: %v", err1, err2)
+			return errors.Join(fmt.Errorf("tracer shutdown error: %w", err1), fmt.Errorf("meter shutdown error: %w", err2))
 		}
 
 		if err1 != nil {


### PR DESCRIPTION
## Summary
This PR fixes error wrapping across the backend by replacing `%v` with `%w` in `fmt.Errorf` calls. This ensures that the original error types and chains are preserved, allowing for proper `errors.Is` and `errors.As` unwrapping upstream.

## Related Issue

*(Leave this blank or remove it if you don't have an issue number for this yet)*

## Changes

- Fixed error formatting by replacing `%v` with `%w` in `fmt.Errorf` calls to preserve error chains.
- Refactored `kubeconfig`, `exec`, `serviceproxy`, `auth`, `portforward`, `config`, and `telemetry` packages for clarity and adherence to modern Go standard library best practices.

## Steps to Test

1. Run the backend unit tests using `go test ./...` in the backend directory.
2. Verify that all updated packages (`kubeconfig`, `exec`, `serviceproxy`, `auth`, `portforward`, `config`, `telemetry`) pass successfully.
3. Verify that standard error logs are still human-readable and correctly formatted when backend operations (like loading an invalid kubeconfig) fail.

## Screenshots (if applicable)

*(Not applicable as this is a purely backend code quality update)*

## Notes for the Reviewer

- **Note to maintainers:** While making these error wrapping fixes, I noticed the codebase is still using the deprecated third-party `github.com/pkg/errors` library in some places (like `backend/pkg/kubeconfig/file.go`). Since Go 1.13 introduced native error wrapping in the standard library, would you be open to me removing `pkg/errors` entirely in this PR or a follow-up PR?
