### PR TITLE
frontend: serviceaccount/Details: Show referencing role bindings

### DIFF
--- a/frontend/src/components/serviceaccount/Details.stories.tsx
+++ b/frontend/src/components/serviceaccount/Details.stories.tsx
@@ -17,118 +17,251 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { API_BASE, TestContext } from '../../test';
-import Details from './Details';
-import { SERVICE_ACCOUNT_DUMMY_DATA } from './storyHelper';
+import ServiceAccountDetails from './Details';
+import { BASE_EMPTY_SERVICE_ACCOUNT, BASE_SERVICE_ACCOUNT } from './storyHelper';
+
+const demoRoleBinding = {
+  kind: 'RoleBinding',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name: 'demo-rb',
+    namespace: 'default',
+    uid: 'rb-demo-uid',
+    resourceVersion: '2',
+    creationTimestamp: '2026-06-14T14:31:50Z',
+  },
+  roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'Role', name: 'demo-role' },
+  subjects: [{ kind: 'ServiceAccount', name: 'my-sa', namespace: 'default' }],
+};
+
+// Lives in a different namespace from the ServiceAccount it targets — valid Kubernetes RBAC
+// (a RoleBinding's own namespace need not match its subjects' namespaces) — and must still be
+// found, since the list is fetched cluster-wide rather than scoped to the SA's own namespace.
+const demoRoleBindingFromOtherNamespace = {
+  kind: 'RoleBinding',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name: 'demo-rb-cross-namespace',
+    namespace: 'other-ns',
+    uid: 'rb-demo-cross-ns-uid',
+    resourceVersion: '6',
+    creationTimestamp: '2026-06-14T14:31:50Z',
+  },
+  roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'Role', name: 'cross-namespace-role' },
+  subjects: [{ kind: 'ServiceAccount', name: 'my-sa', namespace: 'default' }],
+};
+
+// References a different ServiceAccount; should be filtered out of the section.
+const unrelatedRoleBinding = {
+  kind: 'RoleBinding',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name: 'other-rb',
+    namespace: 'default',
+    uid: 'rb-other-uid',
+    resourceVersion: '3',
+    creationTimestamp: '2026-06-14T14:31:50Z',
+  },
+  roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'Role', name: 'other-role' },
+  subjects: [{ kind: 'ServiceAccount', name: 'other', namespace: 'default' }],
+};
+
+// A namespaced RoleBinding referencing a cluster-scoped ClusterRole (valid Kubernetes RBAC:
+// a RoleBinding may bind either a Role or a ClusterRole). The role link must omit the
+// binding's namespace, or it resolves as a namespaced Role instead of a ClusterRole.
+const demoRoleBindingToClusterRole = {
+  kind: 'RoleBinding',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name: 'demo-rb-shared-role',
+    namespace: 'default',
+    uid: 'rb-demo-shared-uid',
+    resourceVersion: '5',
+    creationTimestamp: '2026-06-14T14:31:50Z',
+  },
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'ClusterRole',
+    name: 'demo-shared-clusterrole',
+  },
+  subjects: [{ kind: 'ServiceAccount', name: 'my-sa', namespace: 'default' }],
+};
+
+const demoClusterRoleBinding = {
+  kind: 'ClusterRoleBinding',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  metadata: {
+    name: 'demo-crb',
+    uid: 'crb-demo-uid',
+    resourceVersion: '4',
+    creationTimestamp: '2026-06-14T14:31:50Z',
+  },
+  roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'demo-clusterrole' },
+  subjects: [{ kind: 'ServiceAccount', name: 'my-sa', namespace: 'default' }],
+};
+
+const SA_LIST_URL = `${API_BASE}/api/v1/namespaces/default/serviceaccounts`;
+const SA_URL = `${API_BASE}/api/v1/namespaces/default/serviceaccounts/my-sa`;
+// Fetched cluster-wide (no namespace segment) — see the comment on RoleBinding.useList in Details.tsx.
+const ROLE_BINDINGS_URL = `${API_BASE}/apis/rbac.authorization.k8s.io/v1/rolebindings`;
+const CLUSTER_ROLE_BINDINGS_URL = `${API_BASE}/apis/rbac.authorization.k8s.io/v1/clusterrolebindings`;
+
+const EMPTY_ROLE_BINDING_LIST = {
+  kind: 'RoleBindingList',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  items: [],
+  metadata: {},
+};
+const EMPTY_CLUSTER_ROLE_BINDING_LIST = {
+  kind: 'ClusterRoleBindingList',
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  items: [],
+  metadata: {},
+};
 
 export default {
   title: 'ServiceAccount/DetailsView',
-  component: Details,
+  component: ServiceAccountDetails,
+  argTypes: {},
   decorators: [
-    (Story, context) => {
-      const routerMap = context.parameters.routerMap ?? {
-        namespace: 'default',
-        name: 'my-service-account',
-      };
+    Story => {
       return (
-        <TestContext routerMap={routerMap}>
+        <TestContext routerMap={{ namespace: 'default', name: 'my-sa' }}>
           <Story />
         </TestContext>
       );
     },
   ],
-
   parameters: {
     msw: {
       handlers: {
         storyBase: [
-          http.get(`${API_BASE}/api/v1/namespaces/default/serviceaccounts`, () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
-              kind: 'ServiceAccountList',
-              apiVersion: 'v1',
+              kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
-            HttpResponse.json({ kind: 'EventList', apiVersion: 'v1', items: [], metadata: {} })
-          ),
+          // Only the shared events handler lives here. The ServiceAccount, RoleBinding and
+          // ClusterRoleBinding handlers are defined per-story so that each story's own data takes
+          // effect — msw-storybook-addon concatenates storyBase handlers before story handlers and
+          // MSW resolves the first match, so a storyBase handler for the same URL would always win
+          // over a story override.
         ],
       },
     },
   },
 } as Meta;
 
-const Template: StoryFn = () => <Details />;
+const Template: StoryFn = () => {
+  return <ServiceAccountDetails />;
+};
 
-export const Loading = Template.bind({});
-Loading.parameters = {
-  storyshots: { disable: true },
+export const WithBase = Template.bind({});
+WithBase.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          `${API_BASE}/api/v1/namespaces/default/serviceaccounts/my-service-account`,
-          () => new Promise(() => {})
+        http.get(SA_LIST_URL, () =>
+          HttpResponse.json({
+            kind: 'ServiceAccountList',
+            apiVersion: 'v1',
+            items: [BASE_SERVICE_ACCOUNT],
+            metadata: {},
+          })
+        ),
+        http.get(SA_URL, () => HttpResponse.json(BASE_SERVICE_ACCOUNT)),
+        http.get(ROLE_BINDINGS_URL, () => HttpResponse.json(EMPTY_ROLE_BINDING_LIST)),
+        http.get(CLUSTER_ROLE_BINDINGS_URL, () =>
+          HttpResponse.json(EMPTY_CLUSTER_ROLE_BINDING_LIST)
         ),
       ],
     },
   },
 };
 
