### PR TITLE
frontend: tests: Centralize hardcoded backend URL as API_BASE

### DIFF
--- a/frontend/src/components/App/Layout.stories.tsx
+++ b/frontend/src/components/App/Layout.stories.tsx
@@ -19,7 +19,7 @@ import { delay, http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import store from '../../redux/stores/store';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Layout from './Layout';
 
 export default {
@@ -36,7 +36,7 @@ export default {
     msw: {
       handlers: [
         // Mock cluster config
-        http.get('http://localhost:4466/config', () =>
+        http.get(`${API_BASE}/config`, () =>
           HttpResponse.json({
             clusters: {
               minikube: {
@@ -51,9 +51,9 @@ export default {
           })
         ),
         // Mock plugins
-        http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
+        http.get(`${API_BASE}/plugins`, () => HttpResponse.json([])),
         // Mock cluster version
-        http.get('http://localhost:4466/version', () =>
+        http.get(`${API_BASE}/version`, () =>
           HttpResponse.json({
             major: '1',
             minor: '28',
@@ -61,14 +61,14 @@ export default {
           })
         ),
         // Mock events
-        http.get('http://localhost:4466/*/api/v1/events', () =>
+        http.get(`${API_BASE}/*/api/v1/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],
           })
         ),
         // Mock namespaces
-        http.get('http://localhost:4466/*/api/v1/namespaces', () =>
+        http.get(`${API_BASE}/*/api/v1/namespaces`, () =>
           HttpResponse.json({
             kind: 'NamespaceList',
             items: [
@@ -81,23 +81,19 @@ export default {
           })
         ),
         // Mock CRDs
-        http.get(
-          'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-          () =>
-            HttpResponse.json({
-              kind: 'List',
-              items: [],
-              metadata: {},
-            })
+        http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: [],
+            metadata: {},
+          })
         ),
-        http.get(
-          'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-          () =>
-            HttpResponse.json({
-              kind: 'List',
-              items: [],
-              metadata: {},
-            })
+        http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: [],
+            metadata: {},
+          })
         ),
       ],
     },
@@ -159,7 +155,7 @@ LoadingState.parameters = {
   msw: {
     handlers: [
       // Delay config response to show loading for 5 seconds
-      http.get('http://localhost:4466/config', async () => {
+      http.get(`${API_BASE}/config`, async () => {
         await delay(5000);
         return HttpResponse.json({
           clusters: {
@@ -170,22 +166,20 @@ LoadingState.parameters = {
           },
         });
       }),
-      http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
-      http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+      http.get(`${API_BASE}/plugins`, () => HttpResponse.json([])),
+      http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
         HttpResponse.json({
           kind: 'List',
           items: [],
           metadata: {},
         })
       ),
-      http.get(
-        'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-        () =>
-          HttpResponse.json({
-            kind: 'List',
-            items: [],
-            metadata: {},
-          })
+      http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+        HttpResponse.json({
+          kind: 'List',
+          items: [],
+          metadata: {},
+        })
       ),
     ],
   },
@@ -200,23 +194,21 @@ ErrorState.parameters = {
   },
   msw: {
     handlers: [
-      http.get('http://localhost:4466/config', () => HttpResponse.error()),
-      http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
-      http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+      http.get(`${API_BASE}/config`, () => HttpResponse.error()),
+      http.get(`${API_BASE}/plugins`, () => HttpResponse.json([])),
+      http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
         HttpResponse.json({
           kind: 'List',
           items: [],
           metadata: {},
         })
       ),
-      http.get(
-        'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-        () =>
-          HttpResponse.json({
-            kind: 'List',
-            items: [],
-            metadata: {},
-          })
+      http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+        HttpResponse.json({
+          kind: 'List',
+          items: [],
+          metadata: {},
+        })
       ),
     ],
   },
@@ -242,7 +234,7 @@ MultiCluster.parameters = {
   },
   msw: {
     handlers: [
-      http.get('http://localhost:4466/config', () =>
+      http.get(`${API_BASE}/config`, () =>
         HttpResponse.json({
           clusters: {
             minikube: {
@@ -260,22 +252,20 @@ MultiCluster.parameters = {
           },
         })
       ),
-      http.get('http://localhost:4466/plugins', () => HttpResponse.json([])),
-      http.get('http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions', () =>
+      http.get(`${API_BASE}/plugins`, () => HttpResponse.json([])),
+      http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
         HttpResponse.json({
           kind: 'List',
           items: [],
           metadata: {},
         })
       ),
-      http.get(
-        'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-        () =>
-          HttpResponse.json({
-            kind: 'List',
-            items: [],
-            metadata: {},
-          })
+      http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+        HttpResponse.json({
+          kind: 'List',
+          items: [],
+          metadata: {},
+        })
       ),
     ],
   },

--- a/frontend/src/components/App/Notifications/Notifications.stories.tsx
+++ b/frontend/src/components/App/Notifications/Notifications.stories.tsx
@@ -21,6 +21,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { getTestDate } from '../../../helpers/testHelpers';
+import { API_BASE } from '../../../test';
 import Notifications from './Notifications';
 import { Notification } from './notificationsSlice';
 
@@ -67,15 +68,11 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/clusters/staging-cluster/api/v1/events', () =>
+          http.get(`${API_BASE}/clusters/staging-cluster/api/v1/events`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/clusters/dev-cluster/api/v1/events', () =>
-            HttpResponse.error()
-          ),
-          http.get('http://localhost:4466/clusters/prod-cluster/api/v1/events', () =>
-            HttpResponse.error()
-          ),
+          http.get(`${API_BASE}/clusters/dev-cluster/api/v1/events`, () => HttpResponse.error()),
+          http.get(`${API_BASE}/clusters/prod-cluster/api/v1/events`, () => HttpResponse.error()),
         ],
       },
     },

--- a/frontend/src/components/App/TopBar.stories.tsx
+++ b/frontend/src/components/App/TopBar.stories.tsx
@@ -24,6 +24,7 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { AppBarActionsProcessor } from '../../redux/actionButtonsSlice';
 import { uiSlice } from '../../redux/uiSlice';
+import { API_BASE } from '../../test';
 import { initialState as themeInitialState } from './themeSlice';
 import { processAppBarActions, PureTopBar, PureTopBarProps } from './TopBar';
 
@@ -129,11 +130,11 @@ OneCluster.parameters = {
   msw: {
     handlers: [
       http.get(
-        'http://localhost:4466/clusters/ak8s-desktop/me',
+        `${API_BASE}/clusters/ak8s-desktop/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       http.post(
-        'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () => HttpResponse.json({ status: { userInfo: { username: 'one-cluster-user' } } })
       ),
     ],
@@ -151,11 +152,11 @@ TwoCluster.parameters = {
   msw: {
     handlers: [
       http.get(
-        'http://localhost:4466/clusters/ak8s-desktop/me',
+        `${API_BASE}/clusters/ak8s-desktop/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       http.post(
-        'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () => HttpResponse.json({ status: { userInfo: { username: 'two-cluster-user' } } })
       ),
     ],
@@ -173,11 +174,11 @@ WithUserInfo.parameters = {
   msw: {
     handlers: [
       http.get(
-        'http://localhost:4466/clusters/ak8s-desktop/me',
+        `${API_BASE}/clusters/ak8s-desktop/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       http.post(
-        'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () =>
           HttpResponse.json({
             status: {
@@ -202,11 +203,11 @@ WithEmailOnly.parameters = {
   msw: {
     handlers: [
       http.get(
-        'http://localhost:4466/clusters/ak8s-desktop/me',
+        `${API_BASE}/clusters/ak8s-desktop/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       http.post(
-        'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () =>
           HttpResponse.json({
             status: {
@@ -231,12 +232,12 @@ UndefinedData.parameters = {
   msw: {
     handlers: [
       http.get(
-        'http://localhost:4466/clusters/ak8s-desktop/me',
+        `${API_BASE}/clusters/ak8s-desktop/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       // Return 404 to simulate missing API or data
       http.post(
-        'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () => new HttpResponse(null, { status: 404 })
       ),
     ],
@@ -254,11 +255,11 @@ EmptyUserInfo.parameters = {
   msw: {
     handlers: [
       http.get(
-        'http://localhost:4466/clusters/ak8s-desktop/me',
+        `${API_BASE}/clusters/ak8s-desktop/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       http.post(
-        'http://localhost:4466/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/ak8s-desktop/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () => HttpResponse.json({})
       ),
     ],
@@ -281,15 +282,15 @@ MultiCluster.parameters = {
   msw: {
     handlers: [
       http.get(
-        'http://localhost:4466/clusters/admin-cluster/me',
+        `${API_BASE}/clusters/admin-cluster/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       http.get(
-        'http://localhost:4466/clusters/view-cluster/me',
+        `${API_BASE}/clusters/view-cluster/me`,
         () => new HttpResponse(null, { status: 404 })
       ),
       http.post(
-        'http://localhost:4466/clusters/admin-cluster/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/admin-cluster/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () =>
           HttpResponse.json({
             status: {
@@ -301,7 +302,7 @@ MultiCluster.parameters = {
           })
       ),
       http.post(
-        'http://localhost:4466/clusters/view-cluster/apis/authentication.k8s.io/v1/selfsubjectreviews',
+        `${API_BASE}/clusters/view-cluster/apis/authentication.k8s.io/v1/selfsubjectreviews`,
         () =>
           HttpResponse.json({
             status: {

--- a/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route } from 'react-router-dom';
 import { initialState as configInitialState } from '../../redux/configSlice';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import NavigationTabs from './NavigationTabs';
 import {
   DefaultSidebars,
@@ -159,23 +159,19 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                items: [],
-                metadata: {},
-              })
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+              metadata: {},
+            })
           ),
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                items: [],
-                metadata: {},
-              })
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+              metadata: {},
+            })
           ),
         ],
       },

--- a/frontend/src/components/Sidebar/Sidebar.stories.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.stories.tsx
@@ -23,7 +23,7 @@ import { initialState as THEME_INITIAL_STATE } from '../../components/App/themeS
 import { initialState as CONFIG_INITIAL_STATE } from '../../redux/configSlice';
 import { initialState as FILTER_INITIAL_STATE } from '../../redux/filterSlice';
 import { uiSlice } from '../../redux/uiSlice';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Sidebar, { DefaultSidebars, PureSidebar } from './Sidebar';
 import { initialState as SIDEBAR_INITIAL_STATE, SidebarState } from './sidebarSlice';
 
@@ -34,23 +34,19 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                items: [],
-                metadata: {},
-              })
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+              metadata: {},
+            })
           ),
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                items: [],
-                metadata: {},
-              })
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+              metadata: {},
+            })
           ),
         ],
       },

--- a/frontend/src/components/advancedSearch/ResourceSearch.stories.tsx
+++ b/frontend/src/components/advancedSearch/ResourceSearch.stories.tsx
@@ -18,7 +18,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { ApiResource } from '../../lib/k8s/api/v2/ApiResource';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { ResourceSearch } from './ResourceSearch';
 
 export default {
@@ -29,7 +29,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/clusters/kind-kind/api/v1/pods', () =>
+          http.get(`${API_BASE}/clusters/kind-kind/api/v1/pods`, () =>
             HttpResponse.json({
               kind: 'PodList',
               apiVersion: 'v1',
@@ -62,7 +62,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/clusters/kind-kind/apis/apps/v1/deployments', () =>
+          http.get(`${API_BASE}/clusters/kind-kind/apis/apps/v1/deployments`, () =>
             HttpResponse.json({
               kind: 'DeploymentList',
               apiVersion: 'apps/v1',

--- a/frontend/src/components/cluster/Overview.stories.tsx
+++ b/frontend/src/components/cluster/Overview.stories.tsx
@@ -17,7 +17,7 @@
 import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Overview from './Overview';
 
 export default {
@@ -37,7 +37,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/api/v1/events', () =>
+          http.get(`${API_BASE}/api/v1/events`, () =>
             HttpResponse.json({
               kind: 'EventsList',
               items: [
@@ -169,7 +169,7 @@ export default {
               metadata: {},
             })
           ),
-          http.get('http://localhost:4466/api/v1/pods', () =>
+          http.get(`${API_BASE}/api/v1/pods`, () =>
             HttpResponse.json({
               kind: 'PodList',
               apiVersion: 'v1',
@@ -198,14 +198,14 @@ EmptyState.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/events', () =>
+        http.get(`${API_BASE}/api/v1/events`, () =>
           HttpResponse.json({
             kind: 'EventsList',
             items: [],
             metadata: {},
           })
         ),
-        http.get('http://localhost:4466/api/v1/pods', () =>
+        http.get(`${API_BASE}/api/v1/pods`, () =>
           HttpResponse.json({
             kind: 'PodList',
             apiVersion: 'v1',
@@ -224,8 +224,8 @@ LoadingState.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/events', () => new Promise(() => {})),
-        http.get('http://localhost:4466/api/v1/pods', () => new Promise(() => {})),
+        http.get(`${API_BASE}/api/v1/events`, () => new Promise(() => {})),
+        http.get(`${API_BASE}/api/v1/pods`, () => new Promise(() => {})),
       ],
     },
   },
@@ -236,8 +236,8 @@ ErrorState.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/events', () => HttpResponse.error()),
-        http.get('http://localhost:4466/api/v1/pods', () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/events`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/pods`, () => HttpResponse.error()),
       ],
     },
   },

--- a/frontend/src/components/common/ObjectEventList.stories.tsx
+++ b/frontend/src/components/common/ObjectEventList.stories.tsx
@@ -22,7 +22,7 @@ import { getTestDate } from '../../helpers/testHelpers';
 import { KubeEvent } from '../../lib/k8s/event';
 import { KubeObject } from '../../lib/k8s/KubeObject';
 import store from '../../redux/stores/store';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ObjectEventList, { ObjectEventListProps } from './ObjectEventList';
 
 const mockOwnerObject = new KubeObject({
@@ -118,38 +118,33 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get(
-            'http://localhost:4466/api/v1/namespaces/:namespace/events',
-            ({ params, request }) => {
-              const url = new URL(request.url);
-              const fieldSelector = url.searchParams.get('fieldSelector');
-              const reqNamespace = params.namespace;
+          http.get(`${API_BASE}/api/v1/namespaces/:namespace/events`, ({ params, request }) => {
+            const url = new URL(request.url);
+            const fieldSelector = url.searchParams.get('fieldSelector');
+            const reqNamespace = params.namespace;
 
-              if (
-                reqNamespace === mockOwnerObject.metadata.namespace &&
-                fieldSelector &&
-                fieldSelector.includes(`involvedObject.kind=${mockOwnerObject.kind}`) &&
-                fieldSelector.includes(`involvedObject.name=${mockOwnerObject.metadata.name}`)
-              ) {
-                return HttpResponse.json({
-                  kind: 'EventList',
-                  items: mockEvents,
-                  metadata: {},
-                });
-              }
-              if (
-                reqNamespace === mockOwnerObjectNoEvents.metadata.namespace &&
-                fieldSelector &&
-                fieldSelector.includes(`involvedObject.kind=${mockOwnerObjectNoEvents.kind}`) &&
-                fieldSelector.includes(
-                  `involvedObject.name=${mockOwnerObjectNoEvents.metadata.name}`
-                )
-              ) {
-                return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
-              }
+            if (
+              reqNamespace === mockOwnerObject.metadata.namespace &&
+              fieldSelector &&
+              fieldSelector.includes(`involvedObject.kind=${mockOwnerObject.kind}`) &&
+              fieldSelector.includes(`involvedObject.name=${mockOwnerObject.metadata.name}`)
+            ) {
+              return HttpResponse.json({
+                kind: 'EventList',
+                items: mockEvents,
+                metadata: {},
+              });
+            }
+            if (
+              reqNamespace === mockOwnerObjectNoEvents.metadata.namespace &&
+              fieldSelector &&
+              fieldSelector.includes(`involvedObject.kind=${mockOwnerObjectNoEvents.kind}`) &&
+              fieldSelector.includes(`involvedObject.name=${mockOwnerObjectNoEvents.metadata.name}`)
+            ) {
               return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
             }
-          ),
+            return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
+          }),
         ],
       },
     },
@@ -193,10 +188,10 @@ ErrorFetching.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () => {
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () => {
           return HttpResponse.json({ kind: 'EventList', items: [], metadata: {} });
         }),
-        http.get('http://localhost:4466/api/v1/namespaces/errors/events', ({ request }) => {
+        http.get(`${API_BASE}/api/v1/namespaces/errors/events`, ({ request }) => {
           const url = new URL(request.url);
           const fieldSelector = url.searchParams.get('fieldSelector');
           if (fieldSelector && fieldSelector.includes('involvedObject.name=error-secret')) {

--- a/frontend/src/components/common/Resource/DocsViewer.stories.tsx
+++ b/frontend/src/components/common/Resource/DocsViewer.stories.tsx
@@ -17,6 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { resetDocsPromise } from '../../../lib/docs';
+import { API_BASE } from '../../../test';
 import DocsViewer, { DocsViewerProps } from './DocsViewer';
 
 export default {
@@ -27,7 +28,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/openapi/v2', () =>
+          http.get(`${API_BASE}/openapi/v2`, () =>
             HttpResponse.json({
               swagger: '2.0',
               info: { title: 'Test API', version: '1.0.0' },
@@ -132,7 +133,7 @@ ErrorDocumentation.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/openapi/v2',
+          `${API_BASE}/openapi/v2`,
           () =>
             new HttpResponse(null, {
               status: 500,

--- a/frontend/src/components/common/Resource/ResourceTableMultiActions.stories.tsx
+++ b/frontend/src/components/common/Resource/ResourceTableMultiActions.stories.tsx
@@ -25,7 +25,7 @@ import Deployment from '../../../lib/k8s/deployment';
 import { KubeObject } from '../../../lib/k8s/KubeObject';
 import ReplicaSet from '../../../lib/k8s/replicaSet';
 import StatefulSet from '../../../lib/k8s/statefulSet';
-import { TestContext } from '../../../test';
+import { API_BASE, TestContext } from '../../../test';
 import ActionsNotifier from '../ActionsNotifier';
 import ResourceTableMultiActions from './ResourceTableMultiActions';
 
@@ -47,12 +47,11 @@ export default {
       handlers: {
         story: [
           http.post(
-            'http://localhost:4466/clusters/local/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
+            `${API_BASE}/clusters/local/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`,
             () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
           ),
         ],
       },

--- a/frontend/src/components/configmap/Details.stories.tsx
+++ b/frontend/src/components/configmap/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './Details';
 import { BASE_CONFIG_MAP, BASE_EMPTY_CONFIG_MAP } from './storyHelper';
 
@@ -37,8 +37,8 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/api/v1/configmaps', () => HttpResponse.error()),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/configmaps`, () => HttpResponse.error()),
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
@@ -60,9 +60,7 @@ WithBase.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/configmaps/my-cm', () =>
-          HttpResponse.json(BASE_CONFIG_MAP)
-        ),
+        http.get(`${API_BASE}/api/v1/configmaps/my-cm`, () => HttpResponse.json(BASE_CONFIG_MAP)),
       ],
     },
   },
@@ -73,7 +71,7 @@ Empty.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/configmaps/my-cm', () =>
+        http.get(`${API_BASE}/api/v1/configmaps/my-cm`, () =>
           HttpResponse.json(BASE_EMPTY_CONFIG_MAP)
         ),
       ],

--- a/frontend/src/components/configmap/List.stories.tsx
+++ b/frontend/src/components/configmap/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './List';
 import { BASE_CONFIG_MAP, BASE_EMPTY_CONFIG_MAP } from './storyHelper';
 
@@ -38,7 +38,7 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get('http://localhost:4466/api/v1/configmaps', () =>
+          http.get(`${API_BASE}/api/v1/configmaps`, () =>
             HttpResponse.json({
               kind: 'ConfigMapList',
               items: [BASE_CONFIG_MAP, BASE_EMPTY_CONFIG_MAP],

--- a/frontend/src/components/crd/CustomResourceDefinition.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceDefinition.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext, TestContextProps } from '../../test';
+import { API_BASE, TestContext, TestContextProps } from '../../test';
 import CustomResourceDefinitionDetails from './Details';
 import CustomResourceDefinitionList from './List';
 import { mockCRD, mockCRList } from './storyHelper';
@@ -36,27 +36,25 @@ export default {
       handlers: {
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`,
             () => new HttpResponse(null, { status: 404 })
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/mydefinition.phonyresources.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/mydefinition.phonyresources.io`,
             () => HttpResponse.error()
           ),
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                metadata: {},
-                items: [mockCRD],
-              })
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              metadata: {},
+              items: [mockCRD],
+            })
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mydefinition.phonyresources.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mydefinition.phonyresources.io`,
             () => HttpResponse.json(mockCRD)
           ),
-          http.get('http://localhost:4466/apis/my.phonyresources.io/v1/mycustomresources', () =>
+          http.get(`${API_BASE}/apis/my.phonyresources.io/v1/mycustomresources`, () =>
             HttpResponse.json({
               kind: 'List',
               metadata: {},

--- a/frontend/src/components/crd/CustomResourceDetails.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { CustomResourceDetails, CustomResourceDetailsProps } from './CustomResourceDetails';
 import { mockCRD, mockCRList } from './storyHelper';
 
@@ -28,63 +28,58 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () =>
-              HttpResponse.json(
-                {
-                  kind: 'Status',
-                  apiVersion: 'v1',
-                  status: 'Failure',
-                  message:
-                    'the server could not find the requested resource for /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-                  reason: 'NotFound',
-                  code: 404,
-                },
-                { status: 404 }
-              )
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+            HttpResponse.json(
+              {
+                kind: 'Status',
+                apiVersion: 'v1',
+                status: 'Failure',
+                message:
+                  'the server could not find the requested resource for /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+                reason: 'NotFound',
+                code: 404,
+              },
+              { status: 404 }
+            )
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/mydefinition.phonyresources.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/mydefinition.phonyresources.io`,
             () => HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/error.crd.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/error.crd.io`,
             () => HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/loadingcrd',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/loadingcrd`,
             () => HttpResponse.error()
           ),
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-            () => HttpResponse.json({})
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
+            HttpResponse.json({})
           ),
           http.get(
-            'http://localhost:4466/apis/my.phonyresources.io/v1/namespaces/mynamespace/mycustomresources/mycustomresource',
+            `${API_BASE}/apis/my.phonyresources.io/v1/namespaces/mynamespace/mycustomresources/mycustomresource`,
             () => HttpResponse.json(mockCRList[0])
           ),
           http.get(
-            'http://localhost:4466/apis/my.phonyresources.io/v1/namespaces/mynamespace/mycustomresources',
+            `${API_BASE}/apis/my.phonyresources.io/v1/namespaces/mynamespace/mycustomresources`,
             () => HttpResponse.json({})
           ),
           http.get(
-            'http://localhost:4466/apis/my.phonyresources.io/v1/mycustomresources/nonexistentcustomresource',
+            `${API_BASE}/apis/my.phonyresources.io/v1/mycustomresources/nonexistentcustomresource`,
             () => HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions/error.crd.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions/error.crd.io`,
             () => HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mydefinition.phonyresources.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mydefinition.phonyresources.io`,
             () => HttpResponse.json(mockCRD)
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/mynamespace/events', () =>
-            HttpResponse.error()
-          ),
+          http.get(`${API_BASE}/api/v1/namespaces/mynamespace/events`, () => HttpResponse.error()),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions/loadingcrd',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions/loadingcrd`,
             () => HttpResponse.json(null)
           ),
         ],

--- a/frontend/src/components/crd/CustomResourceList.stories.tsx
+++ b/frontend/src/components/crd/CustomResourceList.stories.tsx
@@ -17,7 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { KubeObjectClass } from '../../lib/k8s/KubeObject';
-import { TestContext, TestContextProps } from '../../test';
+import { API_BASE, TestContext, TestContextProps } from '../../test';
 import CustomResourceList from './CustomResourceList';
 import { mockCRD, mockCRList } from './storyHelper';
 
@@ -35,7 +35,7 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/apis/my.phonyresources.io/v1/mycustomresources', () =>
+          http.get(`${API_BASE}/apis/my.phonyresources.io/v1/mycustomresources`, () =>
             HttpResponse.json({
               kind: 'List',
               metadata: {},
@@ -43,24 +43,22 @@ export default {
             })
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`,
             () => new HttpResponse(null, { status: 404 })
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/mydefinition.phonyresources.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/mydefinition.phonyresources.io`,
             () => HttpResponse.error()
           ),
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                metadata: {},
-                items: [mockCRD],
-              })
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              metadata: {},
+              items: [mockCRD],
+            })
           ),
           http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mydefinition.phonyresources.io',
+            `${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mydefinition.phonyresources.io`,
             () => HttpResponse.json(mockCRD)
           ),
         ],

--- a/frontend/src/components/cronjob/CronJobDetails.stories.tsx
+++ b/frontend/src/components/cronjob/CronJobDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import CronJobDetails from './Details';
 import { cronJobList } from './storyHelper';
 
@@ -28,25 +28,25 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/apis/batch/v1/namespaces/default/cronjobs', () =>
+          http.get(`${API_BASE}/apis/batch/v1/namespaces/default/cronjobs`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.get('http://localhost:4466/apis/batch/v1/namespaces/default/jobs', () =>
+          http.get(`${API_BASE}/apis/batch/v1/namespaces/default/jobs`, () =>
             HttpResponse.json({
               kind: 'JobsList',
               metadata: {},
               items: [],
             })
           ),
-          http.get('http://localhost:4466/apis/batch/v1beta1/cronjobs', () => HttpResponse.error()),
-          http.get('http://localhost:4466/apis/batch/v1/jobs', () => HttpResponse.error()),
+          http.get(`${API_BASE}/apis/batch/v1beta1/cronjobs`, () => HttpResponse.error()),
+          http.get(`${API_BASE}/apis/batch/v1/jobs`, () => HttpResponse.error()),
         ],
       },
     },
@@ -75,9 +75,8 @@ EveryMinute.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/apis/batch/v1/namespaces/default/cronjobs/every-minute',
-          () => HttpResponse.json(cronJobList.find(it => it.metadata.name === 'every-minute'))
+        http.get(`${API_BASE}/apis/batch/v1/namespaces/default/cronjobs/every-minute`, () =>
+          HttpResponse.json(cronJobList.find(it => it.metadata.name === 'every-minute'))
         ),
       ],
     },
@@ -93,7 +92,7 @@ EveryAst.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/batch/v1/namespaces/default/cronjobs/every-minute-one-char',
+          `${API_BASE}/apis/batch/v1/namespaces/default/cronjobs/every-minute-one-char`,
           () =>
             HttpResponse.json(cronJobList.find(it => it.metadata.name === 'every-minute-one-char'))
         ),

--- a/frontend/src/components/cronjob/List.stories.tsx
+++ b/frontend/src/components/cronjob/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './List';
 import { cronJobList } from './storyHelper';
 
@@ -38,9 +38,9 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get('http://localhost:4466/apis/batch/v1/jobs', () => HttpResponse.error()),
-          http.get('http://localhost:4466/apis/batch/v1beta1/cronjobs', () => HttpResponse.error()),
-          http.get('http://localhost:4466/apis/batch/v1/cronjobs', () =>
+          http.get(`${API_BASE}/apis/batch/v1/jobs`, () => HttpResponse.error()),
+          http.get(`${API_BASE}/apis/batch/v1beta1/cronjobs`, () => HttpResponse.error()),
+          http.get(`${API_BASE}/apis/batch/v1/cronjobs`, () =>
             HttpResponse.json({
               kind: 'CronJobList',
               items: cronJobList,

--- a/frontend/src/components/daemonset/Details.stories.tsx
+++ b/frontend/src/components/daemonset/Details.stories.tsx
@@ -17,7 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { KubeObjectInterface } from '../../lib/k8s/KubeObject';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './Details';
 import { DAEMONSET_DUMMY, DAEMONSET_NO_TOLERATIONS } from './storyHelper';
 
@@ -36,19 +36,17 @@ const podMetricsList = {
 // details view fires a watch on it in addition to the get-by-name request.
 function commonHandlers(namespace: string) {
   return [
-    http.get(`http://localhost:4466/apis/apps/v1/namespaces/${namespace}/daemonsets`, () =>
+    http.get(`${API_BASE}/apis/apps/v1/namespaces/${namespace}/daemonsets`, () =>
       HttpResponse.json(emptyList)
     ),
-    http.get(`http://localhost:4466/api/v1/namespaces/${namespace}/pods`, () =>
-      HttpResponse.json(emptyList)
-    ),
-    http.get(`http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/${namespace}/pods`, () =>
+    http.get(`${API_BASE}/api/v1/namespaces/${namespace}/pods`, () => HttpResponse.json(emptyList)),
+    http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/namespaces/${namespace}/pods`, () =>
       HttpResponse.json(podMetricsList)
     ),
-    http.get(`http://localhost:4466/api/v1/namespaces/${namespace}/events`, () =>
+    http.get(`${API_BASE}/api/v1/namespaces/${namespace}/events`, () =>
       HttpResponse.json(emptyList)
     ),
-    http.get(`http://localhost:4466/apis/apps/v1/namespaces/${namespace}/controllerrevisions`, () =>
+    http.get(`${API_BASE}/apis/apps/v1/namespaces/${namespace}/controllerrevisions`, () =>
       HttpResponse.json(emptyList)
     ),
   ];
@@ -74,9 +72,8 @@ function makeStory(daemonSet: KubeObjectInterface) {
     msw: {
       handlers: {
         story: [
-          http.get(
-            `http://localhost:4466/apis/apps/v1/namespaces/${namespace}/daemonsets/${name}`,
-            () => HttpResponse.json(daemonSet)
+          http.get(`${API_BASE}/apis/apps/v1/namespaces/${namespace}/daemonsets/${name}`, () =>
+            HttpResponse.json(daemonSet)
           ),
           ...commonHandlers(namespace),
         ],

--- a/frontend/src/components/daemonset/List.stories.tsx
+++ b/frontend/src/components/daemonset/List.stories.tsx
@@ -17,7 +17,7 @@
 import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import List from './List';
 import { DAEMONSET_DUMMY_LIST } from './storyHelper';
 
@@ -40,7 +40,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
+          http.get(`${API_BASE}/apis/apps/v1/daemonsets`, () =>
             HttpResponse.json({
               kind: 'DaemonSetList',
               items: objList,
@@ -68,9 +68,7 @@ Loading.parameters = {
   storyshots: { disable: true },
   msw: {
     handlers: {
-      story: [
-        http.get('http://localhost:4466/apis/apps/v1/daemonsets', () => new Promise(() => {})),
-      ],
+      story: [http.get(`${API_BASE}/apis/apps/v1/daemonsets`, () => new Promise(() => {}))],
     },
   },
 };
@@ -80,7 +78,7 @@ Empty.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
+        http.get(`${API_BASE}/apis/apps/v1/daemonsets`, () =>
           HttpResponse.json({
             kind: 'DaemonSetList',
             items: [],
@@ -96,9 +94,7 @@ export const Error = Template.bind({});
 Error.parameters = {
   msw: {
     handlers: {
-      story: [
-        http.get('http://localhost:4466/apis/apps/v1/daemonsets', () => HttpResponse.error()),
-      ],
+      story: [http.get(`${API_BASE}/apis/apps/v1/daemonsets`, () => HttpResponse.error())],
     },
   },
 };
@@ -108,7 +104,7 @@ LongName.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
+        http.get(`${API_BASE}/apis/apps/v1/daemonsets`, () =>
           HttpResponse.json({
             kind: 'DaemonSetList',
             items: [

--- a/frontend/src/components/deployments/List.stories.tsx
+++ b/frontend/src/components/deployments/List.stories.tsx
@@ -18,7 +18,7 @@ import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { KubeDeployment } from '../../lib/k8s/deployment';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import List from './List';
 
 const items: KubeDeployment[] = [
@@ -201,7 +201,7 @@ Deployments.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
+        http.get(`${API_BASE}/apis/apps/v1/deployments`, () =>
           HttpResponse.json({
             kind: 'DeploymentList',
             items,

--- a/frontend/src/components/endpointSlices/EndpointSliceDetails.stories.tsx
+++ b/frontend/src/components/endpointSlices/EndpointSliceDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import EndpointSliceDetails from './Details';
 
 export default {
@@ -28,15 +28,13 @@ export default {
       handlers: {
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/my-namespace/endpointslices',
+            `${API_BASE}/apis/discovery.k8s.io/v1/namespaces/my-namespace/endpointslices`,
             () => HttpResponse.error()
           ),
-          http.get('http://localhost:4466/apis/discovery.k8s.io/v1/endpointslices', () =>
+          http.get(`${API_BASE}/apis/discovery.k8s.io/v1/endpointslices`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/my-namespace/events', () =>
-            HttpResponse.error()
-          ),
+          http.get(`${API_BASE}/api/v1/namespaces/my-namespace/events`, () => HttpResponse.error()),
         ],
       },
     },
@@ -57,7 +55,7 @@ Default.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/my-namespace/endpointslices/my-endpoint',
+          `${API_BASE}/apis/discovery.k8s.io/v1/namespaces/my-namespace/endpointslices/my-endpoint`,
           () =>
             HttpResponse.json({
               kind: 'EndpointSlice',
@@ -116,7 +114,7 @@ Error.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/my-namespace/endpointslices/my-endpoint',
+          `${API_BASE}/apis/discovery.k8s.io/v1/namespaces/my-namespace/endpointslices/my-endpoint`,
           () => HttpResponse.error()
         ),
       ],

--- a/frontend/src/components/endpointSlices/EndpointSliceList.stories.tsx
+++ b/frontend/src/components/endpointSlices/EndpointSliceList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import EndpointSliceList from './List';
 
 const list = [
@@ -68,7 +68,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/discovery.k8s.io/v1/endpointslices', () =>
+          http.get(`${API_BASE}/apis/discovery.k8s.io/v1/endpointslices`, () =>
             HttpResponse.json({
               kind: 'EndpointSliceList',
               items: list,

--- a/frontend/src/components/endpoints/EndpointDetails.stories.tsx
+++ b/frontend/src/components/endpoints/EndpointDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import EndpointDetails from './Details';
 
 export default {
@@ -27,12 +27,10 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/api/v1/namespaces/my-namespace/endpoints', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/my-namespace/endpoints`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/my-namespace/events', () =>
-            HttpResponse.error()
-          ),
+          http.get(`${API_BASE}/api/v1/namespaces/my-namespace/events`, () => HttpResponse.error()),
         ],
       },
     },
@@ -52,7 +50,7 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/my-namespace/endpoints/my-endpoint', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespace/endpoints/my-endpoint`, () =>
           HttpResponse.json({
             kind: 'Endpoints',
             apiVersion: 'v1',
@@ -113,7 +111,7 @@ Error.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/my-namespace/endpoints/my-endpoint', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespace/endpoints/my-endpoint`, () =>
           HttpResponse.error()
         ),
       ],

--- a/frontend/src/components/endpoints/EndpointList.stories.tsx
+++ b/frontend/src/components/endpoints/EndpointList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import EndpointList from './List';
 
 const list = [
@@ -72,7 +72,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/api/v1/endpoints', () =>
+          http.get(`${API_BASE}/api/v1/endpoints`, () =>
             HttpResponse.json({
               kind: 'EndpointsList',
               items: list,

--- a/frontend/src/components/gateway/BackendTLSPolicyDetails.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import BackendTLSPolicyDetails from './BackendTLSPolicyDetails';
 import { DEFAULT_BACKEND_TLS_POLICY } from './storyHelper';
 
@@ -36,26 +36,24 @@ export default {
         story: [],
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies`,
             () => HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies/example-policy',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/namespaces/default/backendtlspolicies/example-policy`,
             () => HttpResponse.json(DEFAULT_BACKEND_TLS_POLICY)
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () =>
-              HttpResponse.json({
-                status: { allowed: true, reason: '', code: 200 },
-              })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({
+              status: { allowed: true, reason: '', code: 200 },
+            })
           ),
         ],
       },

--- a/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import BackendTLSPolicyList from './BackendTLSPolicyList';
 import { DEFAULT_BACKEND_TLS_POLICY } from './storyHelper';
 
@@ -35,15 +35,13 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies',
-            () =>
-              HttpResponse.json({
-                kind: 'BackendTLSPolicyList',
-                apiVersion: 'gateway.networking.k8s.io/v1alpha3',
-                metadata: {},
-                items: [DEFAULT_BACKEND_TLS_POLICY],
-              })
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies`, () =>
+            HttpResponse.json({
+              kind: 'BackendTLSPolicyList',
+              apiVersion: 'gateway.networking.k8s.io/v1alpha3',
+              metadata: {},
+              items: [DEFAULT_BACKEND_TLS_POLICY],
+            })
           ),
         ],
       },

--- a/frontend/src/components/gateway/BackendTrafficPolicyDetails.stories.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import BackendTrafficPolicyDetails from './BackendTrafficPolicyDetails';
 import { DEFAULT_BACKEND_TRAFFIC_POLICY } from './storyHelper';
 
@@ -36,26 +36,24 @@ export default {
         story: [],
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/gateway.networking.x-k8s.io/v1alpha1/namespaces/default/xbackendtrafficpolicies',
+            `${API_BASE}/apis/gateway.networking.x-k8s.io/v1alpha1/namespaces/default/xbackendtrafficpolicies`,
             () => HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/gateway.networking.x-k8s.io/v1alpha1/namespaces/default/xbackendtrafficpolicies/example-traffic-policy',
+            `${API_BASE}/apis/gateway.networking.x-k8s.io/v1alpha1/namespaces/default/xbackendtrafficpolicies/example-traffic-policy`,
             () => HttpResponse.json(DEFAULT_BACKEND_TRAFFIC_POLICY)
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () =>
-              HttpResponse.json({
-                status: { allowed: true, reason: '', code: 200 },
-              })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({
+              status: { allowed: true, reason: '', code: 200 },
+            })
           ),
         ],
       },

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.stories.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import BackendTrafficPolicyList from './BackendTrafficPolicyList';
 import { DEFAULT_BACKEND_TRAFFIC_POLICY } from './storyHelper';
 
@@ -36,7 +36,7 @@ export default {
         storyBase: [],
         story: [
           http.get(
-            'http://localhost:4466/apis/gateway.networking.x-k8s.io/v1alpha1/xbackendtrafficpolicies',
+            `${API_BASE}/apis/gateway.networking.x-k8s.io/v1alpha1/xbackendtrafficpolicies`,
             () =>
               HttpResponse.json({
                 kind: 'XBackendTrafficPolicyList',

--- a/frontend/src/components/gateway/ClassDetails.stories.tsx
+++ b/frontend/src/components/gateway/ClassDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './ClassDetails';
 import { DEFAULT_GATEWAY_CLASS } from './storyHelper';
 
@@ -38,18 +38,17 @@ export default {
       handlers: {
         story: [],
         storyBase: [
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/gatewayclasses', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/gatewayclasses`, () =>
             HttpResponse.json({})
           ),
-          http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses',
-            () => HttpResponse.error()
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses`, () =>
+            HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/default-gateway-class',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/default-gateway-class`,
             () => HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
@@ -57,7 +56,7 @@ export default {
             })
           ),
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1/gatewayclasses/default-gateway-class',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1/gatewayclasses/default-gateway-class`,
             () => HttpResponse.json(DEFAULT_GATEWAY_CLASS)
           ),
         ],

--- a/frontend/src/components/gateway/ClassList.stories.tsx
+++ b/frontend/src/components/gateway/ClassList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './ClassList';
 import { DEFAULT_GATEWAY_CLASS } from './storyHelper';
 
@@ -38,11 +38,10 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses',
-            () => HttpResponse.error()
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses`, () =>
+            HttpResponse.error()
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/gatewayclasses', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/gatewayclasses`, () =>
             HttpResponse.json({
               kind: 'GatewayClassList',
               metadata: {},

--- a/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import GRPCRouteDetails from './GRPCRouteDetails';
 import { DEFAULT_GRPC_ROUTE } from './storyHelper';
 
@@ -38,29 +38,28 @@ export default {
       handlers: {
         story: [],
         storyBase: [
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes`, () =>
             HttpResponse.json({})
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/grpcroutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes`, () =>
             HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/grpcroutes/default-grpcroute',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes/default-grpcroute`,
             () => HttpResponse.error()
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
           ),
         ],
       },
@@ -80,9 +79,8 @@ Basic.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes/default-grpcroute',
-          () => HttpResponse.json(DEFAULT_GRPC_ROUTE)
+        http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes/default-grpcroute`, () =>
+          HttpResponse.json(DEFAULT_GRPC_ROUTE)
         ),
       ],
     },

--- a/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteDetails.stories.tsx
@@ -48,9 +48,6 @@ export default {
             `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes/default-grpcroute`,
             () => HttpResponse.error()
           ),
-          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes`, () =>
-            HttpResponse.error()
-          ),
           http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',

--- a/frontend/src/components/gateway/GRPCRouteList.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './GRPCRouteList';
 import { DEFAULT_GRPC_ROUTE } from './storyHelper';
 
@@ -38,17 +38,17 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes`, () =>
             HttpResponse.json({
               kind: 'GRPCRouteList',
               metadata: {},
               items: [DEFAULT_GRPC_ROUTE],
             })
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/grpcroutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/grpcroutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes`, () =>
             HttpResponse.error()
           ),
         ],

--- a/frontend/src/components/gateway/GRPCRouteList.stories.tsx
+++ b/frontend/src/components/gateway/GRPCRouteList.stories.tsx
@@ -45,9 +45,6 @@ export default {
               items: [DEFAULT_GRPC_ROUTE],
             })
           ),
-          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/grpcroutes`, () =>
-            HttpResponse.error()
-          ),
           http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/grpcroutes`, () =>
             HttpResponse.error()
           ),

--- a/frontend/src/components/gateway/GatewayDetails.stories.tsx
+++ b/frontend/src/components/gateway/GatewayDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import GatewayDetails from './GatewayDetails';
 import { DEFAULT_GATEWAY } from './storyHelper';
 
@@ -38,30 +38,28 @@ export default {
       handlers: {
         story: [],
         storyBase: [
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/gateways', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/gateways`, () =>
             HttpResponse.json({})
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/gateways`, () =>
             HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways/default-gateway',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/gateways/default-gateway`,
             () => HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
           ),
-          http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1/gateways/default-gateway',
-            () => HttpResponse.json(DEFAULT_GATEWAY)
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/gateways/default-gateway`, () =>
+            HttpResponse.json(DEFAULT_GATEWAY)
           ),
         ],
       },

--- a/frontend/src/components/gateway/GatewayList.stories.tsx
+++ b/frontend/src/components/gateway/GatewayList.stories.tsx
@@ -67,14 +67,14 @@ BrokenSpec.parameters = {
     handlers: {
       storyBase: [],
       story: [
-        http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/gateways', () =>
+        http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/gateways`, () =>
           HttpResponse.json({
             kind: 'GatewayList',
             metadata: {},
             items: [BROKEN_GATEWAY],
           })
         ),
-        http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways', () =>
+        http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/gateways`, () =>
           HttpResponse.json({ message: 'Not Found' }, { status: 404 })
         ),
       ],

--- a/frontend/src/components/gateway/GatewayList.stories.tsx
+++ b/frontend/src/components/gateway/GatewayList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './GatewayList';
 import { BROKEN_GATEWAY, DEFAULT_GATEWAY } from './storyHelper';
 
@@ -38,14 +38,14 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/gateways', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/gateways`, () =>
             HttpResponse.json({
               kind: 'GatewayList',
               metadata: {},
               items: [DEFAULT_GATEWAY],
             })
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/gateways', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/gateways`, () =>
             HttpResponse.error()
           ),
         ],

--- a/frontend/src/components/gateway/HTTPRouteDetails.stories.tsx
+++ b/frontend/src/components/gateway/HTTPRouteDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import HTTPRouteDetails from './HTTPRouteDetails';
 import { DEFAULT_HTTP_ROUTE, EMPTY_HTTP_ROUTE } from './storyHelper';
 
@@ -38,26 +38,25 @@ export default {
       handlers: {
         story: [],
         storyBase: [
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/httproutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/httproutes`, () =>
             HttpResponse.json({})
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/httproutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/httproutes`, () =>
             HttpResponse.error()
           ),
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/httproutes/default-httproute',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/httproutes/default-httproute`,
             () => HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
           ),
         ],
       },
@@ -77,9 +76,8 @@ Basic.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/apis/gateway.networking.k8s.io/v1/httproutes/default-httproute',
-          () => HttpResponse.json(DEFAULT_HTTP_ROUTE)
+        http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/httproutes/default-httproute`, () =>
+          HttpResponse.json(DEFAULT_HTTP_ROUTE)
         ),
       ],
     },
@@ -94,9 +92,8 @@ Empty.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/apis/gateway.networking.k8s.io/v1/httproutes/default-httproute',
-          () => HttpResponse.json(EMPTY_HTTP_ROUTE)
+        http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/httproutes/default-httproute`, () =>
+          HttpResponse.json(EMPTY_HTTP_ROUTE)
         ),
       ],
     },

--- a/frontend/src/components/gateway/HTTPRouteList.stories.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './HTTPRouteList';
 import { DEFAULT_HTTP_ROUTE, EMPTY_HTTP_ROUTE } from './storyHelper';
 
@@ -38,14 +38,14 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1/httproutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1/httproutes`, () =>
             HttpResponse.json({
               kind: 'HTTPRouteList',
               metadata: {},
               items: [DEFAULT_HTTP_ROUTE, EMPTY_HTTP_ROUTE],
             })
           ),
-          http.get('http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/httproutes', () =>
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/httproutes`, () =>
             HttpResponse.error()
           ),
         ],

--- a/frontend/src/components/gateway/ReferenceGrantDetails.stories.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ReferenceGrantDetails from './ReferenceGrantDetails';
 import { DEFAULT_REFERENCE_GRANT } from './storyHelper';
 
@@ -39,19 +39,18 @@ export default {
         story: [],
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants',
+            `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants`,
             () => HttpResponse.json({})
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
           ),
         ],
       },
@@ -72,7 +71,7 @@ Basic.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants/example-refgrant',
+          `${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/namespaces/default/referencegrants/example-refgrant`,
           () => HttpResponse.json(DEFAULT_REFERENCE_GRANT)
         ),
       ],

--- a/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ReferenceGrantList from './ReferenceGrantList';
 import { DEFAULT_REFERENCE_GRANT } from './storyHelper';
 
@@ -38,15 +38,13 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get(
-            'http://localhost:4466/apis/gateway.networking.k8s.io/v1beta1/referencegrants',
-            () =>
-              HttpResponse.json({
-                kind: 'ReferenceGrantList',
-                apiVersion: 'gateway.networking.k8s.io/v1beta1',
-                metadata: {},
-                items: [DEFAULT_REFERENCE_GRANT],
-              })
+          http.get(`${API_BASE}/apis/gateway.networking.k8s.io/v1beta1/referencegrants`, () =>
+            HttpResponse.json({
+              kind: 'ReferenceGrantList',
+              apiVersion: 'gateway.networking.k8s.io/v1beta1',
+              metadata: {},
+              items: [DEFAULT_REFERENCE_GRANT],
+            })
           ),
         ],
       },

--- a/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
@@ -22,7 +22,7 @@ import type { Cluster } from '../../lib/k8s/cluster';
 import Pod from '../../lib/k8s/pod';
 import { initialState as configInitialState } from '../../redux/configSlice';
 import reducers from '../../redux/reducers/reducers';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { generateK8sResourceList } from '../../test/mocker';
 import { podList } from '../pod/storyHelper';
 import { GlobalSearchContent } from './GlobalSearchContent';
@@ -44,7 +44,7 @@ const sampleCluster: Cluster = {
 };
 
 const recentSearchItemsKey = 'search-recent-items';
-const sampleClusterApiBase = `http://localhost:4466/clusters/${sampleCluster.name}`;
+const sampleClusterApiBase = `${API_BASE}/clusters/${sampleCluster.name}`;
 
 function makeKubeList(apiVersion: string, kind: string, items: any[] = []) {
   return {

--- a/frontend/src/components/horizontalPodAutoscaler/HPADetails.stories.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/HPADetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import HPADetails from './Details';
 
 const mockHPA = {
@@ -135,10 +135,10 @@ export default {
       handlers: {
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/autoscaling/v2/namespaces/my-namespace/horizontalpodautoscalers',
+            `${API_BASE}/apis/autoscaling/v2/namespaces/my-namespace/horizontalpodautoscalers`,
             () => HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
@@ -161,7 +161,7 @@ Default.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/autoscaling/v2/namespaces/my-namespace/horizontalpodautoscalers/my-endpoint',
+          `${API_BASE}/apis/autoscaling/v2/namespaces/my-namespace/horizontalpodautoscalers/my-endpoint`,
           () => HttpResponse.json(mockHPA)
         ),
       ],
@@ -175,7 +175,7 @@ Error.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/autoscaling/v2/namespaces/my-namespace/horizontalpodautoscalers/my-endpoint',
+          `${API_BASE}/apis/autoscaling/v2/namespaces/my-namespace/horizontalpodautoscalers/my-endpoint`,
           () => HttpResponse.error()
         ),
       ],

--- a/frontend/src/components/horizontalPodAutoscaler/HPAList.stories.tsx
+++ b/frontend/src/components/horizontalPodAutoscaler/HPAList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import HpaList from './List';
 
 const list = [
@@ -135,7 +135,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/autoscaling/v2/horizontalpodautoscalers', () =>
+          http.get(`${API_BASE}/apis/autoscaling/v2/horizontalpodautoscalers`, () =>
             HttpResponse.json({
               kind: 'HpaList',
               metadata: {},

--- a/frontend/src/components/ingress/ClassDetails.stories.tsx
+++ b/frontend/src/components/ingress/ClassDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './ClassDetails';
 import { RESOURCE_DEFAULT_INGRESS_CLASS, RESOURCE_INGRESS_CLASS } from './storyHelper';
 
@@ -37,10 +37,10 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingressclasses', () =>
+          http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingressclasses`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
@@ -65,7 +65,7 @@ Basic.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingressclasses/my-ic', () =>
+        http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingressclasses/my-ic`, () =>
           HttpResponse.json(RESOURCE_INGRESS_CLASS)
         ),
       ],
@@ -78,7 +78,7 @@ WithDefault.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingressclasses/my-ic', () =>
+        http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingressclasses/my-ic`, () =>
           HttpResponse.json(RESOURCE_DEFAULT_INGRESS_CLASS)
         ),
       ],

--- a/frontend/src/components/ingress/ClassList.stories.tsx
+++ b/frontend/src/components/ingress/ClassList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './ClassList';
 import { RESOURCE_DEFAULT_INGRESS_CLASS, RESOURCE_INGRESS_CLASS } from './storyHelper';
 
@@ -37,7 +37,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingressclasses', () =>
+          http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingressclasses`, () =>
             HttpResponse.json({
               kind: 'IngressClassList',
               metadata: {},

--- a/frontend/src/components/ingress/Details.stories.tsx
+++ b/frontend/src/components/ingress/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './Details';
 import { PORT_INGRESS, RESOURCE_INGRESS, WILDCARD_TLS_INGRESS } from './storyHelper';
 
@@ -37,25 +37,20 @@ export default {
     msw: {
       handlers: {
         baseStory: [
-          http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingresses', () =>
-            HttpResponse.json({})
-          ),
-          http.get('http://localhost:4466/apis/extensions/v1beta1/ingresses', () =>
+          http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingresses`, () => HttpResponse.json({})),
+          http.get(`${API_BASE}/apis/extensions/v1beta1/ingresses`, () => HttpResponse.error()),
+          http.get(`${API_BASE}/apis/extensions/v1beta1/ingresses/my-ingress`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/apis/extensions/v1beta1/ingresses/my-ingress', () =>
-            HttpResponse.error()
-          ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
               metadata: {},
             })
           ),
-          http.post(
-            'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-            () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
           ),
         ],
       },
@@ -75,7 +70,7 @@ WithTLS.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingresses/my-ingress', () =>
+        http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingresses/my-ingress`, () =>
           HttpResponse.json(PORT_INGRESS)
         ),
       ],
@@ -88,7 +83,7 @@ WithResource.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingresses/my-ingress', () =>
+        http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingresses/my-ingress`, () =>
           HttpResponse.json(RESOURCE_INGRESS)
         ),
       ],
@@ -101,7 +96,7 @@ WithWildcardTLS.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingresses/my-ingress', () =>
+        http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingresses/my-ingress`, () =>
           HttpResponse.json(WILDCARD_TLS_INGRESS)
         ),
       ],

--- a/frontend/src/components/ingress/List.stories.tsx
+++ b/frontend/src/components/ingress/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './List';
 import { PORT_INGRESS, RESOURCE_INGRESS } from './storyHelper';
 
@@ -38,16 +38,14 @@ export default {
       handlers: {
         storyBase: [],
         story: [
-          http.get('http://localhost:4466/apis/networking.k8s.io/v1/ingresses', () =>
+          http.get(`${API_BASE}/apis/networking.k8s.io/v1/ingresses`, () =>
             HttpResponse.json({
               kind: 'IngressClassList',
               metadata: {},
               items: [PORT_INGRESS, RESOURCE_INGRESS],
             })
           ),
-          http.get('http://localhost:4466/apis/extensions/v1beta1/ingresses', () =>
-            HttpResponse.error()
-          ),
+          http.get(`${API_BASE}/apis/extensions/v1beta1/ingresses`, () => HttpResponse.error()),
         ],
       },
     },

--- a/frontend/src/components/job/Details.stories.tsx
+++ b/frontend/src/components/job/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './Details';
 import { JOB_COMPLETE, JOB_RUNNING } from './storyHelper';
 
@@ -40,16 +40,16 @@ const podMetricsList = {
 // to the get-by-name request. Each list handler returns its proper Kubernetes
 // list kind so the mocked responses match the real API shape.
 const commonHandlers = [
-  http.get('http://localhost:4466/apis/batch/v1/namespaces/default/jobs', () =>
+  http.get(`${API_BASE}/apis/batch/v1/namespaces/default/jobs`, () =>
     HttpResponse.json(emptyList('JobList', 'batch/v1'))
   ),
-  http.get('http://localhost:4466/api/v1/namespaces/default/pods', () =>
+  http.get(`${API_BASE}/api/v1/namespaces/default/pods`, () =>
     HttpResponse.json(emptyList('PodList', 'v1'))
   ),
-  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/default/pods', () =>
+  http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/namespaces/default/pods`, () =>
     HttpResponse.json(podMetricsList)
   ),
-  http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+  http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
     HttpResponse.json(emptyList('EventList', 'v1'))
   ),
 ];
@@ -74,7 +74,7 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/batch/v1/namespaces/default/jobs/hello', () =>
+        http.get(`${API_BASE}/apis/batch/v1/namespaces/default/jobs/hello`, () =>
           HttpResponse.json(JOB_COMPLETE)
         ),
         ...commonHandlers,
@@ -88,7 +88,7 @@ Running.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/batch/v1/namespaces/default/jobs/hello', () =>
+        http.get(`${API_BASE}/apis/batch/v1/namespaces/default/jobs/hello`, () =>
           HttpResponse.json(JOB_RUNNING)
         ),
         ...commonHandlers,

--- a/frontend/src/components/job/JobList.stories.tsx
+++ b/frontend/src/components/job/JobList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { generateK8sResourceList } from '../../test/mocker';
 import List from './List';
 import { jobs } from './storyHelper';
@@ -85,7 +85,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/batch/v1/jobs', () =>
+          http.get(`${API_BASE}/apis/batch/v1/jobs`, () =>
             HttpResponse.json({
               kind: 'JobsList',
               metadata: {},

--- a/frontend/src/components/jobset/JobSetList.stories.tsx
+++ b/frontend/src/components/jobset/JobSetList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { generateK8sResourceList } from '../../test/mocker';
 import List from './List';
 import { jobSets } from './storyHelper';
@@ -81,7 +81,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/jobset.x-k8s.io/v1alpha2/jobsets', () =>
+          http.get(`${API_BASE}/apis/jobset.x-k8s.io/v1alpha2/jobsets`, () =>
             HttpResponse.json({
               kind: 'JobSetList',
               metadata: {},

--- a/frontend/src/components/lease/Details.stories.tsx
+++ b/frontend/src/components/lease/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { LeaseDetails } from './Details';
 import { LEASE_DUMMY_DATA } from './storyHelper';
 
@@ -45,13 +45,11 @@ LeaseDetail.parameters = {
     handlers: {
       storyBase: [],
       story: [
-        http.get('http://localhost:4466/apis/coordination.k8s.io/v1/leases/my-lease', () =>
+        http.get(`${API_BASE}/apis/coordination.k8s.io/v1/leases/my-lease`, () =>
           HttpResponse.json(LEASE_DUMMY_DATA[0])
         ),
-        http.get('http://localhost:4466/apis/coordination.k8s.io/v1/leases', () =>
-          HttpResponse.error()
-        ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/apis/coordination.k8s.io/v1/leases`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],

--- a/frontend/src/components/lease/List.stories.tsx
+++ b/frontend/src/components/lease/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { LeaseList } from './List';
 import { LEASE_DUMMY_DATA } from './storyHelper';
 
@@ -39,7 +39,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/coordination.k8s.io/v1/leases', () =>
+          http.get(`${API_BASE}/apis/coordination.k8s.io/v1/leases`, () =>
             HttpResponse.json({
               kind: 'LeaseList',
               metadata: {},

--- a/frontend/src/components/limitRange/Details.stories.tsx
+++ b/frontend/src/components/limitRange/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { LimitRangeDetails } from './Details';
 import { LIMIT_RANGE_DUMMY_DATA } from './storyHelper';
 
@@ -44,11 +44,11 @@ LimitRangeDetail.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/limitranges/my-lr', () =>
+        http.get(`${API_BASE}/api/v1/limitranges/my-lr`, () =>
           HttpResponse.json(LIMIT_RANGE_DUMMY_DATA[0])
         ),
-        http.get('http://localhost:4466/api/v1/limitranges', () => HttpResponse.error()),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/limitranges`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],

--- a/frontend/src/components/limitRange/List.stories.tsx
+++ b/frontend/src/components/limitRange/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { LimitRangeList } from './List';
 import { LIMIT_RANGE_DUMMY_DATA } from './storyHelper';
 
@@ -37,7 +37,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/api/v1/limitranges', () =>
+          http.get(`${API_BASE}/api/v1/limitranges`, () =>
             HttpResponse.json({
               kind: 'LimitRangeList',
               metadata: {},

--- a/frontend/src/components/namespace/NamespaceDetails.stories.tsx
+++ b/frontend/src/components/namespace/NamespaceDetails.stories.tsx
@@ -17,7 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { KubeNamespace } from '../../lib/k8s/namespace';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import NamespaceDetails from './Details';
 
 const createObj = (name: string) =>
@@ -70,45 +70,43 @@ Active.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/my-namespace', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespace`, () =>
           HttpResponse.json(createObj('my-namespaces'))
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/my-namespaces/resourcequotas', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespaces/resourcequotas`, () =>
           HttpResponse.json({ kind: 'List', items: [], metadata: {} })
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/my-namespaces/limitranges', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespaces/limitranges`, () =>
           HttpResponse.json({ kind: 'List', items: [], metadata: {} })
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/my-namespaces/pods', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespaces/pods`, () =>
           HttpResponse.json({ kind: 'List', items: [], metadata: {} })
         ),
-        http.get('http://localhost:4466/api/v1/resourcequotas', () => HttpResponse.error()),
-        http.get('http://localhost:4466/api/v1/limitranges', () => HttpResponse.error()),
-        http.get('http://localhost:4466/api/v1/pods', () => HttpResponse.error()),
-        http.get(
-          'http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/my-namespaces/pods',
-          () =>
-            HttpResponse.json({
-              kind: 'PodMetricsList',
-              apiVersion: 'metrics.k8s.io/v1beta1',
-              metadata: {},
-              items: [
-                {
-                  metadata: {
-                    name: 'successful',
-                  },
-                  containers: [
-                    {
-                      name: 'etcd',
-                      usage: {
-                        cpu: '16317640n',
-                        memory: '47544Ki',
-                      },
-                    },
-                  ],
+        http.get(`${API_BASE}/api/v1/resourcequotas`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/limitranges`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/pods`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/namespaces/my-namespaces/pods`, () =>
+          HttpResponse.json({
+            kind: 'PodMetricsList',
+            apiVersion: 'metrics.k8s.io/v1beta1',
+            metadata: {},
+            items: [
+              {
+                metadata: {
+                  name: 'successful',
                 },
-              ],
-            })
+                containers: [
+                  {
+                    name: 'etcd',
+                    usage: {
+                      cpu: '16317640n',
+                      memory: '47544Ki',
+                    },
+                  },
+                ],
+              },
+            ],
+          })
         ),
       ],
     },

--- a/frontend/src/components/networkpolicy/Details.stories.tsx
+++ b/frontend/src/components/networkpolicy/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { NetworkPolicyDetails } from './Details';
 import { NETWORK_POLICY_DETAIL, NETWORK_POLICY_ITEMS } from './storyHelper';
 
@@ -45,19 +45,17 @@ Default.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/networking.k8s.io/v1/namespaces/default/networkpolicies/allow-frontend-traffic',
+          `${API_BASE}/apis/networking.k8s.io/v1/namespaces/default/networkpolicies/allow-frontend-traffic`,
           () => HttpResponse.json(NETWORK_POLICY_DETAIL)
         ),
-        http.get(
-          'http://localhost:4466/apis/networking.k8s.io/v1/namespaces/default/networkpolicies',
-          () =>
-            HttpResponse.json({
-              kind: 'NetworkPolicyList',
-              items: NETWORK_POLICY_ITEMS,
-              metadata: {},
-            })
+        http.get(`${API_BASE}/apis/networking.k8s.io/v1/namespaces/default/networkpolicies`, () =>
+          HttpResponse.json({
+            kind: 'NetworkPolicyList',
+            items: NETWORK_POLICY_ITEMS,
+            metadata: {},
+          })
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],

--- a/frontend/src/components/networkpolicy/List.stories.tsx
+++ b/frontend/src/components/networkpolicy/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { NetworkPolicyList } from './List';
 import { NETWORK_POLICY_ITEMS } from './storyHelper';
 
@@ -44,7 +44,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/networking.k8s.io/v1/networkpolicies', () =>
+        http.get(`${API_BASE}/apis/networking.k8s.io/v1/networkpolicies`, () =>
           HttpResponse.json({
             kind: 'NetworkPolicyList',
             items: NETWORK_POLICY_ITEMS,

--- a/frontend/src/components/node/Details.stories.tsx
+++ b/frontend/src/components/node/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './Details';
 import { NODE_DETAILED_DATA, NODE_METRICS_DATA } from './storyHelper';
 
@@ -39,10 +39,10 @@ const podMetricsList = {
 // served by the node itself and are independent of metrics-server, so they
 // belong here too.
 const commonHandlers = [
-  http.get('http://localhost:4466/api/v1/nodes/node', () => HttpResponse.json(NODE_DETAILED_DATA)),
-  http.get('http://localhost:4466/api/v1/pods', () => HttpResponse.json(emptyList)),
-  http.get('http://localhost:4466/api/v1/events', () => HttpResponse.json(emptyList)),
-  http.get('http://localhost:4466/api/v1/nodes/node/proxy/stats/summary', () =>
+  http.get(`${API_BASE}/api/v1/nodes/node`, () => HttpResponse.json(NODE_DETAILED_DATA)),
+  http.get(`${API_BASE}/api/v1/pods`, () => HttpResponse.json(emptyList)),
+  http.get(`${API_BASE}/api/v1/events`, () => HttpResponse.json(emptyList)),
+  http.get(`${API_BASE}/api/v1/nodes/node/proxy/stats/summary`, () =>
     HttpResponse.json({
       node: {
         fs: {
@@ -55,7 +55,7 @@ const commonHandlers = [
 ];
 
 const metricsHandlers = [
-  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
+  http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/nodes`, () =>
     HttpResponse.json({
       kind: 'NodeMetricsList',
       apiVersion: 'metrics.k8s.io/v1beta1',
@@ -63,9 +63,7 @@ const metricsHandlers = [
       items: NODE_METRICS_DATA,
     })
   ),
-  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/pods', () =>
-    HttpResponse.json(podMetricsList)
-  ),
+  http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/pods`, () => HttpResponse.json(podMetricsList)),
 ];
 
 const notFound = () =>
@@ -74,8 +72,8 @@ const notFound = () =>
 // metrics-server unavailable: both the node and pod metrics APIs 404. The
 // kubelet summary (ephemeral storage) still works, as it does on a real cluster.
 const noMetricsHandlers = [
-  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', notFound),
-  http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/pods', notFound),
+  http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/nodes`, notFound),
+  http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/pods`, notFound),
 ];
 
 export default {

--- a/frontend/src/components/node/List.stories.tsx
+++ b/frontend/src/components/node/List.stories.tsx
@@ -17,7 +17,7 @@
 import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import List from './List';
 import { NODE_DUMMY_DATA, NODE_DUMMY_DATA_NO_POOLS } from './storyHelper';
 
@@ -38,7 +38,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/api/v1/nodes', () =>
+          http.get(`${API_BASE}/api/v1/nodes`, () =>
             HttpResponse.json({
               kind: 'NodeList',
               apiVersion: 'v1',
@@ -72,7 +72,7 @@ NoNodePools.parameters = {
     handlers: {
       base: null,
       story: [
-        http.get('http://localhost:4466/api/v1/nodes', () =>
+        http.get(`${API_BASE}/api/v1/nodes`, () =>
           HttpResponse.json({
             kind: 'NodeList',
             apiVersion: 'v1',
@@ -80,11 +80,10 @@ NoNodePools.parameters = {
             items: NODE_DUMMY_DATA_NO_POOLS,
           })
         ),
-        http.post(
-          'http://localhost:4466/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
-          () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
+        http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+          HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
         ),
-        http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/nodes', () =>
+        http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/nodes`, () =>
           HttpResponse.json({
             apiVersion: 'metrics.k8s.io/v1beta1',
             kind: 'NodeMetricsList',

--- a/frontend/src/components/pod/PodDebugTerminal.stories.tsx
+++ b/frontend/src/components/pod/PodDebugTerminal.stories.tsx
@@ -18,7 +18,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { useEffect } from 'react';
 import Pod from '../../lib/k8s/pod';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { PodDebugTerminal } from './PodDebugTerminal';
 
 // Mock Pod object for demonstration (all required fields)
@@ -114,12 +114,12 @@ export default {
       handlers: [
         // Mock authorization checks
         http.post(
-          'http://localhost:4466/clusters/default/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
+          `${API_BASE}/clusters/default/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`,
           () => HttpResponse.json({ status: { allowed: true, reason: '', code: 200 } })
         ),
         // Mock the PATCH request to create ephemeral container
         http.patch(
-          'http://localhost:4466/clusters/default/api/v1/namespaces/default/pods/mock-pod/ephemeralcontainers',
+          `${API_BASE}/clusters/default/api/v1/namespaces/default/pods/mock-pod/ephemeralcontainers`,
           async () => {
             // We won't really create an ephemeral container, so always return empty arrays
             return HttpResponse.json({
@@ -136,12 +136,9 @@ export default {
           }
         ),
         // Mock the GET request to poll pod status
-        http.get(
-          'http://localhost:4466/clusters/default/api/v1/namespaces/default/pods/mock-pod',
-          () => {
-            return HttpResponse.json(mockPod.jsonData);
-          }
-        ),
+        http.get(`${API_BASE}/clusters/default/api/v1/namespaces/default/pods/mock-pod`, () => {
+          return HttpResponse.json(mockPod.jsonData);
+        }),
       ],
     },
   },

--- a/frontend/src/components/pod/PodDetails.stories.tsx
+++ b/frontend/src/components/pod/PodDetails.stories.tsx
@@ -18,18 +18,18 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { useEffect } from 'react';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import PodDetails from './Details';
 import { podList } from './storyHelper';
 
 const CLUSTER_NAME = 'default';
 const NAMESPACE = 'default';
 const MOCK_PATH = `/c/${CLUSTER_NAME}/namespace/${NAMESPACE}/name/pod`;
-const API_BASE = `http://localhost:4466/clusters/${CLUSTER_NAME}/api/v1/namespaces/${NAMESPACE}`;
-const PODS_URL = `${API_BASE}/pods`;
-const PODS_URL_NO_CLUSTER = `http://localhost:4466/api/v1/namespaces/${NAMESPACE}/pods`;
-const EVENTS_URL = `${API_BASE}/events`;
-const AUTH_URL = `http://localhost:4466/clusters/${CLUSTER_NAME}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`;
+const NS_API_BASE = `${API_BASE}/clusters/${CLUSTER_NAME}/api/v1/namespaces/${NAMESPACE}`;
+const PODS_URL = `${NS_API_BASE}/pods`;
+const PODS_URL_NO_CLUSTER = `${NS_API_BASE}/api/v1/namespaces/${NAMESPACE}/pods`;
+const EVENTS_URL = `${NS_API_BASE}/events`;
+const AUTH_URL = `${NS_API_BASE}/clusters/${CLUSTER_NAME}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`;
 
 // Store the initial path at module scope, so we can always restore to it
 const INITIAL_PATH = window.location.pathname;

--- a/frontend/src/components/pod/PodDetails.stories.tsx
+++ b/frontend/src/components/pod/PodDetails.stories.tsx
@@ -27,9 +27,9 @@ const NAMESPACE = 'default';
 const MOCK_PATH = `/c/${CLUSTER_NAME}/namespace/${NAMESPACE}/name/pod`;
 const NS_API_BASE = `${API_BASE}/clusters/${CLUSTER_NAME}/api/v1/namespaces/${NAMESPACE}`;
 const PODS_URL = `${NS_API_BASE}/pods`;
-const PODS_URL_NO_CLUSTER = `${NS_API_BASE}/api/v1/namespaces/${NAMESPACE}/pods`;
+const PODS_URL_NO_CLUSTER = `${API_BASE}/api/v1/namespaces/${NAMESPACE}/pods`;
 const EVENTS_URL = `${NS_API_BASE}/events`;
-const AUTH_URL = `${NS_API_BASE}/clusters/${CLUSTER_NAME}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`;
+const AUTH_URL = `${API_BASE}/clusters/${CLUSTER_NAME}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`;
 
 // Store the initial path at module scope, so we can always restore to it
 const INITIAL_PATH = window.location.pathname;

--- a/frontend/src/components/pod/PodList.stories.tsx
+++ b/frontend/src/components/pod/PodList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import PodList from './List';
 import { podList } from './storyHelper';
 
@@ -37,7 +37,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/api/v1/pods', () =>
+          http.get(`${API_BASE}/api/v1/pods`, () =>
             HttpResponse.json({
               kind: 'PodList',
               apiVersion: 'v1',
@@ -45,7 +45,7 @@ export default {
               items: podList,
             })
           ),
-          http.get('http://localhost:4466/apis/metrics.k8s.io/v1beta1/pods', () =>
+          http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/pods`, () =>
             HttpResponse.json({
               kind: 'PodMetricsList',
               apiVersion: 'metrics.k8s.io/v1beta1',

--- a/frontend/src/components/podDisruptionBudget/pdbDetails.stories.tsx
+++ b/frontend/src/components/podDisruptionBudget/pdbDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import HPADetails from './Details';
 
 const mockPDB = {
@@ -81,9 +81,8 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get(
-            'http://localhost:4466/apis/policy/v1/namespaces/my-namespace/poddisruptionbudgets',
-            () => HttpResponse.error()
+          http.get(`${API_BASE}/apis/policy/v1/namespaces/my-namespace/poddisruptionbudgets`, () =>
+            HttpResponse.error()
           ),
         ],
       },
@@ -101,7 +100,7 @@ Default.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/policy/v1/namespaces/my-namespace/poddisruptionbudgets/my-endpoint',
+          `${API_BASE}/apis/policy/v1/namespaces/my-namespace/poddisruptionbudgets/my-endpoint`,
           () => HttpResponse.json(mockPDB)
         ),
       ],
@@ -115,7 +114,7 @@ Error.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/policy/v1/namespaces/my-namespace/poddisruptionbudgets/my-endpoint',
+          `${API_BASE}/apis/policy/v1/namespaces/my-namespace/poddisruptionbudgets/my-endpoint`,
           () => HttpResponse.error()
         ),
       ],

--- a/frontend/src/components/podDisruptionBudget/pdbList.stories.tsx
+++ b/frontend/src/components/podDisruptionBudget/pdbList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import PDBList from './List';
 
 const objList = [
@@ -82,7 +82,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/policy/v1/poddisruptionbudgets', () =>
+          http.get(`${API_BASE}/apis/policy/v1/poddisruptionbudgets`, () =>
             HttpResponse.json({
               kind: 'PodDistruptionBudgetList',
               items: objList,

--- a/frontend/src/components/priorityClass/priorityClassDetails.stories.tsx
+++ b/frontend/src/components/priorityClass/priorityClassDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import HPADetails from './Details';
 
 const mockItem = {
@@ -55,7 +55,7 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/apis/scheduling.k8s.io/v1/priorityclasses', () =>
+          http.get(`${API_BASE}/apis/scheduling.k8s.io/v1/priorityclasses`, () =>
             HttpResponse.error()
           ),
         ],
@@ -72,9 +72,8 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/apis/scheduling.k8s.io/v1/priorityclasses/my-endpoint',
-          () => HttpResponse.json(mockItem)
+        http.get(`${API_BASE}/apis/scheduling.k8s.io/v1/priorityclasses/my-endpoint`, () =>
+          HttpResponse.json(mockItem)
         ),
       ],
     },
@@ -86,9 +85,8 @@ Error.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/apis/scheduling.k8s.io/v1/priorityclasses/my-endpoint',
-          () => HttpResponse.error()
+        http.get(`${API_BASE}/apis/scheduling.k8s.io/v1/priorityclasses/my-endpoint`, () =>
+          HttpResponse.error()
         ),
       ],
     },

--- a/frontend/src/components/priorityClass/priorityClassList.stories.tsx
+++ b/frontend/src/components/priorityClass/priorityClassList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import PriorityClassList from './List';
 
 const items = [
@@ -63,7 +63,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/scheduling.k8s.io/v1/priorityclasses', () =>
+        http.get(`${API_BASE}/apis/scheduling.k8s.io/v1/priorityclasses`, () =>
           HttpResponse.json({
             kind: 'PriorityClassList',
             items,

--- a/frontend/src/components/project/NewProjectPopup.stories.tsx
+++ b/frontend/src/components/project/NewProjectPopup.stories.tsx
@@ -19,7 +19,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { useState } from 'react';
 import reducers from '../../redux/reducers/reducers';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { NewProjectPopup } from './NewProjectPopup';
 import { PROJECT_ID_LABEL } from './projectUtils';
 
@@ -83,7 +83,7 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces', () =>
+        http.get(`${API_BASE}/api/v1/namespaces`, () =>
           HttpResponse.json({
             kind: 'NamespaceList',
             items: [],
@@ -103,7 +103,7 @@ WithExistingProjects.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces', () =>
+        http.get(`${API_BASE}/api/v1/namespaces`, () =>
           HttpResponse.json({
             kind: 'NamespaceList',
             items: [

--- a/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
+++ b/frontend/src/components/project/ProjectCreateFromYaml.stories.tsx
@@ -18,7 +18,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import reducers from '../../redux/reducers/reducers';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { CreateNew } from './ProjectCreateFromYaml';
 import { PROJECT_ID_LABEL } from './projectUtils';
 
@@ -84,20 +84,18 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces', () =>
+        http.get(`${API_BASE}/api/v1/namespaces`, () =>
           HttpResponse.json({
             kind: 'NamespaceList',
             items: [],
             metadata: {},
           })
         ),
-        http.get('http://localhost:4466/clusters/cluster-a/api', () =>
+        http.get(`${API_BASE}/clusters/cluster-a/api`, () =>
           HttpResponse.json({ versions: ['v1'] })
         ),
-        http.get('http://localhost:4466/clusters/cluster-a/apis', () =>
-          HttpResponse.json({ groups: [] })
-        ),
-        http.get('http://localhost:4466/clusters/cluster-a/api/v1', () =>
+        http.get(`${API_BASE}/clusters/cluster-a/apis`, () => HttpResponse.json({ groups: [] })),
+        http.get(`${API_BASE}/clusters/cluster-a/api/v1`, () =>
           HttpResponse.json({
             resources: [
               { name: 'pods', singularName: 'pod', namespaced: true, kind: 'Pod', verbs: ['list'] },
@@ -124,7 +122,7 @@ WithExistingProjects.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces', () =>
+        http.get(`${API_BASE}/api/v1/namespaces`, () =>
           HttpResponse.json({
             kind: 'NamespaceList',
             items: [
@@ -154,13 +152,11 @@ WithExistingProjects.parameters = {
             metadata: {},
           })
         ),
-        http.get('http://localhost:4466/clusters/cluster-a/api', () =>
+        http.get(`${API_BASE}/clusters/cluster-a/api`, () =>
           HttpResponse.json({ versions: ['v1'] })
         ),
-        http.get('http://localhost:4466/clusters/cluster-a/apis', () =>
-          HttpResponse.json({ groups: [] })
-        ),
-        http.get('http://localhost:4466/clusters/cluster-a/api/v1', () =>
+        http.get(`${API_BASE}/clusters/cluster-a/apis`, () => HttpResponse.json({ groups: [] })),
+        http.get(`${API_BASE}/clusters/cluster-a/api/v1`, () =>
           HttpResponse.json({
             resources: [
               { name: 'pods', singularName: 'pod', namespaced: true, kind: 'Pod', verbs: ['list'] },

--- a/frontend/src/components/project/ProjectDetails.stories.tsx
+++ b/frontend/src/components/project/ProjectDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ProjectDetails from './ProjectDetails';
 
 export default {
@@ -28,7 +28,7 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/api/v1/namespaces', () =>
+          http.get(`${API_BASE}/api/v1/namespaces`, () =>
             HttpResponse.json({
               kind: 'List',
               items: [],

--- a/frontend/src/components/replicaset/List.stories.tsx
+++ b/frontend/src/components/replicaset/List.stories.tsx
@@ -17,7 +17,7 @@
 import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import List from './List';
 
 const items = [
@@ -262,7 +262,7 @@ ReplicaSets.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/apps/v1/replicasets', () =>
+        http.get(`${API_BASE}/apis/apps/v1/replicasets`, () =>
           HttpResponse.json({
             kind: 'ReplicaSetList',
             items,

--- a/frontend/src/components/resourceMap/GraphView.stories.tsx
+++ b/frontend/src/components/resourceMap/GraphView.stories.tsx
@@ -17,7 +17,7 @@
 import { Icon } from '@iconify/react';
 import { http, HttpResponse } from 'msw';
 import Pod from '../../lib/k8s/pod';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { podList } from '../pod/storyHelper';
 import { GraphNode, GraphSource } from './graph/graphModel';
 import { GraphView } from './GraphView';
@@ -30,31 +30,27 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                items: [],
-                metadata: {},
-              })
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1/customresourcedefinitions`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+              metadata: {},
+            })
           ),
-          http.get(
-            'http://localhost:4466/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions',
-            () =>
-              HttpResponse.json(
-                {
-                  kind: 'Status',
-                  apiVersion: 'v1',
-                  status: 'Failure',
-                  reason: 'NotFound',
-                  message: 'the server could not find the requested resource',
-                  code: 404,
-                },
-                { status: 404 }
-              )
+          http.get(`${API_BASE}/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions`, () =>
+            HttpResponse.json(
+              {
+                kind: 'Status',
+                apiVersion: 'v1',
+                status: 'Failure',
+                reason: 'NotFound',
+                message: 'the server could not find the requested resource',
+                code: 404,
+              },
+              { status: 404 }
+            )
           ),
-          http.get('http://localhost:4466/apis/autoscaling.k8s.io/v1', () =>
+          http.get(`${API_BASE}/apis/autoscaling.k8s.io/v1`, () =>
             HttpResponse.json(
               {
                 kind: 'Status',

--- a/frontend/src/components/resourceQuota/resourceQuotaDetails.stories.tsx
+++ b/frontend/src/components/resourceQuota/resourceQuotaDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ResourceQuotaDetails from './Details';
 
 const item = {
@@ -69,12 +69,10 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/api/v1/namespaces/my-namespace/resourcequotas', () =>
+          http.get(`${API_BASE}/api/v1/namespaces/my-namespace/resourcequotas`, () =>
             HttpResponse.error()
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/test/events', () =>
-            HttpResponse.error()
-          ),
+          http.get(`${API_BASE}/api/v1/namespaces/test/events`, () => HttpResponse.error()),
         ],
       },
     },
@@ -90,9 +88,8 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/api/v1/namespaces/my-namespace/resourcequotas/my-endpoint',
-          () => HttpResponse.json(item)
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespace/resourcequotas/my-endpoint`, () =>
+          HttpResponse.json(item)
         ),
       ],
     },
@@ -105,9 +102,8 @@ Error.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/api/v1/namespaces/my-namespace/resourcequotas/my-endpoint',
-          () => HttpResponse.error()
+        http.get(`${API_BASE}/api/v1/namespaces/my-namespace/resourcequotas/my-endpoint`, () =>
+          HttpResponse.error()
         ),
       ],
     },

--- a/frontend/src/components/resourceQuota/resourceQuotaList.stories.tsx
+++ b/frontend/src/components/resourceQuota/resourceQuotaList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ResourceQuotaList from './List';
 
 const items = [
@@ -77,7 +77,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/resourcequotas', () =>
+        http.get(`${API_BASE}/api/v1/resourcequotas`, () =>
           HttpResponse.json({
             kind: 'ResourceQuotaList',
             items,

--- a/frontend/src/components/role/storyHelper.ts
+++ b/frontend/src/components/role/storyHelper.ts
@@ -16,9 +16,10 @@
 
 import { KubeRole } from '../../lib/k8s/role';
 import { KubeRoleBinding } from '../../lib/k8s/roleBinding';
+import { API_BASE } from '../../test';
 
 /** Base URL of the mock API server used by the role stories' MSW handlers. */
-export const BASE_URL = 'http://localhost:4466';
+export const BASE_URL = API_BASE;
 
 export const ROLE_DUMMY_DATA: KubeRole[] = [
   {

--- a/frontend/src/components/runtimeClass/Details.stories.tsx
+++ b/frontend/src/components/runtimeClass/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { RuntimeClassDetails as Details } from './Details';
 import { BASE_RC } from './storyHelper';
 
@@ -44,13 +44,11 @@ Base.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/node.k8s.io/v1/runtimeclasses/my-rc', () =>
+        http.get(`${API_BASE}/apis/node.k8s.io/v1/runtimeclasses/my-rc`, () =>
           HttpResponse.json(BASE_RC)
         ),
-        http.get('http://localhost:4466/apis/node.k8s.io/v1/runtimeclasses', () =>
-          HttpResponse.error()
-        ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/apis/node.k8s.io/v1/runtimeclasses`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],

--- a/frontend/src/components/runtimeClass/List.stories.tsx
+++ b/frontend/src/components/runtimeClass/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { RuntimeClassList } from './List';
 import { RUNTIME_CLASS_DUMMY_DATA } from './storyHelper';
 
@@ -44,7 +44,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/node.k8s.io/v1/runtimeclasses', () =>
+        http.get(`${API_BASE}/apis/node.k8s.io/v1/runtimeclasses`, () =>
           HttpResponse.json({
             kind: 'RuntimeClassList',
             items: RUNTIME_CLASS_DUMMY_DATA,

--- a/frontend/src/components/secret/Details.stories.tsx
+++ b/frontend/src/components/secret/Details.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import SecretDetails from './Details';
 import { BASE_EMPTY_SECRET, BASE_SECRET } from './storyHelper';
 
@@ -37,8 +37,8 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/api/v1/secrets', () => HttpResponse.error()),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+          http.get(`${API_BASE}/api/v1/secrets`, () => HttpResponse.error()),
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
             HttpResponse.json({
               kind: 'EventList',
               items: [],
@@ -60,9 +60,7 @@ WithBase.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/secrets/my-secret', () =>
-          HttpResponse.json(BASE_SECRET)
-        ),
+        http.get(`${API_BASE}/api/v1/secrets/my-secret`, () => HttpResponse.json(BASE_SECRET)),
       ],
     },
   },
@@ -73,7 +71,7 @@ Empty.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/secrets/my-secret', () =>
+        http.get(`${API_BASE}/api/v1/secrets/my-secret`, () =>
           HttpResponse.json(BASE_EMPTY_SECRET)
         ),
       ],

--- a/frontend/src/components/secret/List.stories.tsx
+++ b/frontend/src/components/secret/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './List';
 import { BASE_EMPTY_SECRET, BASE_SECRET } from './storyHelper';
 
@@ -44,7 +44,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/secrets', () =>
+        http.get(`${API_BASE}/api/v1/secrets`, () =>
           HttpResponse.json({
             kind: 'SecretList',
             items: [BASE_EMPTY_SECRET, BASE_SECRET],

--- a/frontend/src/components/service/ServiceDetails.stories.tsx
+++ b/frontend/src/components/service/ServiceDetails.stories.tsx
@@ -17,7 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './Details';
 
 const serviceMock = {
@@ -290,30 +290,26 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/services', () =>
-          HttpResponse.error()
-        ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/services/example-service', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/services`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/services/example-service`, () =>
           HttpResponse.json(serviceMock)
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/endpoints', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/endpoints`, () =>
           HttpResponse.json({
             kind: 'List',
             items: endpoints,
             metadata: {},
           })
         ),
-        http.get(
-          'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/default/endpointslices',
-          () =>
-            HttpResponse.json({
-              kind: 'List',
-              items: endpointslices,
-              metadata: {},
-            })
+        http.get(`${API_BASE}/apis/discovery.k8s.io/v1/namespaces/default/endpointslices`, () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: endpointslices,
+            metadata: {},
+          })
         ),
       ],
     },
@@ -325,21 +321,16 @@ ErrorWithEndpoints.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/services', () =>
-          HttpResponse.error()
-        ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/services/example-service', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/services`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/services/example-service`, () =>
           HttpResponse.json(serviceMock)
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/endpoints', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/endpoints`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/apis/discovery.k8s.io/v1/namespaces/default/endpointslices`, () =>
           HttpResponse.error()
-        ),
-        http.get(
-          'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/default/endpointslices',
-          () => HttpResponse.error()
         ),
       ],
     },
@@ -351,31 +342,26 @@ WithA8RAnnotations.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/services', () =>
-          HttpResponse.error()
+        http.get(`${API_BASE}/api/v1/namespaces/default/services`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/services/a8r-annotated-service`, () =>
+          HttpResponse.json(serviceMockWithA8RAnnotations)
         ),
-        http.get(
-          'http://localhost:4466/api/v1/namespaces/default/services/a8r-annotated-service',
-          () => HttpResponse.json(serviceMockWithA8RAnnotations)
-        ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/endpoints', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/endpoints`, () =>
           HttpResponse.json({
             kind: 'List',
             items: endpoints,
             metadata: {},
           })
         ),
-        http.get(
-          'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/default/endpointslices',
-          () =>
-            HttpResponse.json({
-              kind: 'List',
-              items: endpointslices,
-              metadata: {},
-            })
+        http.get(`${API_BASE}/apis/discovery.k8s.io/v1/namespaces/default/endpointslices`, () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: endpointslices,
+            metadata: {},
+          })
         ),
       ],
     },
@@ -388,31 +374,26 @@ WithA8ROwnerOnly.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/services', () =>
-          HttpResponse.error()
+        http.get(`${API_BASE}/api/v1/namespaces/default/services`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/services/owner-only-service`, () =>
+          HttpResponse.json(serviceMockWithA8ROwnerOnly)
         ),
-        http.get(
-          'http://localhost:4466/api/v1/namespaces/default/services/owner-only-service',
-          () => HttpResponse.json(serviceMockWithA8ROwnerOnly)
-        ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/endpoints', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/endpoints`, () =>
           HttpResponse.json({
             kind: 'List',
             items: endpoints,
             metadata: {},
           })
         ),
-        http.get(
-          'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/default/endpointslices',
-          () =>
-            HttpResponse.json({
-              kind: 'List',
-              items: endpointslices,
-              metadata: {},
-            })
+        http.get(`${API_BASE}/apis/discovery.k8s.io/v1/namespaces/default/endpointslices`, () =>
+          HttpResponse.json({
+            kind: 'List',
+            items: endpointslices,
+            metadata: {},
+          })
         ),
       ],
     },
@@ -421,21 +402,18 @@ WithA8ROwnerOnly.parameters = {
 
 function makeServiceHandlers(name: string, mock: object) {
   return [
-    http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+    http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
       HttpResponse.json({ kind: 'EventList', items: [], metadata: {} })
     ),
-    http.get('http://localhost:4466/api/v1/namespaces/default/services', () =>
-      HttpResponse.error()
-    ),
-    http.get(`http://localhost:4466/api/v1/namespaces/default/services/${name}`, () =>
+    http.get(`${API_BASE}/api/v1/namespaces/default/services`, () => HttpResponse.error()),
+    http.get(`${API_BASE}/api/v1/namespaces/default/services/${name}`, () =>
       HttpResponse.json(mock)
     ),
-    http.get('http://localhost:4466/api/v1/namespaces/default/endpoints', () =>
+    http.get(`${API_BASE}/api/v1/namespaces/default/endpoints`, () =>
       HttpResponse.json({ kind: 'List', items: [], metadata: {} })
     ),
-    http.get(
-      'http://localhost:4466/apis/discovery.k8s.io/v1/namespaces/default/endpointslices',
-      () => HttpResponse.json({ kind: 'List', items: [], metadata: {} })
+    http.get(`${API_BASE}/apis/discovery.k8s.io/v1/namespaces/default/endpointslices`, () =>
+      HttpResponse.json({ kind: 'List', items: [], metadata: {} })
     ),
   ];
 }

--- a/frontend/src/components/service/ServiceList.stories.tsx
+++ b/frontend/src/components/service/ServiceList.stories.tsx
@@ -17,7 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import List from './List';
 
 const items = [
@@ -109,7 +109,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/services', () =>
+        http.get(`${API_BASE}/api/v1/services`, () =>
           HttpResponse.json({
             kind: 'List',
             items,
@@ -125,7 +125,7 @@ WithOwnerAnnotation.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/services', () =>
+        http.get(`${API_BASE}/api/v1/services`, () =>
           HttpResponse.json({
             kind: 'List',
             items: [serviceWithOwner],

--- a/frontend/src/components/statefulset/Details.stories.tsx
+++ b/frontend/src/components/statefulset/Details.stories.tsx
@@ -17,7 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router-dom';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import StatefulSetDetails from './Details';
 
 const mockStatefulSet = {
@@ -100,41 +100,36 @@ export default {
     msw: {
       handlers: {
         storyBase: [
-          http.get('http://localhost:4466/apis/apps/v1/namespaces/default/statefulsets', () => {
+          http.get(`${API_BASE}/apis/apps/v1/namespaces/default/statefulsets`, () => {
             return HttpResponse.json({
               kind: 'StatefulSetList',
               items: [],
             });
           }),
-          http.get('http://localhost:4466/api/v1/namespaces/default/pods', () => {
+          http.get(`${API_BASE}/api/v1/namespaces/default/pods`, () => {
             return HttpResponse.json({
               kind: 'PodList',
               items: [],
             });
           }),
-          http.get(
-            'http://localhost:4466/apis/metrics.k8s.io/v1beta1/namespaces/default/pods',
-            () =>
-              HttpResponse.json({
-                kind: 'List',
-                items: [],
-              })
+          http.get(`${API_BASE}/apis/metrics.k8s.io/v1beta1/namespaces/default/pods`, () =>
+            HttpResponse.json({
+              kind: 'List',
+              items: [],
+            })
           ),
-          http.get('http://localhost:4466/api/v1/namespaces/default/events', () => {
+          http.get(`${API_BASE}/api/v1/namespaces/default/events`, () => {
             return HttpResponse.json({
               kind: 'EventList',
               items: [],
             });
           }),
-          http.get(
-            'http://localhost:4466/apis/apps/v1/namespaces/default/controllerrevisions',
-            () => {
-              return HttpResponse.json({
-                kind: 'ControllerRevisionList',
-                items: [],
-              });
-            }
-          ),
+          http.get(`${API_BASE}/apis/apps/v1/namespaces/default/controllerrevisions`, () => {
+            return HttpResponse.json({
+              kind: 'ControllerRevisionList',
+              items: [],
+            });
+          }),
         ],
       },
     },
@@ -152,9 +147,8 @@ Default.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(
-          'http://localhost:4466/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset',
-          () => HttpResponse.json(mockStatefulSet)
+        http.get(`${API_BASE}/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset`, () =>
+          HttpResponse.json(mockStatefulSet)
         ),
       ],
     },
@@ -171,7 +165,7 @@ WithOnDeleteStrategy.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset',
+          `${API_BASE}/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset`,
           () => {
             return HttpResponse.json({
               ...mockStatefulSet,
@@ -199,7 +193,7 @@ WithComplexSelector.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset',
+          `${API_BASE}/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset`,
           () => {
             return HttpResponse.json({
               ...mockStatefulSet,
@@ -231,7 +225,7 @@ WithMultipleContainers.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset',
+          `${API_BASE}/apis/apps/v1/namespaces/default/statefulsets/mock-statefulset`,
           () => {
             return HttpResponse.json({
               ...mockStatefulSet,

--- a/frontend/src/components/statefulset/List.stories.tsx
+++ b/frontend/src/components/statefulset/List.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import StatefulSetList from './List';
 
 const mockStatefulSets = [
@@ -120,7 +120,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/apis/apps/v1/statefulsets', () => {
+          http.get(`${API_BASE}/apis/apps/v1/statefulsets`, () => {
             return HttpResponse.json({
               kind: 'StatefulSetList',
               apiVersion: 'apps/v1',
@@ -145,7 +145,7 @@ EmptyList.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/apps/v1/statefulsets', () => {
+        http.get(`${API_BASE}/apis/apps/v1/statefulsets`, () => {
           return HttpResponse.json({
             kind: 'StatefulSetList',
             apiVersion: 'apps/v1',
@@ -165,7 +165,7 @@ SingleItem.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/apps/v1/statefulsets', () => {
+        http.get(`${API_BASE}/apis/apps/v1/statefulsets`, () => {
           return HttpResponse.json({
             kind: 'StatefulSetList',
             apiVersion: 'apps/v1',
@@ -185,7 +185,7 @@ WithNotReadyReplicas.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/apps/v1/statefulsets', () => {
+        http.get(`${API_BASE}/apis/apps/v1/statefulsets`, () => {
           return HttpResponse.json({
             kind: 'StatefulSetList',
             apiVersion: 'apps/v1',

--- a/frontend/src/components/storage/ClaimDetails.stories.tsx
+++ b/frontend/src/components/storage/ClaimDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './ClaimDetails';
 import { BASE_PVC } from './storyHelper';
 
@@ -47,17 +47,17 @@ Base.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/persistentvolumeclaims/my-pvc', () =>
+        http.get(`${API_BASE}/api/v1/persistentvolumeclaims/my-pvc`, () =>
           HttpResponse.json(BASE_PVC)
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],
             metadata: {},
           })
         ),
-        http.get('http://localhost:4466/api/v1/persistentvolumeclaims', () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/persistentvolumeclaims`, () => HttpResponse.error()),
       ],
     },
   },

--- a/frontend/src/components/storage/ClaimList.stories.tsx
+++ b/frontend/src/components/storage/ClaimList.stories.tsx
@@ -17,7 +17,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { cloneDeep } from 'lodash';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './ClaimList';
 import { BASE_PVC } from './storyHelper';
 
@@ -65,7 +65,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/persistentvolumeclaims', () =>
+        http.get(`${API_BASE}/api/v1/persistentvolumeclaims`, () =>
           HttpResponse.json({
             kind: 'SecretList',
             items,

--- a/frontend/src/components/storage/ClassDetails.stories.tsx
+++ b/frontend/src/components/storage/ClassDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Details from './ClassDetails';
 import { BASE_SC } from './storyHelper';
 
@@ -44,12 +44,10 @@ Base.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/storage.k8s.io/v1/storageclasses/my-sc', () =>
+        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses/my-sc`, () =>
           HttpResponse.json(BASE_SC)
         ),
-        http.get('http://localhost:4466/apis/storage.k8s.io/v1/storageclasses', () =>
-          HttpResponse.error()
-        ),
+        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses`, () => HttpResponse.error()),
       ],
     },
   },

--- a/frontend/src/components/storage/ClassList.stories.tsx
+++ b/frontend/src/components/storage/ClassList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './ClassList';
 import { BASE_SC } from './storyHelper';
 
@@ -44,7 +44,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/storage.k8s.io/v1/storageclasses', () =>
+        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses`, () =>
           HttpResponse.json({
             kind: 'StorageClassList',
             items: [BASE_SC],

--- a/frontend/src/components/storage/VolumeAttributesClassDetails.stories.tsx
+++ b/frontend/src/components/storage/VolumeAttributesClassDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { BASE_VOLUME_ATTRIBUTES_CLASS } from './storyHelper';
 import Details from './VolumeAttributesClassDetails';
 
@@ -45,13 +45,13 @@ Base.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/storage.k8s.io/v1/volumeattributesclasses/my-volume-attributes-class',
+          `${API_BASE}/apis/storage.k8s.io/v1/volumeattributesclasses/my-volume-attributes-class`,
           () => HttpResponse.json(BASE_VOLUME_ATTRIBUTES_CLASS)
         ),
-        http.get('http://localhost:4466/apis/storage.k8s.io/v1/volumeattributesclasses', () =>
+        http.get(`${API_BASE}/apis/storage.k8s.io/v1/volumeattributesclasses`, () =>
           HttpResponse.error()
         ),
-        http.get('http://localhost:4466/api/v1/events', () =>
+        http.get(`${API_BASE}/api/v1/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],

--- a/frontend/src/components/storage/VolumeAttributesClassList.stories.tsx
+++ b/frontend/src/components/storage/VolumeAttributesClassList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { BASE_VOLUME_ATTRIBUTES_CLASS } from './storyHelper';
 import ListView from './VolumeAttributesClassList';
 
@@ -44,7 +44,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/storage.k8s.io/v1/volumeattributesclasses', () =>
+        http.get(`${API_BASE}/apis/storage.k8s.io/v1/volumeattributesclasses`, () =>
           HttpResponse.json({
             kind: 'VolumeAttributesClassList',
             items: [BASE_VOLUME_ATTRIBUTES_CLASS],

--- a/frontend/src/components/storage/VolumeDetails.stories.tsx
+++ b/frontend/src/components/storage/VolumeDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { BASE_PV } from './storyHelper';
 import Details from './VolumeDetails';
 
@@ -44,11 +44,9 @@ Base.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/api/v1/persistentvolumes/my-pv', () =>
-          HttpResponse.json(BASE_PV)
-        ),
-        http.get('http://localhost:4466/api/v1/persistentvolumes', () => HttpResponse.error()),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/persistentvolumes/my-pv`, () => HttpResponse.json(BASE_PV)),
+        http.get(`${API_BASE}/api/v1/persistentvolumes`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],

--- a/frontend/src/components/storage/VolumeList.stories.tsx
+++ b/frontend/src/components/storage/VolumeList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import ListView from './ClassList';
 import { BASE_PV } from './storyHelper';
 
@@ -44,7 +44,7 @@ Items.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/storage.k8s.io/v1/storageclasses', () =>
+        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses`, () =>
           HttpResponse.json({
             kind: 'PersistentVolumeList',
             items: [BASE_PV],

--- a/frontend/src/components/verticalPodAutoscaler/VPADetails.stories.tsx
+++ b/frontend/src/components/verticalPodAutoscaler/VPADetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import VpaDetails from './Details';
 
 const item = {
@@ -136,7 +136,7 @@ export default {
       handlers: {
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/autoscaling.k8s.io/v1/namespaces/default/verticalpodautoscalers',
+            `${API_BASE}/apis/autoscaling.k8s.io/v1/namespaces/default/verticalpodautoscalers`,
             () => HttpResponse.error()
           ),
         ],
@@ -155,10 +155,10 @@ Default.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/autoscaling.k8s.io/v1/namespaces/default/verticalpodautoscalers/multi-container-vpa',
+          `${API_BASE}/apis/autoscaling.k8s.io/v1/namespaces/default/verticalpodautoscalers/multi-container-vpa`,
           () => HttpResponse.json(item)
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],
@@ -176,10 +176,10 @@ Error.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/autoscaling.k8s.io/v1/namespaces/default/verticalpodautoscalers/multi-container-vpa',
+          `${API_BASE}/apis/autoscaling.k8s.io/v1/namespaces/default/verticalpodautoscalers/multi-container-vpa`,
           () => HttpResponse.error()
         ),
-        http.get('http://localhost:4466/api/v1/namespaces/default/events', () =>
+        http.get(`${API_BASE}/api/v1/namespaces/default/events`, () =>
           HttpResponse.json({
             kind: 'EventList',
             items: [],

--- a/frontend/src/components/verticalPodAutoscaler/VPAList.stories.tsx
+++ b/frontend/src/components/verticalPodAutoscaler/VPAList.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import VpaList from './List';
 
 const items = [
@@ -143,10 +143,10 @@ List.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/apis/autoscaling.k8s.io/v1', () =>
+        http.get(`${API_BASE}/apis/autoscaling.k8s.io/v1`, () =>
           HttpResponse.json({ resources: [{ name: 'verticalpodautoscalers' }] })
         ),
-        http.get('http://localhost:4466/apis/autoscaling.k8s.io/v1/verticalpodautoscalers', () =>
+        http.get(`${API_BASE}/apis/autoscaling.k8s.io/v1/verticalpodautoscalers`, () =>
           HttpResponse.json({
             kind: 'VPAList',
             metadata: {},

--- a/frontend/src/components/webhookconfiguration/MutatingWebhookConfigDetails.stories.tsx
+++ b/frontend/src/components/webhookconfiguration/MutatingWebhookConfigDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import MutatingWebhookConfigDetails from './MutatingWebhookConfigDetails';
 import { createMWC } from './storyHelper';
 
@@ -34,7 +34,7 @@ export default {
       handlers: {
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations',
+            `${API_BASE}/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations`,
             () => HttpResponse.error()
           ),
         ],
@@ -58,7 +58,7 @@ WithService.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/my-mwc',
+          `${API_BASE}/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/my-mwc`,
           () => HttpResponse.json(createMWC(true))
         ),
       ],
@@ -73,7 +73,7 @@ WithURL.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/my-mwc',
+          `${API_BASE}/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/my-mwc`,
           () => HttpResponse.json(createMWC(false))
         ),
       ],

--- a/frontend/src/components/webhookconfiguration/MutatingWebhookConfigList.stories.tsx
+++ b/frontend/src/components/webhookconfiguration/MutatingWebhookConfigList.stories.tsx
@@ -18,7 +18,7 @@ import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import MutatingWebhookConfiguration from '../../lib/k8s/mutatingWebhookConfiguration';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { generateK8sResourceList } from '../../test/mocker';
 import List from './MutatingWebhookConfigList';
 import { createMWC } from './storyHelper';
@@ -71,7 +71,7 @@ Items.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations',
+          `${API_BASE}/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations`,
           () =>
             HttpResponse.json({
               kind: 'WebhookConfigurationList',

--- a/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigDetails.stories.tsx
+++ b/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigDetails.stories.tsx
@@ -16,7 +16,7 @@
 
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { createVWC } from './storyHelper';
 import ValidatingWebhookConfigDetails from './ValidatingWebhookConfigDetails';
 
@@ -34,7 +34,7 @@ export default {
       handlers: {
         storyBase: [
           http.get(
-            'http://localhost:4466/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations',
+            `${API_BASE}/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations`,
             () => HttpResponse.error()
           ),
         ],
@@ -60,7 +60,7 @@ WithService.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/my-vwc',
+          `${API_BASE}/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/my-vwc`,
           () => HttpResponse.json(createVWC(true))
         ),
       ],
@@ -74,7 +74,7 @@ WithURL.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/my-vwc',
+          `${API_BASE}/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/my-vwc`,
           () => HttpResponse.json(createVWC(false))
         ),
       ],

--- a/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.stories.tsx
+++ b/frontend/src/components/webhookconfiguration/ValidatingWebhookConfigList.stories.tsx
@@ -18,7 +18,7 @@ import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import ValidatingWebhookConfiguration from '../../lib/k8s/validatingWebhookConfiguration';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import { generateK8sResourceList } from '../../test/mocker';
 import { createVWC } from './storyHelper';
 import List from './ValidatingWebhookConfigList';
@@ -71,7 +71,7 @@ Items.parameters = {
     handlers: {
       story: [
         http.get(
-          'http://localhost:4466/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations',
+          `${API_BASE}/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations`,
           () =>
             HttpResponse.json({
               kind: 'WebhookConfigurationList',

--- a/frontend/src/components/workload/Overview.stories.tsx
+++ b/frontend/src/components/workload/Overview.stories.tsx
@@ -17,7 +17,7 @@
 import Container from '@mui/material/Container';
 import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
-import { TestContext } from '../../test';
+import { API_BASE, TestContext } from '../../test';
 import Overview from './Overview';
 
 export default {
@@ -37,7 +37,7 @@ export default {
     msw: {
       handlers: {
         story: [
-          http.get('http://localhost:4466/api/v1/pods', () =>
+          http.get(`${API_BASE}/api/v1/pods`, () =>
             HttpResponse.json({
               kind: 'PodList',
               apiVersion: 'v1',
@@ -72,7 +72,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/apis/apps/v1/deployments', () =>
+          http.get(`${API_BASE}/apis/apps/v1/deployments`, () =>
             HttpResponse.json({
               kind: 'DeploymentList',
               apiVersion: 'apps/v1',
@@ -96,7 +96,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/apis/apps/v1/statefulsets', () =>
+          http.get(`${API_BASE}/apis/apps/v1/statefulsets`, () =>
             HttpResponse.json({
               kind: 'StatefulSetList',
               apiVersion: 'apps/v1',
@@ -120,7 +120,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/apis/apps/v1/daemonsets', () =>
+          http.get(`${API_BASE}/apis/apps/v1/daemonsets`, () =>
             HttpResponse.json({
               kind: 'DaemonSetList',
               apiVersion: 'apps/v1',
@@ -142,7 +142,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/apis/apps/v1/replicasets', () =>
+          http.get(`${API_BASE}/apis/apps/v1/replicasets`, () =>
             HttpResponse.json({
               kind: 'ReplicaSetList',
               apiVersion: 'apps/v1',
@@ -166,7 +166,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/apis/batch/v1/jobs', () =>
+          http.get(`${API_BASE}/apis/batch/v1/jobs`, () =>
             HttpResponse.json({
               kind: 'JobList',
               apiVersion: 'batch/v1',
@@ -187,7 +187,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/apis/batch/v1/cronjobs', () =>
+          http.get(`${API_BASE}/apis/batch/v1/cronjobs`, () =>
             HttpResponse.json({
               kind: 'CronJobList',
               apiVersion: 'batch/v1',
@@ -206,7 +206,7 @@ export default {
               ],
             })
           ),
-          http.get('http://localhost:4466/apis/jobset.x-k8s.io/v1alpha2/jobsets', () =>
+          http.get(`${API_BASE}/apis/jobset.x-k8s.io/v1alpha2/jobsets`, () =>
             HttpResponse.json({
               kind: 'JobSetList',
               apiVersion: 'jobset.x-k8s.io/v1alpha2',

--- a/frontend/src/test/index.tsx
+++ b/frontend/src/test/index.tsx
@@ -21,6 +21,13 @@ import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import defaultStore from '../redux/stores/store';
 
+/**
+ * Origin (scheme/host/port) of the dev/test backend that MSW handlers intercept
+ * in stories and tests. Matches the default dev backend port used by `getAppUrl`
+ * (4466) but intentionally omits any baseUrl/trailing slash.
+ */
+export const API_BASE = 'http://localhost:4466';
+
 export type TestContextProps = PropsWithChildren<{
   store?: ReturnType<typeof configureStore>;
   routerMap?: Record<string, string>;


### PR DESCRIPTION
## What this does

Fixes #6054.

The dev/test backend base URL `http://localhost:4466` was hardcoded as a string literal ~340 times across 88 Storybook story files when setting up MSW handlers. The value originates from a single place (`getAppUrl`, port `4466`), so duplicating it everywhere is fragile:

- a port/scheme change means editing every handler by hand,
- copy-pasted handlers spread the literal further (came up in review on #6051),
- a typo in one handler silently fails to match.

## Approach

- Export an `API_BASE` constant from the shared test helper (`frontend/src/test`) that the stories already import from.
- Build handler URLs from it via template literals, e.g. `` http.get(`${API_BASE}/api/v1/...`) ``.

Resolved URLs are unchanged, so storyshot snapshots are identical.

`getAppUrl.ts` (the definition) and `helpers.test.ts` (which asserts the literal) are intentionally left untouched.

## Testing

- Storybook snapshot suite passes (`vitest run src/storybook.test.tsx`).
