### PR TITLE
frontend: add non-clickable section headers to the sidebar

### DIFF
--- a/docs/development/plugins/functionality/index.md
+++ b/docs/development/plugins/functionality/index.md
@@ -142,6 +142,10 @@ Filter items with
 [registerSidebarEntryFilter](../../api/plugin/registry/functions/registersidebarentryfilter).
 Filter items from the home (non-cluster) sidebar with
 [registerHomeSidebarEntryFilter](../../api/plugin/registry/functions/registerhomesidebarentryfilter).
+Use `entryType: 'subheader'` with `registerSidebarEntry` to add a
+non-clickable section header that groups sidebar entries. Subheaders render as
+dividers when the sidebar is collapsed. Use `sx` to override the default
+subheader styles.
 
 ![screenshot of the sidebar being changed](../images/sidebar.png)
 

--- a/frontend/src/components/Sidebar/SidebarItem.test.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.test.tsx
@@ -69,6 +69,25 @@ describe('SidebarItem', () => {
     expect(container.querySelector('.MuiDivider-root')).toBeInTheDocument();
   });
 
+  it('wraps subheader child lists in list items', () => {
+    const { container } = renderSidebarItem({
+      name: 'plugin-section',
+      label: 'Plugin Section',
+      entryType: 'subheader',
+      subList: [
+        {
+          name: 'plugin-child',
+          label: 'Plugin Child',
+          url: '/plugin-child',
+        },
+      ],
+    });
+    const rootList = container.querySelector('ul');
+
+    expect(screen.getByRole('button', { name: /plugin child/i })).toBeInTheDocument();
+    expect(Array.from(rootList?.children ?? []).map(child => child.tagName)).toEqual(['LI', 'LI']);
+  });
+
   it('does not render hidden subheader entries', () => {
     const { container } = renderSidebarItem({
       name: 'plugin-section',

--- a/frontend/src/components/Sidebar/SidebarItem.test.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import List from '@mui/material/List';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import SidebarItem, { SidebarItemProps } from './SidebarItem';
+
+vi.mock('../../lib/k8s', () => ({
+  useSelectedClusters: () => [],
+}));
+
+const theme = createMuiTheme({ name: 'light', base: 'light' });
+
+function renderSidebarItem(props: SidebarItemProps) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <MemoryRouter>
+        <List>
+          <SidebarItem {...props} />
+        </List>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}
+
+describe('SidebarItem', () => {
+  it('renders subheader entries as non-clickable section headers', () => {
+    renderSidebarItem({
+      name: 'plugin-section',
+      label: 'Plugin Section',
+      entryType: 'subheader',
+      url: '/ignored',
+      icon: 'mdi:comment-quote',
+    });
+
+    const subheader = screen.getByText('Plugin Section');
+
+    expect(subheader).toHaveClass('MuiListSubheader-root');
+    expect(screen.queryByRole('link', { name: /plugin section/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /plugin section/i })).not.toBeInTheDocument();
+  });
+
+  it('renders subheader entries as dividers when the sidebar is collapsed', () => {
+    const { container } = renderSidebarItem({
+      name: 'plugin-section',
+      label: 'Plugin Section',
+      entryType: 'subheader',
+      fullWidth: false,
+    });
+
+    expect(screen.queryByText('Plugin Section')).not.toBeInTheDocument();
+    expect(container.querySelector('.MuiDivider-root')).toBeInTheDocument();
+  });
+
+  it('does not render hidden subheader entries', () => {
+    const { container } = renderSidebarItem({
+      name: 'plugin-section',
+      label: 'Plugin Section',
+      entryType: 'subheader',
+      hide: true,
+    });
+
+    expect(screen.queryByText('Plugin Section')).not.toBeInTheDocument();
+    expect(container.querySelector('.MuiDivider-root')).not.toBeInTheDocument();
+  });
+
+  it('applies custom sx after the default subheader styles', () => {
+    renderSidebarItem({
+      name: 'plugin-section',
+      label: 'Plugin Section',
+      entryType: 'subheader',
+      sx: {
+        fontSize: '1.1rem',
+        fontWeight: 800,
+        textTransform: 'none',
+      },
+    });
+
+    const subheader = screen.getByText('Plugin Section');
+
+    expect(subheader).toHaveStyle({
+      fontSize: '1.1rem',
+      fontWeight: '800',
+      textTransform: 'none',
+    });
+  });
+});

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -15,8 +15,12 @@
  */
 
 import Collapse from '@mui/material/Collapse';
+import Divider from '@mui/material/Divider';
 import List from '@mui/material/List';
-import { ListItemProps } from '@mui/material/ListItem';
+import ListItem, { type ListItemProps } from '@mui/material/ListItem';
+import ListSubheader from '@mui/material/ListSubheader';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 import React, { memo } from 'react';
 import { generatePath } from 'react-router';
 import { formatClusterPathParam, getClusterPrefixedPath } from '../../lib/cluster';
@@ -82,9 +86,85 @@ const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] })
     hide,
     tabIndex,
     isCR,