-export const WithData = Template.bind({});
-WithData.parameters = {
+export const Empty = Template.bind({});
+Empty.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(`${API_BASE}/api/v1/namespaces/default/serviceaccounts/my-service-account`, () =>
-          HttpResponse.json(SERVICE_ACCOUNT_DUMMY_DATA[0])
+        http.get(SA_LIST_URL, () =>
+          HttpResponse.json({
+            kind: 'ServiceAccountList',
+            apiVersion: 'v1',
+            items: [BASE_EMPTY_SERVICE_ACCOUNT],
+            metadata: {},
+          })
+        ),
+        http.get(SA_URL, () => HttpResponse.json(BASE_EMPTY_SERVICE_ACCOUNT)),
+        http.get(ROLE_BINDINGS_URL, () => HttpResponse.json(EMPTY_ROLE_BINDING_LIST)),
+        http.get(CLUSTER_ROLE_BINDINGS_URL, () =>
+          HttpResponse.json(EMPTY_CLUSTER_ROLE_BINDING_LIST)
         ),
       ],
     },
   },
 };
 
-export const NoSecrets = Template.bind({});
-NoSecrets.parameters = {
-  routerMap: { name: 'no-secrets-account', namespace: 'default' },
+export const WithBindings = Template.bind({});
+WithBindings.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(`${API_BASE}/api/v1/namespaces/default/serviceaccounts/no-secrets-account`, () =>
-          HttpResponse.json(SERVICE_ACCOUNT_DUMMY_DATA[2])
+        http.get(SA_LIST_URL, () =>
+          HttpResponse.json({
+            kind: 'ServiceAccountList',
+            apiVersion: 'v1',
+            items: [BASE_SERVICE_ACCOUNT],
+            metadata: {},
+          })
+        ),
+        http.get(SA_URL, () => HttpResponse.json(BASE_SERVICE_ACCOUNT)),
+        http.get(ROLE_BINDINGS_URL, () =>
+          HttpResponse.json({
+            kind: 'RoleBindingList',
+            apiVersion: 'rbac.authorization.k8s.io/v1',
+            items: [
+              demoRoleBinding,
+              demoRoleBindingToClusterRole,
+              demoRoleBindingFromOtherNamespace,
+              unrelatedRoleBinding,
+            ],
+            metadata: {},
+          })
+        ),
+        http.get(CLUSTER_ROLE_BINDINGS_URL, () =>
+          HttpResponse.json({
+            kind: 'ClusterRoleBindingList',
+            apiVersion: 'rbac.authorization.k8s.io/v1',
+            items: [demoClusterRoleBinding],
+            metadata: {},
+          })
         ),
       ],
     },
   },
 };
 
