### PR TITLE
frontend: backend: brotli-precompress static assets and serve .br sidecars

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -323,7 +323,8 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	addPluginListRoute(config, r)
 
 	// Serve development plugins
-	pluginHandler := http.StripPrefix(config.BaseURL+"/plugins/", http.FileServer(http.Dir(config.PluginDir)))
+	pluginHandler := http.StripPrefix(config.BaseURL+"/plugins/",
+		spa.BrotliSidecars(config.PluginDir, http.FileServer(http.Dir(config.PluginDir))))
 	// If we're running locally, then do not cache the plugins. This ensures that reloading them (development,
 	// update) will actually get the new content.
 	if !config.UseInCluster {
@@ -335,7 +336,7 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	// Serve user-installed plugins
 	if config.UserPluginDir != "" {
 		userPluginsHandler := http.StripPrefix(config.BaseURL+"/user-plugins/",
-			http.FileServer(http.Dir(config.UserPluginDir)))
+			spa.BrotliSidecars(config.UserPluginDir, http.FileServer(http.Dir(config.UserPluginDir))))
 		if !config.UseInCluster {
 			userPluginsHandler = serveWithNoCacheHeader(userPluginsHandler)
 		}
@@ -346,7 +347,7 @@ func addPluginRoutes(config *HeadlampConfig, r *mux.Router) {
 	// Serve shipped/static plugins
 	if config.StaticPluginDir != "" {
 		staticPluginsHandler := http.StripPrefix(config.BaseURL+"/static-plugins/",
-			http.FileServer(http.Dir(config.StaticPluginDir)))
+			spa.BrotliSidecars(config.StaticPluginDir, http.FileServer(http.Dir(config.StaticPluginDir))))
 		r.PathPrefix("/static-plugins/").Handler(staticPluginsHandler)
 	}
 }

--- a/backend/pkg/spa/contentType.go
+++ b/backend/pkg/spa/contentType.go
@@ -1,0 +1,28 @@
+package spa
+
+import (
+	"io"
+	"mime"
+	"net/http"
+	"path/filepath"
+)
+
+// detectContentType returns the content type for a file path, preferring
+// extension-based lookup and falling back to sniffing up to 512 bytes.
+func detectContentType(path string, open func() (io.ReadCloser, error)) string {
+	ctype := mime.TypeByExtension(filepath.Ext(path))
+	if ctype != "" {
+		return ctype
+	}
+
+	f, err := open()
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, 512)
+	n, _ := f.Read(buf)
+
+	return http.DetectContentType(buf[:n])
+}

--- a/backend/pkg/spa/embeddedSPAHandler.go
+++ b/backend/pkg/spa/embeddedSPAHandler.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"io"
 	"io/fs"
-	"mime"
 	"net/http"
 	"path"
 	"strings"
-
-	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+	"time"
 )
 
 // embeddedSpaHandler serves the static files embedded in the binary.
@@ -24,11 +22,8 @@ type embeddedSpaHandler struct {
 
 // ServeHTTP serves the static files embedded in the binary.
 func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rPath := strings.TrimPrefix(r.URL.Path, h.baseURL)
-	rPath = strings.TrimPrefix(rPath, "/")
-	rPath = path.Clean(rPath)
-
-	if rPath == ".." || strings.HasPrefix(rPath, "../") {
+	rPath, ok := sanitizeEmbeddedPath(strings.TrimPrefix(r.URL.Path, h.baseURL))
+	if !ok {
 		http.Error(w, "Invalid path", http.StatusBadRequest)
 		return
 	}
@@ -39,53 +34,131 @@ func (h embeddedSpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Prepend "static" to the path as that's the root in our embed.FS
 	fullPath := path.Join("static", rPath)
-	servedPath := fullPath
+
+	// `Vary: Accept-Encoding` must be set on every response so caches keep
+	// per-encoding entries even when we end up serving identity bytes.
+	setEncodingHeaders(w, "")
+
+	// Detect whether this request would resolve to the index.html so we
+	// can decide up front whether the precompressed sidecar is safe to
+	// use. We must skip the sidecar for the index document because the
+	// `__baseUrl__` replacement below mutates the served bytes.
+	isServingIndex := rPath == h.indexPath
+
+	// Try to serve a precompressed sidecar (`.br`) when the client
+	// supports it and the file isn't the index.html (which we rewrite
+	// below).
+	if !isServingIndex && h.tryServePrecompressed(w, r, fullPath) {
+		return
+	}
 
 	content, err := h.serveFile(fullPath)
-	isServingIndex := false
-
 	if err != nil {
-		// If there's any error, serve the index file
-		servedPath = path.Join("static", h.indexPath)
-
-		content, err = h.serveFile(servedPath)
+		// If there's any error, serve the index file.
+		// Use path.Join (not filepath.Join) — embed.FS paths must use forward slashes.
+		content, err = h.serveFile(path.Join("static", h.indexPath))
 		if err != nil {
 			http.Error(w, "Unable to read index file", http.StatusInternalServerError)
 			return
 		}
 
 		isServingIndex = true
-	} else {
-		// Check if we're directly serving the index file
-		isServingIndex = rPath == h.indexPath
 	}
 
-	// if we're serving the index.html file and have a baseURL, replace the headlampBaseUrl with the baseURL
-	if h.baseURL != "" && isServingIndex {
-		// Replace the __baseUrl__ assignment to use the baseURL instead of './'
-		oldPattern := "__baseUrl__ = './<%= BASE_URL %>'.replace('%BASE_' + 'URL%', '').replace('<' + '%= BASE_URL %>', '');"
-		newPattern := "__baseUrl__ = '" + h.baseURL + "';"
-		content = bytes.ReplaceAll(content, []byte(oldPattern), []byte(newPattern))
-		// Replace any remaining './' patterns in the content
-		content = bytes.ReplaceAll(content, []byte("'./'"), []byte(h.baseURL+"/"))
-		// Replace url( patterns for CSS
-		content = bytes.ReplaceAll(content, []byte("url("), []byte("url("+h.baseURL+"/"))
+	content = h.rewriteIndexContent(content, isServingIndex)
+
+	// Set the correct Content-Type header. When we fell back to serving the
+	// index file, use the index path's extension (always .html), not the
+	// originally-requested path (which could be .css, .js, etc.).
+	// Use path.Join (not filepath.Join) — embed.FS paths must use forward
+	// slashes on all platforms, including Windows.
+	contentPath := fullPath
+	if isServingIndex {
+		contentPath = path.Join("static", h.indexPath)
 	}
 
-	// Set the correct Content-Type header
-	ext := path.Ext(servedPath)
-
-	contentType := mime.TypeByExtension(ext)
-	if contentType == "" {
-		contentType = http.DetectContentType(content)
+	ctype := detectContentType(contentPath, func() (io.ReadCloser, error) {
+		return h.staticFS.Open(contentPath)
+	})
+	if ctype != "" {
+		w.Header().Set("Content-Type", ctype)
 	}
 
-	w.Header().Set("Content-Type", contentType)
+	http.ServeContent(w, r, contentPath, time.Time{}, bytes.NewReader(content))
+}
 
-	_, err = w.Write(content) //nolint:gosec
+func sanitizeEmbeddedPath(rPath string) (string, bool) {
+	// Strip the leading "/" so path.Join keeps "static" as the root.
+	// embed.FS paths are always forward-slash-separated, so use path.Join,
+	// not filepath.Join (which emits OS separators on Windows).
+	rPath = strings.TrimLeft(rPath, "/")
+
+	// Reject backslashes — HTTP paths must use '/', and '\\' is a Windows
+	// path separator that could be used for traversal.
+	if strings.ContainsRune(rPath, '\\') {
+		return "", false
+	}
+
+	// Normalise and reject any path that would escape the embedded root.
+	// path.Join cleans ".." segments, but the cleaned result can start with
+	// ".." when there are more ".." components than path components, which
+	// would escape the "static/" prefix we prepend below.
+	rPath = path.Clean(rPath)
+
+	if rPath == ".." || strings.HasPrefix(rPath, "../") {
+		return "", false
+	}
+
+	return rPath, true
+}
+
+func (h embeddedSpaHandler) rewriteIndexContent(content []byte, isServingIndex bool) []byte {
+	if h.baseURL == "" || !isServingIndex {
+		return content
+	}
+
+	// Replace the __baseUrl__ assignment to use the baseURL instead of './'.
+	oldPattern := "__baseUrl__ = './<%= BASE_URL %>'.replace('%BASE_' + 'URL%', '').replace('<' + '%= BASE_URL %>', '');"
+	newPattern := "__baseUrl__ = '" + h.baseURL + "';"
+	content = bytes.ReplaceAll(content, []byte(oldPattern), []byte(newPattern))
+
+	// Replace any remaining './' patterns in the content.
+	content = bytes.ReplaceAll(content, []byte("'./'"), []byte(h.baseURL+"/"))
+
+	// Replace url( patterns for CSS.
+	return bytes.ReplaceAll(content, []byte("url("), []byte("url("+h.baseURL+"/"))
+}
+
+// tryServePrecompressed attempts to serve a precompressed sidecar (e.g.
+// `.br`) for fullPath when the client advertises support for it. It
+// returns true when the response has been written and the caller should
+// stop, or false when the caller should fall back to identity content.
+func (h embeddedSpaHandler) tryServePrecompressed(
+	w http.ResponseWriter, r *http.Request, fullPath string,
+) bool {
+	encoding := pickEncoding(r.Header.Get("Accept-Encoding"))
+	if encoding == "" {
+		return false
+	}
+
+	data, err := h.serveFile(fullPath + encodingExt(encoding))
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "writing content")
+		return false
 	}
+
+	ctype := detectContentType(fullPath, func() (io.ReadCloser, error) {
+		return h.staticFS.Open(fullPath)
+	})
+
+	if ctype != "" {
+		w.Header().Set("Content-Type", ctype)
+	}
+
+	setEncodingHeaders(w, encoding)
+	sidecarPath := fullPath + encodingExt(encoding)
+	http.ServeContent(w, r, sidecarPath, time.Time{}, bytes.NewReader(data))
+
+	return true
 }
 
 func (h embeddedSpaHandler) serveFile(filePath string) ([]byte, error) {

--- a/backend/pkg/spa/embeddedSPAHandler_test.go
+++ b/backend/pkg/spa/embeddedSPAHandler_test.go
@@ -124,3 +124,39 @@ func testFileNotFoundUsesIndexContentType(t *testing.T, testHTML string) {
 	assert.Contains(t, rr.Header().Get("Content-Type"), "text/html")
 	assert.Contains(t, rr.Body.String(), "__baseUrl__ = '/headlamp';")
 }
+
+// TestEmbeddedSpaHandlerTraversal verifies that the embedded handler rejects
+// paths containing ".." components or backslashes with 400, consistent with
+// the on-disk spaHandler.
+func TestEmbeddedSpaHandlerTraversal(t *testing.T) {
+	testHTML := getTestHTML()
+
+	files := map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(testHTML)},
+	}
+
+	handler := spa.NewEmbeddedHandler(createTestFS(files), "index.html", "/headlamp")
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"dotdot escape", "/headlamp/../../etc/passwd"},
+		{"dotdot in segment", "/headlamp/../secret"},
+		{"backslash in path", `/headlamp\..\secret`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(
+				context.Background(), "GET", tt.path, nil)
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code,
+				"path %q should be rejected with 400", tt.path)
+		})
+	}
+}

--- a/backend/pkg/spa/encoding.go
+++ b/backend/pkg/spa/encoding.go
@@ -1,0 +1,264 @@
+package spa
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// pickEncoding returns the best precompressed encoding to serve for a request
+// based on its Accept-Encoding header. It returns "br" or "".
+//
+// Only brotli is supported: every browser Headlamp targets ships with brotli,
+// the build pipeline only emits `.br` sidecars, and serving gzip would
+// require a parallel set of files for no real-world benefit. Encodings whose
+// quality value (`q=`) is explicitly 0 are never selected, including when
+// the wildcard `*` appears later in the same header (RFC 7231 §5.3.4: an
+// explicit q=0 for a coding overrides the wildcard). The function does
+// not parse the full RFC 7231 grammar; it implements just enough to recognise
+// the common cases produced by browsers and well-behaved HTTP clients.
+func pickEncoding(acceptEncoding string) string {
+	if acceptEncoding == "" {
+		return ""
+	}
+
+	// First pass: collect which encodings (and the wildcard) have been
+	// explicitly disabled with q=0, so that a later "*" cannot re-enable
+	// them. We deliberately make a second pass below to honour the
+	// preference order of the entries that *are* enabled.
+	disabled := map[string]bool{}
+
+	for _, raw := range strings.Split(acceptEncoding, ",") {
+		token := strings.TrimSpace(raw)
+		if token == "" {
+			continue
+		}
+
+		name, params := splitEncoding(token)
+		if hasZeroQ(params) {
+			disabled[strings.ToLower(name)] = true
+		}
+	}
+
+	for _, raw := range strings.Split(acceptEncoding, ",") {
+		token := strings.TrimSpace(raw)
+		if token == "" {
+			continue
+		}
+
+		name, params := splitEncoding(token)
+		// q=0 disables this encoding even if it would otherwise match.
+		if hasZeroQ(params) {
+			continue
+		}
+
+		switch strings.ToLower(name) {
+		case "br":
+			return "br"
+		case "*":
+			// Wildcard matches br only if br wasn't explicitly disabled
+			// elsewhere in this same header.
+			if !disabled["br"] {
+				return "br"
+			}
+		}
+	}
+
+	return ""
+}
+
+// splitEncoding splits an Accept-Encoding token like "br;q=0.5" into its
+// coding name and parameter list (without the leading ";").
+func splitEncoding(token string) (string, string) {
+	if i := strings.Index(token, ";"); i >= 0 {
+		return strings.TrimSpace(token[:i]), token[i+1:]
+	}
+
+	return token, ""
+}
+
+// hasZeroQ reports whether an Accept-Encoding parameter list contains q=0
+// (or any case/whitespace variant such as "Q = 0", "q=0.0", "q=0.000").
+func hasZeroQ(params string) bool {
+	for _, p := range strings.Split(params, ";") {
+		p = strings.TrimSpace(p)
+
+		eq := strings.IndexByte(p, '=')
+		if eq < 0 {
+			continue
+		}
+
+		key := strings.ToLower(strings.TrimSpace(p[:eq]))
+		val := strings.TrimSpace(p[eq+1:])
+
+		if key != "q" {
+			continue
+		}
+
+		// "0", "0.", "0.0", "0.000" all mean disabled. Anything with a
+		// non-zero digit anywhere means a positive (or malformed) weight.
+		if val == "" {
+			continue
+		}
+
+		isZero := true
+
+		for _, r := range val {
+			if r >= '1' && r <= '9' {
+				isZero = false
+				break
+			}
+		}
+
+		if isZero {
+			return true
+		}
+	}
+
+	return false
+}
+
+// encodingExt returns the filename suffix (".br") for a given negotiated
+// encoding, or "" if no precompressed sidecar should be served.
+func encodingExt(encoding string) string {
+	if encoding == "br" {
+		return ".br"
+	}
+
+	return ""
+}
+
+// setEncodingHeaders writes the response headers required when serving a
+// precompressed sidecar. The original Content-Type (derived from the
+// non-compressed filename) must already be set on w.
+//
+// It is safe to call multiple times per request: Accept-Encoding is added to
+// Vary only when not already present (avoiding duplicate entries), and
+// Content-Encoding is deleted when encoding is empty so identity responses
+// never carry a stale marker from a previous call.
+func setEncodingHeaders(w http.ResponseWriter, encoding string) {
+	h := w.Header()
+
+	// Add Accept-Encoding to Vary only when not already present.
+	// Parse the Vary header as a comma-separated token list and compare
+	// case-insensitively so we handle "Vary: Accept-Encoding",
+	// "Vary: Origin, Accept-Encoding", and "Vary: *" correctly, without
+	// false-positives from tokens like "X-Accept-Encoding".
+	hasAcceptEncoding := false
+
+	for _, field := range h["Vary"] {
+		for _, token := range strings.Split(field, ",") {
+			t := strings.ToLower(strings.TrimSpace(token))
+			if t == "accept-encoding" || t == "*" {
+				hasAcceptEncoding = true
+				break
+			}
+		}
+
+		if hasAcceptEncoding {
+			break
+		}
+	}
+
+	if !hasAcceptEncoding {
+		h.Add("Vary", "Accept-Encoding")
+	}
+
+	if encoding != "" {
+		h.Set("Content-Encoding", encoding)
+	} else {
+		// Remove any Content-Encoding set by an earlier call so identity
+		// responses never carry a stale encoding marker.
+		h.Del("Content-Encoding")
+	}
+}
+
+// BrotliSidecars returns an http.Handler that transparently serves precompressed
+// .br sidecars when the client advertises brotli support and a matching sidecar
+// exists alongside the requested file in dir. It falls back to next for all
+// other cases, so it is safe to wrap any existing file-serving handler.
+//
+// dir must be the same root directory that next serves from (e.g. the value
+// passed to http.Dir) so the middleware can resolve file paths correctly.
+//
+// Reuses the same pickEncoding / encodingExt / setEncodingHeaders helpers as
+// the SPA handlers, giving plugins identical brotli negotiation behaviour.
+func BrotliSidecars(dir string, next http.Handler) http.Handler {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		// Cannot resolve dir — brotli is best-effort, fall through unchanged.
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setEncodingHeaders(w, "")
+
+		if served := tryBrotliSidecar(w, r, absDir); served {
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// tryBrotliSidecar attempts to serve a precompressed .br sidecar for the
+// requested path. It returns true when a sidecar was found and served.
+func tryBrotliSidecar(w http.ResponseWriter, r *http.Request, absDir string) bool {
+	// Convert the URL path to a safe OS-relative path. urlToRel rejects
+	// backslashes; os.Root then enforces the containment boundary.
+	rel, ok := urlToRel(r.URL.Path)
+	if !ok {
+		http.Error(w, "Invalid file path", http.StatusBadRequest)
+		return true
+	}
+
+	encoding := pickEncoding(r.Header.Get("Accept-Encoding"))
+	if encoding == "" {
+		return false
+	}
+
+	root, err := os.OpenRoot(absDir)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = root.Close() }()
+
+	sidecarRel := rel + encodingExt(encoding)
+
+	info, err := root.Stat(sidecarRel)
+	if err != nil || info.IsDir() {
+		return false
+	}
+
+	origInfo, origErr := root.Stat(rel)
+	if origErr != nil || origInfo.IsDir() {
+		return false
+	}
+
+	ctype := detectContentType(rel, func() (io.ReadCloser, error) {
+		return root.Open(rel)
+	})
+
+	file, err := root.Open(sidecarRel)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = file.Close() }()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return false
+	}
+
+	if ctype != "" {
+		w.Header().Set("Content-Type", ctype)
+	}
+
+	setEncodingHeaders(w, encoding)
+
+	http.ServeContent(w, r, sidecarRel, fileInfo.ModTime(), file)
+
+	return true
+}

