### PR TITLE
frontend: AuthVisible: Fix rules-of-hooks violation by moving hooks

### DIFF
--- a/frontend/src/components/common/Resource/AuthVisible.test.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthVisible from './AuthVisible';
+
+describe('AuthVisible', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+  });
+
+  it('renders children if authorized', async () => {
+    const mockItem = {
+      _class: () => ({
+        apiName: 'pods',
+        apiVersion: 'v1',
+      }),
+      getName: () => 'test-pod',
+      getAuthorization: vi.fn().mockResolvedValue({
+        status: {
+          allowed: true,
+          reason: 'Allowed',
+        },
+      }),
+    };
+
+    const onAuthResult = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={mockItem as any} authVerb="get" onAuthResult={onAuthResult}>
+          <div>Authorized Content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(onAuthResult).toHaveBeenCalledWith({
+        allowed: true,
+        reason: 'Allowed',
+      });
+    });
+
+    expect(screen.getByText('Authorized Content')).toBeInTheDocument();
+  });
+
+  it('does not render children if not authorized', async () => {
+    const mockItem = {
+      _class: () => ({
+        apiName: 'pods',
+        apiVersion: 'v1',
+      }),
+      getName: () => 'test-pod',
+      getAuthorization: vi.fn().mockResolvedValue({
+        status: {
+          allowed: false,
+          reason: 'Forbidden',
+        },
+      }),
+    };
+
+    const onAuthResult = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={mockItem as any} authVerb="get" onAuthResult={onAuthResult}>
+          <div>Authorized Content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(onAuthResult).toHaveBeenCalledWith({
+        allowed: false,
+        reason: 'Forbidden',
+      });
+    });
+
+    expect(screen.queryByText('Authorized Content')).toBeNull();
+  });
+
+  it('warns and returns null if authVerb is invalid', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mockItem = {
+      _class: () => ({
+        apiName: 'pods',
+        apiVersion: 'v1',
+      }),
+      getName: () => 'test-pod',
+    };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={mockItem as any} authVerb="invalid-verb">
+          <div>Authorized Content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid authVerb provided: "invalid-verb"')
+    );
+    expect(screen.queryByText('Authorized Content')).toBeNull();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('does not crash if item is null', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthVisible item={null} authVerb="get">
+          <div>Authorized Content</div>
+        </AuthVisible>
+      </QueryClientProvider>
+    );
+
+    expect(screen.queryByText('Authorized Content')).toBeNull();
+  });
+});

--- a/frontend/src/components/common/Resource/AuthVisible.tsx
+++ b/frontend/src/components/common/Resource/AuthVisible.tsx
@@ -56,22 +56,24 @@ export interface AuthVisibleProps extends React.PropsWithChildren<{}> {
 export default function AuthVisible(props: AuthVisibleProps) {
   const { item, authVerb, subresource, namespace, onError, onAuthResult, children } = props;
 
-  if (!VALID_AUTH_VERBS.includes(authVerb)) {
-    console.warn(`Invalid authVerb provided: "${authVerb}". Skipping authorization check.`);
-    return null;
-  }
+  const isAuthVerbValid = VALID_AUTH_VERBS.includes(authVerb);
+
+  useEffect(() => {
+    if (!isAuthVerbValid) {
+      console.warn(`Invalid authVerb provided: "${authVerb}". Skipping authorization check.`);
+    }
+  }, [isAuthVerbValid, authVerb]);
 
   const itemClass: KubeObjectClass | null = (item as KubeObject)?._class?.() ?? item;
   const itemName = (item as KubeObject)?.getName?.();
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { data } = useQuery<any>({
-    enabled: !!item,
+    enabled: !!item && isAuthVerbValid,
     queryKey: [
       'authVisible',
       itemName,
-      itemClass.apiName,
-      itemClass.apiVersion,
+      itemClass?.apiName,
+      itemClass?.apiVersion,
       authVerb,
       subresource,
       namespace,
@@ -92,7 +94,6 @@ export default function AuthVisible(props: AuthVisibleProps) {
 
   const visible = data?.status?.allowed ?? false;
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (data) {
       onAuthResult?.({
@@ -102,6 +103,10 @@ export default function AuthVisible(props: AuthVisibleProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
+
+  if (!isAuthVerbValid) {
+    return null;
+  }
 
   if (!visible) {
     return null;


### PR DESCRIPTION
## Summary

This PR fixes a `react-hooks/rules-of-hooks` violation in `AuthVisible` by moving all hooks above early return statements and wrapping the console warning side-effect in a `useEffect`.

## Related Issue

Fixes #5187   

## Changes

- Updated `AuthVisible.tsx` : Moved hooks above returns, added optional chaining on `itemClass` properties, and wrapped the console warning in `useEffect`.
- Added `AuthVisible.test.tsx` : Created comprehensive unit tests validating authorized/unauthorized rendering, invalid verbs, and null items.

## Steps to Test

1. Run `npm run frontend:lint` to verify the rules-of-hooks error is gone.
2. Run `npm run frontend:test -- src/components/common/Resource/AuthVisible.test.tsx --run` to verify unit tests pass.
3. Start the application locally with `npm start` and verify that resource details views (like Pod logs/terminal action buttons) render correctly.

## Notes for the Reviewer

-Optional chaining was added to `itemClass` properties to prevent potential null pointer errors during query key initialization when `item` is null.