-export const AutomountDisabled = Template.bind({});
-AutomountDisabled.parameters = {
-  routerMap: { name: 'automount-disabled-account', namespace: 'default' },
+// Both binding lists fail (e.g. the user lacks permission to list bindings), so the section
+// renders its explicit "Unable to list…" error state rather than the empty message.
+export const ListError = Template.bind({});
+ListError.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          `${API_BASE}/api/v1/namespaces/default/serviceaccounts/automount-disabled-account`,
-          () =>
-            HttpResponse.json({
-              ...SERVICE_ACCOUNT_DUMMY_DATA[1],
-              secrets: SERVICE_ACCOUNT_DUMMY_DATA[0].secrets,
-            })
+        http.get(SA_LIST_URL, () =>
+          HttpResponse.json({
+            kind: 'ServiceAccountList',
+            apiVersion: 'v1',
+            items: [BASE_SERVICE_ACCOUNT],
+            metadata: {},
+          })
         ),
-      ],
-    },
-  },
-};
-
-export const Error = Template.bind({});
-Error.parameters = {
-  msw: {
-    handlers: {
-      story: [
-        http.get(`${API_BASE}/api/v1/namespaces/default/serviceaccounts/my-service-account`, () =>
-          HttpResponse.json({ message: 'Not found' }, { status: 404 })
-        ),
+        http.get(SA_URL, () => HttpResponse.json(BASE_SERVICE_ACCOUNT)),
+        http.get(ROLE_BINDINGS_URL, () => HttpResponse.error()),
+        http.get(CLUSTER_ROLE_BINDINGS_URL, () => HttpResponse.error()),
       ],
     },
   },

--- a/frontend/src/components/serviceaccount/Details.tsx
+++ b/frontend/src/components/serviceaccount/Details.tsx
@@ -17,9 +17,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { ResourceClasses } from '../../lib/k8s';
+import ClusterRoleBinding from '../../lib/k8s/clusterRoleBinding';
+import RoleBinding from '../../lib/k8s/roleBinding';
 import ServiceAccount from '../../lib/k8s/serviceAccount';
 import Link from '../common/Link';
 import { DetailsGrid } from '../common/Resource';
+import { SectionBox } from '../common/SectionBox';
+import SimpleTable from '../common/SimpleTable';
 
 function SecretLinks(props: { items?: { name: string }[]; namespace: string }) {
   const { items, namespace } = props;
@@ -35,6 +40,129 @@ function SecretLinks(props: { items?: { name: string }[]; namespace: string }) {
         </React.Fragment>
       ))}
     </React.Fragment>
