### PR TITLE
backend: k8cache: add unit test for returnGVRList

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation_internal_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_internal_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestReturnGVRList(t *testing.T) {
+	apiResourceLists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:  "pods",
+					Kind:  "Pod",
+					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+				},
+				{
+					Name:  "events",
+					Kind:  "Event", // skipped: Kind in skipKinds
+					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+				},
+				{
+					Name:  "pods/status", // skipped: name contains "/"
+					Kind:  "Pod",
+					Verbs: metav1.Verbs{"get", "patch", "update"},
+				},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:  "deployments",
+					Kind:  "Deployment",
+					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+				},
+				{
+					Name:  "replicasets",
+					Kind:  "ReplicaSet",
+					Verbs: metav1.Verbs{"create", "delete", "get", "patch", "update"}, // skipped: missing list and watch
+				},
+			},
+		},
+		{
+			GroupVersion: "coordination.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:  "leases",
+					Kind:  "Lease", // skipped: Kind in skipKinds
+					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+				},
+			},
+		},
+		{
+			GroupVersion: "invalid/group/version", // skipped: ParseGroupVersion fails
+			APIResources: []metav1.APIResource{
+				{
+					Name:  "foos",
+					Kind:  "Foo",
+					Verbs: metav1.Verbs{"list", "watch"},
+				},
+			},
+		},
+	}
+
+	expected := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "pods"},
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+	}
+
+	result := returnGVRList(apiResourceLists)
+	assert.ElementsMatch(t, expected, result)
+}


### PR DESCRIPTION
## Summary

Adds a unit test for the previously untested `returnGVRList` function in
`pkg/k8cache/cacheInvalidation.go`.

Fixes #6046 

## Changes

- **Added** `backend/pkg/k8cache/cacheInvalidation_internal_test.go`
  - Uses `package k8cache` (internal test package) to access the unexported
    `returnGVRList` function without modifying its visibility
  - `TestReturnGVRList` covers all five filtering branches of the function

## Why a separate file?

The existing `cacheInvalidation_test.go` uses `package k8cache_test` (external
black-box testing), which cannot access unexported symbols. Go requires that
internal (`package k8cache`) and external (`package k8cache_test`) tests live in
separate files. Creating `cacheInvalidation_internal_test.go` is the idiomatic
Go convention for white-box tests of unexported functions.

## Test cases covered

| Scenario | Expected outcome |
|---|---|
| Resource with `list` + `watch` verbs (`pods`, `deployments`) | Included in GVR list |
| Subresource with `/` in name (`pods/status`) | Skipped |
| `Event` kind | Skipped |
| `Lease` kind | Skipped |
| Resource missing `list`/`watch` verbs (`replicasets`) | Skipped |

## Coverage impact

| Function | Before | After |
|---|---|---|
| `returnGVRList` | 0.0% | 91.7% |
| `pkg/k8cache` total | 75.8% | 78.7% |

## Steps to Test

1. `cd backend && go test -v ./pkg/k8cache -run TestReturnGVRList`
2. `npm run backend:coverage` — verify `returnGVRList` is no longer at 0%

## Notes for the Reviewer

No production code was changed. The test is purely additive and requires no
mocks or external dependencies — it calls `returnGVRList` directly with a
hand-crafted `[]*metav1.APIResourceList` and asserts the returned GVR slice.

### Screenshot

this is from my loacl machine when I did the npm run backend:coverage
<img width="1539" height="66" alt="image" src="https://github.com/user-attachments/assets/be0b0b1c-41b5-4ba7-af6b-5ce2407070ec" />
 