### PR TITLE
docs: Add example MCP server configs to MCP support page

### DIFF
--- a/docs/learn/mcp-support.md
+++ b/docs/learn/mcp-support.md
@@ -59,6 +59,33 @@ You can configure servers using the form-based UI or by editing the JSON configu
 
 <img width="1430" height="829" alt="MCP configuration" src="https://github.com/user-attachments/assets/4a8ad48b-0b54-4d8d-9eeb-dc06d1d358ff" />
 
+### Example MCP Servers
+
+Each of the servers below runs as a local command, which is what the desktop app expects. Install the tool first, then add it from the AI Assistant settings using the fields above.
+
+[Flux Operator MCP](https://github.com/controlplaneio-fluxcd/flux-operator/tree/main/cmd/mcp) surfaces Flux sources, Kustomizations, and HelmReleases.
+
+- **Name** — `flux`
+- **Command** — `flux-operator-mcp`
+- **Args** — `serve --kube-context HEADLAMP_CURRENT_CLUSTER`
+
+As noted above, `HEADLAMP_CURRENT_CLUSTER` is not something you set yourself. Headlamp replaces it with the name of the selected cluster when it starts the server.
+
+[K8sGPT](https://github.com/k8sgpt-ai/k8sgpt) analyzes cluster issues and returns AI-assisted explanations. The `serve --mcp` command runs its MCP server over stdio, which needs no environment variables or extra configuration.
+
+- **Name** — `k8sgpt`
+- **Command** — `k8sgpt`
+- **Args** — `serve --mcp`
+
+[Inspektor Gadget](https://github.com/inspektor-gadget/ig-mcp-server) exposes eBPF gadgets for tracing DNS, TCP connections, process execution, and more. It needs either a gadget discoverer or an explicit list of gadgets, otherwise it will not start.
+
+- **Name** — `inspektor-gadget`
+- **Command** — `ig-mcp-server`
+- **Args** — `-gadget-discoverer=artifacthub`
+- **Example (pin specific gadgets)** — `-gadget-images=trace_dns:latest,trace_tcp:latest` loads only the listed gadgets instead of discovering all of them
+
+Each project keeps its own install steps and flags up to date, so check its page for the latest options.
+
 ## Managing MCP Tools
 
 Once a server is connected, Headlamp lists the tools it exposes.


### PR DESCRIPTION
## What

The MCP support page explains how to configure a server, but the only concrete value anywhere on the page is `flux-operator-mcp` mentioned inline. This adds a short **Example MCP Servers** section with ready-to-use Name / Command / Args for three servers that run as local stdio commands (which is what the desktop app expects):

- Flux Operator MCP: `flux-operator-mcp serve --kube-context HEADLAMP_CURRENT_CLUSTER`
- K8sGPT: `k8sgpt serve --mcp`
- Inspektor Gadget: `ig-mcp-server -gadget-discoverer=artifacthub`

Each entry links to the project, and every command and flag was taken from that project's own MCP docs (k8sgpt's stdio mode, ig-mcp-server's required discoverer flag, the existing Flux command). Docs only, no code changes.

## Why

Flux, K8sGPT, and Inspektor Gadget all ship stdio MCP servers and are the ones already referenced in the Headlamp MCP and HolmesGPT write-ups, so a couple of copy-pasteable examples should lower the barrier to trying MCP support without sending people off to hunt for the right command.

## Testing

Ran the repo's prettier over the page:

```
$ prettier --check docs/learn/mcp-support.md
Checking formatting...
All matched files use Prettier code style!
```

cc @illume
