### PR TITLE
backend: invoke cancel() in runWatcher defer to prevent context

### DIFF
--- a/backend/pkg/auth/marshal_test.go
+++ b/backend/pkg/auth/marshal_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage // tests cover unexported marshalToString helper.
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+		ok       bool
+	}{
+		{
+			name:     "valid map",
+			input:    map[string]string{"foo": "bar"},
+			expected: `{"foo":"bar"}`,
+			ok:       true,
+		},
+		{
+			name:     "valid string",
+			input:    "hello",
+			expected: `"hello"`,
+			ok:       true,
+		},
+		{
+			name:     "invalid non-marshalable type",
+			input:    make(chan int), // channels cannot be marshaled
+			expected: "",
+			ok:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := marshalToString(tt.input)
+			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}


### PR DESCRIPTION
### Purpose
Fixes a potential memory leak where a cancelable context's `cancel()` function was omitted on early return paths in `runWatcher`.

### Issue: #6006 

### Problem
In `backend/pkg/k8cache/cacheInvalidation.go`, `runWatcher` registers a context cancel function in the `contextCancel` map. If the function exits early due to an initialization error, the deferred cleanup block calls `contextCancel.Delete(contextKey)`. This removes the tracking reference but fails to actually *call* the `cancel()` function, causing a context leak.

### Solution
Updated the `defer` block in `runWatcher` to:
1. Look up the `contextKey` in the `contextCancel` map.
2. Type-assert the retrieved value to `context.CancelFunc`.
3. Explicitly invoke `cancel()` before deleting the key from the map.

Because this lives inside the `defer` block, it guarantees context cleanup on both successful completions and all early error returns.

### PR Checklist
- [x] Backend tests passing (`npm run backend:test`)
- [x] Code formatted (`npm run backend:format`)
- [x] Linter passing with 0 issues (`npm run backend:lint`)

<img width="1078" height="284" alt="image" src="https://github.com/user-attachments/assets/96dda6e4-439e-468a-9080-72f556d42498" />
<img width="1078" height="284" alt="image" src="https://github.com/user-attachments/assets/feeef15b-7613-4060-a1dc-d8aaa8ad9df9" />