+  );
+}
+
+/**
+ * Renders the role referenced by a (Cluster)RoleBinding as a link to the Role/ClusterRole
+ * detail page, falling back to plain text when the resource class is not available.
+ */
+function RoleRefLink(props: { binding: RoleBinding | ClusterRoleBinding }) {
+  const { binding } = props;
+  const roleRef = binding.roleRef;
+  if (!roleRef) {
+    return null;
+  }
+
+  const label = `${roleRef.kind}: ${roleRef.name}`;
+  const roleClass = ResourceClasses[roleRef.kind as keyof typeof ResourceClasses];
+  if (!roleClass) {
+    return <>{label}</>;
+  }
+
+  // A RoleBinding may reference either a Role or a ClusterRole. Only pass a namespace
+  // when the referenced role is itself namespaced — a RoleBinding's own namespace must
+  // not be attached to a ClusterRole link, or it resolves as a namespaced Role instead.
+  const params = roleClass.isNamespaced
+    ? { name: roleRef.name, namespace: binding.metadata.namespace }
+    : { name: roleRef.name };
+
+  return (
+    <Link routeName={roleClass.detailsRoute} activeCluster={binding.cluster} params={params}>
+      {label}
+    </Link>
+  );
+}
+
+/**
+ * Lists the RoleBindings and ClusterRoleBindings whose subjects reference this
+ * ServiceAccount, so the permissions granted to the account are discoverable from
+ * its detail page. Each row links to the binding and to its Role/ClusterRole.
+ */
+function ServiceAccountBindings(props: { serviceAccount: ServiceAccount }) {
+  const { serviceAccount } = props;
+  const { t } = useTranslation('glossary');
+  const name = serviceAccount.metadata.name;
+  const namespace = serviceAccount.metadata.namespace ?? '';
+
+  // Fetched cluster-wide (no namespace scope): a RoleBinding can live in any namespace while
+  // still referencing a ServiceAccount from another namespace via its subject, so scoping the
+  // list to the ServiceAccount's own namespace would miss cross-namespace RoleBindings.
+  const {
+    items: roleBindings,
+    isLoading: roleBindingsLoading,
+    isError: roleBindingsError,
+  } = RoleBinding.useList({
+    cluster: serviceAccount.cluster,
+  });
+  const {
+    items: clusterRoleBindings,
+    isLoading: clusterRoleBindingsLoading,
+    isError: clusterRoleBindingsError,
+  } = ClusterRoleBinding.useList({ cluster: serviceAccount.cluster });
+
+  const bindings = React.useMemo(() => {
+    const all = [...(roleBindings ?? []), ...(clusterRoleBindings ?? [])];
+    return all.filter(binding =>
+      binding.subjects?.some(
+        subject =>
+          subject.kind === 'ServiceAccount' &&
+          subject.name === name &&
+          // A subject that omits namespace implicitly refers to the binding's own namespace
+          // (Kubernetes semantics for RoleBindings). For ClusterRoleBindings,
+          // binding.metadata.namespace is undefined, so omitting namespace produces no match.
+          (subject.namespace ?? binding.metadata.namespace) === namespace
+      )
+    );
+  }, [roleBindings, clusterRoleBindings, name, namespace]);
+
+  const isLoading = roleBindingsLoading || clusterRoleBindingsLoading;
+  // Surface an error when we have no results to show and at least one of the list calls failed —
+  // useKubeObjectList returns items: [] on error, so an empty result after a failure could
+  // otherwise be misreported as "no bindings" when the listing was really just incomplete. If we
+  // do have any results (even partial/stale), prefer showing them rather than an error.
+  const hasError = (roleBindingsError || clusterRoleBindingsError) && bindings.length === 0;
+
+  // Show the loading state until both lists have finished their initial fetch, then render the
+  // (possibly empty) results. When a list errors with no results, pass null data alongside an
+  // errorMessage so the table surfaces an explicit "cannot list" state instead of a misleading
+  // empty message; partial results from a succeeding list stay visible.
+  const data = isLoading || hasError ? null : bindings;
+
+  return (
+    <SectionBox title={t('Role Bindings')}>
+      <SimpleTable
+        data={data}
+        emptyMessage={t('No role bindings reference this service account.')}
+        errorMessage={
+          hasError ? t('Unable to list the role bindings for this service account.') : undefined
+        }
+        columns={[
+          {
+            label: t('translation|Name'),
+            getter: (binding: RoleBinding | ClusterRoleBinding) => (
+              <Link kubeObject={binding}>{binding.metadata.name}</Link>
+            ),
+          },
+          {
+            label: t('Kind'),
+            getter: (binding: RoleBinding | ClusterRoleBinding) => binding.kind,
+          },
+          {
+            label: t('Role'),
+            getter: (binding: RoleBinding | ClusterRoleBinding) => (
+              <RoleRefLink binding={binding} />
+            ),
+          },
+          {
+            label: t('Namespace'),
+            getter: (binding: RoleBinding | ClusterRoleBinding) =>
+              binding.metadata.namespace || '-',
+          },
+        ]}
+        reflectInURL="roleBindings"
+      />
+    </SectionBox>
   );
 }
 
