### PR TITLE
frontend: ViewButton: Fix react-hooks/exhaustive-deps — use ref for i…

### DIFF
--- a/frontend/src/components/common/Resource/ViewButton.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.tsx
@@ -82,11 +82,11 @@ function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
     });
   };
 
+  const initialToggleRef = React.useRef(initialToggle);
   useEffect(() => {
-    if (initialToggle) {
+    if (initialToggleRef.current) {
       launchActivity();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/frontend/src/components/common/Resource/ViewButton.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.tsx
@@ -84,14 +84,14 @@ function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
 
   const initialToggleRef = React.useRef(initialToggle);
 
-useEffect(() => {
-  if (!initialToggleRef.current) {
-    return;
-  }
+  useEffect(() => {
+    if (!initialToggleRef.current) {
+      return;
+    }
 
-  initialToggleRef.current = false;
-  launchActivity();
-}, [launchActivity]);
+    initialToggleRef.current = false;
+    launchActivity();
+  }, [launchActivity]);
 
   return (
     <>

--- a/frontend/src/components/common/Resource/ViewButton.tsx
+++ b/frontend/src/components/common/Resource/ViewButton.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Icon } from '@iconify/react';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { KubeObject } from '../../../lib/k8s/cluster';
 import { Activity } from '../../activity/Activity';
@@ -36,7 +36,7 @@ function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
   const activityId = 'yaml-' + item.metadata.uid;
   const launchRequestRef = React.useRef(0);
 
-  const launchActivity = async () => {
+  const launchActivity = useCallback(async () => {
     const requestId = ++launchRequestRef.current;
     let editorItem = item;
     try {
@@ -80,14 +80,18 @@ function ViewButton({ item, buttonStyle, initialToggle }: ViewButtonProps) {
         />
       ),
     });
-  };
+  }, [activityId, item]);
 
   const initialToggleRef = React.useRef(initialToggle);
-  useEffect(() => {
-    if (initialToggleRef.current) {
-      launchActivity();
-    }
-  }, []);
+
+useEffect(() => {
+  if (!initialToggleRef.current) {
+    return;
+  }
+
+  initialToggleRef.current = false;
+  launchActivity();
+}, [launchActivity]);
 
   return (
     <>


### PR DESCRIPTION
Fixes the react-hooks/exhaustive-deps suppression in ViewButton.tsx by capturing the initial value of `initialToggle` in a ref. This allows the useEffect to run correctly on mount without needing to suppress the linter.

Ref #5183