--- a/backend/pkg/spa/encoding_internal_test.go
+++ b/backend/pkg/spa/encoding_internal_test.go
@@ -1,0 +1,147 @@
+package spa
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetEncodingHeadersDoesNotFalsePositiveOnSimilarVaryToken(t *testing.T) {
+	rr := httptest.NewRecorder()
+	rr.Header().Add("Vary", "X-Accept-Encoding")
+
+	setEncodingHeaders(rr, "")
+
+	vary := rr.Header().Values("Vary")
+	acceptCount := 0
+	similarCount := 0
+
+	for _, v := range vary {
+		if v == "Accept-Encoding" {
+			acceptCount++
+		}
+
+		if v == "X-Accept-Encoding" {
+			similarCount++
+		}
+	}
+
+	if similarCount != 1 {
+		t.Fatalf("expected X-Accept-Encoding to be preserved once, got %d in %v", similarCount, vary)
+	}
+
+	if acceptCount != 1 {
+		t.Fatalf("expected Accept-Encoding to be added once, got %d in %v", acceptCount, vary)
+	}
+}
+
+func TestTryBrotliSidecarRejectsInvalidPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "backslash path", path: `/foo\\bar.js`},
+		{name: "parent escape", path: `/../outside.js`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req.Header.Set("Accept-Encoding", "br")
+
+			rr := httptest.NewRecorder()
+			served := tryBrotliSidecar(rr, req, dir)
+
+			if !served {
+				t.Fatalf("expected invalid path to be handled by middleware")
+			}
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for invalid path, got %d", rr.Code)
+			}
+		})
+	}
+}
+
+func TestTryBrotliSidecarRequiresOriginalFile(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, body string) {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Leave only sidecar file; original does not exist.
+	write("app.js.br", "STALE")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/app.js", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Accept-Encoding", "br")
+
+	rr := httptest.NewRecorder()
+	served := tryBrotliSidecar(rr, req, dir)
+
+	if served {
+		t.Fatalf("expected middleware not to serve stale sidecar when original is missing")
+	}
+}
+
+func TestTryBrotliSidecarDoesNotSetEncodingOnOpenFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, body string) {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("app.js", "console.log(1)")
+	write("app.js.br", "BROTLI")
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/app.js", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Accept-Encoding", "br")
+
+	// Remove sidecar after it exists to emulate a race where open/stat fails
+	// after an earlier existence check.
+	if err := os.Remove(filepath.Join(dir, "app.js.br")); err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	served := tryBrotliSidecar(rr, req, dir)
+
+	if served {
+		t.Fatalf("expected middleware to fall through when sidecar open fails")
+	}
+
+	if got := rr.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("expected no Content-Encoding on fallback, got %q", got)
+	}
+}

--- a/backend/pkg/spa/encoding_test.go
+++ b/backend/pkg/spa/encoding_test.go
@@ -1,0 +1,387 @@
+package spa_test
+
+import (
+	"context"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/spa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile is a small helper to create an arbitrary file under dir.
+func writeFile(t *testing.T, dir, name string, content []byte) {
+	t.Helper()
+
+	full := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+	require.NoError(t, os.WriteFile(full, content, 0o600))
+}
+
+// TestSpaHandlerServesPrecompressedSidecar verifies that the on-disk
+// spaHandler picks the brotli sidecar when it exists and the client
+// advertises support, and falls back to identity when it doesn't.
+func TestSpaHandlerServesPrecompressedSidecar(t *testing.T) {
+	dir := t.TempDir()
+
+	originalJS := []byte("// big readable javascript here\n" +
+		"function hello() { console.log('hi'); }\n")
+	brBytes := []byte("BROTLI-PAYLOAD") // contents are arbitrary; handler must not decode them
+
+	writeFile(t, dir, "index.html", []byte("the-index"))
+	writeFile(t, dir, "app.js", originalJS)
+	writeFile(t, dir, "app.js.br", brBytes)
+
+	handler := spa.NewHandler(dir, "index.html", "/headlamp")
+
+	tests := []struct {
+		name           string
+		acceptEncoding string
+		wantBody       []byte
+		wantEncoding   string
+	}{
+		{"prefers brotli when offered", "br, gzip", brBytes, "br"},
+		{"identity when client only offers gzip", "gzip", originalJS, ""},
+		{"explicit brotli only", "br", brBytes, "br"},
+		{"identity when no encoding header", "", originalJS, ""},
+		{"identity when brotli is disabled", "br;q=0", originalJS, ""},
+		{"brotli via wildcard", "*", brBytes, "br"},
+		{"q=0 for br with wildcard later still disables br", "br;q=0, *;q=0.5", originalJS, ""},
+		{"unsupported encoding falls through to identity", "deflate", originalJS, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(
+				context.Background(), "GET", "/headlamp/app.js", nil)
+			require.NoError(t, err)
+
+			if tc.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tc.acceptEncoding)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, string(tc.wantBody), rr.Body.String())
+			assert.Equal(t, tc.wantEncoding, rr.Header().Get("Content-Encoding"))
+			// Vary must always be present so caches keep per-encoding entries.
+			assert.Contains(t, rr.Header().Get("Vary"), "Accept-Encoding")
+			// Content-Type must reflect the original (.js) regardless of encoding.
+			assert.Contains(t, rr.Header().Get("Content-Type"), "javascript")
+		})
+	}
+}
+
+// TestSpaHandlerNoSidecarUsesIdentity ensures we don't break files that
+// don't have a precompressed sidecar even when the client supports brotli.
+func TestSpaHandlerNoSidecarUsesIdentity(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "index.html", []byte("the-index"))
+	writeFile(t, dir, "small.css", []byte(".x{}"))
+
+	handler := spa.NewHandler(dir, "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), "GET", "/headlamp/small.css", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "br")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, ".x{}", rr.Body.String())
+	assert.Empty(t, rr.Header().Get("Content-Encoding"))
+	assert.Contains(t, rr.Header().Get("Vary"), "Accept-Encoding")
+}
+
+// TestEmbeddedSpaHandlerServesPrecompressedSidecar verifies the embed.FS
+// handler does the same brotli negotiation for non-index assets.
+func TestEmbeddedSpaHandlerServesPrecompressedSidecar(t *testing.T) {
+	files := map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(getTestHTML())},
+		"static/app.js":     {Data: []byte("function hi() {}")},
+		"static/app.js.br":  {Data: []byte("BROTLI-PAYLOAD")},
+	}
+
+	handler := spa.NewEmbeddedHandler(fs.FS(fstest.MapFS(files)), "index.html", "/headlamp")
+
+	tests := []struct {
+		name           string
+		acceptEncoding string
+		wantBody       string
+		wantEncoding   string
+	}{
+		{"brotli", "br, gzip", "BROTLI-PAYLOAD", "br"},
+		{"identity when only gzip offered", "gzip", "function hi() {}", ""},
+		{"identity", "", "function hi() {}", ""},
+		{"identity when brotli disabled", "br;q=0", "function hi() {}", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(
+				context.Background(), "GET", "/headlamp/app.js", nil)
+			require.NoError(t, err)
+
+			if tc.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tc.acceptEncoding)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, tc.wantBody, rr.Body.String())
+			assert.Equal(t, tc.wantEncoding, rr.Header().Get("Content-Encoding"))
+			assert.Contains(t, rr.Header().Get("Vary"), "Accept-Encoding")
+			assert.Contains(t, rr.Header().Get("Content-Type"), "javascript")
+		})
+	}
+}
+
+// TestEmbeddedSpaHandlerNeverServesEncodedIndex makes sure we don't try to
+// serve the index.html via a precompressed sidecar, because the handler
+// rewrites its body for baseURL substitution.
+func TestEmbeddedSpaHandlerNeverServesEncodedIndex(t *testing.T) {
+	files := map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(getTestHTML())},
+		// A bogus index.html.br that, if served, would produce wrong bytes.
+		"static/index.html.br": {Data: []byte("SHOULD-NEVER-BE-SERVED")},
+	}
+
+	handler := spa.NewEmbeddedHandler(fs.FS(fstest.MapFS(files)), "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), "GET", "/headlamp/index.html", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "br")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("Content-Encoding"),
+		"index.html must be served as identity so baseURL rewriting works")
+	assert.Contains(t, rr.Body.String(), "__baseUrl__ = '/headlamp';")
+	assert.Contains(t, rr.Header().Get("Vary"), "Accept-Encoding")
+}
+
+// TestEmbeddedSpaHandlerMissingSidecarFallsThrough ensures a missing sidecar
+// doesn't break the response: we still serve the identity bytes with the
+// correct content-type and no Content-Encoding header.
+func TestEmbeddedSpaHandlerMissingSidecarFallsThrough(t *testing.T) {
+	files := map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(getTestHTML())},
+		"static/app.js":     {Data: []byte("function hi() {}")},
+	}
+
+	handler := spa.NewEmbeddedHandler(fs.FS(fstest.MapFS(files)), "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), "GET", "/headlamp/app.js", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "br")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "function hi() {}", rr.Body.String())
+	assert.Empty(t, rr.Header().Get("Content-Encoding"))
+	assert.Contains(t, rr.Header().Get("Content-Type"), "javascript")
+	assert.Contains(t, rr.Header().Get("Vary"), "Accept-Encoding")
+}
+
+func TestEmbeddedSpaHandlerPrecompressedHonorsHEAD(t *testing.T) {
+	files := map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(getTestHTML())},
+		"static/app.js":     {Data: []byte("function hi() {}")},
+		"static/app.js.br":  {Data: []byte("BROTLI-PAYLOAD")},
+	}
+
+	handler := spa.NewEmbeddedHandler(fs.FS(fstest.MapFS(files)), "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodHead, "/headlamp/app.js", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "br")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "", rr.Body.String())
+	assert.Equal(t, "br", rr.Header().Get("Content-Encoding"))
+	assert.Contains(t, rr.Header().Get("Vary"), "Accept-Encoding")
+}
+
+func TestEmbeddedSpaHandlerPrecompressedSupportsRange(t *testing.T) {
+	files := map[string]*fstest.MapFile{
+		"static/index.html": {Data: []byte(getTestHTML())},
+		"static/app.js":     {Data: []byte("function hi() {}")},
+		"static/app.js.br":  {Data: []byte("BROTLI-PAYLOAD")},
+	}
+
+	handler := spa.NewEmbeddedHandler(fs.FS(fstest.MapFS(files)), "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/headlamp/app.js", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "br")
+	req.Header.Set("Range", "bytes=0-5")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusPartialContent, rr.Code)
+	assert.Equal(t, "BROTLI", rr.Body.String())
+	assert.Equal(t, "br", rr.Header().Get("Content-Encoding"))
+	assert.Contains(t, rr.Header().Get("Content-Range"), "bytes 0-5/")
+}
+
+// TestSetEncodingHeadersNoDuplicateVary ensures that calling setEncodingHeaders
+// more than once (as happens when the handler first marks the identity path then
+// falls back to serving a sidecar) does not accumulate duplicate
+// Vary: Accept-Encoding entries.
+func TestSetEncodingHeadersNoDuplicateVary(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "index.html", []byte("<html>"))
+	writeFile(t, dir, "app.js", []byte("console.log(1)"))
+	writeFile(t, dir, "app.js.br", []byte("BROTLI"))
+
+	handler := spa.NewHandler(dir, "index.html", "/")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/app.js", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "br")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	varyValues := rr.Header()["Vary"]
+	count := 0
+
+	for _, v := range varyValues {
+		if v == "Accept-Encoding" {
+			count++
+		}
+	}
+
+	assert.Equal(t, 1, count, "Vary: Accept-Encoding must appear exactly once, got %v", varyValues)
+}
+
+// TestBrotliSidecarsMiddleware verifies that BrotliSidecars correctly wraps
+// a file handler to serve .br sidecars for plugin dist folders.
+func TestBrotliSidecarsMiddleware(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "myplugin/main.js", []byte("function plugin() {}"))
+	writeFile(t, dir, "myplugin/main.js.br", []byte("BROTLI-PLUGIN"))
+
+	// Simulate how headlamp.go wraps http.FileServer for plugins.
+	fileServer := http.FileServer(http.Dir(dir))
+	handler := http.StripPrefix("/plugins/", spa.BrotliSidecars(dir, fileServer))
+
+	tests := []struct {
+		name           string
+		acceptEncoding string
+		wantBody       string
+		wantEncoding   string
+	}{
+		{"serves sidecar when br offered", "br", "BROTLI-PLUGIN", "br"},
+		{"falls back to identity for gzip-only", "gzip", "function plugin() {}", ""},
+		{"falls back to identity when no encoding", "", "function plugin() {}", ""},
+		{"identity when brotli disabled via q=0", "br;q=0", "function plugin() {}", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(
+				context.Background(), "GET", "/plugins/myplugin/main.js", nil)
+			require.NoError(t, err)
+
+			if tc.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tc.acceptEncoding)
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, tc.wantBody, rr.Body.String())
+			assert.Equal(t, tc.wantEncoding, rr.Header().Get("Content-Encoding"))
+			assert.Contains(t, rr.Header().Get("Vary"), "Accept-Encoding")
+			assert.Contains(t, rr.Header().Get("Content-Type"), "javascript")
+		})
+	}
+}
+
+// TestSpaHandlerNeverServesEncodedIndex ensures that the on-disk spaHandler
+// never serves a precompressed index.html.br sidecar. headlamp.go rewrites
+// index.html at startup for baseURL substitution, so a build-time sidecar
+// would contain stale unrewritten bytes.
+func TestSpaHandlerNeverServesEncodedIndex(t *testing.T) {
+	dir := t.TempDir()
+
+	indexHTML := []byte("<html>index</html>")
+	writeFile(t, dir, "index.html", indexHTML)
+	writeFile(t, dir, "index.html.br", []byte("STALE-BROTLI-BYTES"))
+
+	handler := spa.NewHandler(dir, "index.html", "/headlamp")
+
+	// Request the root — spaHandler serves index.html as the SPA entry point.
+	// http.ServeFile redirects explicit ".../index.html" requests to "./",
+	// so we use the trailing-slash form which is the real browser entrypoint.
+	req, err := http.NewRequestWithContext(
+		context.Background(), "GET", "/headlamp/", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept-Encoding", "br")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("Content-Encoding"), "index.html must not be served brotli-encoded")
+	assert.Equal(t, string(indexHTML), rr.Body.String())
+}
+
+func TestSpaHandlerDirectoryRequestFallsBackToIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "index.html", []byte("the-index"))
+	writeFile(t, dir, "assets/file.txt", []byte("x"))
+
+	handler := spa.NewHandler(dir, "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), "GET", "/headlamp/assets", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "the-index", rr.Body.String())
+}
+
+func TestSpaHandlerTraversalDoesNotLeakFilesystemError(t *testing.T) {
+	handler := spa.NewHandler("headlamp_testdata/static_files/", "index.html", "/headlamp")
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), "GET", "/headlamp/../outside.txt", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "escapes from parent")
+}

