### PR TITLE
frontend: RestartButton: Fix react-hooks/rules-of-hooks

### DIFF
--- a/frontend/src/components/common/Resource/RestartButton.tsx
+++ b/frontend/src/components/common/Resource/RestartButton.tsx
@@ -46,20 +46,23 @@ interface RestartButtonProps {
 }
 
 export function RestartButton(props: RestartButtonProps) {
-  const dispatch: AppDispatch = useDispatch();
   const { item, buttonStyle, afterConfirm } = props;
 
   if (!item || !isRestartableResource(item)) {
     return null;
   }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return <RestartButtonInner item={item} buttonStyle={buttonStyle} afterConfirm={afterConfirm} />;
+}
+
+function RestartButtonInner(
+  props: { item: RestartableResource } & Omit<RestartButtonProps, 'item'>
+) {
+  const dispatch: AppDispatch = useDispatch();
+  const { item, buttonStyle, afterConfirm } = props;
   const [openDialog, setOpenDialog] = useState(false);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const location = useLocation();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { t } = useTranslation(['translation']);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const dispatchRestartEvent = useEventCallback(HeadlampEventType.RESTART_RESOURCE);
 
   async function restartResource() {


### PR DESCRIPTION
useState, useLocation, useTranslation, and useEventCallback were called
after the early-return guard clause, violating the Rules of Hooks. Hooks
must be called unconditionally on every render.

Move all four hook calls above the guard so they execute on every render,
then let the guard return null for non-restartable items. Remove the four
eslint-disable-next-line suppressions that masked the violation.

## Summary

This PR fixes a react-hooks/rules-of-hooks violation in RestartButton by
moving all hook calls before the early-return guard clause.

## Related Issue

Fixes #5190

## Changes

- Moved `useState`, `useLocation`, `useTranslation`, and `useEventCallback`
  calls above the `if (!item || !isRestartableResource(item))` guard clause
- Removed the four `// eslint-disable-next-line react-hooks/rules-of-hooks`
  comments that were suppressing the violation

## Steps to Test

1. Run `npm run frontend:lint` — should pass with 0 errors and 0 warnings
2. Navigate to a Deployment, StatefulSet, or DaemonSet detail page — confirm
   the restart button renders and the confirmation dialog opens correctly
3. Navigate to a Pod detail page — confirm the restart button does not render
   (component returns null for non-restartable resources)

## Screenshots (if applicable)

N/A — no visual change, behaviour is identical.

## Notes for the Reviewer

- No behavioural change: the early return still fires for non-restartable
  items; only the hook invocation order is corrected to satisfy React's rules.
- The hooks have no side effects on the early-return path — `useState` is
  just initial state, `useLocation`/`useTranslation` are read-only, and
  `useEventCallback` registers a callback that is never called when the
  component returns null.