### PR TITLE
frontend: Add tests for Lease, RuntimeClass and StorageClass components

### DIFF
--- a/frontend/src/components/lease/Details.test.tsx
+++ b/frontend/src/components/lease/Details.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { LeaseDetails } from './Details';
+import { LEASE_DUMMY_DATA } from './storyHelper';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/lease', () => ({
+  Lease: { kind: 'Lease' },
+}));
+
+vi.mock('../common/Label', () => ({
+  DateLabel: () => null,
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+}));
+
+const lease = LEASE_DUMMY_DATA[0] as any;
+
+describe('LeaseDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes the Lease resource type and route params to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'lease' }}>
+        <LeaseDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.name).toBe('lease');
+    expect(props.namespace).toBe('default');
+    expect(props.withEvents).toBe(true);
+  });
+
+  it('builds extraInfo from the lease spec', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'lease' }}>
+        <LeaseDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const extraInfo = props.extraInfo(lease);
+    const byName = Object.fromEntries(extraInfo.map((f: any) => [f.name, f.value]));
+
+    expect(byName['Holder Identity']).toBe('holder');
+    expect(byName['Lease Duration Seconds']).toBe(10);
+    expect(byName['Renew Time']).toBeDefined();
+  });
+
+  it('returns nothing from extraInfo when there is no item', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'lease' }}>
+        <LeaseDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.extraInfo(null)).toBeFalsy();
+  });
+});

--- a/frontend/src/components/lease/List.test.tsx
+++ b/frontend/src/components/lease/List.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { LeaseList } from './List';
+import { LEASE_DUMMY_DATA } from './storyHelper';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/lease', () => ({
+  Lease: { kind: 'Lease' },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+describe('LeaseList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders with the Lease resource class and the expected columns', () => {
+    render(
+      <TestContext>
+        <LeaseList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toEqual(['name', 'namespace', 'cluster', 'holder', 'labels', 'age']);
+  });
+
+  it('reads the holder column value from the lease spec', () => {
+    render(
+      <TestContext>
+        <LeaseList />
+      </TestContext>
+    );
+
+    const props = mockListView.mock.calls[0][0];
+    const holder = props.columns.find((c: any) => c?.id === 'holder');
+    expect(holder.getValue(LEASE_DUMMY_DATA[0])).toBe('holder');
+  });
+});

--- a/frontend/src/components/runtimeClass/Details.test.tsx
+++ b/frontend/src/components/runtimeClass/Details.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { RuntimeClassDetails } from './Details';
+import { RUNTIME_CLASS_DUMMY_DATA } from './storyHelper';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/runtime', () => ({
+  RuntimeClass: { kind: 'RuntimeClass' },
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+}));
+
+const runtimeClass = { jsonData: RUNTIME_CLASS_DUMMY_DATA[0] } as any;
+
+describe('RuntimeClassDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes the route name and withEvents to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ name: 'runtime-class' }}>
+        <RuntimeClassDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.name).toBe('runtime-class');
+    expect(props.withEvents).toBe(true);
+  });
+
+  it('exposes the handler in extraInfo', () => {
+    render(
+      <TestContext routerMap={{ name: 'runtime-class' }}>
+        <RuntimeClassDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const extraInfo = props.extraInfo(runtimeClass);
+    expect(extraInfo).toHaveLength(1);
+    expect(extraInfo[0].name).toContain('Handler');
+    expect(extraInfo[0].value).toBe('handler');
+  });
+
+  it('returns nothing from extraInfo when there is no item', () => {
+    render(
+      <TestContext routerMap={{ name: 'runtime-class' }}>
+        <RuntimeClassDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.extraInfo(null)).toBeFalsy();
+  });
+});

--- a/frontend/src/components/runtimeClass/List.test.tsx
+++ b/frontend/src/components/runtimeClass/List.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { RuntimeClassList } from './List';
+import { RUNTIME_CLASS_DUMMY_DATA } from './storyHelper';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/runtime', () => ({
+  RuntimeClass: { kind: 'RuntimeClass' },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+describe('RuntimeClassList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the expected columns', () => {
+    render(
+      <TestContext>
+        <RuntimeClassList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toEqual(['name', 'cluster', 'handler', 'labels', 'age']);
+  });
+
+  it('reads the handler column value from jsonData', () => {
+    render(
+      <TestContext>
+        <RuntimeClassList />
+      </TestContext>
+    );
+
+    const props = mockListView.mock.calls[0][0];
+    const handler = props.columns.find((c: any) => c?.id === 'handler');
+    expect(handler.getValue({ jsonData: RUNTIME_CLASS_DUMMY_DATA[0] })).toBe('handler');
+  });
+});

