### PR TITLE
e2e: add accessibility checks for Services and Security pages

### DIFF
--- a/e2e-tests/tests/headlamp.spec.ts
+++ b/e2e-tests/tests/headlamp.spec.ts
@@ -49,6 +49,7 @@ test('headlamp is there and so is minikube', async () => {
 
 test('main page should have Network tab', async () => {
   await headlampPage.hasNetworkTab();
+  await headlampPage.a11y();
 });
 
 test('main page should have global search along with react-hotkey hint text', async () => {
@@ -79,7 +80,7 @@ test('service page should have headlamp service', async () => {
 
   // Check if there is text "headlamp" on the page
   await headlampPage.checkPageContent('headlamp');
-  await headlampPage.a11y();
+  await servicesPage.a11y();
 });
 
 test('headlamp service page should contain port', async () => {
@@ -94,6 +95,11 @@ test('headlamp service page should contain port', async () => {
 
 test('main page should have Security tab', async () => {
   await headlampPage.hasSecurityTab();
+});
+
+test('security page is accessible', async () => {
+  await securityPage.navigateToSecurity();
+  await securityPage.a11y();
 });
 
 test('Service account tab should have headlamp-admin', async () => {

--- a/e2e-tests/tests/securityPage.ts
+++ b/e2e-tests/tests/securityPage.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-import { Page } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
+import { expect, Page } from '@playwright/test';
 
 export class SecurityPage {
   constructor(private page: Page) {}
+
+  async a11y() {
+    const axeBuilder = new AxeBuilder({ page: this.page });
+    const accessibilityResults = await axeBuilder.analyze();
+    expect(accessibilityResults.violations).toStrictEqual([]);
+  }
 
   async navigateToSecurity() {
     // Click on the "Security" button

--- a/e2e-tests/tests/servicesPage.ts
+++ b/e2e-tests/tests/servicesPage.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-import { Page } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
+import { expect, Page } from '@playwright/test';
 
 export class ServicesPage {
   constructor(private page: Page) {}
+
+  async a11y() {
+    const axeBuilder = new AxeBuilder({ page: this.page });
+    const accessibilityResults = await axeBuilder.analyze();
+    expect(accessibilityResults.violations).toStrictEqual([]);
+  }
 
   async navigateToServices() {
     // Click on the "Network" button


### PR DESCRIPTION
## Summary

Add accessibility scans for key navigation pages in E2E tests by introducing `a11y()` methods for Services and Security page objects and invoking them from `headlamp.spec.ts`.

Related to the accessibility testing TODO in `frontend/src/index.tsx`.

## Changes

- Added `a11y()` method to `ServicesPage`
- Added `a11y()` method to `SecurityPage`
- Added accessibility scan coverage for:
  - Home page
  - Services page
  - Security page

## Steps to Test

1. Run E2E tests:
   ```bash
   npm run test:e2e
   ```
2. Verify accessibility checks pass for the covered pages.

## Notes for the Reviewer

- Follows the existing accessibility testing pattern used by `HeadlampPage`, `PodsPage`, and `NamespacesPage`.