### PR TITLE
app: Restrict server cleanup to current Windows user

### DIFF
--- a/app/electron/headlampServerProcess.test.ts
+++ b/app/electron/headlampServerProcess.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  filterCurrentUserHeadlampProcesses,
+  isHeadlampProcessOnPort,
+  isWindowsProcessOwnerCurrentUser,
+} from './headlampServerProcess';
+
+describe('isHeadlampProcessOnPort', () => {
+  it('matches Headlamp server processes using --port=value', () => {
+    expect(isHeadlampProcessOnPort({ pid: 1, cmd: 'headlamp-server --port=4467' }, 4467)).toBe(
+      true
+    );
+  });
+
+  it('matches Headlamp server processes using --port value', () => {
+    expect(isHeadlampProcessOnPort({ pid: 1, cmd: 'headlamp-server --port 4468' }, 4468)).toBe(
+      true
+    );
+  });
+
+  it('matches the default port when the command has no explicit port', () => {
+    expect(
+      isHeadlampProcessOnPort({ pid: 1, cmd: 'headlamp-server --listen-addr=localhost' }, 4466)
+    ).toBe(true);
+  });
+
+  it('does not match processes without command line data', () => {
+    expect(isHeadlampProcessOnPort({ pid: 1 }, 4466)).toBe(false);
+  });
+});
+
+describe('isWindowsProcessOwnerCurrentUser', () => {
+  const currentUser = { domain: 'contoso', username: 'alice' };
+
+  it('matches the current Windows domain user case-insensitively', () => {
+    expect(isWindowsProcessOwnerCurrentUser('CONTOSO\\Alice', currentUser)).toBe(true);
+  });
+
+  it('matches owner strings without a domain', () => {
+    expect(isWindowsProcessOwnerCurrentUser('Alice', currentUser)).toBe(true);
+  });
+
+  it('does not match another Windows user', () => {
+    expect(isWindowsProcessOwnerCurrentUser('CONTOSO\\Bob', currentUser)).toBe(false);
+  });
+
+  it('does not match the same user name from another domain', () => {
+    expect(isWindowsProcessOwnerCurrentUser('FABRIKAM\\Alice', currentUser)).toBe(false);
+  });
+});
+
+describe('filterCurrentUserHeadlampProcesses', () => {
+  const processes = [
+    { pid: 1, cmd: 'headlamp-server --port=4466' },
+    { pid: 2, cmd: 'headlamp-server --port=4467' },
+    { pid: 3, cmd: 'headlamp-server --port=4468' },
+  ];
+
+  it('keeps all Headlamp processes on non-Windows platforms', async () => {
+    await expect(
+      filterCurrentUserHeadlampProcesses(processes, { platform: 'linux' })
+    ).resolves.toEqual(processes);
+  });
+
+  it('keeps only Headlamp processes owned by the current Windows user', async () => {
+    const currentUser = { domain: 'contoso', username: 'alice' };
+    const ownerByPid = new Map([
+      [1, 'CONTOSO\\Alice'],
+      [2, 'CONTOSO\\Bob'],
+      [3, null],
+    ]);
+
+    await expect(
+      filterCurrentUserHeadlampProcesses(processes, {
+        currentUser,
+        getProcessOwner: async pid => ownerByPid.get(pid) ?? null,
+        platform: 'win32',
+      })
+    ).resolves.toEqual([processes[0]]);
+  });
+
+  it('limits concurrent Windows process owner lookups', async () => {
+    const currentUser = { domain: 'contoso', username: 'alice' };
+    let activeLookups = 0;
+    let maxActiveLookups = 0;
+
+    await expect(
+      filterCurrentUserHeadlampProcesses(processes, {
+        currentUser,
+        getProcessOwner: async () => {
+          activeLookups++;
+          maxActiveLookups = Math.max(maxActiveLookups, activeLookups);
+          await new Promise(resolve => setTimeout(resolve, 5));
+          activeLookups--;
+          return 'CONTOSO\\Alice';
+        },
+        ownerLookupConcurrency: 2,
+        platform: 'win32',
+      })
+    ).resolves.toEqual(processes);
+
+    expect(maxActiveLookups).toBe(2);
+  });
+});

