### PR TITLE
 backend: Add configurable default node shell image

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -172,6 +172,7 @@ type clientConfig struct {
 	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
 	AllowKubeconfigChanges  bool      `json:"allowKubeconfigChanges"`
 	DefaultPodDebugImage    string    `json:"defaultPodDebugImage"`
+	DefaultNodeShellImage   string    `json:"defaultNodeShellImage"`
 	DefaultLightTheme       string    `json:"defaultLightTheme,omitempty"`
 	DefaultDarkTheme        string    `json:"defaultDarkTheme,omitempty"`
 	ForceTheme              string    `json:"forceTheme,omitempty"`
@@ -2233,6 +2234,7 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 		IsDynamicClusterEnabled: c.EnableDynamicClusters,
 		AllowKubeconfigChanges:  c.AllowKubeconfigChanges,
 		DefaultPodDebugImage:    c.PodDebugImage,
+		DefaultNodeShellImage:   c.NodeShellImage,
 		DefaultLightTheme:       c.DefaultLightTheme,
 		DefaultDarkTheme:        c.DefaultDarkTheme,
 		ForceTheme:              c.ForceTheme,

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -175,6 +175,28 @@ func TestGetConfigIncludesDefaultPodDebugImage(t *testing.T) {
 	assert.Equal(t, "registry.example.com/debug:latest", config.DefaultPodDebugImage)
 }
 
+func TestGetConfigIncludesDefaultNodeShellImage(t *testing.T) {
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeconfig.NewContextStore(),
+				NodeShellImage:  "registry.example.com/shell:latest",
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil)
+	recorder := httptest.NewRecorder()
+
+	c.getConfig(recorder, req)
+
+	var config clientConfig
+
+	err := json.Unmarshal(recorder.Body.Bytes(), &config)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com/shell:latest", config.DefaultNodeShellImage)
+}
+
 //nolint:gocognit,funlen
 func TestDynamicClusters(t *testing.T) {
 	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -115,6 +115,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		TLSKeyPath:                            conf.TLSKeyPath,
 		SessionTTL:                            conf.SessionTTL,
 		PodDebugImage:                         conf.PodDebugImage,
+		NodeShellImage:                        conf.NodeShellImage,
 		OidcUseCookie:                         conf.OidcUseCookie,
 		DefaultLightTheme:                     conf.DefaultLightTheme,
 		DefaultDarkTheme:                      conf.DefaultDarkTheme,

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	BaseURL                string `koanf:"base-url"`
 	SessionTTL             int    `koanf:"session-ttl"`
 	PodDebugImage          string `koanf:"pod-debug-image"`
+	NodeShellImage         string `koanf:"node-shell-image"`
 	ProxyURLs              string `koanf:"proxy-urls"`
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
@@ -559,6 +560,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.Int("session-ttl", defaultSessionTTL, "The time in seconds for the session to be valid"+
 		"(Default: 86400/24h, Min: 1 , Max: 31536000/1yr )")
 	f.String("pod-debug-image", "", "Default image to use when creating pod debug containers")
+	f.String("node-shell-image", "", "Default image to use when creating node shell pods")
 	f.String("listen-addr", "", "Address to listen on; default is empty, which means listening to any address")
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -97,10 +97,15 @@ func TestParseBasic(t *testing.T) {
 		},
 		{
 			name: "with_args",
-			args: []string{"go run ./cmd", "--port=3456", "--pod-debug-image=registry.example.com/debug:latest"},
+			args: []string{
+				"go run ./cmd", "--port=3456",
+				"--pod-debug-image=registry.example.com/debug:latest",
+				"--node-shell-image=registry.example.com/shell:latest",
+			},
 			verify: func(t *testing.T, conf *config.Config) {
 				assert.Equal(t, uint(3456), conf.Port)
 				assert.Equal(t, "registry.example.com/debug:latest", conf.PodDebugImage)
+				assert.Equal(t, "registry.example.com/shell:latest", conf.NodeShellImage)
 				assert.Equal(t, config.DefaultMeUsernamePath, conf.MeUsernamePath)
 			},
 		},

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -74,6 +74,7 @@ type HeadlampCFG struct {
 	TLSKeyPath                   string
 	SessionTTL                   int
 	PodDebugImage                string
+	NodeShellImage               string
 	OidcUseCookie                bool
 	DefaultLightTheme            string
 	DefaultDarkTheme             string

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -135,6 +135,7 @@ config:
 | config.pluginsDir  | string | `"/headlamp/plugins"` | Directory to load Headlamp plugins from                                   |
 | config.enableHelm  | bool   | `false`               | Enable Helm operations like install, upgrade and uninstall of Helm charts |
 | config.podDebugImage | string | `""`                | Default image to use when creating pod debug containers                    |
+| config.nodeShellImage | string | `""`               | Default image to use when creating node shell pods                         |
 | config.clusterInventory.enabled | bool | `false` | Enable experimental/alpha Cluster Inventory discovery |
 | config.clusterInventory.accessProvidersConfig | object | `{}` | Experimental/alpha Cluster Inventory access providers config. Required when Cluster Inventory is enabled |
 | config.clusterInventory.plugins | list | `[]` | Kubernetes image volumes that provide experimental/alpha Cluster Inventory access provider binaries |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -269,6 +269,9 @@ spec:
             {{- with .Values.config.podDebugImage }}
             - "-pod-debug-image={{ . }}"
             {{- end }}
+            {{- with .Values.config.nodeShellImage }}
+            - "-node-shell-image={{ . }}"
+            {{- end }}
             {{- if and .Values.config.inCluster .Values.config.unsafeUseServiceAccountToken }}
             - "-unsafe-use-service-account-token"
             {{- end }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -184,6 +184,10 @@
           "type": "string",
           "description": "Default image to use when creating pod debug containers"
         },
+        "nodeShellImage": {
+          "type": "string",
+          "description": "Default image to use when creating node shell pods"
+        },
         "unsafeUseServiceAccountToken": {
           "type": "boolean",
           "description": "UNSAFE: authenticate every user as the pod's service account in-cluster mode"

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -127,6 +127,8 @@ config:
   watchPlugins: false
   # -- Default image to use when creating pod debug containers. If empty, Headlamp uses its built-in default.
   podDebugImage: ""
+  # -- Default image to use when creating node shell pods. If empty, Headlamp uses its built-in default.
+  nodeShellImage: ""
   # tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
   # tlsKeyPath: "/headlamp-cert/headlamp-tls.key"
   clusterInventory:

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -29,6 +29,7 @@ import { stream, StreamResultsCb } from '../../lib/k8s/api/v1/streamingApi';
 import Node from '../../lib/k8s/node';
 import { KubePod } from '../../lib/k8s/pod';
 import { Channel, useTerminalStream, XTerminalConnected } from '../../lib/k8s/useTerminalStream';
+import { useTypedSelector } from '../../redux/hooks';
 
 interface NodeShellTerminalProps {
   item: Node;
@@ -103,7 +104,7 @@ function uniqueString() {
   return res;
 }
 
-async function shell(item: Node, onExec: StreamResultsCb) {
+async function shell(item: Node, onExec: StreamResultsCb, defaultImage: string) {
   const cluster = getCluster();
   if (!cluster) {
     return {};
@@ -111,7 +112,7 @@ async function shell(item: Node, onExec: StreamResultsCb) {
 
   const clusterSettings = loadClusterSettings(cluster);
   const config = clusterSettings.nodeShellTerminal;
-  const linuxImage = config?.linuxImage || DEFAULT_NODE_SHELL_LINUX_IMAGE;
+  const linuxImage = config?.linuxImage || defaultImage || DEFAULT_NODE_SHELL_LINUX_IMAGE;
   const namespace = config?.namespace || DEFAULT_NODE_SHELL_NAMESPACE;
   const podName = `node-debugger-${item.getName()}-${uniqueString()}`;
   const kubePod = shellPod(podName, namespace, item.getName(), linuxImage);
@@ -144,12 +145,13 @@ export function NodeShellTerminal(props: NodeShellTerminalProps) {
   const [terminalContainerRef, setTerminalContainerRef] = useState<HTMLElement | null>(null);
   const exitSentRef = useRef(false);
   const pendingExitRef = useRef(false);
+  const defaultNodeShellImage = useTypedSelector(state => state.config.defaultNodeShellImage);
 
   const { xtermRef, streamRef, send } = useTerminalStream({
     containerRef: terminalContainerRef,
     connectStream: async onDataCallback => {
       xtermRef.current?.xterm.writeln('Trying to open a shell');
-      const { stream } = await shell(item, onDataCallback);
+      const { stream } = await shell(item, onDataCallback, defaultNodeShellImage);
       return {
         stream,
       };

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -29,7 +29,7 @@ import { stream, StreamResultsCb } from '../../lib/k8s/api/v1/streamingApi';
 import Node from '../../lib/k8s/node';
 import { KubePod } from '../../lib/k8s/pod';
 import { Channel, useTerminalStream, XTerminalConnected } from '../../lib/k8s/useTerminalStream';
-import { useTypedSelector } from '../../redux/hooks';
+import store from '../../redux/stores/store';
 
 interface NodeShellTerminalProps {
   item: Node;
@@ -104,7 +104,7 @@ function uniqueString() {
   return res;
 }
 
-async function shell(item: Node, onExec: StreamResultsCb, defaultImage: string) {
+async function shell(item: Node, onExec: StreamResultsCb) {
   const cluster = getCluster();
   if (!cluster) {
     return {};
@@ -112,6 +112,7 @@ async function shell(item: Node, onExec: StreamResultsCb, defaultImage: string) 
 
   const clusterSettings = loadClusterSettings(cluster);
   const config = clusterSettings.nodeShellTerminal;
+  const defaultImage = store.getState().config.defaultNodeShellImage;
   const linuxImage = config?.linuxImage || defaultImage || DEFAULT_NODE_SHELL_LINUX_IMAGE;
   const namespace = config?.namespace || DEFAULT_NODE_SHELL_NAMESPACE;
   const podName = `node-debugger-${item.getName()}-${uniqueString()}`;
@@ -145,13 +146,12 @@ export function NodeShellTerminal(props: NodeShellTerminalProps) {
   const [terminalContainerRef, setTerminalContainerRef] = useState<HTMLElement | null>(null);
   const exitSentRef = useRef(false);
   const pendingExitRef = useRef(false);
-  const defaultNodeShellImage = useTypedSelector(state => state.config.defaultNodeShellImage);
 
   const { xtermRef, streamRef, send } = useTerminalStream({
     containerRef: terminalContainerRef,
     connectStream: async onDataCallback => {
       xtermRef.current?.xterm.writeln('Trying to open a shell');
-      const { stream } = await shell(item, onDataCallback, defaultNodeShellImage);
+      const { stream } = await shell(item, onDataCallback);
       return {
         stream,
       };

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -50,6 +50,7 @@ const makeStore = () => {
         isDynamicClusterEnabled: false,
         allowKubeconfigChanges: false,
         defaultPodDebugImage: '',
+        defaultNodeShellImage: '',
       },
       projects: {
         headerActions: {},

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -43,6 +43,7 @@ const makeStore = () => {
         isDynamicClusterEnabled: true,
         allowKubeconfigChanges: false,
         defaultPodDebugImage: '',
+        defaultNodeShellImage: '',
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',

--- a/frontend/src/redux/configSlice.test.ts
+++ b/frontend/src/redux/configSlice.test.ts
@@ -76,6 +76,32 @@ describe('configSlice', () => {
     expect(nextState.defaultPodDebugImage).toBe('');
   });
 
+  it('should handle setConfig with defaultNodeShellImage', () => {
+    const clusters: ConfigState['clusters'] = {
+      'cluster-1': { name: 'cluster-1' } as Cluster,
+    };
+    const nextState = configReducer(
+      initialState,
+      setConfig({
+        clusters,
+        defaultNodeShellImage: 'registry.example.com/shell:latest',
+      })
+    );
+
+    expect(nextState.defaultNodeShellImage).toBe('registry.example.com/shell:latest');
+  });
+
+  it('should handle clearing defaultNodeShellImage', () => {
+    const state = {
+      ...initialState,
+      defaultNodeShellImage: 'registry.example.com/shell:latest',
+    };
+
+    const nextState = configReducer(state, setConfig({ clusters: {}, defaultNodeShellImage: '' }));
+
+    expect(nextState.defaultNodeShellImage).toBe('');
+  });
+
   it('should preserve isDynamicClusterEnabled when setConfig is called without it', () => {
     let state = configReducer(
       initialState,

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -59,6 +59,11 @@ export interface ConfigState {
    */
   defaultPodDebugImage: string;
   /**
+   * Default image used for node shell pods when no per-cluster override is configured.
+   * An empty string indicates that no default image is configured.
+   */
+  defaultNodeShellImage: string;
+  /**
    * Theme configuration from the backend server.
    */
   defaultLightTheme?: string;
@@ -157,6 +162,7 @@ export const initialState: ConfigState = {
   isDynamicClusterEnabled: false,
   allowKubeconfigChanges: false,
   defaultPodDebugImage: '',
+  defaultNodeShellImage: '',
   settings: {
     tableRowsPerPageOptions:
       storedSettings.tableRowsPerPageOptions ?? defaultTableRowsPerPageOptions,
@@ -182,6 +188,7 @@ const configSlice = createSlice({
         isDynamicClusterEnabled?: boolean;
         allowKubeconfigChanges?: boolean;
         defaultPodDebugImage?: string;
+        defaultNodeShellImage?: string;
         defaultLightTheme?: string;
         defaultDarkTheme?: string;
         forceTheme?: string;
@@ -196,6 +203,9 @@ const configSlice = createSlice({
       }
       if (action.payload.defaultPodDebugImage !== undefined) {
         state.defaultPodDebugImage = action.payload.defaultPodDebugImage;
+      }
+      if (action.payload.defaultNodeShellImage !== undefined) {
+        state.defaultNodeShellImage = action.payload.defaultNodeShellImage;
       }
       state.defaultLightTheme = action.payload.defaultLightTheme;
       state.defaultDarkTheme = action.payload.defaultDarkTheme;


### PR DESCRIPTION
## Summary

This PR adds a `node-shell-image` backend flag and the matching Helm chart value, so administrators can configure the default image used when creating node shell pods. This mirrors the existing `pod-debug-image` option and is useful for airgapped or in-cluster deployments that cannot pull the built-in default image. The value is exposed to the frontend via the `/config` endpoint; the frontend will consume it in a follow-up PR.

## Related Issue

Part of #5930

## Changes

- Added the `node-shell-image` flag and `NodeShellImage` config field (`backend/pkg/config`, `backend/pkg/headlampconfig`, `backend/cmd/server.go`)
- Exposed it as `defaultNodeShellImage` in the `/config` response (`backend/cmd/headlamp.go`)
- Wired the matching `config.nodeShellImage` value through the Helm chart (deployment template, values.yaml, values.schema.json, README)
- Added unit tests for flag parsing and the `/config` response

## Steps to Test

1. `cd backend && go test ./cmd/ ./pkg/config/`
2. `helm template charts/headlamp --set config.nodeShellImage=registry.example.com/shell:latest | grep node-shell-image` — confirms the flag is rendered.

## Notes for the Reviewer

- The flag has no frontend consumer yet — a follow-up PR will make the node shell terminal use this default. Split this way for reviewability; happy to combine if you'd prefer a single vertical slice.

I used "Part of #5930" (not Fixes) since this is the first of several PRs — it links the issue without auto-closing it on merge.

## Screen Recording 


https://github.com/user-attachments/assets/775d1d99-17fb-49a0-a7cb-3326d0f799ed


