### PR TITLE
frontend: Add tests for PriorityClass, PodDisruptionBudget and HPA components

### DIFF
--- a/frontend/src/components/horizontalPodAutoscaler/Details.test.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/Details.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import HpaDetails from './Details';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/hpa', () => ({
+  default: { kind: 'HorizontalPodAutoscaler' },
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => children,
+}));
+
+vi.mock('../common/SimpleTable', () => ({
+  default: () => null,
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+  ConditionsSection: () => null,
+}));
+
+const hpa = {
+  referenceObject: { kind: 'Deployment', metadata: { name: 'web' } },
+  metrics: () => [{ definition: 'cpu', value: '50%/80%' }],
+  spec: { minReplicas: 1, maxReplicas: 5 },
+  status: { currentReplicas: 2, desiredReplicas: 3, lastScaleTime: undefined },
+  jsonData: {},
+} as any;
+
+describe('HpaDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes the route params and withEvents to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-hpa' }}>
+        <HpaDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.name).toBe('my-hpa');
+    expect(props.namespace).toBe('default');
+    expect(props.withEvents).toBe(true);
+  });
+
+  it('exposes the min/max replicas in extraInfo', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-hpa' }}>
+        <HpaDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const byName = Object.fromEntries(
+      props.extraInfo(hpa).map((f: any) => [String(f.name).split('|').pop(), f.value])
+    );
+
+    expect(byName['MinReplicas']).toBe(1);
+    expect(byName['MaxReplicas']).toBe(5);
+  });
+
+  it('hides the Last Scale Time row when there is no scale time', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-hpa' }}>
+        <HpaDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const lastScale = props.extraInfo(hpa).find((f: any) => f.name.includes('Last Scale Time'));
+    expect(lastScale.hide).toBe(true);
+  });
+});

--- a/frontend/src/components/horizontalPodAutoscaler/List.test.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/List.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import HpaList from './List';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/hpa', () => ({
+  default: { kind: 'HorizontalPodAutoscaler' },
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => children,
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+function getColumn(id: string) {
+  const props = mockListView.mock.calls[0][0];
+  return props.columns.find((c: any) => c?.id === id);
+}
+
+const hpa = {
+  referenceObject: { kind: 'Deployment', metadata: { name: 'web' } },
+  metrics: () => [{ shortValue: '50%/80%' }, { shortValue: '10/20' }],
+  spec: { minReplicas: 1, maxReplicas: 5 },
+  status: { currentReplicas: 2 },
+} as any;
+
+describe('HpaList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the expected columns', () => {
+    render(
+      <TestContext>
+        <HpaList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toEqual([
+      'name',
+      'namespace',
+      'cluster',
+      'reference',
+      'targets',
+      'minReplicas',
+      'maxReplicas',
+      'currentReplicas',
+      'labels',
+      'age',
+    ]);
+  });
+
+  it('reads reference, replicas and joined target values from the item', () => {
+    render(
+      <TestContext>
+        <HpaList />
+      </TestContext>
+    );
+
+    expect(getColumn('reference').getValue(hpa)).toBe('web');
+    expect(getColumn('minReplicas').getValue(hpa)).toBe(1);
+    expect(getColumn('maxReplicas').getValue(hpa)).toBe(5);
+    expect(getColumn('currentReplicas').getValue(hpa)).toBe(2);
+    expect(getColumn('targets').getValue(hpa)).toBe('50%/80%, 10/20');
+  });
+});

--- a/frontend/src/components/podDisruptionBudget/Details.test.tsx
+++ b/frontend/src/components/podDisruptionBudget/Details.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import PDBDetails from './Details';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/podDisruptionBudget', () => ({
+  default: { kind: 'PodDisruptionBudget' },
+}));
+
+vi.mock('../common/Label', () => ({
+  StatusLabel: ({ children }: any) => children,
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+}));
+
+const pdb = {
+  spec: { minAvailable: 2, maxUnavailable: 1 },
+  selectors: ['app=nginx'],
+  status: {
+    disruptionsAllowed: 3,
+    currentHealthy: 4,
+    desiredHealthy: 4,
+    expectedPods: 5,
+  },
+} as any;
+
+describe('PDBDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes the route params and withEvents to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-pdb' }}>
+        <PDBDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.name).toBe('my-pdb');
+    expect(props.namespace).toBe('default');
+    expect(props.withEvents).toBe(true);
+  });
+
+  it('includes the min/max, selector and status rows in extraInfo', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-pdb' }}>
+        <PDBDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const names = props.extraInfo(pdb).map((f: any) => String(f.name).split('|').pop());
+
+    expect(names).toContain('Max Unavailable');
+    expect(names).toContain('Min Available');
+    expect(names).toContain('Selector');
+    expect(names).toContain('Status');
+  });
+
+  it('returns nothing from extraInfo when there is no item', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-pdb' }}>
+        <PDBDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.extraInfo(null)).toBeFalsy();
+  });
+});

