### PR TITLE
app/pluginctl: Replace deprecated fs.rmdirSync with fs.rmSync

### DIFF
--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -284,7 +284,7 @@ export class PluginManager {
       }
 
       // remove the existing plugin folder
-      fs.rmdirSync(pluginDir, { recursive: true });
+      fs.rmSync(pluginDir, { recursive: true, force: true });
 
       // create the plugin folder
       fs.mkdirSync(pluginDir, { recursive: true });
@@ -332,7 +332,7 @@ export class PluginManager {
       }
 
       if (fs.existsSync(pluginDir)) {
-        fs.rmdirSync(pluginDir, { recursive: true });
+        fs.rmSync(pluginDir, { recursive: true, force: true });
       } else {
         throw new Error('Plugin not found');
       }
@@ -654,7 +654,7 @@ async function downloadExtraFiles(
       // remove the input file folder... if it's empty
       const inputDir = path.dirname(inputFile);
       if (fs.readdirSync(inputDir).length === 0) {
-        fs.rmdirSync(inputDir);
+        fs.rmSync(inputDir);
       }
 
       if (progressCallback) {

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -159,7 +159,7 @@ class PluginManager {
       }
 
       // remove the existing plugin folder
-      fs.rmdirSync(pluginDir, { recursive: true });
+      fs.rmSync(pluginDir, { recursive: true, force: true });
 
       // create the plugin folder
       fs.mkdirSync(pluginDir, { recursive: true });
@@ -199,7 +199,7 @@ class PluginManager {
       }
 
       if (fs.existsSync(pluginDir)) {
-        fs.rmdirSync(pluginDir, { recursive: true });
+        fs.rmSync(pluginDir, { recursive: true, force: true });
       } else {
         throw new Error('Plugin not found');
       }

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -38,7 +38,7 @@ describe('PluginManager Test Cases', () => {
 
   afterAll(() => {
     // Remove the temporary directory after all tests
-    fs.rmdirSync(tempDir, { recursive: true });
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
   beforeEach(() => {
@@ -113,7 +113,7 @@ describe('PluginManager Test Cases', () => {
       message: 'Plugin Uninstalled',
     });
 
-    fs.rmdirSync(tempDir, { recursive: true });
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
## Summary

Replace deprecated fs.rmdirSync() usages with fs.rmSync() in the plugin management code.

## Related Issue

Fixes #6053

## Changes

- Replaced deprecated fs.rmdirSync(..., { recursive: true }) calls with fs.rmSync(..., { recursive: true, force: true })
- Replaced deprecated fs.rmdirSync() usage with fs.rmSync()
- Updated related test files to use the new API

