### PR TITLE
releaser: Sign mac binaries by default when triggering app builds

### DIFF
--- a/tools/releaser/src/utils/github.ts
+++ b/tools/releaser/src/utils/github.ts
@@ -851,7 +851,7 @@ export async function triggerBuildWorkflows(
       workflowId: 'app-artifacts-mac.yml',
       inputs: {
         buildBranch: gitRef,
-        signBinaries: 'false'
+        signBinaries: 'true'
       }
     });
   }


### PR DESCRIPTION
we now have signing working on macos so releaser should default to signed macos binaries