### PR TITLE
backend: Add configurable default node shell namespace

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -168,14 +168,15 @@ const (
 )
 
 type clientConfig struct {
-	Clusters                []Cluster `json:"clusters"`
-	IsDynamicClusterEnabled bool      `json:"isDynamicClusterEnabled"`
-	AllowKubeconfigChanges  bool      `json:"allowKubeconfigChanges"`
-	DefaultPodDebugImage    string    `json:"defaultPodDebugImage"`
-	DefaultNodeShellImage   string    `json:"defaultNodeShellImage"`
-	DefaultLightTheme       string    `json:"defaultLightTheme,omitempty"`
-	DefaultDarkTheme        string    `json:"defaultDarkTheme,omitempty"`
-	ForceTheme              string    `json:"forceTheme,omitempty"`
+	Clusters                  []Cluster `json:"clusters"`
+	IsDynamicClusterEnabled   bool      `json:"isDynamicClusterEnabled"`
+	AllowKubeconfigChanges    bool      `json:"allowKubeconfigChanges"`
+	DefaultPodDebugImage      string    `json:"defaultPodDebugImage"`
+	DefaultNodeShellImage     string    `json:"defaultNodeShellImage"`
+	DefaultNodeShellNamespace string    `json:"defaultNodeShellNamespace"`
+	DefaultLightTheme         string    `json:"defaultLightTheme,omitempty"`
+	DefaultDarkTheme          string    `json:"defaultDarkTheme,omitempty"`
+	ForceTheme                string    `json:"forceTheme,omitempty"`
 }
 
 type OauthConfig struct {
@@ -2233,14 +2234,15 @@ func (c *HeadlampConfig) getConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	clientConfig := clientConfig{
-		Clusters:                c.getClusters(),
-		IsDynamicClusterEnabled: c.EnableDynamicClusters,
-		AllowKubeconfigChanges:  c.AllowKubeconfigChanges,
-		DefaultPodDebugImage:    c.PodDebugImage,
-		DefaultNodeShellImage:   c.NodeShellImage,
-		DefaultLightTheme:       c.DefaultLightTheme,
-		DefaultDarkTheme:        c.DefaultDarkTheme,
-		ForceTheme:              c.ForceTheme,
+		Clusters:                  c.getClusters(),
+		IsDynamicClusterEnabled:   c.EnableDynamicClusters,
+		AllowKubeconfigChanges:    c.AllowKubeconfigChanges,
+		DefaultPodDebugImage:      c.PodDebugImage,
+		DefaultNodeShellImage:     c.NodeShellImage,
+		DefaultNodeShellNamespace: c.NodeShellNamespace,
+		DefaultLightTheme:         c.DefaultLightTheme,
+		DefaultDarkTheme:          c.DefaultDarkTheme,
+		ForceTheme:                c.ForceTheme,
 	}
 
 	if err := json.NewEncoder(w).Encode(&clientConfig); err != nil {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -197,6 +197,28 @@ func TestGetConfigIncludesDefaultNodeShellImage(t *testing.T) {
 	assert.Equal(t, "registry.example.com/shell:latest", config.DefaultNodeShellImage)
 }
 
+func TestGetConfigIncludesDefaultNodeShellNamespace(t *testing.T) {
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore:    kubeconfig.NewContextStore(),
+				NodeShellNamespace: "custom-ns",
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/config", nil)
+	recorder := httptest.NewRecorder()
+
+	c.getConfig(recorder, req)
+
+	var config clientConfig
+
+	err := json.Unmarshal(recorder.Body.Bytes(), &config)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-ns", config.DefaultNodeShellNamespace)
+}
+
 //nolint:gocognit,funlen
 func TestDynamicClusters(t *testing.T) {
 	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -116,6 +116,7 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		SessionTTL:                            conf.SessionTTL,
 		PodDebugImage:                         conf.PodDebugImage,
 		NodeShellImage:                        conf.NodeShellImage,
+		NodeShellNamespace:                    conf.NodeShellNamespace,
 		OidcUseCookie:                         conf.OidcUseCookie,
 		DefaultLightTheme:                     conf.DefaultLightTheme,
 		DefaultDarkTheme:                      conf.DefaultDarkTheme,

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	SessionTTL             int    `koanf:"session-ttl"`
 	PodDebugImage          string `koanf:"pod-debug-image"`
 	NodeShellImage         string `koanf:"node-shell-image"`
+	NodeShellNamespace     string `koanf:"node-shell-namespace"`
 	ProxyURLs              string `koanf:"proxy-urls"`
 
 	ClusterInventoryProviderFile          string        `koanf:"cluster-inventory-provider-file"`
@@ -561,6 +562,7 @@ func addGeneralFlags(f *flag.FlagSet) {
 		"(Default: 86400/24h, Min: 1 , Max: 31536000/1yr )")
 	f.String("pod-debug-image", "", "Default image to use when creating pod debug containers")
 	f.String("node-shell-image", "", "Default image to use when creating node shell pods")
+	f.String("node-shell-namespace", "", "Default namespace to use when creating node shell pods")
 	f.String("listen-addr", "", "Address to listen on; default is empty, which means listening to any address")
 	f.Uint("port", defaultPort, "Port to listen from")
 	f.String("proxy-urls", "", "Allow proxy requests to specified URLs")

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -101,11 +101,13 @@ func TestParseBasic(t *testing.T) {
 				"go run ./cmd", "--port=3456",
 				"--pod-debug-image=registry.example.com/debug:latest",
 				"--node-shell-image=registry.example.com/shell:latest",
+				"--node-shell-namespace=custom-ns",
 			},
 			verify: func(t *testing.T, conf *config.Config) {
 				assert.Equal(t, uint(3456), conf.Port)
 				assert.Equal(t, "registry.example.com/debug:latest", conf.PodDebugImage)
 				assert.Equal(t, "registry.example.com/shell:latest", conf.NodeShellImage)
+				assert.Equal(t, "custom-ns", conf.NodeShellNamespace)
 				assert.Equal(t, config.DefaultMeUsernamePath, conf.MeUsernamePath)
 			},
 		},

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -75,6 +75,7 @@ type HeadlampCFG struct {
 	SessionTTL                   int
 	PodDebugImage                string
 	NodeShellImage               string
+	NodeShellNamespace           string
 	OidcUseCookie                bool
 	DefaultLightTheme            string
 	DefaultDarkTheme             string

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -136,6 +136,7 @@ config:
 | config.enableHelm  | bool   | `false`               | Enable Helm operations like install, upgrade and uninstall of Helm charts |
 | config.podDebugImage | string | `""`                | Default image to use when creating pod debug containers                    |
 | config.nodeShellImage | string | `""`               | Default image to use when creating node shell pods                         |
+| config.nodeShellNamespace | string | `""`            | Default namespace to use when creating node shell pods                      |
 | config.clusterInventory.enabled | bool | `false` | Enable experimental/alpha Cluster Inventory discovery |
 | config.clusterInventory.accessProvidersConfig | object | `{}` | Experimental/alpha Cluster Inventory access providers config. Required when Cluster Inventory is enabled |
 | config.clusterInventory.plugins | list | `[]` | Kubernetes image volumes that provide experimental/alpha Cluster Inventory access provider binaries |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -272,6 +272,9 @@ spec:
             {{- with .Values.config.nodeShellImage }}
             - "-node-shell-image={{ . }}"
             {{- end }}
+            {{- with .Values.config.nodeShellNamespace }}
+            - "-node-shell-namespace={{ . }}"
+            {{- end }}
             {{- if and .Values.config.inCluster .Values.config.unsafeUseServiceAccountToken }}
             - "-unsafe-use-service-account-token"
             {{- end }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -188,6 +188,10 @@
           "type": "string",
           "description": "Default image to use when creating node shell pods"
         },
+        "nodeShellNamespace": {
+          "type": "string",
+          "description": "Default namespace to use when creating node shell pods"
+        },
         "unsafeUseServiceAccountToken": {
           "type": "boolean",
           "description": "UNSAFE: authenticate every user as the pod's service account in-cluster mode"

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -129,6 +129,8 @@ config:
   podDebugImage: ""
   # -- Default image to use when creating node shell pods. If empty, Headlamp uses its built-in default.
   nodeShellImage: ""
+  # -- Default namespace to use when creating node shell pods. If empty, Headlamp uses its built-in default.
+  nodeShellNamespace: ""
   # tlsCertPath: "/headlamp-cert/headlamp-ca.crt"
   # tlsKeyPath: "/headlamp-cert/headlamp-tls.key"
   clusterInventory:

--- a/frontend/src/components/node/NodeShellAction.tsx
+++ b/frontend/src/components/node/NodeShellAction.tsx
@@ -19,6 +19,7 @@ import { DEFAULT_NODE_SHELL_NAMESPACE, loadClusterSettings } from '../../helpers
 import { getCluster } from '../../lib/cluster';
 import Node from '../../lib/k8s/node';
 import Pod from '../../lib/k8s/pod';
+import store from '../../redux/stores/store';
 import { Activity } from '../activity/Activity';
 import ActionButton from '../common/ActionButton';
 import { AuthVisible } from '../common/Resource';
@@ -41,7 +42,10 @@ function nodeTerminalNamespace(cluster: string | null) {
     return DEFAULT_NODE_SHELL_NAMESPACE;
   }
   const clusterSettings = loadClusterSettings(cluster);
-  return clusterSettings.nodeShellTerminal?.namespace ?? DEFAULT_NODE_SHELL_NAMESPACE;
+  const defaultNamespace = store.getState().config.defaultNodeShellNamespace;
+  return (
+    clusterSettings.nodeShellTerminal?.namespace || defaultNamespace || DEFAULT_NODE_SHELL_NAMESPACE
+  );
 }
 
 export function NodeShellAction(props: NodeShellTerminalProps) {

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -112,9 +112,10 @@ async function shell(item: Node, onExec: StreamResultsCb) {
 
   const clusterSettings = loadClusterSettings(cluster);
   const config = clusterSettings.nodeShellTerminal;
+  const defaultNamespace = store.getState().config.defaultNodeShellNamespace;
   const defaultImage = store.getState().config.defaultNodeShellImage;
   const linuxImage = config?.linuxImage || defaultImage || DEFAULT_NODE_SHELL_LINUX_IMAGE;
-  const namespace = config?.namespace || DEFAULT_NODE_SHELL_NAMESPACE;
+  const namespace = config?.namespace || defaultNamespace || DEFAULT_NODE_SHELL_NAMESPACE;
   const podName = `node-debugger-${item.getName()}-${uniqueString()}`;
   const kubePod = shellPod(podName, namespace, item.getName(), linuxImage);
   try {

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -51,6 +51,7 @@ const makeStore = () => {
         allowKubeconfigChanges: false,
         defaultPodDebugImage: '',
         defaultNodeShellImage: '',
+        defaultNodeShellNamespace: '',
       },
       projects: {
         headerActions: {},

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -44,6 +44,7 @@ const makeStore = () => {
         allowKubeconfigChanges: false,
         defaultPodDebugImage: '',
         defaultNodeShellImage: '',
+        defaultNodeShellNamespace: '',
         settings: {
           tableRowsPerPageOptions: [15, 25, 50],
           timezone: 'UTC',

--- a/frontend/src/redux/configSlice.test.ts
+++ b/frontend/src/redux/configSlice.test.ts
@@ -102,6 +102,35 @@ describe('configSlice', () => {
     expect(nextState.defaultNodeShellImage).toBe('');
   });
 
+  it('should handle setConfig with defaultNodeShellNamespace', () => {
+    const clusters: ConfigState['clusters'] = {
+      'cluster-1': { name: 'cluster-1' } as Cluster,
+    };
+    const nextState = configReducer(
+      initialState,
+      setConfig({
+        clusters,
+        defaultNodeShellNamespace: 'custom-ns',
+      })
+    );
+
+    expect(nextState.defaultNodeShellNamespace).toBe('custom-ns');
+  });
+
+  it('should handle clearing defaultNodeShellNamespace', () => {
+    const state = {
+      ...initialState,
+      defaultNodeShellNamespace: 'custom-ns',
+    };
+
+    const nextState = configReducer(
+      state,
+      setConfig({ clusters: {}, defaultNodeShellNamespace: '' })
+    );
+
+    expect(nextState.defaultNodeShellNamespace).toBe('');
+  });
+
   it('should preserve isDynamicClusterEnabled when setConfig is called without it', () => {
     let state = configReducer(
       initialState,

--- a/frontend/src/redux/configSlice.ts
+++ b/frontend/src/redux/configSlice.ts
@@ -64,6 +64,11 @@ export interface ConfigState {
    */
   defaultNodeShellImage: string;
   /**
+   * Default namespace used for node shell pods when no per-cluster override is configured.
+   * An empty string indicates that no default namespace is configured.
+   */
+  defaultNodeShellNamespace: string;
+  /**
    * Theme configuration from the backend server.
    */
   defaultLightTheme?: string;
@@ -163,6 +168,7 @@ export const initialState: ConfigState = {
   allowKubeconfigChanges: false,
   defaultPodDebugImage: '',
   defaultNodeShellImage: '',
+  defaultNodeShellNamespace: '',
   settings: {
     tableRowsPerPageOptions:
       storedSettings.tableRowsPerPageOptions ?? defaultTableRowsPerPageOptions,
@@ -189,6 +195,7 @@ const configSlice = createSlice({
         allowKubeconfigChanges?: boolean;
         defaultPodDebugImage?: string;
         defaultNodeShellImage?: string;
+        defaultNodeShellNamespace?: string;
         defaultLightTheme?: string;
         defaultDarkTheme?: string;
         forceTheme?: string;
@@ -206,6 +213,9 @@ const configSlice = createSlice({
       }
       if (action.payload.defaultNodeShellImage !== undefined) {
         state.defaultNodeShellImage = action.payload.defaultNodeShellImage;
+      }
+      if (action.payload.defaultNodeShellNamespace !== undefined) {
+        state.defaultNodeShellNamespace = action.payload.defaultNodeShellNamespace;
       }
       state.defaultLightTheme = action.payload.defaultLightTheme;
       state.defaultDarkTheme = action.payload.defaultDarkTheme;


### PR DESCRIPTION
## Summary

This PR adds a `--node-shell-namespace` CLI flag (and `config.nodeShellNamespace` Helm value) that lets admins configure the default Kubernetes namespace used when Headlamp creates node shell pods. Without this, the namespace was hardcoded to `default`. The value flows from the flag through the `/config` endpoint into the Redux store, and is read imperatively (via `store.getState()`) in `NodeShellTerminal` and `NodeShellAction` so it does not trigger re-renders or duplicate pods.

## Related Issue

Part of #5930

## Changes

- `backend/pkg/config/config.go`: added `node-shell-namespace` koanf flag
- `backend/pkg/headlampconfig/headlampConfig.go`: added `NodeShellNamespace` field
- `backend/cmd/server.go` + `headlamp.go`: wire flag → `clientConfig` → `/config` response
- `frontend/src/redux/configSlice.ts`: added `defaultNodeShellNamespace` state field and reducer
- `frontend/src/components/node/NodeShellTerminal.tsx` + `NodeShellAction.tsx`: read namespace via `store.getState()` (imperative, avoids re-render/duplicate-pod bug)
- `charts/headlamp/`: added `nodeShellNamespace` value mirroring `nodeShellImage`
- Tests: `headlamp_test.go`, `configSlice.test.ts`, `config_test.go`

## Steps to Test

1. Build and run the backend with the new flag: `./headlamp-server -node-shell-namespace=my-namespace`
2. Open Headlamp in the browser and navigate to a Node page
3. Click the terminal icon to open a node shell
4. Verify the shell pod is created in `my-namespace` instead of `default`
5. Confirm that omitting the flag still falls back to the built-in default namespace

## Screenshots (if applicable)

N/A — namespace is infrastructure config, not visible in the UI.

## Notes for the Reviewer

- Follows the exact same pattern as `--node-shell-image` (merged in #6056) and `--pod-debug-image`
- The namespace is read via `store.getState()` (not `useTypedSelector`) to avoid triggering a re-render that would change the `connectStream` function identity and spawn a duplicate node shell pod
- Per-cluster overrides (set in cluster settings) still take priority over this flag