@@ -75,6 +203,14 @@ export default function ServiceAccountDetails(props: {
                 ? t('translation|Yes')
                 : t('translation|No'),
             hide: item.automountServiceAccountToken === undefined,
+          },
+        ]
+      }
+      extraSections={item =>
+        item && [
+          {
+            id: 'headlamp.serviceaccount-role-bindings',
+            section: <ServiceAccountBindings serviceAccount={item} />,
           },
         ]
       }

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.Empty.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.Empty.stories.storyshot
@@ -204,6 +204,63 @@
                   <h2
                     class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
                   >
+                    Role Bindings
+                  </h2>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              >
+                No role bindings reference this service account.
+              </div>
+              <div
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    No role bindings reference this service account.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h2 MuiTypography-noWrap css-m5vcfd-MuiTypography-root"
+                  >
                     Events
                   </h2>
                   <div

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.ListError.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.ListError.stories.storyshot
@@ -264,21 +264,15 @@
                 aria-live="polite"
                 class="MuiBox-root css-ty8jgw"
                 role="status"
-              >
-                No role bindings reference this service account.
-              </div>
+              />
               <div
-                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+                class="MuiBox-root css-19midj6"
               >
-                <div
-                  class="MuiBox-root css-19midj6"
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-9ldkza-MuiTypography-root"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
-                  >
-                    No role bindings reference this service account.
-                  </p>
-                </div>
+                  Unable to list the role bindings for this service account.
+                </p>
               </div>
             </div>
           </div>

--- a/frontend/src/components/serviceaccount/__snapshots__/Details.WithBindings.stories.storyshot
+++ b/frontend/src/components/serviceaccount/__snapshots__/Details.WithBindings.stories.storyshot
@@ -264,21 +264,187 @@
                 aria-live="polite"
                 class="MuiBox-root css-ty8jgw"
                 role="status"
-              >
-                No role bindings reference this service account.
-              </div>
+              />
               <div
-                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-1guobrs-MuiPaper-root"
+                class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+                tabindex="0"
               >
-                <div
-                  class="MuiBox-root css-19midj6"
+                <table
+                  class="MuiTable-root css-qzmaqi-MuiTable-root"
                 >
-                  <p
-                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  <thead
+                    class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
                   >
-                    No role bindings reference this service account.
-                  </p>
-                </div>
+                    <tr
+                      class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Name
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Kind
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Role
+                      </th>
+                      <th
+                        class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Namespace
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          demo-rb
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        RoleBinding
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          Role: demo-role
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        default
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          demo-rb-shared-role
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        RoleBinding
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          ClusterRole: demo-shared-clusterrole
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        default
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          demo-rb-cross-namespace
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        RoleBinding
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          Role: cross-namespace-role
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        other-ns
+                      </td>
+                    </tr>
+                    <tr
+                      class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          demo-crb
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        ClusterRoleBinding
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/"
+                        >
+                          ClusterRole: demo-clusterrole
+                        </a>
+                      </td>
+                      <td
+                        class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+                      >
+                        -
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>

--- a/frontend/src/components/serviceaccount/storyHelper.ts
+++ b/frontend/src/components/serviceaccount/storyHelper.ts
@@ -16,6 +16,43 @@
 
 import { KubeServiceAccount } from '../../lib/k8s/serviceAccount';
 
