### PR TITLE
docs: fix command of the Keycloak OIDC tutorial

### DIFF
--- a/docs/installation/in-cluster/keycloak/index.md
+++ b/docs/installation/in-cluster/keycloak/index.md
@@ -113,7 +113,8 @@ kubectl config set-credentials keycloak-oidc \
   --exec-arg=--oidc-issuer-url=<YOUR-KEYCLOAK-URL>/realms/<REALM-NAME> \
   --exec-arg=--oidc-client-id=<CLIENT-ID> \
   --exec-arg=--oidc-client-secret=<CLIENT-SECRET> \
-  --exec-arg=--oidc-extra-scope=email,profile
+  --exec-arg=--oidc-extra-scope=email \
+  --exec-arg=--oidc-extra-scope=profile
 ```
 
 4. Link the User to the Cluster: To associate the user with the cluster, create a new context using these commands:


### PR DESCRIPTION
## Summary

This PR fixes the command in the "Configuring kubectl for OIDC User Authentication" section of the Keycloak OIDC tutorial (`docs/installation/in-cluster/keycloak/index.md`) because running it as currently documented creates an invalid kubeconfig entry and causes `kubectl get ns` to fail.

## Related Issue

Fixes #6035   

## Changes

- Updated `docs/installation/in-cluster/keycloak/index.md`
  - Replaced `--exec-arg=--oidc-extra-scope=email,profile` with separate `--exec-arg` entries for `email` and `profile` so the example works with pflag's `StringSlice` parsing used by `--exec-arg`.

## Steps to Test

Follow the updated Keycloak OIDC tutorial in `docs/installation/in-cluster/keycloak/index.md` and confirm that the setup completes successfully and `kubectl get ns` does not fail.