### PR TITLE
charts: add appProtocol support to Service

### DIFF
--- a/charts/headlamp/templates/service.yaml
+++ b/charts/headlamp/templates/service.yaml
@@ -27,6 +27,9 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+      {{- if .Values.service.appProtocol }}
+      appProtocol: {{ .Values.service.appProtocol | quote }}
+      {{- end }}
       name: http
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}

--- a/charts/headlamp/tests/expected_templates/service-appprotocol.yaml
+++ b/charts/headlamp/tests/expected_templates/service-appprotocol.yaml
@@ -1,0 +1,143 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      appProtocol: "kubernetes.io/ws"
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.42.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.42.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.42.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}

--- a/charts/headlamp/tests/test_cases/service-appprotocol.yaml
+++ b/charts/headlamp/tests/test_cases/service-appprotocol.yaml
@@ -1,0 +1,2 @@
+service:
+  appProtocol: kubernetes.io/ws

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -398,6 +398,10 @@
           "type": "integer",
           "description": "Kubernetes Service port"
         },
+        "appProtocol": {
+          "type": ["string", "null"],
+          "description": "Kubernetes Service port appProtocol (for the main http port)"
+        },
         "clusterIP": {
           "type": "string",
           "description": "Kubernetes Service clusterIP"

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -251,6 +251,8 @@ service:
   type: ClusterIP
   # -- Kubernetes Service port
   port: 80
+  # -- Kubernetes Service port appProtocol (for the main http port)
+  appProtocol: null
   # -- Kubernetes Service clusterIP
   clusterIP: ""
   # -- Kubernetes Service loadBalancerIP


### PR DESCRIPTION
## Summary

This PR adds appProtocol support to headlamp Service by including a 'service.appProtocol' value in headlamp helm chart.

## Related Issue

#2899, #4138 and #4309
All previous issues are related to WebSockets and Ingress. 

This PR fixes issues related to WebSockets and Gateway API.

## Changes

- Added service.appProtocol value with a `null` as default value.
- Service only includes appProtocol field if user sets the value.
- Added related tests.

## Steps to Test
1. Deploy  helm chart with `httpRoute.enabled=true` and `service.appProtocol=kubernetes.io/ws`.
2. Use a Gateway Controller that supports [Backend Protocol](https://gateway-api.sigs.k8s.io/guides/user-guides/backend-protocol/) (tested with apisix).
3. User can see pod logs and exec shell from the UI.