+export const BASE_SERVICE_ACCOUNT: KubeServiceAccount = {
+  apiVersion: 'v1',
+  kind: 'ServiceAccount',
+  metadata: {
+    creationTimestamp: '2023-04-27T20:31:27Z',
+    name: 'my-sa',
+    namespace: 'default',
+    resourceVersion: '1234',
+    uid: 'abc-1234',
+  },
+  secrets: [
+    {
+      apiVersion: 'v1',
+      fieldPath: '',
+      kind: 'Secret',
+      name: 'my-sa-token',
+      namespace: 'default',
+      uid: 'secret-uid-1234',
+    },
+  ],
+  imagePullSecrets: [{ name: 'my-registry-secret' }],
+  automountServiceAccountToken: true,
+};
+
+export const BASE_EMPTY_SERVICE_ACCOUNT: KubeServiceAccount = {
+  apiVersion: 'v1',
+  kind: 'ServiceAccount',
+  metadata: {
+    creationTimestamp: '2023-04-27T20:31:27Z',
+    name: 'my-sa',
+    namespace: 'default',
+    resourceVersion: '1234',
+    uid: 'abc-1234',
+  },
+  secrets: [],
+};
+
 const creationTimestamp = new Date('2022-01-01').toISOString();
 
 export const SERVICE_ACCOUNT_DUMMY_DATA: KubeServiceAccount[] = [

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "الخدمات",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "خريطة",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "নোড পোর্ট",
   "App Protocol": "অ্যাপ প্রোটোকল",
   "Services": "সার্ভিস",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "ইমেজ পুল সিক্রেট",
   "Automount Service Account Token": "সার্ভিস অ্যাকাউন্ট টোকেন স্বয়ংক্রিয় মাউন্ট",
   "Map": "মানচিত্র",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Dienste",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "Node Port",
   "App Protocol": "App Protocol",
   "Services": "Services",
+  "No role bindings reference this service account.": "No role bindings reference this service account.",
+  "Unable to list the role bindings for this service account.": "Unable to list the role bindings for this service account.",
   "Image Pull Secrets": "Image Pull Secrets",
   "Automount Service Account Token": "Automount Service Account Token",
   "Map": "Map",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Services",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Services",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "Carte",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Services",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "Map",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "सर्विसेज",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "मैप",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Servizi",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "Mappa",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "サービス",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "マップ",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "서비스",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "맵",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Services",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Сервисы",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "Карта",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "சேவைகள்",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "வரைபடம்",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "خدمات",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "میپ",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "服務",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "地圖",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -234,6 +234,8 @@
   "Node Port": "",
   "App Protocol": "",
   "Services": "Services",
+  "No role bindings reference this service account.": "",
+  "Unable to list the role bindings for this service account.": "",
   "Image Pull Secrets": "",
   "Automount Service Account Token": "",
   "Map": "资源全景图",


### PR DESCRIPTION
## Summary

The ServiceAccount detail page currently shows no information about the permissions granted to the account. Headlamp already surfaces the *inverse* direction, a RoleBinding's detail page lists its subjects and `roleRef`, and Role pages show their rules, but there was no way, from a ServiceAccount, to discover which RoleBindings/ClusterRoleBindings reference it. Today, a user has to open every binding and scan its subjects, across namespaces, to answer "what can this ServiceAccount do?".

This PR adds a **Role Bindings** section to the ServiceAccount detail page that lists the **RoleBindings** and **ClusterRoleBindings** whose subjects reference the account, each row linking to the binding and to its Role/ClusterRole.

## Related Issue

Closes #3761

## Changes

- **`frontend/src/components/serviceaccount/Details.tsx`**

  - Added a `ServiceAccountBindings` section, rendered via `DetailsGrid`'s `extraSections`, that lists `RoleBindings` (fetched cluster-wide across all namespaces, so cross-namespace subjects aren't missed) and `ClusterRoleBindings` whose subjects reference this ServiceAccount.
  - Each row links to the binding (`Link` with `kubeObject`) and to its `Role`/`ClusterRole` (`roleRef`), reusing the existing binding/role routes.
  - Distinguishes loading, empty, and error states: a loader until both lists settle, an empty message ("No role bindings reference this service account.") when neither list references the account, and an explicit error ("Unable to list the role bindings for this service account.") when at least one of the `RoleBinding` / `ClusterRoleBinding` list calls fails (e.g. insufficient RBAC) and there are no results to show — so an incomplete listing is never silently misreported as "no bindings", while partial results from a succeeding list stay visible.
