### PR TITLE
frontend: i18n: Add regression test for undefined locale handling

### DIFF
--- a/frontend/src/i18n/ThemeProviderNexti18n.test.tsx
+++ b/frontend/src/i18n/ThemeProviderNexti18n.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTheme } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import ThemeProviderNexti18n from './ThemeProviderNexti18n';
+
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      i18n: {
+        language: undefined,
+        on: vi.fn(),
+        off: vi.fn(),
+      },
+      ready: true,
+    }),
+  };
+});
+
+describe('ThemeProviderNexti18n', () => {
+  it('renders children when i18n language is undefined', () => {
+    render(
+      <ThemeProviderNexti18n theme={createTheme()}>
+        <div>content</div>
+      </ThemeProviderNexti18n>
+    );
+
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds regression test coverage for `ThemeProviderNexti18n` to prevent reintroducing a previously fixed crash caused by an undefined i18n language.

The added test verifies that the provider successfully renders its children when `i18n.language` is undefined, covering the fallback locale handling path introduced in PR #5802 to resolve the Firefox crash.

## Related Issue

Fixes #6025

Related to PR #5802 (`frontend: i18n: Fix crash on Firefox when locale is undefined`)

## Changes

* Added `frontend/src/i18n/ThemeProviderNexti18n.test.tsx`
* Added regression coverage for undefined locale handling
* Verified that `ThemeProviderNexti18n` renders successfully when `i18n.language` is undefined
* Added coverage for the fix introduced in PR #5802
* Prevented accidental reintroduction of the previously fixed Firefox crash scenario

## Steps to Test

1. Run:

   ```bash
   npm test -- src/i18n/ThemeProviderNexti18n.test.tsx
   ```

2. Verify the test passes.

3. Temporarily replace:

   ```ts
   const normalizedLocale = locale?.toLowerCase() ?? 'en';
   ```

   with:

   ```ts
   const normalizedLocale = locale.toLowerCase();
   ```

4. Re-run the test and verify it fails.


## Notes for the Reviewer

* This is a focused regression test covering the Firefox crash fixed in PR #5802.
* The test reproduces the undefined locale code path and confirms that the provider continues rendering successfully.
* Reverting the locale fallback logic causes the test to fail, demonstrating regression coverage for the original bug.
* The added test file passes locally, and lint checks for the file also pass.
