### PR TITLE
frontend: crd: Fix Served column displaying storage value

### DIFF
--- a/frontend/src/components/crd/Details.test.tsx
+++ b/frontend/src/components/crd/Details.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import CustomResourceDefinitionDetails from './Details';
+import { mockCRD } from './storyHelper';
+
+vi.mock('react-i18next', async importOriginal => {
+  const actual: any = await importOriginal();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key.split('|').pop() ?? key,
+    }),
+  };
+});
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/crd', () => ({
+  default: { kind: 'CustomResourceDefinition' },
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+  ConditionsTable: () => null,
+}));
+
+describe('CustomResourceDefinitionDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('uses the served field for the Served column and the storage field for the Storage column', () => {
+    render(
+      <TestContext routerMap={{ name: 'mydefinition.phonyresources.io' }}>
+        <CustomResourceDefinitionDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const sections = props.extraSections(mockCRD);
+
+    const versionsSection = sections.find((section: any) => section.id === 'headlamp.crd-versions');
+
+    expect(versionsSection).toBeDefined();
+
+    const table = versionsSection.section.props.children;
+    const columns = table.props.columns;
+
+    const servedColumn = columns.find((c: any) => c.label === 'Served');
+    const storageColumn = columns.find((c: any) => c.label === 'Storage');
+
+    expect(servedColumn).toBeDefined();
+    expect(storageColumn).toBeDefined();
+
+    const versionA = {
+      name: 'v1',
+      served: true,
+      storage: false,
+    };
+
+    const versionB = {
+      name: 'v1',
+      served: false,
+      storage: true,
+    };
+
+    expect(servedColumn.getter(versionA)).toBe('true');
+    expect(storageColumn.getter(versionA)).toBe('false');
+
+    expect(servedColumn.getter(versionB)).toBe('false');
+    expect(storageColumn.getter(versionB)).toBe('true');
+  });
+});

--- a/frontend/src/components/crd/Details.tsx
+++ b/frontend/src/components/crd/Details.tsx
@@ -121,7 +121,7 @@ export default function CustomResourceDefinitionDetails(props: {
                     },
                     {
                       label: t('Served'),
-                      getter: version => version.storage.toString(),
+                      getter: version => version.served.toString(),
                     },
                     {
                       label: t('Storage'),

--- a/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
+++ b/frontend/src/components/crd/__snapshots__/CustomResourceDefinition.Details.stories.storyshot
@@ -421,7 +421,7 @@
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
                       >
-                        false
+                        true
                       </td>
                       <td
                         class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"

--- a/frontend/src/components/crd/storyHelper.ts
+++ b/frontend/src/components/crd/storyHelper.ts
@@ -37,7 +37,7 @@ export const mockCRD = {
     versions: [
       {
         name: 'v1',
-        served: false,
+        served: true,
         storage: false,
         additionalPrinterColumns: [
           {


### PR DESCRIPTION
## Summary

This PR fixes an issue in the CRD Details Versions table where the **Served** column displayed the `storage` value instead of the `served` value.

It also adds regression coverage to ensure the Served and Storage columns remain independent and updates the Storybook fixture to expose this scenario.

## Related Issue

Fixes #6094 

## Changes

- Fixed the Served column to use `version.served`
- Added regression coverage for CRD versions with distinct `served` and `storage` values
- Updated the Storybook fixture to use different values for `served` and `storage`
- Updated the affected Storybook snapshot

## Steps to Test

1. Run the test suite:

   ```bash
   npm test
   ```

2. Open the CRD Details story in Storybook.
3. Navigate to the **Versions** section.
4. Verify that:
   - Served displays `true`
   - Storage displays `false`
     when the underlying version data has `served: true` and `storage: false`.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The previous Storybook fixture used identical values for `served` and `storage`, which masked the issue.
- The added regression coverage ensures the Served column cannot accidentally fall back to the Storage field in future changes.