- **`frontend/src/components/serviceaccount/Details.stories.tsx`** (new)

  - `WithBindings` — a matching RoleBinding and ClusterRoleBinding are shown; an unrelated RoleBinding (different subject) is filtered out.
  - `WithBase` / `Empty` — empty-state message.
  - `ListError` — both list calls fail, so the explicit "Unable to list…" error state is shown.
- **`frontend/src/components/serviceaccount/__snapshots__/`** — storyshot snapshots for the stories.
- **`frontend/src/i18n/locales/*/glossary.json`** — registered the one new translation key.

## Screen Recording

The attached recording walks through:

1. Start on **Service Accounts → `default/demo`** — the new **Role Bindings** section shows `demo-rb`.
2. Click **`demo-rb`** → navigates to the RoleBinding detail page (binding link works).
3. Back, click **`Role: demo-role`** → lands on the Role detail showing its rules (role link works).
4. In a side terminal, add a second namespaced binding **and** a cluster-scoped one, then refresh the page so the new rows appear live, demonstrating multiple bindings and the ClusterRoleBinding path (note the `—` namespace for the cluster-scoped row):

   ```bash
   # second namespaced RoleBinding
   kubectl create role demo-role-2 --verb=get --resource=configmaps -n default
   kubectl create rolebinding demo-rb-2 --role=demo-role-2 --serviceaccount=default:demo -n default

   # cluster-scoped ClusterRoleBinding
   kubectl create clusterrole demo-clusterrole --verb=get,list --resource=nodes
   kubectl create clusterrolebinding demo-crb --clusterrole=demo-clusterrole --serviceaccount=default:demo
   ```
6. Click **`demo-crb`** → **`ClusterRole: demo-clusterrole`** to show the cluster-scoped links navigate too.
7. Open a different ServiceAccount with no bindings → the **No role bindings reference this service account.** empty state.


https://github.com/user-attachments/assets/e9941fe2-fb33-40c5-8896-4f284ab8e42f



## Steps to Test

1. `cd frontend && npm install && npm start` (and run the backend / use the desktop app) against a cluster (e.g. `kind`).
2. Create a ServiceAccount with a namespaced binding:

   ```bash
   kubectl create serviceaccount demo -n default
   kubectl create role demo-role --verb=get,list --resource=pods -n default
   kubectl create rolebinding demo-rb --role=demo-role --serviceaccount=default:demo -n default
   ```
4. (Optional, to exercise the ClusterRoleBinding path) add a cluster-scoped binding:

   ```bash
   kubectl create clusterrole demo-clusterrole --verb=get,list --resource=nodes
   kubectl create clusterrolebinding demo-crb --clusterrole=demo-clusterrole --serviceaccount=default:demo
   ```
6. Navigate to **Service Accounts → `default / demo`**. Verify a **Role Bindings** section appears listing `demo-rb` (Role: demo-role) and, if created, `demo-crb` (ClusterRole: demo-clusterrole).
7. Click the binding name → lands on the RoleBinding/ClusterRoleBinding detail page. Click the role → lands on the Role/ClusterRole detail page.
8. **Filtering:** create a binding for a *different* SA in the same namespace and confirm it does **not** appear on `demo`'s page.
9. **Empty state:** open a ServiceAccount with no bindings → the section shows "No role bindings reference this service account.".

## Notes for the Reviewer

- Opening this as a proposal off the back of #3761, @jcpunk confirmed it covers the use case. Very open to feedback on placement/approach.
- The section is a self-contained frontend change, no backend changes. It reuses `RoleBinding`/`ClusterRoleBinding` (`useList`) and the existing detail routes.
- A binding matches when a subject has `kind: ServiceAccount` and the same `name` + `namespace` as the account.
- `ClusterRoleBinding.useList()` is cluster-scoped; the section omits the role link (renders plain text) if a `roleRef` kind has no registered resource class. If a list call fails (e.g. the user lacks permission to list bindings) and there are no results to show, it surfaces an explicit error state rather than a misleading empty message; if the other list still returned matches, those partial results are shown instead.