--- a/frontend/src/components/podDisruptionBudget/List.test.tsx
+++ b/frontend/src/components/podDisruptionBudget/List.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import PDBList from './List';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/podDisruptionBudget', () => ({
+  default: { kind: 'PodDisruptionBudget' },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+function getColumn(id: string) {
+  const props = mockListView.mock.calls[0][0];
+  return props.columns.find((c: any) => c?.id === id);
+}
+
+describe('PDBList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the expected columns', () => {
+    render(
+      <TestContext>
+        <PDBList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toEqual([
+      'name',
+      'namespace',
+      'cluster',
+      'minAvailable',
+      'maxUnavailable',
+      'allowedDisruptions',
+      'labels',
+      'age',
+    ]);
+  });
+
+  it('reads min/max and allowed disruptions from the item', () => {
+    render(
+      <TestContext>
+        <PDBList />
+      </TestContext>
+    );
+
+    const pdb = {
+      spec: { minAvailable: 2, maxUnavailable: 1 },
+      status: { disruptionsAllowed: 3 },
+    } as any;
+
+    expect(getColumn('minAvailable').getValue(pdb)).toBe(2);
+    expect(getColumn('maxUnavailable').getValue(pdb)).toBe(1);
+    expect(getColumn('allowedDisruptions').getValue(pdb)).toBe(3);
+  });
+
+  it('falls back to N/A when fields are missing', () => {
+    render(
+      <TestContext>
+        <PDBList />
+      </TestContext>
+    );
+
+    const empty = { spec: {}, status: {} } as any;
+    expect(getColumn('minAvailable').getValue(empty)).toContain('N/A');
+    expect(getColumn('allowedDisruptions').getValue(empty)).toContain('N/A');
+  });
+});

--- a/frontend/src/components/priorityClass/Details.test.tsx
+++ b/frontend/src/components/priorityClass/Details.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import PriorityClassDetails from './Details';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/priorityClass', () => ({
+  default: { kind: 'PriorityClass' },
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+}));
+
+const priorityClass = {
+  value: 1000000,
+  globalDefault: true,
+  preemptionPolicy: 'PreemptLowerPriority',
+  description: 'Mission Critical apps.',
+} as any;
+
+describe('PriorityClassDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes the route name and withEvents to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ name: 'high-priority-apps' }}>
+        <PriorityClassDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.name).toBe('high-priority-apps');
+    expect(props.withEvents).toBe(true);
+  });
+
+  it('maps the priority class fields into extraInfo', () => {
+    render(
+      <TestContext routerMap={{ name: 'high-priority-apps' }}>
+        <PriorityClassDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const byName = Object.fromEntries(
+      props.extraInfo(priorityClass).map((f: any) => [String(f.name).split('|').pop(), f.value])
+    );
+
+    expect(byName['Value']).toBe(1000000);
+    expect(byName['Global Default']).toBe(true);
+    expect(byName['Preemption Policy']).toBe('PreemptLowerPriority');
+    expect(byName['Description']).toBe('Mission Critical apps.');
+  });
+
+  it('falls back to False when globalDefault is unset', () => {
+    render(
+      <TestContext routerMap={{ name: 'high-priority-apps' }}>
+        <PriorityClassDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const extraInfo = props.extraInfo({ ...priorityClass, globalDefault: false });
+    const globalDefault = extraInfo.find((f: any) => f.name.includes('Global Default'));
+    expect(globalDefault.value).toBe('False');
+  });
+});

--- a/frontend/src/components/priorityClass/List.test.tsx
+++ b/frontend/src/components/priorityClass/List.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import PriorityClassList from './List';
+
+const { mockListView } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/priorityClass', () => ({
+  default: { kind: 'PriorityClass' },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+describe('PriorityClassList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+  });
+
+  it('renders the expected columns', () => {
+    render(
+      <TestContext>
+        <PriorityClassList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toEqual(['name', 'cluster', 'value', 'globalDefault', 'labels', 'age']);
+  });
+
+  it('reads the value and global default columns from the item', () => {
+    render(
+      <TestContext>
+        <PriorityClassList />
+      </TestContext>
+    );
+
+    const props = mockListView.mock.calls[0][0];
+    const value = props.columns.find((c: any) => c?.id === 'value');
+    const globalDefault = props.columns.find((c: any) => c?.id === 'globalDefault');
+
+    expect(value.getValue({ value: 1000000 })).toBe(1000000);
+    expect(globalDefault.getValue({ globalDefault: true })).toBe('true');
+    expect(globalDefault.getValue({ globalDefault: false })).toBe('False');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds test coverage for the PriorityClass, PodDisruptionBudget and HorizontalPodAutoscaler resource components, which previously had no test files. Each component is a thin wrapper around `ResourceListView` / `DetailsGrid`, so the tests assert the resource-specific configuration (columns and `extraInfo`) that each component declares, including fallback branches like "N/A", the `globalDefault` default, and the hidden "Last Scale Time" row.

## Related Issue

No related issue — fills test-coverage gaps for previously untested components.

## Changes

- Added `List.test.tsx` and `Details.test.tsx` for `priorityClass/`
- Added `List.test.tsx` and `Details.test.tsx` for `podDisruptionBudget/`
- Added `List.test.tsx` and `Details.test.tsx` for `horizontalPodAutoscaler/`
- Tests follow the existing `job/Details.test.tsx` pattern (mock `DetailsGrid` / `ResourceListView`, capture the props passed, assert the columns and `extraInfo`)

## Steps to Test

1. Run `cd frontend && npm test -- src/components/priorityClass src/components/podDisruptionBudget src/components/horizontalPodAutoscaler`
2. Observe all 16 tests pass.
3. Optionally run `npm run lint` and `npm run format-check` — both pass clean.

## Screenshots (if applicable)


## Notes for the Reviewer

- These are configuration-level tests: they verify the columns and `extraInfo` each component declares (via the mocked `DetailsGrid` / `ResourceListView`), not full DOM rendering. This matches the existing `job/Details.test.tsx` approach.
- No production code is changed — these are pure test additions.
