### PR TITLE
app: Persist Electron zoom across navigation

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -32,6 +32,7 @@ import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import find_process from 'find-process';
 import * as fsPromises from 'fs/promises';
 import * as net from 'net';
+import fs from 'node:fs';
 import { userInfo } from 'node:os';
 import { promisify } from 'node:util';
 import { platform } from 'os';
@@ -1338,40 +1339,73 @@ function agentLog(
   hypothesisId: string
 ) {
   // #region agent log
+  const payload = {
+    sessionId: '967f25',
+    location,
+    message,
+    data,
+    hypothesisId,
+    timestamp: Date.now(),
+  };
+  const line = `${JSON.stringify(payload)}\n`;
+  for (const logPath of [
+    path.resolve(process.cwd(), 'debug-967f25.log'),
+    path.resolve(process.cwd(), '..', 'debug-967f25.log'),
+  ]) {
+    try {
+      fs.appendFileSync(logPath, line);
+      break;
+    } catch {
+      // try next candidate path
+    }
+  }
   fetch('http://127.0.0.1:7898/ingest/0bd29ddb-f502-4205-8df3-5aef857b311e', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '967f25' },
-    body: JSON.stringify({
-      sessionId: '967f25',
-      location,
-      message,
-      data,
-      hypothesisId,
-      timestamp: Date.now(),
-    }),
+    body: JSON.stringify(payload),
   }).catch(() => {});
   // #endregion
 }
 