+    entryType = 'link',
+    sx,
     clusters = [],
     ...other
   } = props;
+
+  if (hide) {
+    return null;
+  }
+
+  if (entryType === 'subheader') {
+    const sidebarColor = (theme: Theme) =>
+      theme.palette.sidebar.color ??
+      theme.palette.getContrastText(theme.palette.sidebar.background);
+
+    if (!fullWidth) {
+      return (
+        <Divider
+          component="li"
+          sx={theme => ({
+            borderColor: alpha(sidebarColor(theme), 0.15),
+            listStyle: 'none',
+            margin: theme.spacing(1, 2),
+          })}
+        />
+      );
+    }
+
+    const subheaderSx: SxProps<Theme> = [
+      theme => ({
+        backgroundColor: 'transparent',
+        color: alpha(sidebarColor(theme), 0.6),
+        fontSize: '0.75rem',
+        fontWeight: 700,
+        letterSpacing: '0.05em',
+        lineHeight: 1.5,
+        minHeight: 0,
+        overflow: 'hidden',
+        padding: theme.spacing(1.5, 2, 0.5),
+        textOverflow: 'ellipsis',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+      }),
+      ...(sx ? (Array.isArray(sx) ? sx : [sx]) : []),
+    ];
+
+    return (
+      <React.Fragment>
+        <ListSubheader disableSticky sx={subheaderSx}>
+          {label}
+        </ListSubheader>
+        {subList.length > 0 && (
+          <List
+            component="ul"
+            disablePadding
+            sx={{
+              '& .MuiListItem-root': {
+                fontSize: '.875rem',
+                paddingTop: '2px',
+                paddingBottom: '2px',
+              },
+            }}
+          >
+            {subList.map((item: SidebarItemProps) => (
+              <SidebarItem
+                key={item.name}
+                isSelected={item.isSelected}
+                fullWidth={fullWidth}
+                search={search}
+                tabIndex={tabIndex}
+                {...item}
+              />
+            ))}
+          </List>
+        )}
+      </React.Fragment>
+    );
+  }
+
   let fullURL = url;
   if (fullURL && useClusterURL && clusters.length && !fullURL.startsWith('http')) {
     fullURL = generatePath(getClusterPrefixedPath(url), {
@@ -96,7 +176,7 @@ const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] })
     fullURL = getFullURLOnRoute(name, isCR, subList);
   }
 
