### PR TITLE
frontend: useKubeObjectList: Refactor how request watching is being stopped

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -65,7 +65,7 @@ export interface ListResponse<K extends KubeObject> {
 export function kubeObjectListQuery<K extends KubeObject>(
   kubeObjectClass: KubeObjectClass,
   endpoint: KubeObjectEndpoint,
-  namespace: string | undefined,
+  namespace: string | undefined = '',
   cluster: string,
   queryParams: QueryParameters,
   refetchInterval?: number
@@ -80,7 +80,7 @@ export function kubeObjectListQuery<K extends KubeObject>(
       kubeObjectClass.apiVersion,
       kubeObjectClass.apiName,
       cluster,
-      namespace ?? '',
+      namespace,
       queryParams,
     ],
     queryFn: async () => {
@@ -533,15 +533,24 @@ export function useKubeObjectList<K extends KubeObject>({
     setListsToWatch([...listsToWatch, ...listsNotYetWatched]);
   }
 
-  const listsToStopWatching = listsToWatch.filter(
-    watching =>
-      requests.find(request => {
-        if (watching.cluster !== request?.cluster) return false;
-        return !request.namespaces?.length
-          ? !watching.namespace
-          : watching.namespace !== undefined && request.namespaces.includes(watching.namespace);
-      }) === undefined
-  );
+  const listsToStopWatching = listsToWatch.filter(watchingList => {
+    const requestThatNeedsThisList = requests.find(request => {
+      if (request.cluster !== watchingList.cluster) {
+        return false;
+      }
+
+      if (!request.namespaces || request.namespaces.length === 0) {
+        return watchingList.namespace === undefined || watchingList.namespace === '';
+      }
+
+      return (
+        watchingList.namespace !== undefined && request.namespaces.includes(watchingList.namespace)
+      );
+    });
+
+    // If there's no request that needs this list then we can stop watching it
+    return requestThatNeedsThisList === undefined;
+  });
 
   if (listsToStopWatching.length > 0) {
     setListsToWatch(listsToWatch.filter(it => !listsToStopWatching.includes(it)));


### PR DESCRIPTION
Tested on flux plugin and various namespace scenarios

# how to test

- install flux, open overview page, it shouldn't crash
- go to any resource list (like deployments), select two namespaces, then clear all namespaces, there should be just one websocket connection for that resource