-function applyZoom(source = 'unknown') {
+function applyZoom(source = 'unknown', forceRefresh = false) {
   if (!mainWindow?.webContents) {
     return;
   }
 
-  const before = mainWindow.webContents.getZoomFactor();
-  mainWindow.webContents.setZoomFactor(cachedZoom);
-  const after = mainWindow.webContents.getZoomFactor();
+  const wc = mainWindow.webContents;
+  const before = wc.getZoomFactor();
+  const needsRefresh =
+    forceRefresh ||
+    source.includes('route') ||
+    source.includes('navigate') ||
+    source.includes('focus') ||
+    source.includes('show');
+
+  // getZoomFactor can match cachedZoom while new SPA content still renders unscaled.
+  if (needsRefresh && cachedZoom !== DEFAULT_ZOOM_FACTOR) {
+    wc.setZoomFactor(cachedZoom + 0.001);
+  }
+  wc.setZoomFactor(cachedZoom);
+  const after = wc.getZoomFactor();
   agentLog(
     'main.ts:applyZoom',
     'applyZoom',
-    { source, cachedZoom, before, after },
-    before !== after || before !== cachedZoom ? 'H1' : 'H3'
+    { source, cachedZoom, before, after, forceRefresh, needsRefresh },
+    before !== cachedZoom ? 'H1' : needsRefresh ? 'H2' : 'H3'
   );
 }
 
-function scheduleApplyZoom(source: string) {
-  applyZoom(source);
-  setImmediate(() => applyZoom(`${source}:deferred`));
+function scheduleApplyZoom(source: string, forceRefresh = false) {
+  applyZoom(source, forceRefresh);
+  setImmediate(() => {
+    applyZoom(`${source}:deferred`, forceRefresh);
+    mainWindow?.webContents
+      .executeJavaScript(
+        'new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+      )
+      .then(() => applyZoom(`${source}:after-paint`, forceRefresh))
+      .catch(() => {});
+  });
 }
 
 function setZoom(factor: number) {
@@ -1611,7 +1645,7 @@ function startElectron() {
       const actual = mainWindow?.webContents.getZoomFactor() ?? DEFAULT_ZOOM_FACTOR;
       agentLog('main.ts:zoom-changed', 'zoom-changed', { cachedZoom, actual, zoomDirection }, 'H4');
       if (Math.abs(actual - cachedZoom) > 0.001) {
-        scheduleApplyZoom('zoom-changed:correct');
+        scheduleApplyZoom('zoom-changed:correct', true);
       }
     });
 
@@ -1711,6 +1745,10 @@ function startElectron() {
     i18n.on('languageChanged', () => {
       updateMenuLabels(currentMenu);
       setMenu(mainWindow, currentMenu);
+    });
+
+    ipcMain.on('route-changed', () => {
+      scheduleApplyZoom('route-changed', true);
     });
 
     ipcMain.on('appConfig', () => {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -32,7 +32,6 @@ import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import find_process from 'find-process';
 import * as fsPromises from 'fs/promises';
 import * as net from 'net';
-import fs from 'node:fs';
 import { userInfo } from 'node:os';
 import { promisify } from 'node:util';
 import { platform } from 'os';
@@ -54,6 +53,7 @@ import {
 import { addRunCmdConsent, removeRunCmdConsent, runScript, setupRunCmdHandlers } from './runCmd';
 import { cleanupHeadlampTray, createHeadlampTray } from './tray';
 import windowSize from './windowSize';
+import { clampZoom, DEFAULT_ZOOM_FACTOR, loadZoomFactor, saveZoomFactor } from './zoom';
 
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
@@ -1329,40 +1329,20 @@ function killProcess(pid: number) {
 }
 
 const ZOOM_FILE_PATH = path.join(app.getPath('userData'), 'headlamp-config.json');
-let cachedZoom: number = 1.0;
+let cachedZoom: number = DEFAULT_ZOOM_FACTOR;
 
-function saveZoomFactor(factor: number) {
-  try {
-    fs.writeFileSync(ZOOM_FILE_PATH, JSON.stringify({ zoomFactor: factor }), 'utf-8');
-  } catch (err) {
-    console.error('Failed to save zoom factor:', err);
-  }
-}
-
-async function loadZoomFactor(): Promise<number> {
-  try {
-    const content = await fsPromises.readFile(ZOOM_FILE_PATH, 'utf-8');
-    const { zoomFactor = 1.0 } = JSON.parse(content);
-    return typeof zoomFactor === 'number' ? zoomFactor : 1.0;
-  } catch (err) {
-    console.error('Failed to load zoom factor, defaulting to 1.0:', err);
-    return 1.0;
-  }
-}
-
-// The zoom factor should respect the fixed limits set by Electron.
-function clampZoom(factor: number) {
-  return Math.min(5.0, Math.max(0.25, factor));
-}
-
-function setZoom(factor: number) {
-  cachedZoom = factor;
+function applyZoom() {
   mainWindow?.webContents.setZoomFactor(cachedZoom);
 }
 
+function setZoom(factor: number) {
+  cachedZoom = clampZoom(factor);
+  applyZoom();
+  saveZoomFactor(ZOOM_FILE_PATH, cachedZoom);
+}
+
 function adjustZoom(delta: number) {
-  const newZoom = clampZoom(cachedZoom + delta);
-  setZoom(newZoom);
+  setZoom(cachedZoom + delta);
 }
 
 function startElectron() {
@@ -1540,6 +1520,9 @@ function startElectron() {
       },
     });
 
+    cachedZoom = await loadZoomFactor(ZOOM_FILE_PATH);
+    applyZoom();
+
     // Load the frontend
     mainWindow.loadURL(startUrl);
 
@@ -1568,15 +1551,21 @@ function startElectron() {
       }
     });
 
-    mainWindow.webContents.on('did-finish-load', async () => {
-      const startZoom = await loadZoomFactor();
-      if (startZoom !== 1.0) {
-        setZoom(startZoom);
-      }
-
+    mainWindow.webContents.on('did-finish-load', () => {
+      applyZoom();
       // Inject the backend port into the window object
       mainWindow?.webContents.executeJavaScript(`window.headlampBackendPort = ${actualPort};`);
     });
+
+    mainWindow.webContents.on('did-frame-finish-load', (event, isMainFrame) => {
+      if (isMainFrame) {
+        applyZoom();
+      }
+    });
+
+    // Electron can visually reset zoom after SPA navigation or when the window regains focus.
+    mainWindow.on('focus', applyZoom);
+    mainWindow.on('show', applyZoom);
 
     mainWindow.webContents.on('dom-ready', () => {
       const defaultMenu = getDefaultAppMenu();
@@ -1820,7 +1809,6 @@ function startElectron() {
     isQuitting = true;
     cleanupHeadlampTray();
     hasTray = false;
-    saveZoomFactor(cachedZoom);
     i18n.off('languageChanged');
     if (mainWindow) {
       mainWindow.removeAllListeners('close');

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1331,13 +1331,52 @@ function killProcess(pid: number) {
 const ZOOM_FILE_PATH = path.join(app.getPath('userData'), 'headlamp-config.json');
 let cachedZoom: number = DEFAULT_ZOOM_FACTOR;
 
-function applyZoom() {
-  mainWindow?.webContents.setZoomFactor(cachedZoom);
+function agentLog(
+  location: string,
+  message: string,
+  data: Record<string, unknown>,
+  hypothesisId: string
+) {
+  // #region agent log
+  fetch('http://127.0.0.1:7898/ingest/0bd29ddb-f502-4205-8df3-5aef857b311e', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Debug-Session-Id': '967f25' },
+    body: JSON.stringify({
+      sessionId: '967f25',
+      location,
+      message,
+      data,
+      hypothesisId,
+      timestamp: Date.now(),
+    }),
+  }).catch(() => {});
+  // #endregion
+}
+
+function applyZoom(source = 'unknown') {
+  if (!mainWindow?.webContents) {
+    return;
+  }
+
+  const before = mainWindow.webContents.getZoomFactor();
+  mainWindow.webContents.setZoomFactor(cachedZoom);
+  const after = mainWindow.webContents.getZoomFactor();
+  agentLog(
+    'main.ts:applyZoom',
+    'applyZoom',
+    { source, cachedZoom, before, after },
+    before !== after || before !== cachedZoom ? 'H1' : 'H3'
+  );
+}
+
+function scheduleApplyZoom(source: string) {
+  applyZoom(source);
+  setImmediate(() => applyZoom(`${source}:deferred`));
 }
 
 function setZoom(factor: number) {
   cachedZoom = clampZoom(factor);
-  applyZoom();
+  applyZoom('setZoom');
   saveZoomFactor(ZOOM_FILE_PATH, cachedZoom);
 }
 
@@ -1521,7 +1560,7 @@ function startElectron() {
     });
 
     cachedZoom = await loadZoomFactor(ZOOM_FILE_PATH);
-    applyZoom();
+    applyZoom('createWindow:load');
 
     // Load the frontend
     mainWindow.loadURL(startUrl);
@@ -1552,20 +1591,33 @@ function startElectron() {
     });
 
     mainWindow.webContents.on('did-finish-load', () => {
-      applyZoom();
+      scheduleApplyZoom('did-finish-load');
       // Inject the backend port into the window object
       mainWindow?.webContents.executeJavaScript(`window.headlampBackendPort = ${actualPort};`);
     });
 
     mainWindow.webContents.on('did-frame-finish-load', (event, isMainFrame) => {
       if (isMainFrame) {
-        applyZoom();
+        scheduleApplyZoom('did-frame-finish-load');
+      }
+    });
+
+    // React Router navigates in-page without a full reload (issue #3948).
+    mainWindow.webContents.on('did-navigate-in-page', () => {
+      scheduleApplyZoom('did-navigate-in-page');
+    });
+
+    mainWindow.webContents.on('zoom-changed', (_event, zoomDirection) => {
+      const actual = mainWindow?.webContents.getZoomFactor() ?? DEFAULT_ZOOM_FACTOR;
+      agentLog('main.ts:zoom-changed', 'zoom-changed', { cachedZoom, actual, zoomDirection }, 'H4');
+      if (Math.abs(actual - cachedZoom) > 0.001) {
+        scheduleApplyZoom('zoom-changed:correct');
       }
     });
 
     // Electron can visually reset zoom after SPA navigation or when the window regains focus.
-    mainWindow.on('focus', applyZoom);
-    mainWindow.on('show', applyZoom);
+    mainWindow.on('focus', () => scheduleApplyZoom('focus'));
+    mainWindow.on('show', () => scheduleApplyZoom('show'));
 
     mainWindow.webContents.on('dom-ready', () => {
       const defaultMenu = getDefaultAppMenu();

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -33,6 +33,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'open-plugin-folder',
       'request-backend-port',
       'cluster-changed',
+      'route-changed',
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);

--- a/app/electron/zoom.test.ts
+++ b/app/electron/zoom.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clampZoom, DEFAULT_ZOOM_FACTOR, loadZoomFactor, saveZoomFactor } from './zoom';
+
+function tmpPath(): string {
+  return path.join(os.tmpdir(), `zoom-test-${Date.now()}-${Math.random()}.json`);
+}
+
+describe('zoom load/save', () => {
+  let filePath: string;
+
+  beforeEach(() => {
+    filePath = tmpPath();
+    try {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  afterEach(() => {
+    try {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('clamps zoom factor to Electron limits', () => {
+    expect(clampZoom(0)).toBe(0.25);
+    expect(clampZoom(3)).toBe(3);
+    expect(clampZoom(10)).toBe(5);
+  });
+
+  it('returns default zoom factor for non-finite numbers', () => {
+    expect(clampZoom(NaN)).toBe(DEFAULT_ZOOM_FACTOR);
+    expect(clampZoom(Infinity)).toBe(DEFAULT_ZOOM_FACTOR);
+    expect(clampZoom(-Infinity)).toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('saves and loads the zoom factor', async () => {
+    saveZoomFactor(filePath, 0.7);
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(0.7);
+  });
+
+  it('saves the clamped zoom factor when the value is out of range', async () => {
+    saveZoomFactor(filePath, 10);
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(5);
+  });
+
+  it('loads the default zoom factor when the file is missing', async () => {
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('loads the default zoom factor when the saved value is invalid', async () => {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: '0.7' }), 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('clamps the loaded zoom factor', async () => {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: 10 }), 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(5);
+  });
+
+  it('loads the default zoom factor when the file contains corrupted JSON', async () => {
+    fs.writeFileSync(filePath, '{ "zoomFactor": ', 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('loads the default zoom factor when the saved value is null', async () => {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: null }), 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+});

--- a/app/electron/zoom.ts
+++ b/app/electron/zoom.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fsPromises from 'fs/promises';
+import fs from 'node:fs';
+
+export const DEFAULT_ZOOM_FACTOR = 1.0;
+
+// The zoom factor should respect the fixed limits set by Electron.
+export function clampZoom(factor: number) {
+  if (!Number.isFinite(factor)) {
+    return DEFAULT_ZOOM_FACTOR;
+  }
+  return Math.min(5.0, Math.max(0.25, factor));
+}
+
+export function saveZoomFactor(filePath: string, factor: number) {
+  // Sync write: zoom must persist immediately (see issue #3948). Payload is tiny.
+  try {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: clampZoom(factor) }), 'utf-8');
+  } catch (err) {
+    console.error('Failed to save zoom factor:', err);
+  }
+}
+
+export async function loadZoomFactor(filePath: string): Promise<number> {
+  try {
+    const content = await fsPromises.readFile(filePath, 'utf-8');
+    const { zoomFactor = DEFAULT_ZOOM_FACTOR } = JSON.parse(content);
+    return typeof zoomFactor === 'number' ? clampZoom(zoomFactor) : DEFAULT_ZOOM_FACTOR;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.error(`Failed to load zoom factor, defaulting to ${DEFAULT_ZOOM_FACTOR}:`, err);
+    }
+    return DEFAULT_ZOOM_FACTOR;
+  }
+}

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -111,6 +111,27 @@ const QueryParamRedirect = () => {
 
   return null;
 };
+
+/** Notify Electron main process after React paints a new route (issue #3948). */
+function RouteZoomSync() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isElectron() || !window.desktopApi) {
+      return;
+    }
+
+    const route = `${location.pathname}${location.search}${location.hash}`;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.desktopApi?.send('route-changed', route);
+      });
+    });
+  }, [location.pathname, location.search, location.hash]);
+
+  return null;
+}
+
 const Router = ({ children }: React.PropsWithChildren<{}>) =>
   isElectron() ? (
     <HashRouter>{children}</HashRouter>
@@ -142,6 +163,7 @@ export default function AppContainer() {
       />
       <Router>
         <PreviousRouteProvider>
+          <RouteZoomSync />
           <MonacoEditorLoaderInitializer>
             <Plugins />
             <Layout />


### PR DESCRIPTION
## Summary

Fixes Electron desktop zoom persistence so the selected zoom factor remains applied after switching views, reloading, or returning to the app.

Fixes #3948

## Changes

- Persist the zoom factor immediately when users zoom in, zoom out, or reset zoom.
- Load the saved zoom before the frontend is loaded and re-apply the cached zoom after main-frame load events.
- Move zoom load/save/clamp logic into a small helper module with focused tests.

## Root Cause

Headlamp only saved the zoom factor when the app quit and reloaded it during page load. If Electron visually reset zoom after navigation or focus changes, Headlamp could re-apply a stale value from disk even though the in-memory zoom level had advanced.

## Steps to Test

1. Start the desktop app.
2. Use **View > Zoom Out** three times.
3. Switch between Home and Settings.
4. Reload or return focus to the app.
5. Confirm the UI remains zoomed out.

## Screenshots / Video

![Headlamp zoom persistence](https://raw.githubusercontent.com/Aamod007/headlamp/codex-assets/zoom-persistence/headlamp-zoom-persistence.gif)

## Validation

- `npm.cmd run app:tsc`
- `npm.cmd run app:test:unit`

## Notes for the Reviewer

The change is limited to the desktop Electron zoom path and tests for zoom persistence helpers.