--- a/backend/pkg/spa/pathSafety.go
+++ b/backend/pkg/spa/pathSafety.go
@@ -1,0 +1,49 @@
+package spa
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// urlToRel converts a URL path to a relative OS path for use with os.Root.
+//
+// Three checks are applied in order:
+//  1. Backslash rejection — a backslash is a path separator on Windows and
+//     could be used for traversal.
+//  2. Leading-slash stripping — URL paths begin with '/'; the result must be
+//     relative so it can be passed to os.Root.
+//  3. Parent-escape rejection — after cleaning (which resolves any ".."
+//     components), any path that escapes the root directory is rejected.
+//     os.Root enforces containment at the OS level, but detecting escapes
+//     here lets us return 400 Bad Request rather than an internal error.
+//
+// Returns ("", false) when the path must be rejected.
+func urlToRel(urlPath string) (string, bool) {
+	if strings.ContainsRune(urlPath, '\\') {
+		return "", false
+	}
+
+	rel := filepath.Clean(filepath.FromSlash(strings.TrimLeft(urlPath, "/")))
+
+	// Reject absolute or volume-qualified paths (for example, "C:..." on
+	// Windows) so URL paths cannot resolve outside the root.
+	if filepath.IsAbs(rel) || filepath.VolumeName(rel) != "" || hasWindowsDrivePrefix(rel) {
+		return "", false
+	}
+
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+
+	return rel, true
+}
+
+func hasWindowsDrivePrefix(p string) bool {
+	if len(p) < 2 || p[1] != ':' {
+		return false
+	}
+
+	c := p[0]
+
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}

--- a/backend/pkg/spa/pathSafety_internal_test.go
+++ b/backend/pkg/spa/pathSafety_internal_test.go
@@ -1,0 +1,33 @@
+package spa
+
+import "testing"
+
+func TestURLToRelRejectsUnsafePaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "parent escape", path: "/../outside.txt"},
+		{name: "backslash separator", path: `/headlamp\\..\\..\\etc\\passwd`},
+		{name: "windows volume path", path: "/C:/Windows/system32"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if rel, ok := urlToRel(tc.path); ok {
+				t.Fatalf("expected path %q to be rejected, got rel=%q", tc.path, rel)
+			}
+		})
+	}
+}
+
+func TestURLToRelAcceptsSafeRelativePath(t *testing.T) {
+	rel, ok := urlToRel("/headlamp/assets/main.js")
+	if !ok {
+		t.Fatalf("expected safe path to be accepted")
+	}
+
+	if rel != "headlamp/assets/main.js" {
+		t.Fatalf("unexpected relative path: got %q", rel)
+	}
+}

--- a/backend/pkg/spa/spaHandler.go
+++ b/backend/pkg/spa/spaHandler.go
@@ -1,9 +1,9 @@
 package spa
 
 import (
+	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -23,63 +23,146 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	absStaticPath, err := filepath.Abs(h.staticPath)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "getting absolute static path")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 
 		return
 	}
 
-	// Clean the path to prevent directory traversal
-	rPath := strings.TrimPrefix(r.URL.Path, h.baseURL)
-	rPath = strings.TrimPrefix(rPath, "/")
-	rPath = path.Clean(rPath)
+	// Strip the base URL prefix before converting to a safe relative path.
+	urlPath := strings.TrimPrefix(r.URL.Path, h.baseURL)
 
-	// Reject direct traversal hacks explicitly
-	if rPath == ".." || strings.HasPrefix(rPath, "../") {
-		http.Error(w, "Invalid file name", http.StatusBadRequest)
+	rel, ok := urlToRel(urlPath)
+	if !ok {
+		// urlToRel rejects backslashes: HTTP paths must use forward slashes
+		// only, and a backslash could be used for traversal on Windows.
+		http.Error(w, "Invalid file path", http.StatusBadRequest)
 		return
 	}
 
-	if rPath == "" || rPath == "." {
-		rPath = h.indexPath
+	// A request for the bare base URL (e.g. "/headlamp" with no trailing
+	// slash) produces an empty or "." rel after cleaning. Map it to the index
+	// directly so http.ServeContent doesn't try to serve the root directory.
+	indexRel := filepath.FromSlash(h.indexPath)
+	if rel == "" || rel == "." {
+		rel = indexRel
 	}
 
-	// prepend the path with the path to the static directory
-	fullPath := filepath.Join(absStaticPath, rPath)
-
-	// This is defensive, for preventing using files outside of the staticPath
-	// if in the future we touch the code.
-	absPath, err := filepath.Abs(fullPath)
+	// Open a root-scoped handle for the static directory. All file access goes
+	// through this root so the OS enforces the containment boundary.
+	root, err := os.OpenRoot(absStaticPath)
 	if err != nil {
-		http.Error(w, "Invalid file name", http.StatusBadRequest)
+		logger.Log(logger.LevelError, nil, err, "opening static root")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+
 		return
 	}
+	defer func() { _ = root.Close() }()
 
-	relPath, err := filepath.Rel(absStaticPath, absPath)
-	if err != nil ||
-		filepath.IsAbs(relPath) ||
-		relPath == ".." ||
-		strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
-		http.Error(w, "Invalid file name (file to serve is outside of the static dir!)", http.StatusBadRequest)
+	// Check whether the requested file exists inside the root.
+	_, statErr := root.Stat(rel)
+	if os.IsNotExist(statErr) {
+		// File does not exist — serve index.html as the SPA entry point.
+		h.serveStatic(w, r, root, indexRel)
 		return
-	}
+	} else if statErr != nil {
+		if strings.Contains(statErr.Error(), "escapes from parent") {
+			http.Error(w, "Invalid file path", http.StatusBadRequest)
+			return
+		}
 
-	// check whether a file exists at the given path
-	_, err = os.Stat(fullPath)
-	if os.IsNotExist(err) {
-		// file does not exist, serve index.html
-		http.ServeFile(w, r, filepath.Join(absStaticPath, h.indexPath))
-		return
-	} else if err != nil {
-		// if we got an error (that wasn't that the file doesn't exist) stating the
-		// file, return a 500 internal server error and stop
-		logger.Log(logger.LevelError, nil, err, "stating file")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.Log(logger.LevelError, nil, statErr, "stating file")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 
 		return
 	}
 
-	// The file does exist, so we serve that.
-	http.ServeFile(w, r, fullPath)
+	h.serveStatic(w, r, root, rel)
+}
+
+// serveStatic serves a static file through root, transparently swapping in a
+// precompressed `.br` sidecar when the client advertises support and the
+// sidecar exists. The Content-Type is always derived from the original
+// filename so the encoding handshake is invisible to the client.
+func (h spaHandler) serveStatic(w http.ResponseWriter, r *http.Request, root *os.Root, rel string) {
+	// `Vary: Accept-Encoding` must be set on every response so caches keep
+	// per-encoding entries even when we end up serving the identity bytes.
+	setEncodingHeaders(w, "")
+
+	if h.tryServeSidecar(w, r, root, rel) {
+		return
+	}
+
+	// Identity fallback: serve the file directly from the root.
+	file, err := root.Open(rel)
+	if err != nil {
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	fi, err := file.Stat()
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if fi.IsDir() {
+		h.serveStatic(w, r, root, filepath.FromSlash(h.indexPath))
+		return
+	}
+
+	http.ServeContent(w, r, rel, fi.ModTime(), file)
+}
+
+func (h spaHandler) tryServeSidecar(w http.ResponseWriter, r *http.Request, root *os.Root, rel string) bool {
+	encoding := pickEncoding(r.Header.Get("Accept-Encoding"))
+	if encoding == "" {
+		return false
+	}
+
+	// Skip the precompressed sidecar for the index document. headlamp.go
+	// rewrites index.html at startup for baseURL substitution, so any
+	// build-time .br sidecar would contain stale unrewritten bytes.
+	isIndex := filepath.Base(rel) == filepath.Base(filepath.FromSlash(h.indexPath))
+	if isIndex {
+		return false
+	}
+
+	sidecarRel := rel + encodingExt(encoding)
+
+	info, err := root.Stat(sidecarRel)
+	if err != nil || info.IsDir() {
+		return false
+	}
+
+	origInfo, err := root.Stat(rel)
+	if err != nil || origInfo.IsDir() {
+		return false
+	}
+
+	ctype := detectContentType(rel, func() (io.ReadCloser, error) {
+		return root.Open(rel)
+	})
+
+	file, err := root.Open(sidecarRel)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = file.Close() }()
+
+	fi, err := file.Stat()
+	if err != nil {
+		return false
+	}
+
+	if ctype != "" {
+		w.Header().Set("Content-Type", ctype)
+	}
+
+	setEncodingHeaders(w, encoding)
+	http.ServeContent(w, r, sidecarRel, fi.ModTime(), file)
+
+	return true
 }
 
 // NewHandler creates a new handler.

--- a/backend/pkg/spa/spaHandler_test.go
+++ b/backend/pkg/spa/spaHandler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -105,6 +107,19 @@ func TestSpaHandlerTraversal(t *testing.T) {
 			path:       "/headlamp/%2e%2e/outside.txt",
 			wantStatus: http.StatusBadRequest,
 		},
+		// HasPrefix bypass: a sibling directory whose name starts with the
+		// static dir name must be rejected, not matched.
+		{
+			name:       "sibling dir with shared prefix is rejected",
+			path:       "/headlamp/../headlamp_evil/secret.txt",
+			wantStatus: http.StatusBadRequest,
+		},
+		// Backslash in URL path — dangerous on Windows, rejected everywhere.
+		{
+			name:       "backslash in path is rejected",
+			path:       `/headlamp\..\..\etc\passwd`,
+			wantStatus: http.StatusBadRequest,
+		},
 	}
 
 	for _, tt := range tests {
@@ -123,5 +138,65 @@ func TestSpaHandlerTraversal(t *testing.T) {
 					tt.name, rr.Code, tt.wantStatus)
 			}
 		})
+	}
+}
+
+// TestSpaHandlerBareBaseURL verifies that a request for the bare base URL
+// (e.g. "/headlamp" with no trailing slash) serves index.html directly
+// instead of issuing a 301 redirect to add the trailing slash.
+func TestSpaHandlerBareBaseURL(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := spa.NewHandler(staticTestPath, "index.html", "/headlamp")
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("bare base URL: got status %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestSpaHandlerAbsErrorDoesNotLeakDetails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("removing current working directory is platform-dependent on windows")
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origWD)
+	})
+
+	// Force filepath.Abs to fail by deleting the current working directory.
+	if err := os.RemoveAll(tmp); err != nil {
+		t.Skipf("could not remove cwd to trigger Abs failure: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/headlamp/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := spa.NewHandler("relative-static", "index.html", "/headlamp")
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("handler returned wrong status code: got %v want %v", rr.Code, http.StatusInternalServerError)
+	}
+
+	if got := rr.Body.String(); got != "Internal server error\n" {
+		t.Fatalf("unexpected error body: %q", got)
 	}
 }

