### PR TITLE
Backend: Add fuzz targets and update backend:fuzz script

### DIFF
--- a/backend/pkg/auth/auth_fuzz_test.go
+++ b/backend/pkg/auth/auth_fuzz_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+)
+
+// FuzzDecodeBase64JSON tests DecodeBase64JSON with various inputs.
+func FuzzDecodeBase64JSON(f *testing.F) {
+	// Seed corpus with representative inputs.
+	f.Add("eyJmb28iOiJiYXIifQ")  // base64url of {"foo":"bar"}
+	f.Add("")                    // empty
+	f.Add("not-valid-base64!!!") // invalid base64url
+	f.Add("YWJj")                // valid base64url of "abc", invalid JSON
+	f.Add("bnVsbA")              // valid base64url of "null"
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_, _ = auth.DecodeBase64JSON(input)
+	})
+}

--- a/backend/pkg/clusterinventory/clusterinventory_fuzz_test.go
+++ b/backend/pkg/clusterinventory/clusterinventory_fuzz_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage // fuzz target covers unexported normalizeServerURL behavior.
+package clusterinventory
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzNormalizeServerURL tests normalizeServerURL with various inputs.
+func FuzzNormalizeServerURL(f *testing.F) {
+	f.Add("https://example.com/")
+	f.Add("https://example.com/path/")
+	f.Add("http://example.com:9123/api/v1/?q=1#fragment")
+	f.Add("")
+	f.Add("/")
+	f.Add("not a url")
+	f.Add("://bad")
+
+	f.Fuzz(func(t *testing.T, host string) {
+		result := normalizeServerURL(host)
+
+		// Invariant: result should not end with a trailing slash.
+		if strings.HasSuffix(result, "/") {
+			t.Errorf("normalizeServerURL(%q) = %q ends with a trailing slash", host, result)
+		}
+	})
+}

--- a/backend/pkg/kubeconfig/kubeconfig_fuzz_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_fuzz_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig_test
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+)
+
+// FuzzUnmarshalKubeconfig tests UnmarshalKubeconfig with various inputs.
+func FuzzUnmarshalKubeconfig(f *testing.F) {
+	// Seed corpus with representative inputs.
+	f.Add([]byte("apiVersion: v1\nkind: Config\n")) // minimal valid
+	f.Add([]byte(""))                               // empty
+	f.Add([]byte("contexts: [}"))                   // malformed YAML
+	f.Add([]byte("not yaml at all: : :"))           // invalid YAML
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = kubeconfig.UnmarshalKubeconfig(data)
+	})
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "backend:lint:fix": "npm run backend:install:linter && cd backend && ./tools/golangci-lint run --fix",
     "backend:install:linter": "GOBIN=`pwd`/backend/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2",
     "backend:test": "cd backend && go test -v -p 1 ./...",
-    "backend:fuzz": "cd backend && go test -fuzz=. -fuzztime=30s ./pkg/auth/",
+    "backend:fuzz": "cd backend && go test -run=FuzzSanitizeClusterName -fuzz=FuzzSanitizeClusterName -fuzztime=10s ./pkg/auth/ && go test -run=FuzzDecodeBase64JSON -fuzz=FuzzDecodeBase64JSON -fuzztime=10s ./pkg/auth/ && go test -run=FuzzUnmarshalKubeconfig -fuzz=FuzzUnmarshalKubeconfig -fuzztime=10s ./pkg/kubeconfig/ && go test -run=FuzzNormalizeServerURL -fuzz=FuzzNormalizeServerURL -fuzztime=10s ./pkg/clusterinventory/",
     "backend:coverage": "cd backend && go test -v -p 1 -coverprofile=coverage.out ./... && go tool cover -func=coverage.out",
     "backend:coverage:html": "cd backend && go test -v -p 1 -coverprofile=coverage.out ./... && go tool cover -html=coverage.out",
     "backend:format": "cd backend && go fmt ./cmd/ ./pkg/**",


### PR DESCRIPTION
## Summary

This PR expands backend fuzz coverage with focused fuzz tests for parser and normalizer paths, and updates the backend fuzz npm script to run all newly configured fuzz targets explicitly. 

## Related Issue

Related to [#2085](https://github.com/kubernetes-sigs/headlamp/issues/2085)
- https://github.com/kubernetes-sigs/headlamp/issues/2085

## Changes

- Added `backend/pkg/auth/auth_fuzz_test.go`
- Added `backend/pkg/kubeconfig/kubeconfig_fuzz_test.go`
- Added `backend/pkg/clusterinventory/clusterinventory_fuzz_test.go`
- Updated `package.json` `backend:fuzz` script to run:
  - `FuzzSanitizeClusterName`
  - `FuzzDecodeBase64JSON`
  - `FuzzUnmarshalKubeconfig`
  - `FuzzNormalizeServerURL`

## Steps to Test

You can either run: 
1. npm run backend:fuzz

Or alternatively manually:

2. cd backend && go test ./pkg/auth/ ./pkg/kubeconfig/ ./pkg/clusterinventory/

## Notes for the Reviewer

- Go fuzzing supports one active fuzz target per invocation, so this script uses explicit target matching per run.
- `FuzzUnmarshalKubeconfig`, and `FuzzDecodeBase64JSON` provide basic crash-oriented coverage, while `FuzzNormalizeServerURL` also asserts an invariant.
- Post this PR, we can set all these new targets to be actively fuzzed via OSS-fuzz. We can onboard with a follow-up PR where we reference the existing targets.