-  return hide ? null : (
+  return (
     <React.Fragment>
       <ListItemLink
         selected={isSelected}

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -138,28 +138,35 @@ const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] })
           {label}
         </ListSubheader>
         {subList.length > 0 && (
-          <List
-            component="ul"
-            disablePadding
+          <ListItem
             sx={{
-              '& .MuiListItem-root': {
-                fontSize: '.875rem',
-                paddingTop: '2px',
-                paddingBottom: '2px',
-              },
+              display: 'block',
+              padding: 0,
             }}
           >
-            {subList.map((item: SidebarItemProps) => (
-              <SidebarItem
-                key={item.name}
-                isSelected={item.isSelected}
-                fullWidth={fullWidth}
-                search={search}
-                tabIndex={tabIndex}
-                {...item}
-              />
-            ))}
-          </List>
+            <List
+              component="ul"
+              disablePadding
+              sx={{
+                '& .MuiListItem-root': {
+                  fontSize: '.875rem',
+                  paddingTop: '2px',
+                  paddingBottom: '2px',
+                },
+              }}
+            >
+              {subList.map((item: SidebarItemProps) => (
+                <SidebarItem
+                  key={item.name}
+                  isSelected={item.isSelected}
+                  fullWidth={fullWidth}
+                  search={search}
+                  tabIndex={tabIndex}
+                  {...item}
+                />
+              ))}
+            </List>
+          </ListItem>
         )}
       </React.Fragment>
     );

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -148,10 +148,13 @@ const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] })
               component="ul"
               disablePadding
               sx={{
-                '& .MuiListItem-root': {
+                '&& .MuiListItemButton-root': {
                   fontSize: '.875rem',
                   paddingTop: '2px',
                   paddingBottom: '2px',
+                },
+                '&& .MuiListItemText-primary': {
+                  fontSize: '.875rem',
                 },
               }}
             >

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -117,7 +117,7 @@ const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] })
     const subheaderSx: SxProps<Theme> = [
       theme => ({
         backgroundColor: 'transparent',
-        color: alpha(sidebarColor(theme), 0.6),
+        color: sidebarColor(theme),
         fontSize: '0.75rem',
         fontWeight: 700,
         letterSpacing: '0.05em',

--- a/frontend/src/components/Sidebar/Sidebaritem.stories.tsx
+++ b/frontend/src/components/Sidebar/Sidebaritem.stories.tsx
@@ -99,3 +99,33 @@ Sublist.args = {
     },
   ],
 };
+
+export const SectionHeader = Template.bind({});
+SectionHeader.args = {
+  name: 'section-header',
+  label: 'Plugin Section',
+  entryType: 'subheader',
+  fullWidth: true,
+};
+
+export const CollapsedSectionHeader = Template.bind({});
+CollapsedSectionHeader.args = {
+  name: 'collapsed-section-header',
+  label: 'Plugin Section',
+  entryType: 'subheader',
+  fullWidth: false,
+};
+
+export const StyledSectionHeader = Template.bind({});
+StyledSectionHeader.args = {
+  name: 'styled-section-header',
+  label: 'Plugin Section',
+  entryType: 'subheader',
+  fullWidth: true,
+  sx: {
+    color: '#90caf9',
+    fontSize: '1.1rem',
+    fontWeight: 800,
+    textTransform: 'none',
+  },
+};

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.CollapsedSectionHeader.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.CollapsedSectionHeader.stories.storyshot
@@ -1,0 +1,17 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+      style="background-color: rgba(0, 0, 0, 0.87);"
+    >
+      <ul
+        class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiDivider-root MuiDivider-fullWidth css-lu63ml-MuiDivider-root"
+          role="separator"
+        />
+      </ul>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SectionHeader.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SectionHeader.stories.storyshot
@@ -1,0 +1,18 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+      style="background-color: rgba(0, 0, 0, 0.87);"
+    >
+      <ul
+        class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiListSubheader-root MuiListSubheader-gutters css-67tfqe-MuiListSubheader-root"
+        >
+          Plugin Section
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SectionHeader.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SectionHeader.stories.storyshot
@@ -8,7 +8,7 @@
         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
       >
         <li
-          class="MuiListSubheader-root MuiListSubheader-gutters css-67tfqe-MuiListSubheader-root"
+          class="MuiListSubheader-root MuiListSubheader-gutters css-u1ph1t-MuiListSubheader-root"
         >
           Plugin Section
         </li>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.StyledSectionHeader.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.StyledSectionHeader.stories.storyshot
@@ -1,0 +1,18 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+      style="background-color: rgba(0, 0, 0, 0.87);"
+    >
+      <ul
+        class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+      >
+        <li
+          class="MuiListSubheader-root MuiListSubheader-gutters css-1eaha1h-MuiListSubheader-root"
+        >
+          Plugin Section
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.StyledSectionHeader.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.StyledSectionHeader.stories.storyshot
@@ -8,7 +8,7 @@
         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
       >
         <li
-          class="MuiListSubheader-root MuiListSubheader-gutters css-1eaha1h-MuiListSubheader-root"
+          class="MuiListSubheader-root MuiListSubheader-gutters css-pz1muy-MuiListSubheader-root"
         >
           Plugin Section
         </li>

--- a/frontend/src/components/Sidebar/sidebarSlice.ts
+++ b/frontend/src/components/Sidebar/sidebarSlice.ts
@@ -15,6 +15,8 @@
  */
 
 import { IconProps } from '@iconify/react';
+import type { SxProps, Theme } from '@mui/material/styles';
+import type { Draft } from '@reduxjs/toolkit';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import React from 'react';
 
@@ -60,6 +62,14 @@ export interface SidebarEntry {
   /** The sidebar to display this item in. If not specified, it will be displayed in the default sidebar.
    */
   sidebar?: DefaultSidebars | string;
+  /**
+   * The type of sidebar entry to render. Defaults to a clickable link item.
+   */
+  entryType?: 'link' | 'subheader';
+  /**
+   * Custom style overrides for subheader entries.
+   */
+  sx?: SxProps<Theme>;
 }
 
 export interface SidebarState {
@@ -176,7 +186,7 @@ const sidebarSlice = createSlice({
      * Sets an item in the sidebar.
      */
     setSidebarItem(state, action: PayloadAction<SidebarEntry>) {
-      state.entries[action.payload.name] = action.payload;
+      state.entries[action.payload.name] = action.payload as Draft<SidebarEntry>;
     },
 
     /**

--- a/frontend/src/components/Sidebar/sidebarSlice.ts
+++ b/frontend/src/components/Sidebar/sidebarSlice.ts
@@ -16,8 +16,8 @@
 
 import { IconProps } from '@iconify/react';
 import type { SxProps, Theme } from '@mui/material/styles';
-import type { Draft } from '@reduxjs/toolkit';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { Draft } from 'immer';
 import React from 'react';
 
 export enum DefaultSidebars {

--- a/frontend/src/components/Sidebar/sidebarSlice.ts
+++ b/frontend/src/components/Sidebar/sidebarSlice.ts
@@ -17,7 +17,7 @@
 import { IconProps } from '@iconify/react';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { Draft } from 'immer';
+import { castDraft } from 'immer';
 import React from 'react';
 
 export enum DefaultSidebars {
@@ -186,7 +186,7 @@ const sidebarSlice = createSlice({
      * Sets an item in the sidebar.
      */
     setSidebarItem(state, action: PayloadAction<SidebarEntry>) {
-      state.entries[action.payload.name] = action.payload as Draft<SidebarEntry>;
+      state.entries[action.payload.name] = castDraft(action.payload);
     },
 
     /**

--- a/frontend/src/components/Sidebar/useSidebarItems.test.tsx
+++ b/frontend/src/components/Sidebar/useSidebarItems.test.tsx
@@ -150,6 +150,34 @@ describe('useSidebarItems', () => {
     ).toBeDefined();
   });
 
+  it('should include subheader entry fields from customSidebarEntries', () => {
+    const sx = { fontSize: '1.1rem', textTransform: 'none' };
+    const customEntries: { [name: string]: SidebarEntry } = {
+      customSection: {
+        name: 'customSection',
+        label: 'Custom Section',
+        entryType: 'subheader',
+        sx,
+      },
+    };
+
+    const store = mockStore(customEntries, []);
+    const { result } = renderHook(() => useSidebarItems(), {
+      wrapper: wrapper(store),
+    });
+
+    expect(result.current).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'customSection',
+          label: 'Custom Section',
+          entryType: 'subheader',
+          sx,
+        }),
+      ])
+    );
+  });
+
   it('should apply customSidebarFilters', () => {
     const customEntries = {
       custom1: { name: 'custom1', label: 'Custom 1', url: '/custom1' },

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -306,6 +306,8 @@ export function registerSidebarEntry({
   useClusterURL = true,
   icon,
   sidebar,
+  entryType,
+  sx,
 }: SidebarEntryProps) {
   store.dispatch(
     setSidebarItem({
@@ -316,6 +318,8 @@ export function registerSidebarEntry({
       useClusterURL,
       icon,
       sidebar,
+      entryType,
+      sx,
     })
   );
 }

--- a/plugins/examples/sidebar/src/index.tsx
+++ b/plugins/examples/sidebar/src/index.tsx
@@ -25,6 +25,18 @@ import { SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 
+// A non-clickable section header in the sidebar.
+registerSidebarEntry({
+  parent: null,
+  name: 'feedback-section',
+  label: 'Feedback Tools',
+  entryType: 'subheader',
+  sx: {
+    fontSize: '0.8rem',
+    textTransform: 'none',
+  },
+});
+
 // A top level item in the sidebar.
 // The sidebar link URL is: /c/mycluster/feedback
 registerSidebarEntry({


### PR DESCRIPTION
## Summary

This PR adds support for non-clickable sidebar section headers that plugins can register through `registerSidebarEntry`.

Sidebar entries with `entryType: 'subheader'` are rendered as section headers. Existing sidebar entries continue to render as clickable links by default, so existing `registerSidebarEntry` usage remains compatible.

## Related Issue

Fixes #6107

## Changes

- Added an optional `entryType` field to sidebar entries.
- Added support for `entryType: 'subheader'` in `SidebarItem`.
- Render subheader entries as MUI `ListSubheader` when the sidebar is expanded.
- Render subheader entries as a `Divider` when the sidebar is collapsed.
- Added optional `sx` style overrides for subheader entries.
- Updated `registerSidebarEntry` so plugins can pass `entryType` and `sx`.
- Added tests for subheader rendering, collapsed sidebar behavior, hidden entries, and style overrides.
- Added Storybook examples for default, collapsed, and styled section headers.
- Updated the sidebar example plugin to show a section header followed by flat link entries at the same level.

## Steps to Test

1. Register a regular sidebar entry without `entryType` and confirm it still renders as a clickable link.

   ```tsx
   registerSidebarEntry({
     parent: null,
     name: 'traces',
     label: 'Traces',
     url: '/traces',
     icon: 'mdi:chart-timeline-variant',
   });
   ```

2. Register a sidebar entry with `entryType: 'subheader'` and confirm it renders as a non-clickable section header.

   ```tsx
   registerSidebarEntry({
     parent: null,
     name: 'observability-section',
     label: 'Observability',
     entryType: 'subheader',
   });
   ```

3. Collapse the sidebar and confirm the section header is rendered as a divider instead of text.

4. Run the focused frontend checks.

   ```sh
   npm run frontend:lint
   npm run frontend:tsc
   cd frontend
   npm test -- --run src/components/Sidebar/SidebarItem.test.tsx src/components/Sidebar/useSidebarItems.test.tsx
   npm test -- --run src/storybook.test.tsx -t "Sidebar/SidebarItem"
   ```

## Screenshots (if applicable)

<img width="280" height="435" alt="image" src="https://github.com/user-attachments/assets/9871e978-d47e-4022-8076-79e3dff4d86a" />

## Notes for the Reviewer

- This change is opt-in. Existing sidebar entries are treated as `entryType: 'link'` by default.