--- a/e2e-tests/tests/staticCompression.spec.ts
+++ b/e2e-tests/tests/staticCompression.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+function findStaticScriptPath(html: string): string {
+  // Use a script URL from the live HTML so the test remains stable with hashed
+  // asset names.
+  const matches = Array.from(html.matchAll(/<script[^>]+src=["']([^"']+\.js(?:\?[^"']*)?)["']/gi));
+
+  for (const match of matches) {
+    const raw = match[1];
+    if (
+      !raw ||
+      raw.startsWith('http://') ||
+      raw.startsWith('https://') ||
+      raw.startsWith('data:')
+    ) {
+      continue;
+    }
+
+    if (raw.startsWith('/')) {
+      return raw;
+    }
+
+    return `/${raw.replace(/^\.\//, '')}`;
+  }
+
+  throw new Error('Could not find a local static script path in app HTML');
+}
+
+test('static asset is served as brotli when client requests br', async ({ request }) => {
+  const shellResponse = await request.get('/');
+  expect(shellResponse.ok()).toBeTruthy();
+
+  const shellHtml = await shellResponse.text();
+  const scriptPath = findStaticScriptPath(shellHtml);
+
+  const brResponse = await request.get(scriptPath, {
+    headers: {
+      'Accept-Encoding': 'br',
+    },
+  });
+  expect(brResponse.ok()).toBeTruthy();
+
+  const brHeaders = brResponse.headers();
+  expect(brHeaders['content-encoding']).toBe('br');
+  expect((brHeaders['vary'] || '').toLowerCase()).toContain('accept-encoding');
+
+  const gzipOnlyResponse = await request.get(scriptPath, {
+    headers: {
+      'Accept-Encoding': 'gzip',
+    },
+  });
+  expect(gzipOnlyResponse.ok()).toBeTruthy();
+
+  const gzipOnlyContentEncoding = (
+    gzipOnlyResponse.headers()['content-encoding'] || ''
+  ).toLowerCase();
+  expect(gzipOnlyContentEncoding).not.toBe('br');
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "productName": "Headlamp",
   "engines": {
     "npm": ">=11.0.0",
-    "node": ">=22.6.0"
+    "node": ">=22.0.0"
   },
   "type": "module",
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "productName": "Headlamp",
   "engines": {
     "npm": ">=11.0.0",
-    "node": ">=22.0.0"
+    "node": ">=22.6.0"
   },
   "type": "module",
   "dependencies": {
@@ -113,6 +113,7 @@
     "preview": "vite preview",
     "prebuild": "npm run make-version",
     "build": "cross-env PUBLIC_URL=./ NODE_OPTIONS=--max-old-space-size=8096 vite build && npx shx rm -f build/frontend/index.baseUrl.html",
+    "postbuild": "node --experimental-strip-types ./scripts/precompress-build.ts build",
     "pretest": "npm run make-version",
     "test": "vitest",
     "start-without-multiplexer": "cross-env REACT_APP_ENABLE_WEBSOCKET_MULTIPLEXER=false npm run start",
@@ -124,10 +125,11 @@
     "build-typedoc": "typedoc",
     "build-storybook": "storybook build -o ../docs/development/storybook",
     "i18n": "i18next 'src/**/*.{ts,tsx}' -c ./src/i18n/i18next-parser.config.js",
-    "tsc": "tsgo",
+    "tsc": "tsgo && tsgo -p scripts/tsconfig.json",
     "make-version": "node ./make-env.js",
     "star": "cross-env REACT_APP_HEADLAMP_BACKEND_TOKEN=headlamp rsbuild dev",
-    "build:rsbuild": "rsbuild build"
+    "build:rsbuild": "rsbuild build",
+    "postbuild:rsbuild": "node --experimental-strip-types ./scripts/precompress-build.ts build"
   },
   "browserslist": {
     "production": [

--- a/frontend/scripts/precompress-build.test.ts
+++ b/frontend/scripts/precompress-build.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runPrecompressBuild } from './precompress-build';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'precompress-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('precompress-build', () => {
+  it('removes orphan .br sidecars', async () => {
+    const buildDir = makeTempDir();
+    const orphan = path.join(buildDir, 'assets', 'stale.js.br');
+
+    fs.mkdirSync(path.dirname(orphan), { recursive: true });
+    fs.writeFileSync(orphan, 'stale-sidecar');
+
+    const result = await runPrecompressBuild(buildDir);
+
+    expect(fs.existsSync(orphan)).toBe(false);
+    expect(result.orphanRemoved).toBe(1);
+  });
+
+  it('limits compression concurrency with a worker pool', async () => {
+    const buildDir = makeTempDir();
+
+    for (let i = 0; i < 6; i++) {
+      fs.writeFileSync(path.join(buildDir, `asset-${i}.js`), 'x'.repeat(2048));
+    }
+
+    let active = 0;
+    let peak = 0;
+
+    await runPrecompressBuild(buildDir, {
+      maxConcurrency: 2,
+      processFileFn: async () => {
+        active++;
+        peak = Math.max(peak, active);
+        await new Promise(resolve => setTimeout(resolve, 20));
+        active--;
+        return { raw: 0, br: 0, kept: false };
+      },
+    });
+
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+});

--- a/frontend/scripts/precompress-build.ts
+++ b/frontend/scripts/precompress-build.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Walks the production build directory and writes <file>.br sidecars next to
+// every compressible asset above a small threshold. The Go backend
+// (`pkg/spa`) negotiates Accept-Encoding and serves these precompressed
+// files directly, so no on-the-fly compression is ever needed.
+//
+// Only brotli is emitted: every browser Headlamp targets supports it, and
+// emitting a parallel gzip set would double the post-build cost and disk
+// footprint for no real benefit. The backend still negotiates `gzip` and
+// will simply serve identity bytes when a `.br` sidecar is missing or the
+// client only advertises gzip.
+
+import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import zlib from 'zlib';
+
+const brotliCompress = promisify(zlib.brotliCompress);
+
+const BUILD_DIR: string = path.resolve(process.argv[2] ?? 'build');
+const MIN_BYTES: number = 1024; // skip tiny files: framing overhead dominates
+
+// Extensions worth compressing. Everything else (png, woff2, jpg, ...) is
+// already compressed and would only get bigger.
+const COMPRESSIBLE: Set<string> = new Set([
+  '.html', '.js', '.mjs', '.cjs', '.css', '.json', '.map',
+  '.svg', '.txt', '.xml', '.wasm', '.ttf', '.eot', '.ico',
+]);
+
+// Brotli mode by file type: text mode for UTF-8, generic for binary.
+// Quality 11 is the maximum in all cases.
+const TEXT_EXTENSIONS: Set<string> = new Set([
+  '.html', '.js', '.mjs', '.cjs', '.css', '.json', '.map',
+  '.svg', '.txt', '.xml',
+]);
+
+function brotliMode(file: string): number {
+  const ext = path.extname(file).toLowerCase();
+  return TEXT_EXTENSIONS.has(ext)
+    ? zlib.constants.BROTLI_MODE_TEXT
+    : zlib.constants.BROTLI_MODE_GENERIC;
+}
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (entry.isFile()) {
+      yield full;
+    }
+  }
+}
+
+function shouldCompress(file: string, size: number): boolean {
+  if (size < MIN_BYTES) return false;
+  if (file.endsWith('.br') || file.endsWith('.gz')) return false;
+  // Never precompress index.html — the backend rewrites it at startup for
+  // baseURL substitution and never serves precompressed sidecars for it.
+  if (path.basename(file) === 'index.html') return false;
+  return COMPRESSIBLE.has(path.extname(file).toLowerCase());
+}
+
+if (!fs.existsSync(BUILD_DIR)) {
+  console.error(`precompress-build: build dir not found: ${BUILD_DIR}`);
+  process.exit(1);
+}
+
+// Collect eligible files up-front so we can fan out in parallel.
+// Files that are no longer eligible have any stale sidecar removed immediately
+// so incremental rebuilds can't serve mismatched bytes.
+const files: string[] = [];
+for (const file of walk(BUILD_DIR)) {
+  if (file.endsWith('.br') || file.endsWith('.gz')) continue;
+  const { size } = fs.statSync(file);
+  if (shouldCompress(file, size)) {
+    files.push(file);
+  } else {
+    fs.rmSync(file + '.br', { force: true }); // remove stale sidecar if present
+  }
+}
+
+async function processFile(
+  file: string
+): Promise<{ raw: number; br: number; kept: boolean }> {
+  const data = await fs.promises.readFile(file);
+  const compressed = await brotliCompress(data, {
+    params: {
+      [zlib.constants.BROTLI_PARAM_MODE]: brotliMode(file),
+      [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+      [zlib.constants.BROTLI_PARAM_SIZE_HINT]: data.length,
+    },
+  });
+
+  // Only keep the sidecar if it's actually smaller than the original.
+  // (Some pre-minified or already-compressed files don't compress further.)
+  if (compressed.length < data.length) {
+    await fs.promises.writeFile(file + '.br', compressed);
+    return { raw: data.length, br: compressed.length, kept: true };
+  }
+  // Brotli didn't help — remove any stale sidecar so the server can't serve it.
+  await fs.promises.rm(file + '.br', { force: true });
+  return { raw: 0, br: 0, kept: false };
+}
+
+// zlib.brotliCompress runs on the libuv thread pool (UV_THREADPOOL_SIZE,
+// default 4), so Promise.all gives real parallel compression.
+const results = await Promise.all(files.map(processFile));
+
+let rawTotal = 0;
+let brTotal = 0;
+let count = 0;
+let skipped = 0;
+for (const r of results) {
+  if (r.kept) { rawTotal += r.raw; brTotal += r.br; count++; }
+  else { skipped++; }
+}
+
+const fmt = (b: number): string => {
+  if (b >= 1024 * 1024) return (b / 1024 / 1024).toFixed(2) + ' MB';
+  if (b >= 1024) return (b / 1024).toFixed(1) + ' KB';
+  return b + ' B';
+};
+const ratio = rawTotal > 0 ? ((1 - brTotal / rawTotal) * 100).toFixed(1) : '0';
+console.log(
+  `precompress-build: ${count} files compressed (${skipped} skipped), ` +
+  `raw ${fmt(rawTotal)} -> br ${fmt(brTotal)} (-${ratio}%)`
+);

--- a/frontend/scripts/precompress-build.ts
+++ b/frontend/scripts/precompress-build.ts
@@ -76,28 +76,53 @@ function shouldCompress(file: string, size: number): boolean {
   return COMPRESSIBLE.has(path.extname(file).toLowerCase());
 }
 
-if (!fs.existsSync(BUILD_DIR)) {
-  console.error(`precompress-build: build dir not found: ${BUILD_DIR}`);
-  process.exit(1);
-}
+type PrecompressResult = {
+  count: number;
+  skipped: number;
+  rawTotal: number;
+  brTotal: number;
+  orphanRemoved: number;
+};
 
-// Collect eligible files up-front so we can fan out in parallel.
-// Files that are no longer eligible have any stale sidecar removed immediately
-// so incremental rebuilds can't serve mismatched bytes.
-const files: string[] = [];
-for (const file of walk(BUILD_DIR)) {
-  if (file.endsWith('.br') || file.endsWith('.gz')) continue;
-  const { size } = fs.statSync(file);
-  if (shouldCompress(file, size)) {
-    files.push(file);
-  } else {
-    fs.rmSync(file + '.br', { force: true }); // remove stale sidecar if present
+type ProcessFileResult = { raw: number; br: number; kept: boolean };
+
+type RunPrecompressBuildOptions = {
+  maxConcurrency?: number;
+  processFileFn?: (file: string) => Promise<ProcessFileResult>;
+};
+
+const DEFAULT_MAX_CONCURRENCY = 4;
+
+function collectBuildFiles(buildDir: string): { files: string[]; orphanRemoved: number } {
+  const files: string[] = [];
+  let orphanRemoved = 0;
+
+  for (const file of walk(buildDir)) {
+    // Remove orphan .br sidecars when the original file no longer exists.
+    if (file.endsWith('.br')) {
+      const original = file.slice(0, -3);
+      if (!fs.existsSync(original)) {
+        fs.rmSync(file, { force: true });
+        orphanRemoved++;
+      }
+      continue;
+    }
+
+    if (file.endsWith('.gz')) continue;
+
+    const { size } = fs.statSync(file);
+    if (shouldCompress(file, size)) {
+      files.push(file);
+    } else {
+      // Remove stale sidecar if present.
+      fs.rmSync(file + '.br', { force: true });
+    }
   }
+
+  return { files, orphanRemoved };
 }
 
-async function processFile(
-  file: string
-): Promise<{ raw: number; br: number; kept: boolean }> {
+async function processFile(file: string): Promise<ProcessFileResult> {
   const data = await fs.promises.readFile(file);
   const compressed = await brotliCompress(data, {
     params: {
@@ -118,17 +143,75 @@ async function processFile(
   return { raw: 0, br: 0, kept: false };
 }
 
-// zlib.brotliCompress runs on the libuv thread pool (UV_THREADPOOL_SIZE,
-// default 4), so Promise.all gives real parallel compression.
-const results = await Promise.all(files.map(processFile));
+function normalizedConcurrency(maxConcurrency?: number): number {
+  if (!Number.isInteger(maxConcurrency) || !maxConcurrency || maxConcurrency < 1) {
+    return DEFAULT_MAX_CONCURRENCY;
+  }
 
-let rawTotal = 0;
-let brTotal = 0;
-let count = 0;
-let skipped = 0;
-for (const r of results) {
-  if (r.kept) { rawTotal += r.raw; brTotal += r.br; count++; }
-  else { skipped++; }
+  return maxConcurrency;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  maxConcurrency: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      const current = next;
+      next++;
+      if (current >= items.length) {
+        return;
+      }
+
+      results[current] = await worker(items[current]);
+    }
+  }
+
+  const workerCount = Math.min(maxConcurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+  return results;
+}
+
+export async function runPrecompressBuild(
+  buildDir: string,
+  options: RunPrecompressBuildOptions = {}
+): Promise<PrecompressResult> {
+  if (!fs.existsSync(buildDir)) {
+    throw new Error(`precompress-build: build dir not found: ${buildDir}`);
+  }
+
+  const { files, orphanRemoved } = collectBuildFiles(buildDir);
+  const maxConcurrency = normalizedConcurrency(options.maxConcurrency);
+  const processFileFn = options.processFileFn ?? processFile;
+
+  // Keep read/compress concurrency bounded to avoid large memory spikes when
+  // many big assets are processed in one build.
+  const results = await mapWithConcurrency(files, maxConcurrency, processFileFn);
+
+  let rawTotal = 0;
+  let brTotal = 0;
+  let count = 0;
+  let skipped = 0;
+  for (const r of results) {
+    if (r.kept) {
+      rawTotal += r.raw;
+      brTotal += r.br;
+      count++;
+    } else {
+      skipped++;
+    }
+  }
+
+  return { count, skipped, rawTotal, brTotal, orphanRemoved };
 }
 
 const fmt = (b: number): string => {
@@ -136,8 +219,15 @@ const fmt = (b: number): string => {
   if (b >= 1024) return (b / 1024).toFixed(1) + ' KB';
   return b + ' B';
 };
-const ratio = rawTotal > 0 ? ((1 - brTotal / rawTotal) * 100).toFixed(1) : '0';
-console.log(
-  `precompress-build: ${count} files compressed (${skipped} skipped), ` +
-  `raw ${fmt(rawTotal)} -> br ${fmt(brTotal)} (-${ratio}%)`
-);
+if (process.argv[1] && ['precompress-build.ts', 'precompress-build.js'].includes(path.basename(process.argv[1]))) {
+  const result = await runPrecompressBuild(BUILD_DIR);
+  const ratio = result.rawTotal > 0
+    ? ((1 - result.brTotal / result.rawTotal) * 100).toFixed(1)
+    : '0';
+
+  console.log(
+    `precompress-build: ${result.count} files compressed (${result.skipped} skipped), ` +
+    `${result.orphanRemoved} orphan .br removed, ` +
+    `raw ${fmt(result.rawTotal)} -> br ${fmt(result.brTotal)} (-${ratio}%)`
+  );
+}

--- a/frontend/scripts/tsconfig.json
+++ b/frontend/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["."]
+}

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -830,7 +830,20 @@ async function brotliCompressDist(dir) {
   if (!fs.existsSync(dir)) return;
 
   for (const file of walk(dir)) {
-    if (file.endsWith('.br') || file.endsWith('.gz')) continue;
+    if (file.endsWith('.br')) {
+      const original = file.slice(0, -3);
+      if (!fs.existsSync(original)) {
+        // Remove orphan sidecar so stale bytes are never served.
+        try {
+          fs.unlinkSync(file);
+        } catch (e) {
+          if (e.code !== 'ENOENT') throw e;
+        }
+      }
+      continue;
+    }
+
+    if (file.endsWith('.gz')) continue;
 
     const sidecar = file + '.br';
     const ext = path.extname(file).toLowerCase();
@@ -853,7 +866,15 @@ async function brotliCompressDist(dir) {
       },
     });
 
-    if (br.length < data.length) {
+    // Keep sidecars only when beneficial, except for dist/main.js.
+    //
+    // We always emit main.js.br so plugin bundles have a predictable
+    // precompressed entrypoint: backend/plugin loading paths and CI packaging
+    // checks expect this sidecar to exist even for very small bundles where
+    // brotli might not reduce size.
+    const shouldKeep = br.length < data.length || path.basename(file) === 'main.js';
+
+    if (shouldKeep) {
       fs.writeFileSync(sidecar, br);
     } else {
       try {
@@ -883,6 +904,8 @@ async function build(packageFolder) {
     if (!fs.existsSync(path.join(folder, 'package.json'))) {
       return false;
     }
+
+    const distDir = path.resolve(folder, 'dist');
 
     process.chdir(folder);
 
@@ -920,7 +943,7 @@ async function build(packageFolder) {
 
       // Brotli-compress all compressible files in dist/ so the Headlamp backend
       // can serve .br sidecars without on-the-fly compression.
-      await brotliCompressDist(path.join(folder, 'dist'));
+      await brotliCompressDist(distDir);
 
       console.log(`Finished building "${folder}" for production.`);
     } catch (e) {

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -1816,552 +1816,543 @@ function extractI18n(packageFolder, newLocale) {
 // const headlampPluginBin = fs.realpathSync(process.argv[1]);
 // console.log('headlampPluginBin path:', headlampPluginBin);
 
-if (require.main === module)
-  yargs(process.argv.slice(2))
-    .command(
-      'build [package]',
-      'Build the plugin, or folder of plugins. <package> defaults to current working directory.',
-      yargs => {
-        yargs.positional('package', {
-          describe: 'Package or folder of packages to build',
+yargs(process.argv.slice(2))
+  .command(
+    'build [package]',
+    'Build the plugin, or folder of plugins. <package> defaults to current working directory.',
+    yargs => {
+      yargs.positional('package', {
+        describe: 'Package or folder of packages to build',
+        type: 'string',
+        default: '.',
+      });
+    },
+    async argv => {
+      // @ts-ignore
+      process.exitCode = await build(argv.package);
+    }
+  )
+  .command('start', 'Watch for changes and build plugin.', {}, async () => {
+    process.exitCode = await start();
+  })
+  .command(
+    'create <name>',
+    'Create a new plugin folder.',
+    yargs => {
+      yargs
+        .positional('name', {
+          describe: 'Name of package',
           type: 'string',
-          default: '.',
-        });
-      },
-      async argv => {
-        // @ts-ignore
-        process.exitCode = await build(argv.package);
-      }
-    )
-    .command('start', 'Watch for changes and build plugin.', {}, async () => {
-      process.exitCode = await start();
-    })
-    .command(
-      'create <name>',
-      'Create a new plugin folder.',
-      yargs => {
-        yargs
-          .positional('name', {
-            describe: 'Name of package',
-            type: 'string',
-          })
-          .option('link', {
-            describe:
-              'For development of headlamp-plugin itself, so it uses npm link @kinvolk/headlamp-plugin.',
-            type: 'boolean',
-          })
-          .option('noinstall', {
-            describe: 'Skip installing dependencies with npm ci',
-            type: 'boolean',
-          });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = create(argv.name, argv.link, argv.noinstall);
-      }
-    )
-    .command(
-      'i18n [package] [locale]',
-      'Extract translatable strings from plugin source code. Optionally add a new locale. Use --setup to configure i18n for a package. <package> defaults to current working directory.',
-      yargs => {
-        yargs
-          .positional('package', {
-            describe:
-              'Package to extract translatable strings from (or package to setup with --setup)',
-            type: 'string',
-            default: '.',
-          })
-          .positional('locale', {
-            describe: 'New locale to add to the plugin (e.g., es, fr, pt-BR)',
-            type: 'string',
-          })
-          .option('setup', {
-            describe:
-              'Set up i18n for the package or folder of packages instead of extracting strings',
-            type: 'boolean',
-          })
-          .example('headlamp-plugin i18n', 'Extract strings from current directory')
-          .example('headlamp-plugin i18n . es', 'Add Spanish locale and extract strings')
-          .example('headlamp-plugin i18n my-plugin pt-BR', 'Add Brazilian Portuguese to my-plugin')
-          .example('headlamp-plugin i18n --setup', 'Set up i18n in the current package');
-      },
-      argv => {
-        // If --setup flag is provided, run setupI18n and return
-        if (argv.setup) {
-          // @ts-ignore
-          process.exitCode = setupI18n(argv.package);
-          return;
-        }
-
-        // Handle the case where user runs "npm run i18n -- pt"
-        // In this case, "pt" gets passed as the package parameter instead of locale
-        let packageFolder = argv.package;
-        let newLocale = argv.locale;
-
-        // If package looks like a locale code and locale is undefined,
-        // assume they meant to add a locale to the current directory
-        if (!newLocale && packageFolder !== '.' && /^[a-z]{2}(-[A-Z]{2})?$/.test(packageFolder)) {
-          newLocale = packageFolder;
-          packageFolder = '.';
-        }
-
-        // @ts-ignore
-        process.exitCode = extractI18n(packageFolder, newLocale);
-      }
-    )
-    .command(
-      'extract <pluginPackages> <outputPlugins>',
-      'Copies folders of packages from pluginPackages/packageName/dist/main.js ' +
-        'to outputPlugins/packageName/main.js.',
-      yargs => {
-        yargs.positional('pluginPackages', {
+        })
+        .option('link', {
           describe:
-            'A folder of plugin packages that have been built with dist/main.js in them.' +
-            'Can also be a single package folder.',
-          type: 'string',
+            'For development of headlamp-plugin itself, so it uses npm link @kinvolk/headlamp-plugin.',
+          type: 'boolean',
+        })
+        .option('noinstall', {
+          describe: 'Skip installing dependencies with npm ci',
+          type: 'boolean',
         });
-        yargs.positional('outputPlugins', {
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = create(argv.name, argv.link, argv.noinstall);
+    }
+  )
+  .command(
+    'i18n [package] [locale]',
+    'Extract translatable strings from plugin source code. Optionally add a new locale. Use --setup to configure i18n for a package. <package> defaults to current working directory.',
+    yargs => {
+      yargs
+        .positional('package', {
           describe:
-            'A plugins folder (eg. ".plugins") to extract plugins to. ' +
-            'The output is a series of packageName/main.js. ' +
-            'Creates this folder if it does not exist.',
+            'Package to extract translatable strings from (or package to setup with --setup)',
           type: 'string',
-        });
-      },
-      argv => {
+          default: '.',
+        })
+        .positional('locale', {
+          describe: 'New locale to add to the plugin (e.g., es, fr, pt-BR)',
+          type: 'string',
+        })
+        .option('setup', {
+          describe:
+            'Set up i18n for the package or folder of packages instead of extracting strings',
+          type: 'boolean',
+        })
+        .example('headlamp-plugin i18n', 'Extract strings from current directory')
+        .example('headlamp-plugin i18n . es', 'Add Spanish locale and extract strings')
+        .example('headlamp-plugin i18n my-plugin pt-BR', 'Add Brazilian Portuguese to my-plugin')
+        .example('headlamp-plugin i18n --setup', 'Set up i18n in the current package');
+    },
+    argv => {
+      // If --setup flag is provided, run setupI18n and return
+      if (argv.setup) {
         // @ts-ignore
-        process.exitCode = extract(argv.pluginPackages, argv.outputPlugins);
+        process.exitCode = setupI18n(argv.package);
+        return;
       }
-    )
-    .command(
-      'package [pluginPath] [outputDir]',
-      'Creates a tarball of the plugin package in the format Headlamp expects.',
-      yargs => {
-        yargs.positional('pluginPath', {
-          describe:
-            'A folder of a plugin package that have been built with dist/main.js in it.' +
-            ' Defaults to current working directory.',
-          type: 'string',
-        });
-        yargs.positional('outputDir', {
-          describe:
-            'The destination folder in which to create the archive.' +
-            'Creates this folder if it does not exist.',
-          type: 'string',
-        });
-      },
-      async argv => {
-        let pluginPath = argv.pluginPath;
-        if (!pluginPath) {
-          pluginPath = process.cwd();
-        }
 
-        let outputDir = argv.outputDir;
-        if (!outputDir) {
-          outputDir = process.cwd();
-        }
+      // Handle the case where user runs "npm run i18n -- pt"
+      // In this case, "pt" gets passed as the package parameter instead of locale
+      let packageFolder = argv.package;
+      let newLocale = argv.locale;
 
-        process.exitCode = await createArchive(pluginPath, outputDir);
+      // If package looks like a locale code and locale is undefined,
+      // assume they meant to add a locale to the current directory
+      if (!newLocale && packageFolder !== '.' && /^[a-z]{2}(-[A-Z]{2})?$/.test(packageFolder)) {
+        newLocale = packageFolder;
+        packageFolder = '.';
       }
-    )
-    .command(
-      'format [package]',
-      'format the plugin code with prettier. <package> defaults to current working directory.' +
-        ' Can also be a folder of packages.',
-      yargs => {
-        yargs
-          .positional('package', {
-            describe: 'Package to code format',
-            type: 'string',
-            default: '.',
-          })
-          .option('check', {
-            describe: 'Check the formatting without changing files',
-            type: 'boolean',
-          });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = format(argv.package, argv.check);
+
+      // @ts-ignore
+      process.exitCode = extractI18n(packageFolder, newLocale);
+    }
+  )
+  .command(
+    'extract <pluginPackages> <outputPlugins>',
+    'Copies folders of packages from pluginPackages/packageName/dist/main.js ' +
+      'to outputPlugins/packageName/main.js.',
+    yargs => {
+      yargs.positional('pluginPackages', {
+        describe:
+          'A folder of plugin packages that have been built with dist/main.js in them.' +
+          'Can also be a single package folder.',
+        type: 'string',
+      });
+      yargs.positional('outputPlugins', {
+        describe:
+          'A plugins folder (eg. ".plugins") to extract plugins to. ' +
+          'The output is a series of packageName/main.js. ' +
+          'Creates this folder if it does not exist.',
+        type: 'string',
+      });
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = extract(argv.pluginPackages, argv.outputPlugins);
+    }
+  )
+  .command(
+    'package [pluginPath] [outputDir]',
+    'Creates a tarball of the plugin package in the format Headlamp expects.',
+    yargs => {
+      yargs.positional('pluginPath', {
+        describe:
+          'A folder of a plugin package that have been built with dist/main.js in it.' +
+          ' Defaults to current working directory.',
+        type: 'string',
+      });
+      yargs.positional('outputDir', {
+        describe:
+          'The destination folder in which to create the archive.' +
+          'Creates this folder if it does not exist.',
+        type: 'string',
+      });
+    },
+    async argv => {
+      let pluginPath = argv.pluginPath;
+      if (!pluginPath) {
+        pluginPath = process.cwd();
       }
-    )
-    .command(
-      'lint [package]',
-      'Lint the plugin for coding issues with eslint. ' +
-        '<package> defaults to current working directory.' +
-        ' Can also be a folder of packages.',
-      yargs => {
-        yargs
-          .positional('package', {
-            describe: 'Package to lint',
-            type: 'string',
-            default: '.',
-          })
-          .option('fix', {
-            describe: 'Automatically fix problems',
-            type: 'boolean',
-          });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = lint(argv.package, argv.fix);
+
+      let outputDir = argv.outputDir;
+      if (!outputDir) {
+        outputDir = process.cwd();
       }
-    )
-    .command(
-      'tsc [package]',
-      'Type check the plugin for coding issues with tsc. ' +
-        '<package> defaults to current working directory.' +
-        ' Can also be a folder of packages.',
-      yargs => {
-        yargs.positional('package', {
-          describe: 'Package to type check',
+
+      process.exitCode = await createArchive(pluginPath, outputDir);
+    }
+  )
+  .command(
+    'format [package]',
+    'format the plugin code with prettier. <package> defaults to current working directory.' +
+      ' Can also be a folder of packages.',
+    yargs => {
+      yargs
+        .positional('package', {
+          describe: 'Package to code format',
           type: 'string',
           default: '.',
+        })
+        .option('check', {
+          describe: 'Check the formatting without changing files',
+          type: 'boolean',
         });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = tsc(argv.package);
-      }
-    )
-    .command(
-      'storybook [package]',
-      'Start storybook. <package> defaults to current working directory.',
-      yargs => {
-        yargs.positional('package', {
-          describe: 'Package to start storybook for',
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = format(argv.package, argv.check);
+    }
+  )
+  .command(
+    'lint [package]',
+    'Lint the plugin for coding issues with eslint. ' +
+      '<package> defaults to current working directory.' +
+      ' Can also be a folder of packages.',
+    yargs => {
+      yargs
+        .positional('package', {
+          describe: 'Package to lint',
           type: 'string',
           default: '.',
+        })
+        .option('fix', {
+          describe: 'Automatically fix problems',
+          type: 'boolean',
         });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = storybook(argv.package);
-      }
-    )
-    .command(
-      'storybook-build [package]',
-      'Build static storybook. <package> defaults to current working directory.' +
-        ' Can also be a folder of packages.',
-      yargs => {
-        yargs.positional('package', {
-          describe: 'Package to build storybook for',
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = lint(argv.package, argv.fix);
+    }
+  )
+  .command(
+    'tsc [package]',
+    'Type check the plugin for coding issues with tsc. ' +
+      '<package> defaults to current working directory.' +
+      ' Can also be a folder of packages.',
+    yargs => {
+      yargs.positional('package', {
+        describe: 'Package to type check',
+        type: 'string',
+        default: '.',
+      });
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = tsc(argv.package);
+    }
+  )
+  .command(
+    'storybook [package]',
+    'Start storybook. <package> defaults to current working directory.',
+    yargs => {
+      yargs.positional('package', {
+        describe: 'Package to start storybook for',
+        type: 'string',
+        default: '.',
+      });
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = storybook(argv.package);
+    }
+  )
+  .command(
+    'storybook-build [package]',
+    'Build static storybook. <package> defaults to current working directory.' +
+      ' Can also be a folder of packages.',
+    yargs => {
+      yargs.positional('package', {
+        describe: 'Package to build storybook for',
+        type: 'string',
+        default: '.',
+      });
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = storybook_build(argv.package);
+    }
+  )
+  .command(
+    'upgrade [package]',
+    'Upgrade the plugin to latest headlamp-plugin; ' +
+      'upgrades headlamp-plugin and audits packages, formats, lints, type checks.' +
+      '<package> defaults to current working directory. Can also be a folder of packages.',
+    yargs => {
+      yargs
+        .positional('package', {
+          describe: 'Package to upgrade',
           type: 'string',
           default: '.',
-        });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = storybook_build(argv.package);
-      }
-    )
-    .command(
-      'upgrade [package]',
-      'Upgrade the plugin to latest headlamp-plugin; ' +
-        'upgrades headlamp-plugin and audits packages, formats, lints, type checks.' +
-        '<package> defaults to current working directory. Can also be a folder of packages.',
-      yargs => {
-        yargs
-          .positional('package', {
-            describe: 'Package to upgrade',
-            type: 'string',
-            default: '.',
-          })
-          .option('skip-package-updates', {
-            describe:
-              'For development of headlamp-plugin itself, so it does not do package updates.',
-            type: 'boolean',
-          })
-          .option('headlamp-plugin-version', {
-            describe:
-              'Use a specific headlamp-plugin-version when upgrading packages. Defaults to "latest".',
-            type: 'string',
-          });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = upgrade(
-          argv.package,
-          argv.skipPackageUpdates,
-          argv.headlampPluginVersion
-        );
-      }
-    )
-    .command(
-      'test [package]',
-      'Test. <package> defaults to current working directory.' +
-        ' Can also be a folder of packages.',
-      yargs => {
-        yargs.positional('package', {
-          describe: 'Package to test',
+        })
+        .option('skip-package-updates', {
+          describe: 'For development of headlamp-plugin itself, so it does not do package updates.',
+          type: 'boolean',
+        })
+        .option('headlamp-plugin-version', {
+          describe:
+            'Use a specific headlamp-plugin-version when upgrading packages. Defaults to "latest".',
           type: 'string',
-          default: '.',
         });
-      },
-      argv => {
-        // @ts-ignore
-        process.exitCode = test(argv.package);
-      }
-    )
-    .command(
-      'install [URL]',
-      'Install plugin(s) from a configuration file or a plugin artifact Hub URL',
-      yargs => {
-        return yargs
-          .positional('URL', {
-            describe: 'URL of the plugin to install',
-            type: 'string',
-          })
-          .option('config', {
-            alias: 'c',
-            describe: 'Path to plugin configuration file',
-            type: 'string',
-          })
-          .option('folderName', {
-            describe: 'Name of the folder to install the plugin into',
-            type: 'string',
-          })
-          .option('headlampVersion', {
-            describe: 'Version of headlamp to install the plugin into',
-            type: 'string',
-          })
-          .option('quiet', {
-            alias: 'q',
-            describe: 'Do not print logs',
-            type: 'boolean',
-          })
-          .option('watch', {
-            alias: 'w',
-            describe: 'Watch config file for changes and automatically reinstall plugins',
-            type: 'boolean',
-          })
-          .check(argv => {
-            if (!argv.URL && !argv.config) {
-              throw new Error('Either URL or --config must be specified');
-            }
-            if (argv.URL && argv.config) {
-              throw new Error('Cannot specify both URL and --config');
-            }
-            if (argv.watch && !argv.config) {
-              throw new Error('Watch option can only be used with --config');
-            }
-            return true;
-          });
-      },
-      async argv => {
-        const { URL, config, folderName, headlampVersion, quiet, watch } = argv;
-        try {
-          const progressCallback = quiet
-            ? () => {}
-            : data => {
-                const { type = 'info', message, raise = true } = data;
-                if (config && !URL) {
-                  // bulk installation
-                  let prefix = '';
-                  if (data.current || data.total || data.plugin) {
-                    prefix = `${data.current} of ${data.total} (${data.plugin}): `;
-                  }
-                  if (type === 'info' || type === 'success') {
-                    console.log(`${prefix}${type}: ${message}`);
-                  } else if (type === 'error' && raise) {
-                    throw new Error(message);
-                  } else {
-                    console.error(`${prefix}${type}: ${message}`);
-                  }
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = upgrade(argv.package, argv.skipPackageUpdates, argv.headlampPluginVersion);
+    }
+  )
+  .command(
+    'test [package]',
+    'Test. <package> defaults to current working directory.' + ' Can also be a folder of packages.',
+    yargs => {
+      yargs.positional('package', {
+        describe: 'Package to test',
+        type: 'string',
+        default: '.',
+      });
+    },
+    argv => {
+      // @ts-ignore
+      process.exitCode = test(argv.package);
+    }
+  )
+  .command(
+    'install [URL]',
+    'Install plugin(s) from a configuration file or a plugin artifact Hub URL',
+    yargs => {
+      return yargs
+        .positional('URL', {
+          describe: 'URL of the plugin to install',
+          type: 'string',
+        })
+        .option('config', {
+          alias: 'c',
+          describe: 'Path to plugin configuration file',
+          type: 'string',
+        })
+        .option('folderName', {
+          describe: 'Name of the folder to install the plugin into',
+          type: 'string',
+        })
+        .option('headlampVersion', {
+          describe: 'Version of headlamp to install the plugin into',
+          type: 'string',
+        })
+        .option('quiet', {
+          alias: 'q',
+          describe: 'Do not print logs',
+          type: 'boolean',
+        })
+        .option('watch', {
+          alias: 'w',
+          describe: 'Watch config file for changes and automatically reinstall plugins',
+          type: 'boolean',
+        })
+        .check(argv => {
+          if (!argv.URL && !argv.config) {
+            throw new Error('Either URL or --config must be specified');
+          }
+          if (argv.URL && argv.config) {
+            throw new Error('Cannot specify both URL and --config');
+          }
+          if (argv.watch && !argv.config) {
+            throw new Error('Watch option can only be used with --config');
+          }
+          return true;
+        });
+    },
+    async argv => {
+      const { URL, config, folderName, headlampVersion, quiet, watch } = argv;
+      try {
+        const progressCallback = quiet
+          ? () => {}
+          : data => {
+              const { type = 'info', message, raise = true } = data;
+              if (config && !URL) {
+                // bulk installation
+                let prefix = '';
+                if (data.current || data.total || data.plugin) {
+                  prefix = `${data.current} of ${data.total} (${data.plugin}): `;
+                }
+                if (type === 'info' || type === 'success') {
+                  console.log(`${prefix}${type}: ${message}`);
+                } else if (type === 'error' && raise) {
+                  throw new Error(message);
                 } else {
-                  if (type === 'error' || type === 'success') {
-                    console.error(`${type}: ${message}`);
-                  }
+                  console.error(`${prefix}${type}: ${message}`);
                 }
-              };
-
-          /**
-           * @param {string} configPath
-           */
-          async function installFromConfig(configPath) {
-            const installer = new MultiPluginManager(folderName, headlampVersion, progressCallback);
-            const result = await installer.installFromConfig(configPath);
-            if (result.failed > 0) {
-              throw new Error(`${result.failed} plugins failed to install`);
-            }
-          }
-
-          if (URL) {
-            // Single plugin installation
-            try {
-              await PluginManager.install(URL, folderName, headlampVersion, progressCallback);
-            } catch (e) {
-              console.error(e.message);
-              process.exit(1); // Exit with error status
-            }
-          } else if (config) {
-            // Bulk installation from config
-            try {
-              await installFromConfig(config);
-            } catch (error) {
-              console.error('Installation failed', {
-                error: error.message,
-                stack: error.stack,
-              });
-            }
-
-            if (watch) {
-              console.log(`Watching ${config} for changes...`);
-              fs.watch(config, async eventType => {
-                if (eventType === 'change') {
-                  console.log(`Config file changed, reinstalling plugins...`);
-                  try {
-                    await installFromConfig(config);
-                    console.log('Plugins reinstalled successfully');
-                  } catch (error) {
-                    console.error('Installation failed', {
-                      error: error.message,
-                      stack: error.stack,
-                    });
-                  }
+              } else {
+                if (type === 'error' || type === 'success') {
+                  console.error(`${type}: ${message}`);
                 }
-              });
+              }
+            };
 
-              // Keep the process running
-              process.stdin.resume();
-
-              // Handle graceful shutdown
-              process.on('SIGINT', () => {
-                console.log('\nStopping config file watch');
-                process.exit(0);
-              });
-            }
+        /**
+         * @param {string} configPath
+         */
+        async function installFromConfig(configPath) {
+          const installer = new MultiPluginManager(folderName, headlampVersion, progressCallback);
+          const result = await installer.installFromConfig(configPath);
+          if (result.failed > 0) {
+            throw new Error(`${result.failed} plugins failed to install`);
           }
-        } catch (error) {
-          console.error('Installation failed', {
-            error: error.message,
-            stack: error.stack,
-          });
-          process.exit(1);
         }
-      }
-    )
-    .command(
-      'update <pluginName>',
-      'Update a plugin to the latest version',
-      yargs => {
-        yargs
-          .positional('pluginName', {
-            describe: 'Name of the plugin to update',
-            type: 'string',
-          })
-          .positional('folderName', {
-            describe: 'Name of the folder that contains the plugin',
-            type: 'string',
-          })
-          .positional('headlampVersion', {
-            describe: 'Version of headlamp to update the plugin into',
-            type: 'string',
-          })
-          .option('quiet', {
-            alias: 'q',
-            describe: 'Do not print logs',
-            type: 'boolean',
-          });
-      },
-      async argv => {
-        const { pluginName, folderName, headlampVersion, quiet } = argv;
-        const progressCallback = quiet
-          ? null
-          : data => {
-              if (data.type === 'error' || data.type === 'success') {
-                console.error(data.type, ':', data.message);
-              }
-            }; // Use console.log for logs if not in quiet mode
-        try {
-          await PluginManager.update(pluginName, folderName, headlampVersion, progressCallback);
-        } catch (e) {
-          console.error(e.message);
-          process.exit(1); // Exit with error status
-        }
-      }
-    )
-    .command(
-      'uninstall <pluginName>',
-      'Uninstall a plugin',
-      yargs => {
-        yargs
-          .positional('pluginName', {
-            describe: 'Name of the plugin to uninstall',
-            type: 'string',
-          })
-          .option('folderName', {
-            describe: 'Name of the folder that contains the plugin',
-            type: 'string',
-          })
-          .option('quiet', {
-            alias: 'q',
-            describe: 'Do not print logs',
-            type: 'boolean',
-          });
-      },
-      async argv => {
-        const { pluginName, folderName, quiet } = argv;
-        const progressCallback = quiet
-          ? null
-          : data => {
-              if (data.type === 'error' || data.type === 'success') {
-                console.error(data.type, ':', data.message);
-              }
-            }; // Use console.log for logs if not in quiet mode
-        try {
-          await PluginManager.uninstall(pluginName, folderName, progressCallback);
-        } catch (e) {
-          console.error(e.message);
-          process.exit(1); // Exit with error status
-        }
-      }
-    )
-    .command(
-      'list',
-      'List installed plugins',
-      yargs => {
-        yargs
-          .option('folderName', {
-            describe: 'Name of the folder that contains the plugins',
-            type: 'string',
-          })
-          .option('json', {
-            alias: 'j',
-            describe: 'Output in JSON format',
-            type: 'boolean',
-          });
-      },
-      async argv => {
-        const { folderName, json } = argv;
-        const progressCallback = data => {
-          if (json) {
-            console.log(JSON.stringify(data.data));
-          } else {
-            // display table
-            const rows = [['Name', 'Version', 'Folder Name', 'Repo', 'Author']];
-            data.data.forEach(plugin => {
-              rows.push([
-                plugin.pluginName,
-                plugin.pluginVersion,
-                plugin.folderName,
-                plugin.repoName,
-                plugin.author,
-              ]);
+
+        if (URL) {
+          // Single plugin installation
+          try {
+            await PluginManager.install(URL, folderName, headlampVersion, progressCallback);
+          } catch (e) {
+            console.error(e.message);
+            process.exit(1); // Exit with error status
+          }
+        } else if (config) {
+          // Bulk installation from config
+          try {
+            await installFromConfig(config);
+          } catch (error) {
+            console.error('Installation failed', {
+              error: error.message,
+              stack: error.stack,
             });
-            console.log(table(rows));
           }
-        };
-        try {
-          await PluginManager.list(folderName, progressCallback);
-        } catch (e) {
-          console.error(e.message);
-          process.exit(1); // Exit with error status
-        }
-      }
-    )
-    .demandCommand(1, '')
-    .strict()
-    .help().argv;
 
-module.exports = { brotliCompressDist };
+          if (watch) {
+            console.log(`Watching ${config} for changes...`);
+            fs.watch(config, async eventType => {
+              if (eventType === 'change') {
+                console.log(`Config file changed, reinstalling plugins...`);
+                try {
+                  await installFromConfig(config);
+                  console.log('Plugins reinstalled successfully');
+                } catch (error) {
+                  console.error('Installation failed', {
+                    error: error.message,
+                    stack: error.stack,
+                  });
+                }
+              }
+            });
+
+            // Keep the process running
+            process.stdin.resume();
+
+            // Handle graceful shutdown
+            process.on('SIGINT', () => {
+              console.log('\nStopping config file watch');
+              process.exit(0);
+            });
+          }
+        }
+      } catch (error) {
+        console.error('Installation failed', {
+          error: error.message,
+          stack: error.stack,
+        });
+        process.exit(1);
+      }
+    }
+  )
+  .command(
+    'update <pluginName>',
+    'Update a plugin to the latest version',
+    yargs => {
+      yargs
+        .positional('pluginName', {
+          describe: 'Name of the plugin to update',
+          type: 'string',
+        })
+        .positional('folderName', {
+          describe: 'Name of the folder that contains the plugin',
+          type: 'string',
+        })
+        .positional('headlampVersion', {
+          describe: 'Version of headlamp to update the plugin into',
+          type: 'string',
+        })
+        .option('quiet', {
+          alias: 'q',
+          describe: 'Do not print logs',
+          type: 'boolean',
+        });
+    },
+    async argv => {
+      const { pluginName, folderName, headlampVersion, quiet } = argv;
+      const progressCallback = quiet
+        ? null
+        : data => {
+            if (data.type === 'error' || data.type === 'success') {
+              console.error(data.type, ':', data.message);
+            }
+          }; // Use console.log for logs if not in quiet mode
+      try {
+        await PluginManager.update(pluginName, folderName, headlampVersion, progressCallback);
+      } catch (e) {
+        console.error(e.message);
+        process.exit(1); // Exit with error status
+      }
+    }
+  )
+  .command(
+    'uninstall <pluginName>',
+    'Uninstall a plugin',
+    yargs => {
+      yargs
+        .positional('pluginName', {
+          describe: 'Name of the plugin to uninstall',
+          type: 'string',
+        })
+        .option('folderName', {
+          describe: 'Name of the folder that contains the plugin',
+          type: 'string',
+        })
+        .option('quiet', {
+          alias: 'q',
+          describe: 'Do not print logs',
+          type: 'boolean',
+        });
+    },
+    async argv => {
+      const { pluginName, folderName, quiet } = argv;
+      const progressCallback = quiet
+        ? null
+        : data => {
+            if (data.type === 'error' || data.type === 'success') {
+              console.error(data.type, ':', data.message);
+            }
+          }; // Use console.log for logs if not in quiet mode
+      try {
+        await PluginManager.uninstall(pluginName, folderName, progressCallback);
+      } catch (e) {
+        console.error(e.message);
+        process.exit(1); // Exit with error status
+      }
+    }
+  )
+  .command(
+    'list',
+    'List installed plugins',
+    yargs => {
+      yargs
+        .option('folderName', {
+          describe: 'Name of the folder that contains the plugins',
+          type: 'string',
+        })
+        .option('json', {
+          alias: 'j',
+          describe: 'Output in JSON format',
+          type: 'boolean',
+        });
+    },
+    async argv => {
+      const { folderName, json } = argv;
+      const progressCallback = data => {
+        if (json) {
+          console.log(JSON.stringify(data.data));
+        } else {
+          // display table
+          const rows = [['Name', 'Version', 'Folder Name', 'Repo', 'Author']];
+          data.data.forEach(plugin => {
+            rows.push([
+              plugin.pluginName,
+              plugin.pluginVersion,
+              plugin.folderName,
+              plugin.repoName,
+              plugin.author,
+            ]);
+          });
+          console.log(table(rows));
+        }
+      };
+      try {
+        await PluginManager.list(folderName, progressCallback);
+      } catch (e) {
+        console.error(e.message);
+        process.exit(1); // Exit with error status
+      }
+    }
+  )
+  .demandCommand(1, '')
+  .strict()
+  .help().argv;

--- a/plugins/headlamp-plugin/bin/headlamp-plugin.js
+++ b/plugins/headlamp-plugin/bin/headlamp-plugin.js
@@ -797,6 +797,75 @@ function runScriptOnPackages(packageFolder, scriptName, cmdLine, env) {
 }
 
 /**
+ * Brotli-compress all compressible files in a directory, writing <file>.br
+ * sidecars alongside each asset. Stale sidecars for ineligible files are
+ * removed so the server cannot serve mismatched bytes on incremental builds.
+ * Uses only Node.js built-ins (no extra dependencies).
+ *
+ * @param {string} dir - directory to walk (typically the plugin dist/ folder)
+ */
+async function brotliCompressDist(dir) {
+  const zlib = require('zlib');
+  const COMPRESSIBLE = new Set([
+    '.js',
+    '.mjs',
+    '.cjs',
+    '.css',
+    '.json',
+    '.map',
+    '.svg',
+    '.txt',
+    '.xml',
+    '.wasm',
+  ]);
+
+  function* walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) yield* walk(full);
+      else if (entry.isFile()) yield full;
+    }
+  }
+
+  if (!fs.existsSync(dir)) return;
+
+  for (const file of walk(dir)) {
+    if (file.endsWith('.br') || file.endsWith('.gz')) continue;
+
+    const sidecar = file + '.br';
+    const ext = path.extname(file).toLowerCase();
+
+    if (!COMPRESSIBLE.has(ext)) {
+      // Remove any stale sidecar so the server cannot serve mismatched bytes.
+      try {
+        fs.unlinkSync(sidecar);
+      } catch (e) {
+        if (e.code !== 'ENOENT') throw e;
+      }
+      continue;
+    }
+
+    const data = fs.readFileSync(file);
+    const br = zlib.brotliCompressSync(data, {
+      params: {
+        [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+        [zlib.constants.BROTLI_PARAM_SIZE_HINT]: data.length,
+      },
+    });
+
+    if (br.length < data.length) {
+      fs.writeFileSync(sidecar, br);
+    } else {
+      try {
+        fs.unlinkSync(sidecar);
+      } catch (e) {
+        if (e.code !== 'ENOENT') throw e;
+      }
+    }
+  }
+}
+
+/**
  * Build the plugin package or folder of packages for production.
  *
  * @param packageFolder {string} - folder where the package, or folder of packages is.
@@ -848,6 +917,10 @@ async function build(packageFolder) {
 
       // Copy extra dist files after successful build
       await copyExtraDistFiles('.');
+
+      // Brotli-compress all compressible files in dist/ so the Headlamp backend
+      // can serve .br sidecars without on-the-fly compression.
+      await brotliCompressDist(path.join(folder, 'dist'));
 
       console.log(`Finished building "${folder}" for production.`);
     } catch (e) {
@@ -1720,543 +1793,552 @@ function extractI18n(packageFolder, newLocale) {
 // const headlampPluginBin = fs.realpathSync(process.argv[1]);
 // console.log('headlampPluginBin path:', headlampPluginBin);
 
-yargs(process.argv.slice(2))
-  .command(
-    'build [package]',
-    'Build the plugin, or folder of plugins. <package> defaults to current working directory.',
-    yargs => {
-      yargs.positional('package', {
-        describe: 'Package or folder of packages to build',
-        type: 'string',
-        default: '.',
-      });
-    },
-    async argv => {
-      // @ts-ignore
-      process.exitCode = await build(argv.package);
-    }
-  )
-  .command('start', 'Watch for changes and build plugin.', {}, async () => {
-    process.exitCode = await start();
-  })
-  .command(
-    'create <name>',
-    'Create a new plugin folder.',
-    yargs => {
-      yargs
-        .positional('name', {
-          describe: 'Name of package',
-          type: 'string',
-        })
-        .option('link', {
-          describe:
-            'For development of headlamp-plugin itself, so it uses npm link @kinvolk/headlamp-plugin.',
-          type: 'boolean',
-        })
-        .option('noinstall', {
-          describe: 'Skip installing dependencies with npm ci',
-          type: 'boolean',
-        });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = create(argv.name, argv.link, argv.noinstall);
-    }
-  )
-  .command(
-    'i18n [package] [locale]',
-    'Extract translatable strings from plugin source code. Optionally add a new locale. Use --setup to configure i18n for a package. <package> defaults to current working directory.',
-    yargs => {
-      yargs
-        .positional('package', {
-          describe:
-            'Package to extract translatable strings from (or package to setup with --setup)',
+if (require.main === module)
+  yargs(process.argv.slice(2))
+    .command(
+      'build [package]',
+      'Build the plugin, or folder of plugins. <package> defaults to current working directory.',
+      yargs => {
+        yargs.positional('package', {
+          describe: 'Package or folder of packages to build',
           type: 'string',
           default: '.',
-        })
-        .positional('locale', {
-          describe: 'New locale to add to the plugin (e.g., es, fr, pt-BR)',
-          type: 'string',
-        })
-        .option('setup', {
-          describe:
-            'Set up i18n for the package or folder of packages instead of extracting strings',
-          type: 'boolean',
-        })
-        .example('headlamp-plugin i18n', 'Extract strings from current directory')
-        .example('headlamp-plugin i18n . es', 'Add Spanish locale and extract strings')
-        .example('headlamp-plugin i18n my-plugin pt-BR', 'Add Brazilian Portuguese to my-plugin')
-        .example('headlamp-plugin i18n --setup', 'Set up i18n in the current package');
-    },
-    argv => {
-      // If --setup flag is provided, run setupI18n and return
-      if (argv.setup) {
+        });
+      },
+      async argv => {
         // @ts-ignore
-        process.exitCode = setupI18n(argv.package);
-        return;
+        process.exitCode = await build(argv.package);
       }
-
-      // Handle the case where user runs "npm run i18n -- pt"
-      // In this case, "pt" gets passed as the package parameter instead of locale
-      let packageFolder = argv.package;
-      let newLocale = argv.locale;
-
-      // If package looks like a locale code and locale is undefined,
-      // assume they meant to add a locale to the current directory
-      if (!newLocale && packageFolder !== '.' && /^[a-z]{2}(-[A-Z]{2})?$/.test(packageFolder)) {
-        newLocale = packageFolder;
-        packageFolder = '.';
-      }
-
-      // @ts-ignore
-      process.exitCode = extractI18n(packageFolder, newLocale);
-    }
-  )
-  .command(
-    'extract <pluginPackages> <outputPlugins>',
-    'Copies folders of packages from pluginPackages/packageName/dist/main.js ' +
-      'to outputPlugins/packageName/main.js.',
-    yargs => {
-      yargs.positional('pluginPackages', {
-        describe:
-          'A folder of plugin packages that have been built with dist/main.js in them.' +
-          'Can also be a single package folder.',
-        type: 'string',
-      });
-      yargs.positional('outputPlugins', {
-        describe:
-          'A plugins folder (eg. ".plugins") to extract plugins to. ' +
-          'The output is a series of packageName/main.js. ' +
-          'Creates this folder if it does not exist.',
-        type: 'string',
-      });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = extract(argv.pluginPackages, argv.outputPlugins);
-    }
-  )
-  .command(
-    'package [pluginPath] [outputDir]',
-    'Creates a tarball of the plugin package in the format Headlamp expects.',
-    yargs => {
-      yargs.positional('pluginPath', {
-        describe:
-          'A folder of a plugin package that have been built with dist/main.js in it.' +
-          ' Defaults to current working directory.',
-        type: 'string',
-      });
-      yargs.positional('outputDir', {
-        describe:
-          'The destination folder in which to create the archive.' +
-          'Creates this folder if it does not exist.',
-        type: 'string',
-      });
-    },
-    async argv => {
-      let pluginPath = argv.pluginPath;
-      if (!pluginPath) {
-        pluginPath = process.cwd();
-      }
-
-      let outputDir = argv.outputDir;
-      if (!outputDir) {
-        outputDir = process.cwd();
-      }
-
-      process.exitCode = await createArchive(pluginPath, outputDir);
-    }
-  )
-  .command(
-    'format [package]',
-    'format the plugin code with prettier. <package> defaults to current working directory.' +
-      ' Can also be a folder of packages.',
-    yargs => {
-      yargs
-        .positional('package', {
-          describe: 'Package to code format',
-          type: 'string',
-          default: '.',
-        })
-        .option('check', {
-          describe: 'Check the formatting without changing files',
-          type: 'boolean',
-        });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = format(argv.package, argv.check);
-    }
-  )
-  .command(
-    'lint [package]',
-    'Lint the plugin for coding issues with eslint. ' +
-      '<package> defaults to current working directory.' +
-      ' Can also be a folder of packages.',
-    yargs => {
-      yargs
-        .positional('package', {
-          describe: 'Package to lint',
-          type: 'string',
-          default: '.',
-        })
-        .option('fix', {
-          describe: 'Automatically fix problems',
-          type: 'boolean',
-        });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = lint(argv.package, argv.fix);
-    }
-  )
-  .command(
-    'tsc [package]',
-    'Type check the plugin for coding issues with tsc. ' +
-      '<package> defaults to current working directory.' +
-      ' Can also be a folder of packages.',
-    yargs => {
-      yargs.positional('package', {
-        describe: 'Package to type check',
-        type: 'string',
-        default: '.',
-      });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = tsc(argv.package);
-    }
-  )
-  .command(
-    'storybook [package]',
-    'Start storybook. <package> defaults to current working directory.',
-    yargs => {
-      yargs.positional('package', {
-        describe: 'Package to start storybook for',
-        type: 'string',
-        default: '.',
-      });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = storybook(argv.package);
-    }
-  )
-  .command(
-    'storybook-build [package]',
-    'Build static storybook. <package> defaults to current working directory.' +
-      ' Can also be a folder of packages.',
-    yargs => {
-      yargs.positional('package', {
-        describe: 'Package to build storybook for',
-        type: 'string',
-        default: '.',
-      });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = storybook_build(argv.package);
-    }
-  )
-  .command(
-    'upgrade [package]',
-    'Upgrade the plugin to latest headlamp-plugin; ' +
-      'upgrades headlamp-plugin and audits packages, formats, lints, type checks.' +
-      '<package> defaults to current working directory. Can also be a folder of packages.',
-    yargs => {
-      yargs
-        .positional('package', {
-          describe: 'Package to upgrade',
-          type: 'string',
-          default: '.',
-        })
-        .option('skip-package-updates', {
-          describe: 'For development of headlamp-plugin itself, so it does not do package updates.',
-          type: 'boolean',
-        })
-        .option('headlamp-plugin-version', {
-          describe:
-            'Use a specific headlamp-plugin-version when upgrading packages. Defaults to "latest".',
-          type: 'string',
-        });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = upgrade(argv.package, argv.skipPackageUpdates, argv.headlampPluginVersion);
-    }
-  )
-  .command(
-    'test [package]',
-    'Test. <package> defaults to current working directory.' + ' Can also be a folder of packages.',
-    yargs => {
-      yargs.positional('package', {
-        describe: 'Package to test',
-        type: 'string',
-        default: '.',
-      });
-    },
-    argv => {
-      // @ts-ignore
-      process.exitCode = test(argv.package);
-    }
-  )
-  .command(
-    'install [URL]',
-    'Install plugin(s) from a configuration file or a plugin artifact Hub URL',
-    yargs => {
-      return yargs
-        .positional('URL', {
-          describe: 'URL of the plugin to install',
-          type: 'string',
-        })
-        .option('config', {
-          alias: 'c',
-          describe: 'Path to plugin configuration file',
-          type: 'string',
-        })
-        .option('folderName', {
-          describe: 'Name of the folder to install the plugin into',
-          type: 'string',
-        })
-        .option('headlampVersion', {
-          describe: 'Version of headlamp to install the plugin into',
-          type: 'string',
-        })
-        .option('quiet', {
-          alias: 'q',
-          describe: 'Do not print logs',
-          type: 'boolean',
-        })
-        .option('watch', {
-          alias: 'w',
-          describe: 'Watch config file for changes and automatically reinstall plugins',
-          type: 'boolean',
-        })
-        .check(argv => {
-          if (!argv.URL && !argv.config) {
-            throw new Error('Either URL or --config must be specified');
-          }
-          if (argv.URL && argv.config) {
-            throw new Error('Cannot specify both URL and --config');
-          }
-          if (argv.watch && !argv.config) {
-            throw new Error('Watch option can only be used with --config');
-          }
-          return true;
-        });
-    },
-    async argv => {
-      const { URL, config, folderName, headlampVersion, quiet, watch } = argv;
-      try {
-        const progressCallback = quiet
-          ? () => {}
-          : data => {
-              const { type = 'info', message, raise = true } = data;
-              if (config && !URL) {
-                // bulk installation
-                let prefix = '';
-                if (data.current || data.total || data.plugin) {
-                  prefix = `${data.current} of ${data.total} (${data.plugin}): `;
-                }
-                if (type === 'info' || type === 'success') {
-                  console.log(`${prefix}${type}: ${message}`);
-                } else if (type === 'error' && raise) {
-                  throw new Error(message);
-                } else {
-                  console.error(`${prefix}${type}: ${message}`);
-                }
-              } else {
-                if (type === 'error' || type === 'success') {
-                  console.error(`${type}: ${message}`);
-                }
-              }
-            };
-
-        /**
-         * @param {string} configPath
-         */
-        async function installFromConfig(configPath) {
-          const installer = new MultiPluginManager(folderName, headlampVersion, progressCallback);
-          const result = await installer.installFromConfig(configPath);
-          if (result.failed > 0) {
-            throw new Error(`${result.failed} plugins failed to install`);
-          }
-        }
-
-        if (URL) {
-          // Single plugin installation
-          try {
-            await PluginManager.install(URL, folderName, headlampVersion, progressCallback);
-          } catch (e) {
-            console.error(e.message);
-            process.exit(1); // Exit with error status
-          }
-        } else if (config) {
-          // Bulk installation from config
-          try {
-            await installFromConfig(config);
-          } catch (error) {
-            console.error('Installation failed', {
-              error: error.message,
-              stack: error.stack,
-            });
-          }
-
-          if (watch) {
-            console.log(`Watching ${config} for changes...`);
-            fs.watch(config, async eventType => {
-              if (eventType === 'change') {
-                console.log(`Config file changed, reinstalling plugins...`);
-                try {
-                  await installFromConfig(config);
-                  console.log('Plugins reinstalled successfully');
-                } catch (error) {
-                  console.error('Installation failed', {
-                    error: error.message,
-                    stack: error.stack,
-                  });
-                }
-              }
-            });
-
-            // Keep the process running
-            process.stdin.resume();
-
-            // Handle graceful shutdown
-            process.on('SIGINT', () => {
-              console.log('\nStopping config file watch');
-              process.exit(0);
-            });
-          }
-        }
-      } catch (error) {
-        console.error('Installation failed', {
-          error: error.message,
-          stack: error.stack,
-        });
-        process.exit(1);
-      }
-    }
-  )
-  .command(
-    'update <pluginName>',
-    'Update a plugin to the latest version',
-    yargs => {
-      yargs
-        .positional('pluginName', {
-          describe: 'Name of the plugin to update',
-          type: 'string',
-        })
-        .positional('folderName', {
-          describe: 'Name of the folder that contains the plugin',
-          type: 'string',
-        })
-        .positional('headlampVersion', {
-          describe: 'Version of headlamp to update the plugin into',
-          type: 'string',
-        })
-        .option('quiet', {
-          alias: 'q',
-          describe: 'Do not print logs',
-          type: 'boolean',
-        });
-    },
-    async argv => {
-      const { pluginName, folderName, headlampVersion, quiet } = argv;
-      const progressCallback = quiet
-        ? null
-        : data => {
-            if (data.type === 'error' || data.type === 'success') {
-              console.error(data.type, ':', data.message);
-            }
-          }; // Use console.log for logs if not in quiet mode
-      try {
-        await PluginManager.update(pluginName, folderName, headlampVersion, progressCallback);
-      } catch (e) {
-        console.error(e.message);
-        process.exit(1); // Exit with error status
-      }
-    }
-  )
-  .command(
-    'uninstall <pluginName>',
-    'Uninstall a plugin',
-    yargs => {
-      yargs
-        .positional('pluginName', {
-          describe: 'Name of the plugin to uninstall',
-          type: 'string',
-        })
-        .option('folderName', {
-          describe: 'Name of the folder that contains the plugin',
-          type: 'string',
-        })
-        .option('quiet', {
-          alias: 'q',
-          describe: 'Do not print logs',
-          type: 'boolean',
-        });
-    },
-    async argv => {
-      const { pluginName, folderName, quiet } = argv;
-      const progressCallback = quiet
-        ? null
-        : data => {
-            if (data.type === 'error' || data.type === 'success') {
-              console.error(data.type, ':', data.message);
-            }
-          }; // Use console.log for logs if not in quiet mode
-      try {
-        await PluginManager.uninstall(pluginName, folderName, progressCallback);
-      } catch (e) {
-        console.error(e.message);
-        process.exit(1); // Exit with error status
-      }
-    }
-  )
-  .command(
-    'list',
-    'List installed plugins',
-    yargs => {
-      yargs
-        .option('folderName', {
-          describe: 'Name of the folder that contains the plugins',
-          type: 'string',
-        })
-        .option('json', {
-          alias: 'j',
-          describe: 'Output in JSON format',
-          type: 'boolean',
-        });
-    },
-    async argv => {
-      const { folderName, json } = argv;
-      const progressCallback = data => {
-        if (json) {
-          console.log(JSON.stringify(data.data));
-        } else {
-          // display table
-          const rows = [['Name', 'Version', 'Folder Name', 'Repo', 'Author']];
-          data.data.forEach(plugin => {
-            rows.push([
-              plugin.pluginName,
-              plugin.pluginVersion,
-              plugin.folderName,
-              plugin.repoName,
-              plugin.author,
-            ]);
+    )
+    .command('start', 'Watch for changes and build plugin.', {}, async () => {
+      process.exitCode = await start();
+    })
+    .command(
+      'create <name>',
+      'Create a new plugin folder.',
+      yargs => {
+        yargs
+          .positional('name', {
+            describe: 'Name of package',
+            type: 'string',
+          })
+          .option('link', {
+            describe:
+              'For development of headlamp-plugin itself, so it uses npm link @kinvolk/headlamp-plugin.',
+            type: 'boolean',
+          })
+          .option('noinstall', {
+            describe: 'Skip installing dependencies with npm ci',
+            type: 'boolean',
           });
-          console.log(table(rows));
-        }
-      };
-      try {
-        await PluginManager.list(folderName, progressCallback);
-      } catch (e) {
-        console.error(e.message);
-        process.exit(1); // Exit with error status
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = create(argv.name, argv.link, argv.noinstall);
       }
-    }
-  )
-  .demandCommand(1, '')
-  .strict()
-  .help().argv;
+    )
+    .command(
+      'i18n [package] [locale]',
+      'Extract translatable strings from plugin source code. Optionally add a new locale. Use --setup to configure i18n for a package. <package> defaults to current working directory.',
+      yargs => {
+        yargs
+          .positional('package', {
+            describe:
+              'Package to extract translatable strings from (or package to setup with --setup)',
+            type: 'string',
+            default: '.',
+          })
+          .positional('locale', {
+            describe: 'New locale to add to the plugin (e.g., es, fr, pt-BR)',
+            type: 'string',
+          })
+          .option('setup', {
+            describe:
+              'Set up i18n for the package or folder of packages instead of extracting strings',
+            type: 'boolean',
+          })
+          .example('headlamp-plugin i18n', 'Extract strings from current directory')
+          .example('headlamp-plugin i18n . es', 'Add Spanish locale and extract strings')
+          .example('headlamp-plugin i18n my-plugin pt-BR', 'Add Brazilian Portuguese to my-plugin')
+          .example('headlamp-plugin i18n --setup', 'Set up i18n in the current package');
+      },
+      argv => {
+        // If --setup flag is provided, run setupI18n and return
+        if (argv.setup) {
+          // @ts-ignore
+          process.exitCode = setupI18n(argv.package);
+          return;
+        }
+
+        // Handle the case where user runs "npm run i18n -- pt"
+        // In this case, "pt" gets passed as the package parameter instead of locale
+        let packageFolder = argv.package;
+        let newLocale = argv.locale;
+
+        // If package looks like a locale code and locale is undefined,
+        // assume they meant to add a locale to the current directory
+        if (!newLocale && packageFolder !== '.' && /^[a-z]{2}(-[A-Z]{2})?$/.test(packageFolder)) {
+          newLocale = packageFolder;
+          packageFolder = '.';
+        }
+
+        // @ts-ignore
+        process.exitCode = extractI18n(packageFolder, newLocale);
+      }
+    )
+    .command(
+      'extract <pluginPackages> <outputPlugins>',
+      'Copies folders of packages from pluginPackages/packageName/dist/main.js ' +
+        'to outputPlugins/packageName/main.js.',
+      yargs => {
+        yargs.positional('pluginPackages', {
+          describe:
+            'A folder of plugin packages that have been built with dist/main.js in them.' +
+            'Can also be a single package folder.',
+          type: 'string',
+        });
+        yargs.positional('outputPlugins', {
+          describe:
+            'A plugins folder (eg. ".plugins") to extract plugins to. ' +
+            'The output is a series of packageName/main.js. ' +
+            'Creates this folder if it does not exist.',
+          type: 'string',
+        });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = extract(argv.pluginPackages, argv.outputPlugins);
+      }
+    )
+    .command(
+      'package [pluginPath] [outputDir]',
+      'Creates a tarball of the plugin package in the format Headlamp expects.',
+      yargs => {
+        yargs.positional('pluginPath', {
+          describe:
+            'A folder of a plugin package that have been built with dist/main.js in it.' +
+            ' Defaults to current working directory.',
+          type: 'string',
+        });
+        yargs.positional('outputDir', {
+          describe:
+            'The destination folder in which to create the archive.' +
+            'Creates this folder if it does not exist.',
+          type: 'string',
+        });
+      },
+      async argv => {
+        let pluginPath = argv.pluginPath;
+        if (!pluginPath) {
+          pluginPath = process.cwd();
+        }
+
+        let outputDir = argv.outputDir;
+        if (!outputDir) {
+          outputDir = process.cwd();
+        }
+
+        process.exitCode = await createArchive(pluginPath, outputDir);
+      }
+    )
+    .command(
+      'format [package]',
+      'format the plugin code with prettier. <package> defaults to current working directory.' +
+        ' Can also be a folder of packages.',
+      yargs => {
+        yargs
+          .positional('package', {
+            describe: 'Package to code format',
+            type: 'string',
+            default: '.',
+          })
+          .option('check', {
+            describe: 'Check the formatting without changing files',
+            type: 'boolean',
+          });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = format(argv.package, argv.check);
+      }
+    )
+    .command(
+      'lint [package]',
+      'Lint the plugin for coding issues with eslint. ' +
+        '<package> defaults to current working directory.' +
+        ' Can also be a folder of packages.',
+      yargs => {
+        yargs
+          .positional('package', {
+            describe: 'Package to lint',
+            type: 'string',
+            default: '.',
+          })
+          .option('fix', {
+            describe: 'Automatically fix problems',
+            type: 'boolean',
+          });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = lint(argv.package, argv.fix);
+      }
+    )
+    .command(
+      'tsc [package]',
+      'Type check the plugin for coding issues with tsc. ' +
+        '<package> defaults to current working directory.' +
+        ' Can also be a folder of packages.',
+      yargs => {
+        yargs.positional('package', {
+          describe: 'Package to type check',
+          type: 'string',
+          default: '.',
+        });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = tsc(argv.package);
+      }
+    )
+    .command(
+      'storybook [package]',
+      'Start storybook. <package> defaults to current working directory.',
+      yargs => {
+        yargs.positional('package', {
+          describe: 'Package to start storybook for',
+          type: 'string',
+          default: '.',
+        });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = storybook(argv.package);
+      }
+    )
+    .command(
+      'storybook-build [package]',
+      'Build static storybook. <package> defaults to current working directory.' +
+        ' Can also be a folder of packages.',
+      yargs => {
+        yargs.positional('package', {
+          describe: 'Package to build storybook for',
+          type: 'string',
+          default: '.',
+        });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = storybook_build(argv.package);
+      }
+    )
+    .command(
+      'upgrade [package]',
+      'Upgrade the plugin to latest headlamp-plugin; ' +
+        'upgrades headlamp-plugin and audits packages, formats, lints, type checks.' +
+        '<package> defaults to current working directory. Can also be a folder of packages.',
+      yargs => {
+        yargs
+          .positional('package', {
+            describe: 'Package to upgrade',
+            type: 'string',
+            default: '.',
+          })
+          .option('skip-package-updates', {
+            describe:
+              'For development of headlamp-plugin itself, so it does not do package updates.',
+            type: 'boolean',
+          })
+          .option('headlamp-plugin-version', {
+            describe:
+              'Use a specific headlamp-plugin-version when upgrading packages. Defaults to "latest".',
+            type: 'string',
+          });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = upgrade(
+          argv.package,
+          argv.skipPackageUpdates,
+          argv.headlampPluginVersion
+        );
+      }
+    )
+    .command(
+      'test [package]',
+      'Test. <package> defaults to current working directory.' +
+        ' Can also be a folder of packages.',
+      yargs => {
+        yargs.positional('package', {
+          describe: 'Package to test',
+          type: 'string',
+          default: '.',
+        });
+      },
+      argv => {
+        // @ts-ignore
+        process.exitCode = test(argv.package);
+      }
+    )
+    .command(
+      'install [URL]',
+      'Install plugin(s) from a configuration file or a plugin artifact Hub URL',
+      yargs => {
+        return yargs
+          .positional('URL', {
+            describe: 'URL of the plugin to install',
+            type: 'string',
+          })
+          .option('config', {
+            alias: 'c',
+            describe: 'Path to plugin configuration file',
+            type: 'string',
+          })
+          .option('folderName', {
+            describe: 'Name of the folder to install the plugin into',
+            type: 'string',
+          })
+          .option('headlampVersion', {
+            describe: 'Version of headlamp to install the plugin into',
+            type: 'string',
+          })
+          .option('quiet', {
+            alias: 'q',
+            describe: 'Do not print logs',
+            type: 'boolean',
+          })
+          .option('watch', {
+            alias: 'w',
+            describe: 'Watch config file for changes and automatically reinstall plugins',
+            type: 'boolean',
+          })
+          .check(argv => {
+            if (!argv.URL && !argv.config) {
+              throw new Error('Either URL or --config must be specified');
+            }
+            if (argv.URL && argv.config) {
+              throw new Error('Cannot specify both URL and --config');
+            }
+            if (argv.watch && !argv.config) {
+              throw new Error('Watch option can only be used with --config');
+            }
+            return true;
+          });
+      },
+      async argv => {
+        const { URL, config, folderName, headlampVersion, quiet, watch } = argv;
+        try {
+          const progressCallback = quiet
+            ? () => {}
+            : data => {
+                const { type = 'info', message, raise = true } = data;
+                if (config && !URL) {
+                  // bulk installation
+                  let prefix = '';
+                  if (data.current || data.total || data.plugin) {
+                    prefix = `${data.current} of ${data.total} (${data.plugin}): `;
+                  }
+                  if (type === 'info' || type === 'success') {
+                    console.log(`${prefix}${type}: ${message}`);
+                  } else if (type === 'error' && raise) {
+                    throw new Error(message);
+                  } else {
+                    console.error(`${prefix}${type}: ${message}`);
+                  }
+                } else {
+                  if (type === 'error' || type === 'success') {
+                    console.error(`${type}: ${message}`);
+                  }
+                }
+              };
+
+          /**
+           * @param {string} configPath
+           */
+          async function installFromConfig(configPath) {
+            const installer = new MultiPluginManager(folderName, headlampVersion, progressCallback);
+            const result = await installer.installFromConfig(configPath);
+            if (result.failed > 0) {
+              throw new Error(`${result.failed} plugins failed to install`);
+            }
+          }
+
+          if (URL) {
+            // Single plugin installation
+            try {
+              await PluginManager.install(URL, folderName, headlampVersion, progressCallback);
+            } catch (e) {
+              console.error(e.message);
+              process.exit(1); // Exit with error status
+            }
+          } else if (config) {
+            // Bulk installation from config
+            try {
+              await installFromConfig(config);
+            } catch (error) {
+              console.error('Installation failed', {
+                error: error.message,
+                stack: error.stack,
+              });
+            }
+
+            if (watch) {
+              console.log(`Watching ${config} for changes...`);
+              fs.watch(config, async eventType => {
+                if (eventType === 'change') {
+                  console.log(`Config file changed, reinstalling plugins...`);
+                  try {
+                    await installFromConfig(config);
+                    console.log('Plugins reinstalled successfully');
+                  } catch (error) {
+                    console.error('Installation failed', {
+                      error: error.message,
+                      stack: error.stack,
+                    });
+                  }
+                }
+              });
+
+              // Keep the process running
+              process.stdin.resume();
+
+              // Handle graceful shutdown
+              process.on('SIGINT', () => {
+                console.log('\nStopping config file watch');
+                process.exit(0);
+              });
+            }
+          }
+        } catch (error) {
+          console.error('Installation failed', {
+            error: error.message,
+            stack: error.stack,
+          });
+          process.exit(1);
+        }
+      }
+    )
+    .command(
+      'update <pluginName>',
+      'Update a plugin to the latest version',
+      yargs => {
+        yargs
+          .positional('pluginName', {
+            describe: 'Name of the plugin to update',
+            type: 'string',
+          })
+          .positional('folderName', {
+            describe: 'Name of the folder that contains the plugin',
+            type: 'string',
+          })
+          .positional('headlampVersion', {
+            describe: 'Version of headlamp to update the plugin into',
+            type: 'string',
+          })
+          .option('quiet', {
+            alias: 'q',
+            describe: 'Do not print logs',
+            type: 'boolean',
+          });
+      },
+      async argv => {
+        const { pluginName, folderName, headlampVersion, quiet } = argv;
+        const progressCallback = quiet
+          ? null
+          : data => {
+              if (data.type === 'error' || data.type === 'success') {
+                console.error(data.type, ':', data.message);
+              }
+            }; // Use console.log for logs if not in quiet mode
+        try {
+          await PluginManager.update(pluginName, folderName, headlampVersion, progressCallback);
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1); // Exit with error status
+        }
+      }
+    )
+    .command(
+      'uninstall <pluginName>',
+      'Uninstall a plugin',
+      yargs => {
+        yargs
+          .positional('pluginName', {
+            describe: 'Name of the plugin to uninstall',
+            type: 'string',
+          })
+          .option('folderName', {
+            describe: 'Name of the folder that contains the plugin',
+            type: 'string',
+          })
+          .option('quiet', {
+            alias: 'q',
+            describe: 'Do not print logs',
+            type: 'boolean',
+          });
+      },
+      async argv => {
+        const { pluginName, folderName, quiet } = argv;
+        const progressCallback = quiet
+          ? null
+          : data => {
+              if (data.type === 'error' || data.type === 'success') {
+                console.error(data.type, ':', data.message);
+              }
+            }; // Use console.log for logs if not in quiet mode
+        try {
+          await PluginManager.uninstall(pluginName, folderName, progressCallback);
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1); // Exit with error status
+        }
+      }
+    )
+    .command(
+      'list',
+      'List installed plugins',
+      yargs => {
+        yargs
+          .option('folderName', {
+            describe: 'Name of the folder that contains the plugins',
+            type: 'string',
+          })
+          .option('json', {
+            alias: 'j',
+            describe: 'Output in JSON format',
+            type: 'boolean',
+          });
+      },
+      async argv => {
+        const { folderName, json } = argv;
+        const progressCallback = data => {
+          if (json) {
+            console.log(JSON.stringify(data.data));
+          } else {
+            // display table
+            const rows = [['Name', 'Version', 'Folder Name', 'Repo', 'Author']];
+            data.data.forEach(plugin => {
+              rows.push([
+                plugin.pluginName,
+                plugin.pluginVersion,
+                plugin.folderName,
+                plugin.repoName,
+                plugin.author,
+              ]);
+            });
+            console.log(table(rows));
+          }
+        };
+        try {
+          await PluginManager.list(folderName, progressCallback);
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1); // Exit with error status
+        }
+      }
+    )
+    .demandCommand(1, '')
+    .strict()
+    .help().argv;
+
+module.exports = { brotliCompressDist };

--- a/plugins/headlamp-plugin/test-headlamp-plugin.js
+++ b/plugins/headlamp-plugin/test-headlamp-plugin.js
@@ -87,6 +87,9 @@ function testHeadlampPlugin() {
   // test headlamp-plugin build
   run('node', [join('..', 'bin', 'headlamp-plugin.js'), 'build']);
   checkFileExists(join(PACKAGE_NAME, 'dist', 'main.js'));
+  // brotli sidecar must be present alongside main.js
+  checkFileExists(join(PACKAGE_NAME, 'dist', 'main.js.br'));
+  console.log('✓ brotli sidecar main.js.br created after build (package dir)');
 
   // test headlamp-plugin build folder
   curDir = '.';
@@ -97,6 +100,9 @@ function testHeadlampPlugin() {
   curDir = '.';
   run('node', ['bin/headlamp-plugin.js', 'build', PACKAGE_NAME]);
   checkFileExists(join(PACKAGE_NAME, 'dist', 'main.js'));
+  // brotli sidecar must also be present when building a named folder
+  checkFileExists(join(PACKAGE_NAME, 'dist', 'main.js.br'));
+  console.log('✓ brotli sidecar main.js.br created after build (folder arg)');
 
   fs.writeFileSync(join(PACKAGE_NAME, 'dist', 'extra.txt'), 'All dist/ files will be copied.');
 


### PR DESCRIPTION
## Summary

This PR introduces precompressed brotli sidecars for frontend and plugin assets, and serves those sidecars from SPA/plugin handlers with safe fallback to identity bytes.

This is a reaction to a complaint about a headlamp install with several plugins, of which some use large golang wasm artefacts, and very large plugins... with quite a few users. In the process stumbled on some existing static file serving bugs.

This is the approximate scenario:

**Transfer size**: brotli achieves ~75-80% reduction on JS/CSS and ~60% on WASM — measured examples:
- Headlamp frontend: 24 MB raw JS/CSS/fonts -> 4.8 MB (measured)
- 4 plugins at something like 4 MB each: 16 MB -> ~4 MB total over the wire
- 90 MB WASM asset: 90 MB -> ~36 MB

Brotli at 11 is quite slow to compress, which is why it's at build time. But it's usually 20-40% better than gzip.

**CPU**: compression work for 100 concurrent fresh loads drops from ~5 CPU-seconds with gzip to zero.

**Build time of frontend (one time)**: a minute 15 seconds without pre-compression, vs 2 minutes 20 seconds with brotli compression.


## Changes

### Frontend

**frontend/scripts/precompress-build.ts**
- Production precompression generates `.br` sidecars for eligible assets.
- Compression work runs with bounded concurrency.
- Orphan/stale sidecars are removed so served sidecars stay aligned with current build outputs.

**frontend/scripts/precompress-build.test.ts**
- Covers orphan sidecar cleanup.
- Covers bounded-concurrency behavior.

**e2e-tests/tests/staticCompression.spec.ts**
- Verifies static assets are served with `Content-Encoding: br` when the client requests brotli.
- Verifies `Vary: Accept-Encoding` is present and gzip-only requests fall back to non-brotli responses.

### Backend SPA / Encoding

**backend/pkg/spa/encoding.go**
- Centralizes content-encoding negotiation and response header handling (`Vary`/`Content-Encoding`).
- Provides reusable sidecar-serving middleware for static handlers.

**backend/pkg/spa/pathSafety.go**
- URL-to-relative path normalization rejects traversal/backslash escapes and absolute, volume-qualified, or drive-prefixed paths.

**backend/pkg/spa/contentType.go**
- Shared content-type detection helper: extension-based first, then 512-byte sniff fallback.

**backend/pkg/spa/spaHandler.go**
- On-disk SPA handler serves `.br` sidecars when appropriate.
- Keeps index-sidecar exclusion and identity fallback behavior.

**backend/pkg/spa/embeddedSPAHandler.go**
- Embedded SPA handler serves `.br` sidecars with index exclusion and identity fallback.
- Uses slash-safe embedded path handling for index fallback resolution.
- Uses shared content-type detection helper (without full-file reads for sniffing).

**backend/cmd/headlamp.go**
- Plugin static routes are wrapped with sidecar-serving middleware.

**Tests**
- SPA and encoding test suites cover negotiation, fallback behavior, path safety, and traversal cases.

### Plugin CLI

**plugins/headlamp-plugin/bin/headlamp-plugin.js**
- Plugin builds generate `dist/*.br` sidecars.
- `main.js.br` is always produced.
- Sidecar generation targets the correct dist directory in both package-dir and named-folder build paths.

**plugins/headlamp-plugin/test-headlamp-plugin.js**
- Verifies sidecar presence for package-dir and folder-arg build paths.

## Validation

- `go test ./pkg/spa/...` passes.
- `GOTOOLCHAIN=go1.26.3 npm run backend:lint` passes.
- `npm test -- --run scripts/precompress-build.test.ts` passes.
- `npx playwright test --list tests/staticCompression.spec.ts` recognizes the new e2e compression test.

## Notes for Reviewer

- Assisted by copilot.
- `index.html` sidecars are intentionally skipped where runtime rewriting is required.
- Sidecar serving remains best-effort: missing/unusable sidecars fall back to identity responses.
- No new runtime dependencies were introduced for plugin or frontend precompression logic.


