### PR TITLE
frontend: util: Fix react-hooks/purity — replace Math.random() with useId

### DIFF
--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -561,11 +561,11 @@ export function normalizeUnit(resourceType: string, quantity: string) {
  * If UNDER_TEST is set to true, it will return the same ID every time, so snapshots do not get invalidated.
  */
 export function useId(prefix = '') {
-  const [id] = React.useState<string | undefined>(() =>
-    import.meta.env.UNDER_TEST ? prefix + 'id' : prefix + Math.random().toString(16).slice(2)
-  );
-
-  return id;
+  const reactId = React.useId();
+  if (import.meta.env.UNDER_TEST) {
+    return prefix + 'id';
+  }
+  return prefix + reactId.replace(/:/g, '');
 }
 
 // Make units available from here


### PR DESCRIPTION
## Summary
Fixes the react-hooks/purity violation in frontend/src/lib/util.ts where Math.random() was called during render inside a React.useState initializer. Replaced with React 18's built-in React.useId().

## Related Issue
Fixes #6038 
Part of umbrella issue #5183

## Changes
- Replaced Math.random() with React.useId() in the useId() function in frontend/src/lib/util.ts

## Steps to Test
1. Run `cd frontend && npm run lint`
2. Confirm no react-hooks/purity violation in util.ts

## Notes for the Reviewer
Only frontend/src/lib/util.ts is modified. The UNDER_TEST behaviour is fully preserved so existing snapshots are not affected.