### PR TITLE
frontend: utils: Use parseFloat in compareUnits to support decimals and add test coverage

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -16,6 +16,7 @@
 
 import {
   combineClusterListErrors,
+  compareUnits,
   flattenClusterListItems,
   formatDuration,
   getPercentStr,
@@ -342,5 +343,46 @@ describe('normalizeUnit', () => {
     it('shows plural cores', () => {
       expect(normalizeUnit('cpu', '2')).toBe('2 cores');
     });
+  });
+});
+
+describe('compareUnits', () => {
+  it('compares identical values', () => {
+    expect(compareUnits('500m', '500m')).toBe(true);
+  });
+
+  it('ignores whitespace differences', () => {
+    expect(compareUnits('  500 m  ', '500m')).toBe(true);
+    expect(compareUnits('500m', ' 500m ')).toBe(true);
+  });
+
+  it('ignores case differences', () => {
+    expect(compareUnits('500Mi', '500mi')).toBe(true);
+    expect(compareUnits('2ki', '2Ki')).toBe(true);
+  });
+
+  it('treats normalized formatting as equal when numeric value matches', () => {
+    expect(compareUnits('1k', normalizeUnit('memory', '1k'))).toBe(true);
+  });
+
+  it('returns true for matching decimal/fractional numbers', () => {
+    expect(compareUnits('1.5', '1.50')).toBe(true);
+    expect(compareUnits('2.3Mi', '2.3')).toBe(true);
+  });
+
+  it('returns false for mismatched decimal/fractional values', () => {
+    expect(compareUnits('1.5Gi', '1.61 GB')).toBe(false);
+    expect(compareUnits('2.3', '2.4')).toBe(false);
+  });
+
+  it('returns false for mismatched parsed values', () => {
+    expect(compareUnits('500m', '250m')).toBe(false);
+    expect(compareUnits('1Ki', '2Ki')).toBe(false);
+  });
+
+  it('returns false when either value does not start with a number (NaN cases)', () => {
+    expect(compareUnits('abc', '1')).toBe(false);
+    expect(compareUnits('1', 'abc')).toBe(false);
+    expect(compareUnits('', '')).toBe(false);
   });
 });

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -470,14 +470,16 @@ export function useURLState<T extends string | number | undefined = string>(
   return [value, setValue] as [T, React.Dispatch<React.SetStateAction<T>>];
 }
 
-// compareUnits compares two units and returns true if they are equal
+// compareUnits compares the parsed numeric portion of two quantities (ignoring unit suffixes) and returns true if they are equal.
 export function compareUnits(quantity1: string, quantity2: string) {
   // strip whitespace and convert to lowercase
   const qty1 = quantity1.replace(/\s/g, '').toLowerCase();
   const qty2 = quantity2.replace(/\s/g, '').toLowerCase();
 
-  // compare numbers
-  return parseInt(qty1) === parseInt(qty2);
+  // Compare the parsed numeric portion only (unit suffix is ignored).
+  const n1 = Number.parseFloat(qty1);
+  const n2 = Number.parseFloat(qty2);
+  return !Number.isNaN(n1) && !Number.isNaN(n2) && n1 === n2;
 }
 
 export function normalizeUnit(resourceType: string, quantity: string) {


### PR DESCRIPTION
## Summary

This PR updates `compareUnits` in `util.ts` to use `parseFloat` instead of `parseInt`. This ensures that fractional/decimal values are compared accurately. In addition, it adds comprehensive unit test coverage.

## Changes

- Modified `compareUnits` in `frontend/src/lib/util.ts` to parse values using `Number.parseFloat` instead of `parseInt`, with added safety checks against `NaN`.
- Updated `util.test.ts` to verify the new behavior, including checks for matching and mismatching decimal values.

## Steps to Test

Run the frontend utility tests to verify they all pass:
1. `cd frontend`
2. `npm run test src/lib/util.test.ts`

## Screenshots (if applicable)

*N/A (Utility/logic unit tests)*

## Notes for the Reviewer

Previously, `compareUnits` used `parseInt` which caused fractional quantities to lose their decimal precision (e.g., comparing `1.5Gi` and `1.61 GB` incorrectly returned `true` because both parsed as `1`). In the ResourceQuota details view, this would incorrectly collapse/hide the original input value (rendering only `1.61 GB`). 
With `parseFloat`, these comparisons are accurate (they now evaluate to `false`), allowing the UI to correctly display both values, e.g., `1.5Gi (1.61 GB)`.
