### PR TITLE
charts: Headlamp: Allow valueFrom in env values schema

### DIFF
--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -342,9 +342,124 @@
           "value": {
             "type": "string",
             "description": "Value of the environment variable"
+          },
+          "valueFrom": {
+            "type": "object",
+            "description": "Source for the environment variable's value",
+            "properties": {
+              "secretKeyRef": {
+                "type": "object",
+                "description": "Selects a key of a Secret",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the Secret"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Key of the Secret to select from"
+                  },
+                  "optional": {
+                    "type": "boolean",
+                    "description": "Specify whether the Secret or its key must be defined"
+                  }
+                },
+                "required": ["key"],
+                "additionalProperties": false
+              },
+              "configMapKeyRef": {
+                "type": "object",
+                "description": "Selects a key of a ConfigMap",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the ConfigMap"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Key of the ConfigMap to select from"
+                  },
+                  "optional": {
+                    "type": "boolean",
+                    "description": "Specify whether the ConfigMap or its key must be defined"
+                  }
+                },
+                "required": ["key"],
+                "additionalProperties": false
+              },
+              "fieldRef": {
+                "type": "object",
+                "description": "Selects a field of the pod",
+                "properties": {
+                  "apiVersion": {
+                    "type": "string",
+                    "description": "API version of the schema the fieldPath is written in"
+                  },
+                  "fieldPath": {
+                    "type": "string",
+                    "description": "Path of the field to select in the specified API version"
+                  }
+                },
+                "required": ["fieldPath"],
+                "additionalProperties": false
+              },
+              "resourceFieldRef": {
+                "type": "object",
+                "description": "Selects a resource of the container",
+                "properties": {
+                  "containerName": {
+                    "type": "string",
+                    "description": "Container name to select resources from"
+                  },
+                  "resource": {
+                    "type": "string",
+                    "description": "Resource to select"
+                  },
+                  "divisor": {
+                    "type": "string",
+                    "description": "Output format of the exposed resource"
+                  }
+                },
+                "required": ["resource"],
+                "additionalProperties": false
+              }
+            },
+            "oneOf": [
+              {
+                "required": ["secretKeyRef"],
+                "not": { "anyOf": [{ "required": ["configMapKeyRef"] }, { "required": ["fieldRef"] }, { "required": ["resourceFieldRef"] }] }
+              },
+              {
+                "required": ["configMapKeyRef"],
+                "not": { "anyOf": [{ "required": ["secretKeyRef"] }, { "required": ["fieldRef"] }, { "required": ["resourceFieldRef"] }] }
+              },
+              {
+                "required": ["fieldRef"],
+                "not": { "anyOf": [{ "required": ["secretKeyRef"] }, { "required": ["configMapKeyRef"] }, { "required": ["resourceFieldRef"] }] }
+              },
+              {
+                "required": ["resourceFieldRef"],
+                "not": { "anyOf": [{ "required": ["secretKeyRef"] }, { "required": ["configMapKeyRef"] }, { "required": ["fieldRef"] }] }
+              }
+            ],
+            "additionalProperties": false
           }
         },
-        "required": ["name", "value"],
+        "required": ["name"],
+        "oneOf": [
+          {
+            "required": ["value"],
+            "not": {
+              "required": ["valueFrom"]
+            }
+          },
+          {
+            "required": ["valueFrom"],
+            "not": {
+              "required": ["value"]
+            }
+          }
+        ],
         "additionalProperties": false
       }
     },


### PR DESCRIPTION
## Summary
This PR fixes a bug in the Helm chart's values schema by allowing `env` entries to use `valueFrom` (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef) in addition to plain `value`, matching the real Kubernetes `EnvVar`/`EnvVarSource` API.

## Related Issue
Fixes #4862

## Changes
- Updated `charts/headlamp/values.schema.json` to add a `valueFrom` property under `env[].items`, mirroring the Kubernetes `EnvVarSource` shape (secretKeyRef, configMapKeyRef, fieldRef, resourceFieldRef)
- Changed `env[].items.required` from `["name", "value"]` to `["name"]`
- Added a `oneOf` constraint requiring exactly one of `value` or `valueFrom` per entry, matching upstream Kubernetes validation

## Steps to Test
1. Run `helm lint .` from `charts/headlamp` to confirm no regressions
2. Run `helm template . --set 'env[0].name=OIDC_CLIENT_ID' --set 'env[0].valueFrom.secretKeyRef.name=headlamp-oidc' --set 'env[0].valueFrom.secretKeyRef.key=clientID'` and confirm it renders successfully with `valueFrom` in the output
3. Run `helm template . --set 'env[0].name=FOO' --set 'env[0].value=bar'` and confirm plain `value` still works (backward compatibility)
4. Run `helm template . --set 'env[0].name=FOO' --set 'env[0].value=bar' --set 'env[0].valueFrom.secretKeyRef.name=x' --set 'env[0].valueFrom.secretKeyRef.key=y'` and confirm it fails schema validation (both `value` and `valueFrom` set)

## Screenshots (if applicable)
<img width="1452" height="78" alt="Screenshot from 2026-06-12 16-49-21" src="https://github.com/user-attachments/assets/8459518e-9bfd-4230-80d1-e8ffa7b327a0" />
<img width="1508" height="943" alt="Screenshot from 2026-06-12 16-50-37" src="https://github.com/user-attachments/assets/08f70089-583f-48a1-b28a-b9bfe357cdac" />
<img width="1508" height="943" alt="Screenshot from 2026-06-12 16-50-55" src="https://github.com/user-attachments/assets/f4a0cd83-109e-44b6-b9bf-939ed05ba329" />
<img width="1508" height="136" alt="Screenshot from 2026-06-12 16-51-08" src="https://github.com/user-attachments/assets/2a622bee-6a0a-409a-a98a-ceeeb64087d9" />

## Notes for the Reviewer
- This is a schema-only change, no template files were modified
- The `oneOf` pattern used here mirrors the existing pattern in the same schema file (`ingress.hosts[].paths[].backend.service.port`)
- `additionalProperties: false` is preserved at both the top-level `env[].items` and within `valueFrom`, so typos in field names will still be caught