### PR TITLE
Feature/remove pkg errors

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/schema v1.4.1
 	github.com/knadh/koanf v1.5.0
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0

--- a/backend/pkg/kubeconfig/file.go
+++ b/backend/pkg/kubeconfig/file.go
@@ -1,11 +1,12 @@
 package kubeconfig
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -22,7 +23,7 @@ func WriteToFile(config clientcmdapi.Config, path string) error {
 
 		err = clientcmd.WriteToFile(config, newKubeConfigFile)
 		if err != nil {
-			return errors.Wrap(err, "failed to write new kubeconfig file")
+			return fmt.Errorf("failed to write new kubeconfig file: %w", err)
 		}
 
 		defer func() { _ = os.Remove(newKubeConfigFile) }()
@@ -33,7 +34,7 @@ func WriteToFile(config clientcmdapi.Config, path string) error {
 
 		mergedConfig, err := load.Load()
 		if err != nil {
-			return errors.Wrap(err, "failed to load merged kubeconfig")
+			return fmt.Errorf("failed to load merged kubeconfig: %w", err)
 		}
 
 		config = *mergedConfig
@@ -47,7 +48,7 @@ func WriteToFile(config clientcmdapi.Config, path string) error {
 func RemoveContextFromFile(context string, path string) error {
 	config, err := clientcmd.LoadFromFile(path)
 	if err != nil {
-		return errors.Wrap(err, "failed to load kubeconfig file")
+		return fmt.Errorf("failed to load kubeconfig file: %w", err)
 	}
 
 	// remove the context from the config

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -3,6 +3,7 @@ package kubeconfig_test
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
## Summary

This PR cleans up the backend by replacing the direct usage of the deprecated third-party `github.com/pkg/errors` library. Since Go 1.13 introduced native error wrapping, this direct external dependency is no longer needed. The PR replaces it with Go's standard library `errors` package and `fmt.Errorf` with the `%w` verb.

## Related Issue

N/A

## Changes

- Replaced direct usage of `github.com/pkg/errors` with the standard library. Note: The package remains in `go.mod` as an `// indirect` dependency because it is transitively required by Helm (`helm.sh/helm/v3/pkg/action`).
- Refactored `backend/pkg/kubeconfig/file.go` to use standard `fmt.Errorf("...: %w", err)` for error wrapping
- Refactored `backend/pkg/kubeconfig/kubeconfig_test.go` to use the standard library's `errors.New()`
- Fixed standard library import grouping per `goimports` standard to resolve linter warnings.

## Steps to Test

1. Navigate to the `backend` directory
2. Run the test suite for the modified package: `go test ./pkg/kubeconfig/...`
3. Observe that all tests pass successfully without the deprecated library being directly used.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- I noticed `github.com/pkg/errors` was only being used directly in exactly two files in the `kubeconfig` package, so this is a very small, safe, and backwards-compatible refactor.
