### PR TITLE
 backend: cmd: Add unit tests for config helper functions

### DIFF
--- a/backend/cmd/config_helpers_test.go
+++ b/backend/cmd/config_helpers_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTelemetryConfig(t *testing.T) {
+	conf := &config.Config{
+		ServiceName:        "headlamp",
+		ServiceVersion:     &[]string{"1.2.3"}[0],
+		TracingEnabled:     &[]bool{true}[0],
+		MetricsEnabled:     &[]bool{false}[0],
+		JaegerEndpoint:     &[]string{"http://localhost:14268"}[0],
+		OTLPEndpoint:       &[]string{"localhost:4317"}[0],
+		UseOTLPHTTP:        &[]bool{true}[0],
+		StdoutTraceEnabled: &[]bool{false}[0],
+		SamplingRate:       &[]float64{0.5}[0],
+	}
+
+	got := buildTelemetryConfig(conf)
+
+	assert.Equal(t, conf.ServiceName, got.ServiceName)
+	assert.Equal(t, conf.ServiceVersion, got.ServiceVersion)
+	assert.Equal(t, conf.TracingEnabled, got.TracingEnabled)
+	assert.Equal(t, conf.MetricsEnabled, got.MetricsEnabled)
+	assert.Equal(t, conf.JaegerEndpoint, got.JaegerEndpoint)
+	assert.Equal(t, conf.OTLPEndpoint, got.OTLPEndpoint)
+	assert.Equal(t, conf.UseOTLPHTTP, got.UseOTLPHTTP)
+	assert.Equal(t, conf.StdoutTraceEnabled, got.StdoutTraceEnabled)
+	assert.Equal(t, conf.SamplingRate, got.SamplingRate)
+}
+
+func TestLoadOidcCACert(t *testing.T) {
+	assert.Equal(t, "", loadOidcCACert(""), "empty path should return empty string")
+
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(caFile, []byte("test-ca-cert"), 0o600))
+
+	assert.Equal(t, "test-ca-cert", loadOidcCACert(caFile))
+}


### PR DESCRIPTION
## Summary

This PR adds unit tests for two config helper functions in `backend/cmd/server.go`. `buildTelemetryConfig` is verified to copy every telemetry field from the source config, and `loadOidcCACert` is verified for the empty-path and file-read cases.

## Related Issue

No related issue — fills a test-coverage gap in `backend/cmd`.

## Changes

- Added `backend/cmd/config_helpers_test.go` with `TestBuildTelemetryConfig` and `TestLoadOidcCACert`

## Steps to Test

1. `cd backend && go test ./cmd/ -run 'TestBuildTelemetryConfig|TestLoadOidcCACert' -v`
2. Observe both tests pass.

## Screenshots (if applicable)


## Notes for the Reviewer

- Test-only change, no production code modified.
- `loadOidcCACert`'s read-error path calls `os.Exit(1)`, so it isn't covered here — testing it would require changing the function's signature, which is out of scope for a test PR.
