### PR TITLE
frontend: limitrange: Add details regression tests

### DIFF
--- a/frontend/src/components/limitRange/Details.test.tsx
+++ b/frontend/src/components/limitRange/Details.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+  MetadataDictGrid: () => null,
+}));
+
+vi.mock('../../lib/k8s/limitRange', () => ({
+  LimitRange: {
+    kind: 'LimitRange',
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import { TestContext } from '../../test';
+import { LimitRangeDetails } from './Details';
+
+describe('LimitRangeDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes limit range specific configuration to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'limit-range' }}>
+        <LimitRangeDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+
+    expect(props.resourceType.kind).toBe('LimitRange');
+    expect(props.withEvents).toBe(true);
+    expect(typeof props.extraInfo).toBe('function');
+  });
+
+  it('provides Container Limits section through extraInfo', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'limit-range' }}>
+        <LimitRangeDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+
+    const fakeLimitRange: any = {
+      jsonData: {
+        spec: {
+          limits: [
+            {
+              default: {
+                cpu: '100m',
+                memory: '128Mi',
+              },
+              defaultRequest: {
+                cpu: '50m',
+                memory: '64Mi',
+              },
+              max: {
+                cpu: '500m',
+                memory: '1Gi',
+              },
+              min: {
+                cpu: '10m',
+                memory: '4Mi',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const extraInfo = props.extraInfo(fakeLimitRange);
+
+    expect(extraInfo).toHaveLength(1);
+    expect(extraInfo[0].name).toContain('Container Limits');
+    expect(extraInfo[0].value).toBeDefined();
+  });
+
+  it('includes all container limit subsections in the extraInfo content', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'limit-range' }}>
+        <LimitRangeDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+
+    const fakeLimitRange: any = {
+      jsonData: {
+        spec: {
+          limits: [
+            {
+              default: {},
+              defaultRequest: {},
+              max: {},
+              min: {},
+            },
+          ],
+        },
+      },
+    };
+
+    const extraInfo = props.extraInfo(fakeLimitRange);
+
+    render(<>{extraInfo[0].value}</>);
+
+    expect(screen.getByText('translation|Default')).toBeInTheDocument();
+    expect(screen.getByText('translation|Default Request')).toBeInTheDocument();
+    expect(screen.getByText('translation|Max')).toBeInTheDocument();
+    expect(screen.getByText('translation|Min')).toBeInTheDocument();
+  });
+
+  it('returns a falsy value when no limit range resource is available', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'limit-range' }}>
+        <LimitRangeDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+
+    expect(props.extraInfo(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds regression test coverage for the `LimitRangeDetails` component by verifying the LimitRange-specific details exposed through `DetailsGrid`.

## Related Issue

Fixes #6012 

## Changes

* Added `frontend/src/components/limitRange/Details.test.tsx`
* Added regression tests for `DetailsGrid` configuration
* Verified the Container Limits section is exposed through `extraInfo`
* Verified the Default, Default Request, Max, and Min limit categories are rendered
* Verified behavior when no LimitRange resource is available
* Added i18n mocking to keep tests isolated and deterministic

## Steps to Test

1. Checkout this branch locally.
2. Navigate to the frontend directory.
3. Run:

   ```bash
   npm test -- src/components/limitRange/Details.test.tsx
   ```
5. Verify all tests pass successfully.

## Notes for the Reviewer

* This change only adds regression test coverage and does not modify runtime behavior.
* The tests focus on protecting LimitRange-specific details and sections from future regressions.
* Verified locally that the added test file passes both test execution and lint checks.