--- a/app/electron/headlampServerProcess.ts
+++ b/app/electron/headlampServerProcess.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execFile } from 'node:child_process';
+import { userInfo } from 'node:os';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_OWNER_LOOKUP_CONCURRENCY = 8;
+
+export interface HeadlampProcessInfo {
+  pid: number;
+  cmd?: string;
+}
+
+interface WindowsUser {
+  username: string;
+  domain?: string;
+}
+
+function normalizeAccountPart(value?: string): string {
+  return (value || '').trim().toLowerCase();
+}
+
+function parseWindowsAccount(account: string): WindowsUser {
+  const normalizedAccount = account.trim().replaceAll('/', '\\');
+  const separatorIndex = normalizedAccount.lastIndexOf('\\');
+
+  if (separatorIndex === -1) {
+    return {
+      username: normalizeAccountPart(normalizedAccount),
+    };
+  }
+
+  return {
+    domain: normalizeAccountPart(normalizedAccount.slice(0, separatorIndex)),
+    username: normalizeAccountPart(normalizedAccount.slice(separatorIndex + 1)),
+  };
+}
+
+export function getCurrentWindowsUser(): WindowsUser {
+  return {
+    domain: normalizeAccountPart(process.env.USERDOMAIN),
+    username: normalizeAccountPart(process.env.USERNAME || userInfo().username),
+  };
+}
+
+export function isWindowsProcessOwnerCurrentUser(owner: string, currentUser: WindowsUser): boolean {
+  if (!owner.trim()) {
+    return false;
+  }
+
+  const processOwner = parseWindowsAccount(owner);
+  if (processOwner.username !== currentUser.username) {
+    return false;
+  }
+
+  // If the process owner doesn't report a domain, fall back to username match.
+  if (!processOwner.domain) {
+    return true;
+  }
+
+  // If we can't determine the current user's domain, don't match a domain-qualified owner.
+  if (!currentUser.domain) {
+    return false;
+  }
+
+  return processOwner.domain === currentUser.domain;
+}
+
+export async function getWindowsProcessOwner(pid: number): Promise<string | null> {
+  try {
+    const command = [
+      `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
+      'if ($null -eq $process) { exit 0 }',
+      '$owner = Invoke-CimMethod -InputObject $process -MethodName GetOwner',
+      'if ($owner.ReturnValue -eq 0) { Write-Output "$($owner.Domain)\\$($owner.User)" }',
+    ].join('; ');
+
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', command],
+      { windowsHide: true }
+    );
+
+    const owner = stdout.trim();
+    return owner || null;
+  } catch (error) {
+    console.warn(`Failed to get owner for Headlamp process ${pid}:`, error);
+    return null;
+  }
+}
+
+export async function filterCurrentUserHeadlampProcesses(
+  processes: HeadlampProcessInfo[],
+  options: {
+    currentUser?: WindowsUser;
+    getProcessOwner?: (pid: number) => Promise<string | null>;
+    ownerLookupConcurrency?: number;
+    platform?: NodeJS.Platform;
+  } = {}
+): Promise<HeadlampProcessInfo[]> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'win32') {
+    return processes;
+  }
+
+  const currentUser = options.currentUser ?? getCurrentWindowsUser();
+  const getProcessOwner = options.getProcessOwner ?? getWindowsProcessOwner;
+  const ownerLookupConcurrency = Math.max(
+    1,
+    Math.floor(options.ownerLookupConcurrency ?? DEFAULT_OWNER_LOOKUP_CONCURRENCY)
+  );
+
+  const processOwners = await mapWithConcurrency(processes, ownerLookupConcurrency, getOwner);
+
+  return processOwners.filter(
+    (processOwner): processOwner is HeadlampProcessInfo => processOwner !== null
+  );
+
+  async function getOwner(processInfo: HeadlampProcessInfo): Promise<HeadlampProcessInfo | null> {
+    const owner = await getProcessOwner(processInfo.pid);
+    if (!!owner && isWindowsProcessOwnerCurrentUser(owner, currentUser)) {
+      return processInfo;
+    }
+
+    return null;
+  }
+}
+
+async function mapWithConcurrency<T, TResult>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<TResult>
+): Promise<TResult[]> {
+  const results = new Array<TResult>(items.length);
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await mapper(items[currentIndex]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+export function isHeadlampProcessOnPort(processInfo: HeadlampProcessInfo, port: number): boolean {
+  const commandLine = processInfo.cmd;
+  if (!commandLine) {
+    return false;
+  }
+
+  const portRegex = /--port[=\s]+(\d+)/;
+  const match = commandLine.match(portRegex);
+
+  if (match && match[1]) {
+    return parseInt(match[1], 10) === port;
+  }
+
+  return port === 4466 && !commandLine.includes('--port');
+}

--- a/app/electron/headlampServerProcess.ts
+++ b/app/electron/headlampServerProcess.ts
@@ -170,8 +170,9 @@ export async function getWindowsProcessOwner(pid: number): Promise<string | null
       'if ($owner.ReturnValue -eq 0) { Write-Output "$($owner.Domain)\\$($owner.User)" }',
     ].join('; ');
 
-    const powershellExe =
-      `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+    const powershellExe = `${
+      process.env.SystemRoot ?? 'C:\\Windows'
+    }\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
 
     const { stdout } = await execFileAsync(
       powershellExe,

--- a/app/electron/headlampServerProcess.ts
+++ b/app/electron/headlampServerProcess.ts
@@ -34,7 +34,7 @@ export interface HeadlampProcessInfo {
 /**
  * A parsed Windows user account consisting of an optional domain and a username.
  */
-interface WindowsUser {
+export interface WindowsUser {
   /** The SAM-compatible username (lower-cased, trimmed). */
   username: string;
   /** The Windows domain or machine name (lower-cased, trimmed), if present. */

--- a/app/electron/headlampServerProcess.ts
+++ b/app/electron/headlampServerProcess.ts
@@ -92,9 +92,18 @@ function parseWindowsAccount(account: string): WindowsUser {
  * @returns A {@link WindowsUser} with normalised `domain` and `username` fields.
  */
 export function getCurrentWindowsUser(): WindowsUser {
+  let username = process.env.USERNAME;
+  if (!username) {
+    try {
+      username = userInfo().username;
+    } catch {
+      username = '';
+    }
+  }
+
   return {
-    domain: normalizeAccountPart(process.env.USERDOMAIN),
-    username: normalizeAccountPart(process.env.USERNAME || userInfo().username),
+    domain: normalizeAccountPart(process.env.USERDOMAIN) || undefined,
+    username: normalizeAccountPart(username),
   };
 }
 
@@ -105,8 +114,9 @@ export function getCurrentWindowsUser(): WindowsUser {
  * Matching rules:
  * - An empty or whitespace-only `owner` string is never considered a match.
  * - Usernames must match exactly (case-insensitive, after normalisation).
- * - Domains are optional on either side; a mismatch is only flagged when
- *   *both* sides supply a domain and they differ.
+ * - If the owner includes a domain but the current user's domain is missing,
+ *   the owner is treated as non-matching.
+ * - If both sides supply a domain, they must match (case-insensitive).
  *
  * @param owner - The raw owner string returned by `Win32_Process.GetOwner`
  *   (e.g. `"CORP\\alice"`).

--- a/app/electron/headlampServerProcess.ts
+++ b/app/electron/headlampServerProcess.ts
@@ -170,8 +170,11 @@ export async function getWindowsProcessOwner(pid: number): Promise<string | null
       'if ($owner.ReturnValue -eq 0) { Write-Output "$($owner.Domain)\\$($owner.User)" }',
     ].join('; ');
 
+    const powershellExe =
+      `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+
     const { stdout } = await execFileAsync(
-      'powershell.exe',
+      powershellExe,
       ['-NoProfile', '-NonInteractive', '-Command', command],
       { windowsHide: true }
     );

--- a/app/electron/headlampServerProcess.ts
+++ b/app/electron/headlampServerProcess.ts
@@ -21,20 +21,50 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 const DEFAULT_OWNER_LOOKUP_CONCURRENCY = 8;
 
+/**
+ * Information about a running Headlamp server process.
+ */
 export interface HeadlampProcessInfo {
+  /** The operating-system process identifier. */
   pid: number;
+  /** The full command line used to start the process, if available. */
   cmd?: string;
 }
 
+/**
+ * A parsed Windows user account consisting of an optional domain and a username.
+ */
 interface WindowsUser {
+  /** The SAM-compatible username (lower-cased, trimmed). */
   username: string;
+  /** The Windows domain or machine name (lower-cased, trimmed), if present. */
   domain?: string;
 }
 
+/**
+ * Normalises a single component of a Windows account string by trimming
+ * surrounding whitespace and converting to lower-case.
+ *
+ * @param value - The raw account component to normalise, or `undefined`.
+ * @returns The normalised string; an empty string when `value` is falsy.
+ */
 function normalizeAccountPart(value?: string): string {
   return (value || '').trim().toLowerCase();
 }
 
+/**
+ * Parses a Windows account string of the form `[DOMAIN\]username` into its
+ * constituent parts.
+ *
+ * Both back-slash (`\`) and forward-slash (`/`) are accepted as the
+ * domain–username separator.  Only the *last* separator is used, so accounts
+ * whose domain portion itself contains a separator are handled correctly.
+ *
+ * @param account - The raw account string to parse (e.g. `"CORP\alice"` or
+ *   `"alice"`).
+ * @returns A {@link WindowsUser} object with normalised `username` and,
+ *   when present, `domain` fields.
+ */
 function parseWindowsAccount(account: string): WindowsUser {
   const normalizedAccount = account.trim().replaceAll('/', '\\');
   const separatorIndex = normalizedAccount.lastIndexOf('\\');
@@ -51,6 +81,16 @@ function parseWindowsAccount(account: string): WindowsUser {
   };
 }
 
+/**
+ * Returns the Windows user account that is running the current process.
+ *
+ * The domain is taken from the `USERDOMAIN` environment variable (if set).
+ * The username is taken from the `USERNAME` environment variable, falling back
+ * to {@link https://nodejs.org/api/os.html#osuserinfooptions | `os.userInfo()`}
+ * when the environment variable is absent.
+ *
+ * @returns A {@link WindowsUser} with normalised `domain` and `username` fields.
+ */
 export function getCurrentWindowsUser(): WindowsUser {
   return {
     domain: normalizeAccountPart(process.env.USERDOMAIN),
@@ -58,6 +98,22 @@ export function getCurrentWindowsUser(): WindowsUser {
   };
 }
 
+/**
+ * Determines whether a Windows process owner string refers to the supplied
+ * current user.
+ *
+ * Matching rules:
+ * - An empty or whitespace-only `owner` string is never considered a match.
+ * - Usernames must match exactly (case-insensitive, after normalisation).
+ * - Domains are optional on either side; a mismatch is only flagged when
+ *   *both* sides supply a domain and they differ.
+ *
+ * @param owner - The raw owner string returned by `Win32_Process.GetOwner`
+ *   (e.g. `"CORP\\alice"`).
+ * @param currentUser - The current user to compare against, as returned by
+ *   {@link getCurrentWindowsUser}.
+ * @returns `true` when `owner` refers to `currentUser`; `false` otherwise.
+ */
 export function isWindowsProcessOwnerCurrentUser(owner: string, currentUser: WindowsUser): boolean {
   if (!owner.trim()) {
     return false;
@@ -81,6 +137,20 @@ export function isWindowsProcessOwnerCurrentUser(owner: string, currentUser: Win
   return processOwner.domain === currentUser.domain;
 }
 
+/**
+ * Queries the owner of a Windows process by its PID using PowerShell and the
+ * WMI `Win32_Process` CIM class.
+ *
+ * The function shells out to `powershell.exe` and is therefore only meaningful
+ * on Windows.  Errors (e.g. access-denied, process not found) are swallowed
+ * and produce a `null` return value so that the caller can decide how to
+ * proceed.
+ *
+ * @param pid - The process identifier to query.
+ * @returns A promise that resolves to a `"DOMAIN\\username"` string when the
+ *   owner can be determined, or `null` on failure or when the process no
+ *   longer exists.
+ */
 export async function getWindowsProcessOwner(pid: number): Promise<string | null> {
   try {
     const command = [
@@ -104,6 +174,31 @@ export async function getWindowsProcessOwner(pid: number): Promise<string | null
   }
 }
 
+/**
+ * Filters a list of Headlamp processes to only those owned by the current
+ * Windows user.
+ *
+ * On non-Windows platforms the full `processes` array is returned unchanged
+ * because process-isolation by owner is not required.
+ *
+ * Owner lookups are performed concurrently up to `ownerLookupConcurrency`
+ * simultaneous requests (default: {@link DEFAULT_OWNER_LOOKUP_CONCURRENCY})
+ * to balance speed against system load.
+ *
+ * @param processes - The full list of candidate {@link HeadlampProcessInfo}
+ *   objects to filter.
+ * @param options - Optional overrides for testability and platform behaviour.
+ * @param options.currentUser - The user to match against; defaults to
+ *   {@link getCurrentWindowsUser}.
+ * @param options.getProcessOwner - A function to resolve the owner of a PID;
+ *   defaults to {@link getWindowsProcessOwner}.
+ * @param options.ownerLookupConcurrency - Maximum number of concurrent owner
+ *   lookups; defaults to {@link DEFAULT_OWNER_LOOKUP_CONCURRENCY}.
+ * @param options.platform - The platform string to act upon; defaults to
+ *   `process.platform`.
+ * @returns A promise that resolves to the subset of `processes` owned by the
+ *   current user, or the full `processes` array on non-Windows platforms.
+ */
 export async function filterCurrentUserHeadlampProcesses(
   processes: HeadlampProcessInfo[],
   options: {
@@ -141,6 +236,22 @@ export async function filterCurrentUserHeadlampProcesses(
   }
 }
 
+/**
+ * Maps over an array of items concurrently, resolving up to `concurrency`
+ * promises at a time.
+ *
+ * Items are processed in index order; results are stored at their original
+ * positions so the output array length and order always match the input.
+ *
+ * @typeParam T - The type of each input item.
+ * @typeParam TResult - The type of each mapped result.
+ * @param items - The array of items to process.
+ * @param concurrency - The maximum number of concurrent `mapper` invocations.
+ *   Must be a positive integer; values ≤ 0 are treated as 1 by the caller.
+ * @param mapper - An async function applied to each item.
+ * @returns A promise that resolves to an array of results in the same order as
+ *   `items`.
+ */
 async function mapWithConcurrency<T, TResult>(
   items: T[],
   concurrency: number,
@@ -160,6 +271,20 @@ async function mapWithConcurrency<T, TResult>(
   return results;
 }
 
+/**
+ * Checks whether a Headlamp process is listening on a specific port by
+ * inspecting its command line.
+ *
+ * The function looks for a `--port=<n>` or `--port <n>` argument in the
+ * process's command line.  When no `--port` argument is present the process is
+ * assumed to be using the default port `4466`.
+ *
+ * @param processInfo - The {@link HeadlampProcessInfo} whose command line will
+ *   be inspected.
+ * @param port - The port number to test for.
+ * @returns `true` when the process appears to be bound to `port`; `false`
+ *   when the command line is unavailable or the port does not match.
+ */
 export function isHeadlampProcessOnPort(processInfo: HeadlampProcessInfo, port: number): boolean {
   const commandLine = processInfo.cmd;
   if (!commandLine) {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -40,6 +40,11 @@ import path from 'path';
 import url from 'url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import {
+  filterCurrentUserHeadlampProcesses,
+  type HeadlampProcessInfo,
+  isHeadlampProcessOnPort,
+} from './headlampServerProcess';
 import i18n from './i18next.config';
 import MCPClient from './mcp/MCPClient';
 import {
@@ -739,10 +744,17 @@ async function isPortAvailable(port: number): Promise<boolean> {
  * @returns Available port number, or throws if no port found after MAX_PORT_ATTEMPTS
  */
 async function findAvailablePort(startPort: number): Promise<number> {
+  let headlampProcesses: HeadlampProcessInfo[] = [];
+  try {
+    headlampProcesses = await getCurrentUserHeadlampProcesses();
+  } catch (error) {
+    console.error('Error getting Headlamp processes:', error);
+  }
+
   for (let i = 0; i < MAX_PORT_ATTEMPTS; i++) {
     const port = startPort + i;
     // Skip ports already used by another Headlamp instance.
-    const headlampPIDs = await getHeadlampPIDsOnPort(port);
+    const headlampPIDs = await getHeadlampPIDsOnPort(port, headlampProcesses);
     if (headlampPIDs && headlampPIDs.length > 0) {
       console.info(
         `Port ${port} is occupied by Headlamp process(es) ${headlampPIDs.join(
@@ -1281,46 +1293,37 @@ function menusToTemplate(mainWindow: BrowserWindow | null, menusFromPlugins: App
 }
 
 async function getRunningHeadlampPIDs() {
-  const processes = await find_process('name', 'headlamp-server.*');
-  if (processes.length === 0) {
+  const currentUserProcesses = await getCurrentUserHeadlampProcesses('headlamp-server.*');
+  if (currentUserProcesses.length === 0) {
     return null;
   }
 
-  return processes.map(pInfo => pInfo.pid);
+  return currentUserProcesses.map(pInfo => pInfo.pid);
+}
+
+async function getCurrentUserHeadlampProcesses(
+  processName = 'headlamp-server'
+): Promise<HeadlampProcessInfo[]> {
+  return filterCurrentUserHeadlampProcesses(await find_process('name', processName));
 }
 
 /**
  * Check if a specific port is occupied by a Headlamp process
  * @returns Array of Headlamp PIDs using the port, or null if port is free or used by another process
  */
-async function getHeadlampPIDsOnPort(port: number): Promise<number[] | null> {
+async function getHeadlampPIDsOnPort(
+  port: number,
+  headlampProcesses?: HeadlampProcessInfo[]
+): Promise<number[] | null> {
   try {
     // Get all Headlamp processes
-    const headlampProcesses = await find_process('name', 'headlamp-server');
-    if (headlampProcesses.length === 0) {
+    const processes = headlampProcesses ?? (await getCurrentUserHeadlampProcesses());
+    if (processes.length === 0) {
       return null;
     }
 
     // Parse command line arguments to find which Headlamp process is using this port
-    const headlampOnPort = headlampProcesses.filter(p => {
-      if (!p.cmd) return false;
-
-      // Look for --port=XXXX or --port XXXX in the command line
-      const portRegex = /--port[=\s]+(\d+)/;
-      const match = p.cmd.match(portRegex);
-
-      if (match && match[1]) {
-        const processPort = parseInt(match[1], 10);
-        return processPort === port;
-      }
-
-      // If no port specified, Headlamp uses default port 4466
-      if (port === 4466 && !p.cmd.includes('--port')) {
-        return true;
-      }
-
-      return false;
-    });
+    const headlampOnPort = processes.filter(p => isHeadlampProcessOnPort(p, port));
 
     if (headlampOnPort.length === 0) {
       return null;

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -753,7 +753,7 @@ async function findAvailablePort(startPort: number): Promise<number> {
 
   for (let i = 0; i < MAX_PORT_ATTEMPTS; i++) {
     const port = startPort + i;
-    // Skip ports already used by another Headlamp instance.
+    // Skip ports already used by a Headlamp instance owned by the current OS user.
     const headlampPIDs = await getHeadlampPIDsOnPort(port, headlampProcesses);
     if (headlampPIDs && headlampPIDs.length > 0) {
       console.info(


### PR DESCRIPTION
## Summary

This PR limits Headlamp desktop's Windows server-process handling to `headlamp-server` processes owned by the current OS user. This prevents one remote desktop user from terminating or reusing another user's Headlamp backend process while preserving the existing behavior on non-Windows platforms.

## Related Issue

Fixes #4131

## Changes

- Added a Headlamp server process helper for Windows owner lookup and command-line port matching.
- Updated desktop startup conflict handling to consider only current-user Headlamp server processes.
- Added unit tests for Windows owner matching, current-user process filtering, and port parsing.

## Steps to Test

1. On Windows, start Headlamp as user A so it owns a `headlamp-server` process.
2. Start Headlamp as user B in another remote desktop session.
3. Verify user B does not get prompted to terminate user A's Headlamp server process.
4. Verify user B starts on the next available port if user A already occupies the default port.

## Validation Evidence

```text
npm run app:tsc
> tsc
PASS

npm run app:test:unit
Test Files  8 passed (8)
Tests       114 passed (114)

cd frontend; npx eslint --cache -c package.json ../app/electron/main.ts ../app/electron/headlampServerProcess.ts ../app/electron/headlampServerProcess.test.ts
PASS

cd frontend; npx prettier --config package.json --check ../app/electron/main.ts ../app/electron/headlampServerProcess.ts ../app/electron/headlampServerProcess.test.ts
All matched files use Prettier code style!
```

## Screenshots (if applicable)

Not applicable. This is a desktop process-isolation fix with unit/type/lint validation.

## Notes for the Reviewer

`npm run app:lint` runs the app lint through the frontend lint script and then performs a repository-wide Prettier check. In this Windows checkout, that repository-wide format check reports existing formatting warnings across unrelated files, so the changed Electron files were validated directly with ESLint and Prettier as shown above.