### PR TITLE
backend: cmd: Add error path test for MarshalCustomObject

### DIFF
--- a/backend/cmd/stateless_test.go
+++ b/backend/cmd/stateless_test.go
@@ -427,3 +427,12 @@ func TestWebsocketConnContextKey(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalCustomObject_InvalidJSON(t *testing.T) {
+	mockInfo := &runtime.Unknown{
+		Raw: []byte(`{invalid-json`),
+	}
+
+	_, err := MarshalCustomObject(mockInfo, "test-context")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
### PR description

Adds an isolated test case to ensure MarshalCustomObject correctly handles and surfaces errors when provided with invalid JSON data. 

### Changes:

updated backend/cmd/stateless_test.go with TestMarshalCustomObject_InvalidJSON Steps to 
### Test:
Navigate to the backend directory.
Run npm run backend:test and verify it passes. Notes for the Reviewer: A simple, backward-compatible test that covers the previously untested error branches when handling invalid runtime.Unknown objects.

### Screenshots

<img width="1061" height="316" alt="image" src="https://github.com/user-attachments/assets/e082c13a-b617-46a5-b13f-243f6ad28cbf" />
after running it in my local machine 