### PR TITLE
frontend: Resource YAML: Fetch latest object before opening

### DIFF
--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Icon } from '@iconify/react';
+import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -33,6 +34,7 @@ import { Activity } from '../../activity/Activity';
 import ActionButton, { ButtonStyle } from '../ActionButton';
 import AuthVisible from './AuthVisible';
 import EditorDialog from './EditorDialog';
+import { fetchLatestKubeObject } from './fetchLatestKubeObject';
 import ViewButton from './ViewButton';
 
 interface EditButtonProps {
@@ -49,10 +51,13 @@ export default function EditButton(props: EditButtonProps) {
   const [errorMessage, setErrorMessage] = React.useState<string>('');
   const location = useLocation();
   const { t } = useTranslation(['translation', 'resource']);
+  const { enqueueSnackbar } = useSnackbar();
   const dispatchHeadlampEditEvent = useEventCallback(HeadlampEventType.EDIT_RESOURCE);
   const activityId = 'edit-' + item.metadata.uid;
 
   const originalItemRef = React.useRef<KubeObjectInterface | null>(null);
+  const editorItemRef = React.useRef<KubeObject>(item);
+  const editRequestRef = React.useRef(0);
 
   function makeErrorMessage(err: any) {
     const status = err?.status;
@@ -74,7 +79,7 @@ export default function EditButton(props: EditButtonProps) {
       throw new Error('Cannot compute patch: original resource state was not captured');
     }
     try {
-      await item.patchUpdate(original, newItem);
+      await editorItemRef.current.patchUpdate(original, newItem);
       // Use a normalized clone of the modified object (what the editor shows)
       // as the new baseline, not the server response which includes
       // server-managed fields the editor may not display.
@@ -140,21 +145,58 @@ export default function EditButton(props: EditButtonProps) {
       <ActionButton
         description={t('translation|Edit')}
         buttonStyle={buttonStyle}
-        onClick={() => {
+        onClick={async () => {
+          const requestId = ++editRequestRef.current;
           if (afterConfirm) {
             afterConfirm();
           }
-          const editableObject = item.getEditableObject() as KubeObjectInterface;
+          let editorItem = item;
+          try {
+            editorItem = await fetchLatestKubeObject(item);
+          } catch (err) {
+            if (requestId !== editRequestRef.current) {
+              return;
+            }
+
+            const status = (err as any)?.status;
+            const message = makeErrorMessage(err);
+            console.error(
+              'Error while fetching latest resource for YAML edit:',
+              {
+                kind: item.kind,
+                name: item.metadata.name,
+                namespace: item.metadata.namespace,
+                cluster: item.cluster,
+              },
+              err
+            );
+            if (status === 401 || status === 403) {
+              enqueueSnackbar(message, { variant: 'warning' });
+              editorItem = item;
+            } else {
+              enqueueSnackbar(message, { variant: 'error' });
+              return;
+            }
+          }
+
+          if (requestId !== editRequestRef.current) {
+            return;
+          }
+
+          setErrorMessage('');
+          const editableObject = editorItem.getEditableObject() as KubeObjectInterface;
           // Normalize the baseline to match what EditorDialog presents to the
           // user (which by default hides metadata.managedFields). Otherwise a
           // "save without changes" produces a managedFields-only diff that
           // patchUpdate would reject.
           originalItemRef.current = normalizeBaselineForPatch(editableObject);
+          editorItemRef.current = editorItem;
+          Activity.close(activityId);
           Activity.launch({
             id: activityId,
-            title: t('translation|Edit') + ': ' + item.metadata.name,
+            title: t('translation|Edit') + ': ' + editorItem.metadata.name,
             icon: <Icon icon="mdi:pencil" />,
-            cluster: item.cluster,
+            cluster: editorItem.cluster,
             content: (
               <EditorDialog
                 noDialog
@@ -171,7 +213,7 @@ export default function EditButton(props: EditButtonProps) {
           });
 
           dispatchHeadlampEditEvent({
-            resource: item,
+            resource: editorItem,
             status: EventStatus.OPENED,
           });
         }}

--- a/frontend/src/components/common/Resource/ViewButton.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.tsx
@@ -21,6 +21,7 @@ import { KubeObject } from '../../../lib/k8s/cluster';
 import { Activity } from '../../activity/Activity';
 import ActionButton, { ButtonStyle } from '../ActionButton';
 import EditorDialog from './EditorDialog';
+import { fetchLatestKubeObject } from './fetchLatestKubeObject';
 
 export interface ViewButtonProps {
   /** The item we want to view */
@@ -33,18 +34,45 @@ export interface ViewButtonProps {
 function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
   const { t } = useTranslation();
   const activityId = 'yaml-' + item.metadata.uid;
+  const launchRequestRef = React.useRef(0);
 
-  const launchActivity = () => {
+  const launchActivity = async () => {
+    const requestId = ++launchRequestRef.current;
+    let editorItem = item;
+    try {
+      editorItem = await fetchLatestKubeObject(item);
+    } catch (err) {
+      if (requestId !== launchRequestRef.current) {
+        return;
+      }
+
+      console.error(
+        'Error while fetching latest resource for YAML view:',
+        {
+          kind: item.kind,
+          name: item.metadata.name,
+          namespace: item.metadata.namespace,
+          cluster: item.cluster,
+        },
+        err
+      );
+    }
+
+    if (requestId !== launchRequestRef.current) {
+      return;
+    }
+
+    Activity.close(activityId);
     Activity.launch({
       id: activityId,
-      title: item.metadata.name,
-      cluster: item.cluster,
+      title: editorItem.metadata.name,
+      cluster: editorItem.cluster,
       icon: <Icon icon="mdi:eye" />,
       location: 'window',
       content: (
         <EditorDialog
           noDialog
-          item={item.jsonData}
+          item={editorItem.jsonData}
           open
           allowToHideManagedFields
           onClose={() => Activity.close(activityId)}

--- a/frontend/src/components/common/Resource/fetchLatestKubeObject.test.ts
+++ b/frontend/src/components/common/Resource/fetchLatestKubeObject.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubeObject } from '../../../lib/k8s/KubeObject';
+import { fetchLatestKubeObject } from './fetchLatestKubeObject';
+
+describe('fetchLatestKubeObject', () => {
+  it('fetches the resource by name and namespace and preserves its cluster', async () => {
+    const latestItem = { cluster: '' } as KubeObject;
+    const cancel = vi.fn();
+    const request = vi.fn(() => Promise.resolve(cancel));
+    const apiGet = vi.fn((onGet: (item: KubeObject) => void) => {
+      onGet(latestItem);
+      return request;
+    });
+    const item = {
+      cluster: 'cluster-a',
+      getName: () => 'hardware-1',
+      getNamespace: () => 'tinkerbell',
+      _class: () => ({ apiGet }),
+    } as unknown as KubeObject;
+
+    await expect(fetchLatestKubeObject(item)).resolves.toBe(latestItem);
+
+    expect(apiGet).toHaveBeenCalledWith(
+      expect.any(Function),
+      'hardware-1',
+      'tinkerbell',
+      expect.any(Function),
+      { cluster: 'cluster-a' }
+    );
+    expect(latestItem.cluster).toBe('cluster-a');
+    expect(request).toHaveBeenCalledTimes(1);
+    // Allow the cancel microtask scheduled by fetchLatestKubeObject() to run.
+    await new Promise<void>(resolve => queueMicrotask(resolve));
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/common/Resource/fetchLatestKubeObject.ts
+++ b/frontend/src/components/common/Resource/fetchLatestKubeObject.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubeObject } from '../../../lib/k8s/KubeObject';
+
+export function fetchLatestKubeObject<K extends KubeObject>(item: K): Promise<K> {
+  return new Promise((resolve, reject) => {
+    let cancel: (() => void) | undefined;
+    let cancelScheduled = false;
+    let settled = false;
+
+    function scheduleCancel() {
+      if (!cancel || cancelScheduled) {
+        return;
+      }
+
+      cancelScheduled = true;
+      // Defer cancellation so streamResult can finish initializing its watch socket.
+      queueMicrotask(() => cancel?.());
+    }
+
+    function resolveOnce(latestItem: KubeObject) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      latestItem.cluster = item.cluster;
+      scheduleCancel();
+      resolve(latestItem as K);
+    }
+
+    function rejectOnce(err: unknown) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      scheduleCancel();
+      reject(err);
+    }
+
+    const request = item
+      ._class()
+      .apiGet(resolveOnce, item.getName(), item.getNamespace(), rejectOnce, {
+        cluster: item.cluster,
+      });
+
+    request()
+      .then(cancelFn => {
+        cancel = cancelFn;
+        if (settled) {
+          scheduleCancel();
+        }
+      })
+      .catch(rejectOnce);
+  });
+}

--- a/frontend/src/components/common/Resource/index.test.ts
+++ b/frontend/src/components/common/Resource/index.test.ts
@@ -26,6 +26,7 @@ const avoidCheck = [
   'ActionsNotifier',
   'AlertNotification',
   'ErrorBoundary',
+  'fetchLatestKubeObject',
   'logSeverityFilter',
 ];
 


### PR DESCRIPTION
## Summary

While testing some plugins, I noticed that editing a resource YAML from
a ResourceListView row action could leave the YAML editor/viewer showing
stale data when reopened.

The issue is not plugin-specific. It can affect resources using
Headlamp’s shared ResourceListView/default row actions. The row action
Edit and View YAML buttons opened the editor from the table row object
already held in memory. After applying an edit, reopening YAML could reuse
stale row/activity data instead of fetching the latest live object from
the Kubernetes API.

## Changes

- Add a helper to fetch the latest KubeObject before opening YAML.
- Update the default Edit action to:
  - refetch the resource before opening the editor
  - use the fresh object as the patch baseline
  - patch through the same fresh object used by the editor
  - close any existing edit activity before relaunching it
- Update the default View YAML action to:
  - refetch the resource before opening YAML
  - close any existing YAML activity before relaunching it
- Add a regression test for fetching the latest object by name,
  namespace, and cluster.

## Steps to Test

1. Open a resource list that uses the shared ResourceListView row actions.
2. Open a resource from the row action menu with Edit.
3. Change the YAML and apply it.
4. Reopen Edit or View YAML from the same row action menu.
5. Confirm the YAML shows the latest live resource state, including the
   updated resourceVersion/generation and edited spec.

## Validation

- `npm run frontend:test -- fetchLatestKubeObject.test.ts`
- `npm run frontend:tsc`
- `npm run frontend:lint`

## Proof that the issue exists

https://github.com/user-attachments/assets/a2c6016a-d753-451b-b854-70513f206adb



