### PR TITLE
frontend: stateless: Fix various issues

### DIFF
--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -117,6 +117,8 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 	}
 
 	for _, context := range contexts {
+		contextName := context.Name
+
 		info := context.KubeContext.Extensions["headlamp_info"]
 		if info != nil {
 			customObj, err := MarshalCustomObject(info, context.Name)
@@ -127,11 +129,12 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 				return "", err
 			}
 
-			// Check if the CustomName field is present
 			if customObj.CustomName != "" {
-				key = customObj.CustomName + userID
+				contextName = customObj.CustomName
 			}
-		} else if context.Name != clusterName {
+		}
+
+		if contextName != clusterName {
 			// Skip contexts that don't match the requested cluster name
 			continue
 		}
@@ -141,7 +144,7 @@ func (c *HeadlampConfig) handleStatelessReq(r *http.Request, kubeConfig string) 
 			return "", err
 		}
 
-		contextKey = key
+		contextKey = contextName + userID
 	}
 
 	return contextKey, nil

--- a/frontend/src/components/App/Settings/ClusterNameEditor.tsx
+++ b/frontend/src/components/App/Settings/ClusterNameEditor.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Box, TextField, Typography } from '@mui/material';
+import { keyBy } from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -125,7 +126,9 @@ export function ClusterNameEditor({
                 parseKubeConfig({ kubeconfig: updatedKubeconfig })
                   .then((config: any) => {
                     storeNewClusterName(newClusterName);
-                    dispatch(setStatelessConfig(config));
+                    dispatch(
+                      setStatelessConfig({ statelessClusters: keyBy(config.clusters, 'name') })
+                    );
                   })
                   .catch((err: Error) => {
                     console.error('Error updating cluster name:', err.message);

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -25,6 +25,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/system';
 import * as yaml from 'js-yaml';
+import { keyBy } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useTranslation } from 'react-i18next';
@@ -374,7 +375,11 @@ function KubeConfigLoader() {
         setCluster({ kubeconfig: btoa(yaml.dump(selectedClusterConfig)) })
           .then(res => {
             if (res?.clusters?.length > 0) {
-              dispatch(setStatelessConfig(res));
+              dispatch(
+                setStatelessConfig({
+                  statelessClusters: keyBy(res.clusters, 'name'),
+                })
+              );
             }
             setState(Step.Success);
           })

--- a/frontend/src/lib/k8s/api/v1/clusterApi.ts
+++ b/frontend/src/lib/k8s/api/v1/clusterApi.ts
@@ -145,7 +145,7 @@ export async function setCluster(clusterReq: ClusterRequest) {
       '/parseKubeConfig',
       {
         method: 'POST',
-        body: JSON.stringify(clusterReq),
+        body: JSON.stringify({ kubeconfigs: [kubeconfig] }),
         headers: {
           ...headers,
         },

--- a/frontend/src/stateless/index.ts
+++ b/frontend/src/stateless/index.ts
@@ -372,12 +372,14 @@ export function isEqualClusterConfigs(
  * if the present stored config is different from the fetched one.
  */
 export async function fetchStatelessClusterKubeConfigs(dispatch: any) {
-  const config = await getStatelessClusterKubeConfigs();
+  const kubeconfigs = await getStatelessClusterKubeConfigs();
   const statelessClusters = store.getState().config.statelessClusters;
   const headers = addBackstageAuthHeaders(JSON_HEADERS);
   const clusterReq = {
-    kubeconfigs: config,
+    kubeconfigs,
   };
+
+  if (!kubeconfigs || kubeconfigs.length === 0) return;
 
   // Parses statelessCluster config
   request(


### PR DESCRIPTION
fixes following issues:
 - kubeconfigs were incorrectly passed to the /parseKubeconfigs
 - kubeconfigs were incorrectly set to the redux store through dispatch
 - kubeconfig context key was incorrectly resolved on the backend resulting in requests being routed to wrong clusters

## Testing done

Uploaded, deleted, renamed stateless clusters.  Checked uploading kubeconfig with various clusters to validate it works the same as if it was in the ~/.kube/config
