### PR TITLE
frontend: Poll cluster overview resources

### DIFF
--- a/frontend/src/components/cluster/Overview.test.tsx
+++ b/frontend/src/components/cluster/Overview.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import Overview from './Overview';
+
+const { chartMocks, eventUseList, nodeUseList, nodeUseMetrics, podUseList } = vi.hoisted(() => ({
+  chartMocks: {
+    CpuCircularChart: () => <div>cpu</div>,
+    MemoryCircularChart: () => <div>memory</div>,
+    NodesStatusCircleChart: () => <div>nodes</div>,
+    PodsStatusCircleChart: () => <div>pods</div>,
+  },
+  eventUseList: vi.fn(() => ({ items: [], errors: null })),
+  nodeUseList: vi.fn(() => [[]]),
+  nodeUseMetrics: vi.fn(() => [[], null]),
+  podUseList: vi.fn(() => [[]]),
+}));
+
+vi.mock('react-i18next', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../lib/k8s/event', () => ({
+  default: {
+    maxLimit: 2000,
+    useList: eventUseList,
+  },
+}));
+
+vi.mock('../../lib/k8s/node', () => ({
+  default: {
+    useList: nodeUseList,
+    useMetrics: nodeUseMetrics,
+  },
+}));
+
+vi.mock('../../lib/k8s/pod', () => ({
+  default: {
+    useList: podUseList,
+  },
+}));
+
+vi.mock('../../lib/util', () => ({
+  useFilterFunc: () => () => true,
+}));
+
+vi.mock('../../redux/filterSlice', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../redux/filterSlice')>()),
+  useNamespaces: () => [],
+}));
+
+vi.mock('../../redux/hooks', () => ({
+  useTypedSelector: (selector: any) => selector({ overviewCharts: { processors: [] } }),
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock('../common/Resource', () => ({
+  PageGrid: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../common/SectionBox', () => ({
+  default: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <section>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  ),
+  SectionBox: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <section>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('./Charts', () => chartMocks);
+vi.mock('./Charts/index', () => chartMocks);
+
+describe('Overview', () => {
+  it('polls overview resources instead of opening watch streams', () => {
+    const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
+
+    render(
+      <MemoryRouter>
+        <Overview />
+      </MemoryRouter>
+    );
+
+    expect(podUseList).toHaveBeenCalledWith({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
+    expect(nodeUseList).toHaveBeenCalledWith({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
+    expect(eventUseList).toHaveBeenCalledWith({
+      limit: 2000,
+      namespace: [],
+      refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
+    });
+  });
+});

--- a/frontend/src/components/cluster/Overview.tsx
+++ b/frontend/src/components/cluster/Overview.tsx
@@ -44,10 +44,14 @@ import {
 } from './Charts';
 import { ClusterGroupErrorMessage } from './ClusterGroupErrorMessage';
 
+const OVERVIEW_REFETCH_INTERVAL_MS = 60_000;
+
 export default function Overview() {
   const { t } = useTranslation(['translation']);
-  const [pods] = Pod.useList();
-  const [nodes] = Node.useList();
+  // The overview only needs periodic snapshots for aggregate charts. Avoid long-lived
+  // watches here because large clusters can stream enough events to exhaust the tab.
+  const [pods] = Pod.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
+  const [nodes] = Node.useList({ refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS });
   const [nodeMetrics, metricsError] = Node.useMetrics();
   const chartProcessors = useTypedSelector(state => state.overviewCharts.processors);
 
@@ -122,6 +126,7 @@ function EventsSection() {
   const { items: events, errors: eventsErrors } = Event.useList({
     limit: Event.maxLimit,
     namespace,
+    refetchInterval: OVERVIEW_REFETCH_INTERVAL_MS,
   });
 
   const warningActionFilterFunc = (event: Event, search?: string) => {


### PR DESCRIPTION
## Summary

Mitigates large-cluster browser OOMs on the cluster overview page by polling overview resources instead of opening long-lived watch streams.

Fixes #5863

## Changes

- Adds a one-minute overview polling interval for pod, node, and event lists.
- Keeps node metrics on the existing metrics polling path.
- Adds a regression test to assert overview list hooks use the polling interval, which disables `useKubeObjectList` watch setup.

## Root Cause

The overview page used the default `KubeObject.useList()` behavior for pods, nodes, and events. That default opens Kubernetes watch connections after the initial list. On very large clusters, those watch streams can continuously push enough data into the renderer to grow the browser heap until the tab is killed.

## Steps to Test

1. Open the cluster overview page.
2. Confirm the overview charts and events table still load.
3. Confirm the page does not open pod/node/event watch streams for the overview snapshot data.

## Screenshots / Video

Not applicable. This PR does not change the UI visually; it changes the overview page data-refresh behavior to reduce continuous watch traffic.

## Validation

- `npm.cmd test -- --run src/components/cluster/Overview.test.tsx`
- `npm.cmd run tsc`
- `npx.cmd eslint -c package.json src/components/cluster/Overview.tsx src/components/cluster/Overview.test.tsx`
- `npx.cmd prettier --config package.json --write src/components/cluster/Overview.tsx src/components/cluster/Overview.test.tsx`

## Notes for the Reviewer

This is intentionally scoped to the default overview landing page reported in the issue. It reduces continuous high-volume WebSocket traffic while preserving periodic overview refreshes.
