### PR TITLE
frontend: util: Fix getPercentStr trailing .0 on whole percentages

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -18,6 +18,7 @@ import {
   combineClusterListErrors,
   flattenClusterListItems,
   formatDuration,
+  getPercentStr,
   normalizeUnit,
   timeAgo,
 } from './util';
@@ -316,5 +317,27 @@ describe('normalizeUnit', () => {
     it('shows plural cores', () => {
       expect(normalizeUnit('cpu', '2')).toBe('2 cores');
     });
+  });
+});
+
+describe('getPercentStr', () => {
+  it('returns null when total is zero', () => {
+    expect(getPercentStr(5, 0)).toBeNull();
+  });
+
+  it('drops the decimal for whole-number percentages', () => {
+    expect(getPercentStr(5, 100)).toBe('5 %');
+    expect(getPercentStr(30, 100)).toBe('30 %');
+    expect(getPercentStr(100, 100)).toBe('100 %');
+    expect(getPercentStr(0, 100)).toBe('0 %');
+  });
+
+  it('keeps one decimal for fractional percentages', () => {
+    expect(getPercentStr(1, 3)).toBe('33.3 %');
+    expect(getPercentStr(1, 8)).toBe('12.5 %');
+  });
+
+  it('rounds to one decimal', () => {
+    expect(getPercentStr(2, 3)).toBe('66.7 %');
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -225,7 +225,7 @@ export function getPercentStr(value: number, total: number) {
     return null;
   }
   const percentage = (value / total) * 100;
-  const decimals = percentage % 10 > 0 ? 1 : 0;
+  const decimals = percentage % 1 > 0 ? 1 : 0;
   return `${percentage.toFixed(decimals)} %`;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes `getPercentStr` so whole-number percentages no longer render a spurious trailing `.0` (e.g. `5%` was shown as `5.0 %`).

## Related Issue

Fixes #5999

## Changes

- Fixed the decimal logic in `getPercentStr` (`frontend/src/lib/util.ts`): it used `percentage % 10 > 0`, which is true for any percentage that isn't a multiple of 10, so `5%` got a decimal while `30%` did not. Changed to `percentage % 1 > 0` so a decimal is only shown when there's an actual fractional part.
- Added a `getPercentStr` test block in `frontend/src/lib/util.test.ts`.

## Steps to Test

1. Run `cd frontend && npm test -- src/lib/util.test.ts`.
2. Observe the new `getPercentStr` cases pass:
   - whole numbers drop the decimal: `5 %`, `30 %`, `100 %`, `0 %`
   - fractional percentages keep one decimal: `33.3 %`, `12.5 %`
   - `null` is returned when total is `0`

## Screenshots (if applicable)


## Notes for the Reviewer

- This is a pure-logic fix in a shared util; no UI/i18n changes. The issue-closing keyword is kept in this PR description (not the commit message) to satisfy the prow commit-message check.