### PR TITLE
frontend: LogViewer: Persist lines and showPrevious to localStorage

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -47,11 +47,11 @@ import {
   useEventCallback,
 } from '../../../redux/headlampEventSlice';
 import { Activity } from '../../activity/Activity';
+import { useLocalStorageState } from '../../globalSearch/useLocalStorageState';
 import ActionButton from '../ActionButton';
 import { LogViewer } from '../LogViewer';
 import { LightTooltip } from '../Tooltip';
 import { ALL_SEVERITIES, filterLogsBySeverity, LogSeverity } from './logSeverityFilter';
-
 // Component props interface
 interface LogsButtonProps {
   item: KubeObject | null;
@@ -102,7 +102,8 @@ function LogsButtonContent({ item }: LogsButtonProps) {
 
   const [showTimestamps, setShowTimestamps] = useState<boolean>(true);
   const [follow, setFollow] = useState<boolean>(true);
-  const [lines, setLines] = useState<number>(100);
+  const [lines, _setLines] = useLocalStorageState<number>('headlamp.logs.lines', 100);
+  const setLines = (value: number | string) => _setLines(() => Number(value));
   const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
   const [showReconnectButton, setShowReconnectButton] = useState(false);
   const [selectedSeverities, setSelectedSeverities] = useState<LogSeverity[]>(() => {

--- a/frontend/src/components/pod/Details.test.tsx
+++ b/frontend/src/components/pod/Details.test.tsx
@@ -484,6 +484,8 @@ describe('PodLogViewer prettifyLogs persistence', () => {
 
     const mockItem = {
       getName: () => 'test-pod',
+      cluster: 'main',
+      metadata: { namespace: 'default', name: 'test-pod' },
       spec: {
         containers: [{ name: 'nginx' }],
         initContainers: [],
@@ -522,6 +524,8 @@ describe('PodLogViewer prettifyLogs persistence', () => {
 
     const mockItem = {
       getName: () => 'test-pod',
+      cluster: 'main',
+      metadata: { namespace: 'default', name: 'test-pod' },
       spec: {
         containers: [{ name: 'nginx' }],
         initContainers: [],

--- a/frontend/src/components/pod/Details.tsx
+++ b/frontend/src/components/pod/Details.tsx
@@ -79,7 +79,10 @@ export function PodLogViewer(props: PodLogViewerProps) {
   const [container, setContainer] = React.useState(() =>
     resolveContainerName(item, initialContainer)
   );
-  const [showPrevious, setShowPrevious] = React.useState<boolean>(false);
+  const [showPrevious, setShowPrevious] = useLocalStorageState<boolean>(
+    `headlamp.logs.showPrevious.${item.cluster}.${item.metadata.namespace}.${item.metadata.name}`,
+    false
+  );
   const [showTimestamps, setShowTimestamps] = useLocalStorageState<boolean>(
     'headlamp.logs.showTimestamps',
     true
@@ -91,7 +94,8 @@ export function PodLogViewer(props: PodLogViewerProps) {
   );
   const [formatJsonValues, setFormatJsonValues] = React.useState<boolean>(false);
   const [hasJsonLogs, setHasJsonLogs] = React.useState<boolean>(false);
-  const [lines, setLines] = React.useState<number>(100);
+  const [lines, _setLines] = useLocalStorageState<number>('headlamp.logs.lines', 100);
+  const setLines = (value: number | string) => _setLines(() => Number(value));
   const [logs, setLogs] = React.useState<{ logs: string[]; lastLineShown: number }>({
     logs: [],
     lastLineShown: -1,


### PR DESCRIPTION
## Summary
This PR fixes the log viewer settings reset by persisting `lines` and
`showPrevious` to localStorage using the existing `useLocalStorageState`
hook, so they survive navigation and page reload.

## Related Issue
Fixes #5940

## Changes
- `pod/Details.tsx`: `lines` and `showPrevious` now use `useLocalStorageState`
  instead of plain `useState`
- `Resource/LogsButton.tsx`: `lines` now uses `useLocalStorageState`,
  added import for the hook

## Steps to Test
1. Open any running pod → Logs tab
2. Set lines to 1000
3. Navigate to a different pod, then come back — lines should still be 1000
4. Reload the page (F5) — lines should still be 1000
5. If a container has restarted, enable showPrevious and repeat steps 3-4

## Notes for the Reviewer
- `follow` is intentionally left as plain `useState` — a paused stream
  should not auto-resume when the user navigates back
- `showTimestamps` and `selectedSeverities` were already persisted before
  this PR, so they are not touched