### PR TITLE
frontend: DocsViewer: Replace any with strict type for docSpecs

### DIFF
--- a/frontend/src/components/common/Resource/DocsViewer.stories.tsx
+++ b/frontend/src/components/common/Resource/DocsViewer.stories.tsx
@@ -125,7 +125,7 @@ NoMatchingDocumentation.args = {
 
 export const ErrorDocumentation = Template.bind({});
 ErrorDocumentation.args = {
-  docSpecs: [{}],
+  docSpecs: [{ apiVersion: '', kind: '' }],
 };
 ErrorDocumentation.parameters = {
   msw: {

--- a/frontend/src/components/common/Resource/DocsViewer.tsx
+++ b/frontend/src/components/common/Resource/DocsViewer.tsx
@@ -26,8 +26,7 @@ import Empty from '../EmptyContent';
 import Loader from '../Loader';
 
 export interface DocsViewerProps {
-  // @todo: Declare strict types.
-  docSpecs: any;
+  docSpecs: { apiVersion?: string; kind: string }[];
 }
 
 function DocsViewer(props: DocsViewerProps) {
@@ -54,8 +53,8 @@ function DocsViewer(props: DocsViewerProps) {
     setDocsLoading(true);
     // fetch docSpecs for all the resources specified
     Promise.allSettled(
-      docSpecs.map((docSpec: { apiVersion: string; kind: string }) => {
-        return getDocDefinitions(docSpec.apiVersion, docSpec.kind);
+      docSpecs.map(docSpec => {
+        return getDocDefinitions(docSpec.apiVersion ?? '', docSpec.kind);
       })
     )
       .then(values => {

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -562,7 +562,7 @@ export default function EditorDialog(props: EditorDialogProps) {
                 label: t('translation|Documentation'),
                 component: (
                   <Box sx={{ height: '100%', overflowY: 'auto' }}>
-                    <DocsViewer docSpecs={docSpecs} />
+                    <DocsViewer docSpecs={Array.isArray(docSpecs) ? docSpecs : []} />
                   </Box>
                 ),
               },


### PR DESCRIPTION
## Summary

This PR replaces the `any` type on `DocsViewerProps.docSpecs` with a strict type.

## Related Issue

Fixes #6089

## Changes

- Typed `docSpecs` as `{ apiVersion?: string; kind: string }[]` and removed the `@todo`
- Updated the call sites in `EditorDialog` and the DocsViewer stories to match

## Steps to Test

1. Run `cd frontend && npx tsc --noEmit` and confirm there are no type errors
2. Run `npm run frontend:lint`
3. Run `npm run frontend:test`

## Notes for the Reviewer

Type-only change, no runtime behavior difference. `apiVersion` is optional to match `KubeObjectInterface`, which is what callers pass.