--- a/frontend/src/components/storage/ClassDetails.test.tsx
+++ b/frontend/src/components/storage/ClassDetails.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import StorageClassDetails from './ClassDetails';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/storageClass', () => ({
+  default: { kind: 'StorageClass' },
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+  MetadataDictGrid: () => null,
+}));
+
+const storageClass = {
+  provisioner: 'csi.test',
+  reclaimPolicy: 'Delete',
+  volumeBindingMode: 'Immediate',
+  isDefault: true,
+  allowVolumeExpansion: true,
+  parameters: { type: 'gp2' },
+  mountOptions: ['noatime'],
+} as any;
+
+describe('StorageClassDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes the route name and withEvents to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ name: 'standard' }}>
+        <StorageClassDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.name).toBe('standard');
+    expect(props.withEvents).toBe(true);
+  });
+
+  it('maps the storage class fields into extraInfo', () => {
+    render(
+      <TestContext routerMap={{ name: 'standard' }}>
+        <StorageClassDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const byName = Object.fromEntries(props.extraInfo(storageClass).map((f: any) => [f.name, f]));
+
+    expect(byName['Provisioner'].value).toBe('csi.test');
+    expect(byName['Reclaim Policy'].value).toBe('Delete');
+    expect(byName['Binding Mode'].value).toBe('Immediate');
+    expect(byName['Default'].value).toContain('Yes');
+    expect(byName['Allow Volume Expansion'].value).toContain('Yes');
+  });
+
+  it('hides Parameters and Mount Options when empty', () => {
+    const bare = {
+      ...storageClass,
+      allowVolumeExpansion: undefined,
+      parameters: {},
+      mountOptions: [],
+    };
+
+    render(
+      <TestContext routerMap={{ name: 'standard' }}>
+        <StorageClassDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const byName = Object.fromEntries(props.extraInfo(bare).map((f: any) => [f.name, f]));
+
+    expect(byName['Allow Volume Expansion'].hide).toBe(true);
+    expect(byName['Parameters'].hide).toBe(true);
+    expect(byName['Mount Options'].hide).toBeTruthy();
+  });
+});

--- a/frontend/src/components/storage/ClassList.test.tsx
+++ b/frontend/src/components/storage/ClassList.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import ClassList from './ClassList';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/storageClass', () => ({
+  default: { kind: 'StorageClass' },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+function getColumn(id: string) {
+  const props = mockListView.mock.calls[0][0];
+  return props.columns.find((c: any) => c?.id === id);
+}
+
+describe('ClassList (StorageClass)', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders without a namespace filter and with the expected columns', () => {
+    render(
+      <TestContext>
+        <ClassList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    expect(props.headerProps.noNamespaceFilter).toBe(true);
+
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toEqual([
+      'name',
+      'provisioner',
+      'default',
+      'reclaimPolicy',
+      'volumeBindingMode',
+      'allowVolumeExpansion',
+      'labels',
+      'age',
+    ]);
+  });
+
+  it('reads provisioner and reclaim policy values from the storage class', () => {
+    render(
+      <TestContext>
+        <ClassList />
+      </TestContext>
+    );
+
+    const sc = { provisioner: 'csi.test', reclaimPolicy: 'Delete' } as any;
+    expect(getColumn('provisioner').getValue(sc)).toBe('csi.test');
+    expect(getColumn('reclaimPolicy').getValue(sc)).toBe('Delete');
+  });
+
+  it('renders the default column only when the class is the default', () => {
+    render(
+      <TestContext>
+        <ClassList />
+      </TestContext>
+    );
+
+    const defaultCol = getColumn('default');
+    expect(defaultCol.getValue({ isDefault: true } as any)).toBe('true');
+    expect(defaultCol.render({ isDefault: true } as any)).toBe('Yes');
+    expect(defaultCol.render({ isDefault: false } as any)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds test coverage for the Lease, RuntimeClass and StorageClass resource components, which previously had no test files. Each component is a thin wrapper around `ResourceListView` / `DetailsGrid`, so the tests assert the resource-specific configuration (columns and `extraInfo`) that each component declares.

## Related Issue

No related issue — fills test-coverage gaps for previously untested components.

## Changes

* Added `List.test.tsx` and `Details.test.tsx` for `lease/`
* Added `List.test.tsx` and `Details.test.tsx` for `runtimeClass/`
* Added `ClassList.test.tsx` and `ClassDetails.test.tsx` for `storage/` (StorageClass)
* Tests follow the existing `job/Details.test.tsx` pattern (mock `DetailsGrid` / `ResourceListView`, capture the props passed, assert the columns and `extraInfo`)
* Reused existing `storyHelper` mock data instead of duplicating fixtures

## Steps to Test

1. Run:

   ```bash
   cd frontend && npm test -- src/components/lease src/components/runtimeClass src/components/storage/Class
   ```
2. Verify all 16 tests pass
3. Optionally run:

   ```bash
   npm run lint
   npm run format-check
   ```

   Both should pass cleanly

## Screenshots (if applicable)

<img width="733" height="397" alt="image" src="https://github.com/user-attachments/assets/83dba3c7-a5a4-4e09-8962-4802ea1998d4" />


## Notes for the Reviewer

* These are configuration-level tests: they verify the columns and `extraInfo` each component declares (via mocked `DetailsGrid` / `ResourceListView`), not full DOM rendering
* This approach matches the existing `job/Details.test.tsx` pattern
* No production code changes — test-only PR
* Mock data is reused from existing `storyHelper.ts` files
