### PR TITLE
backend: k8cache: Ensure context is explicitly canceled on early runWatcher exit

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -212,8 +212,13 @@ func runWatcher(
 	kContext kubeconfig.Context,
 ) {
 	defer func() {
+		if cancelVal, ok := contextCancel.LoadAndDelete(contextKey); ok {
+			if cancel, ok := cancelVal.(context.CancelFunc); ok {
+				cancel()
+			}
+		}
+
 		watcherRegistry.Delete(contextKey)
-		contextCancel.Delete(contextKey)
 	}()
 
 	logger.Log(logger.LevelInfo, nil, nil, "running runWatcher for watching k8s resource: "+redactContextKey(contextKey))


### PR DESCRIPTION
### Summary: This PR updates runWatcher in cacheInvalidation.go to explicitly call the cancel() function during its defer block if it exists.

While the previous implementation didn't cause a severe memory leak (since the context parent is context.Background()), explicitly calling the cancel function ensures we strictly follow Go's context best practices. This guarantees that any internal context resources are immediately freed rather than waiting for garbage collection in the event of an early exit (e.g., if obtaining the REST config or discovering server resources fails).

### Changes:
backend/pkg/k8cache/cacheInvalidation.go: Fetches and invokes cancel() from the contextCancel sync map before deleting the key in the defer block of runWatcher.
Steps to Test:

Run npm run backend:test to verify that existing test suites pass.
Confirm no regressions in cache invalidation behavior or watcher lifecycle.


### Screenshots
<img width="1075" height="279" alt="image" src="https://github.com/user-attachments/assets/f92cb1bb-c595-46f0-81ea-3a13d58e7962" />
<img width="1075" height="279" alt="image" src="https://github.com/user-attachments/assets/6023e5c6-f38e-4420-a9d2-fee87d06d4ab" />
