### PR TITLE
backend: portforward: Fix context key to match rest of backend

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -679,24 +679,49 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	// Setup port forwarding handlers.
 	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		portforward.StartPortForward(
 			config.KubeConfigStore,
 			config.Cache,
 			config.shouldUseUnsafeServiceAccountToken(),
+			contextKey,
 			w,
 			r,
 		)
 	}).Methods("POST")
 
 	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
-		portforward.StopOrDeletePortForward(config.Cache, w, r)
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		portforward.StopOrDeletePortForward(config.Cache, contextKey, w, r)
 	}).Methods("DELETE")
 
 	r.HandleFunc("/clusters/{clusterName}/portforward/list", func(w http.ResponseWriter, r *http.Request) {
-		portforward.GetPortForwards(config.Cache, w, r)
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		portforward.GetPortForwards(config.Cache, contextKey, w, r)
 	})
 	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
-		portforward.GetPortForwardByID(config.Cache, w, r)
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		portforward.GetPortForwardByID(config.Cache, contextKey, w, r)
 	}).Methods("GET")
 
 	// Expose user info so the frontend can show the current user in the top bar using the per-cluster auth cookie.

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -760,24 +760,49 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	// Setup port forwarding handlers.
 	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		portforward.StartPortForward(
 			config.KubeConfigStore,
 			config.Cache,
 			config.shouldUseUnsafeServiceAccountToken(),
+			contextKey,
 			w,
 			r,
 		)
 	}).Methods("POST")
 
 	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
-		portforward.StopOrDeletePortForward(config.Cache, w, r)
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		portforward.StopOrDeletePortForward(config.Cache, contextKey, w, r)
 	}).Methods("DELETE")
 
 	r.HandleFunc("/clusters/{clusterName}/portforward/list", func(w http.ResponseWriter, r *http.Request) {
-		portforward.GetPortForwards(config.Cache, w, r)
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		portforward.GetPortForwards(config.Cache, contextKey, w, r)
 	})
 	r.HandleFunc("/clusters/{clusterName}/portforward", func(w http.ResponseWriter, r *http.Request) {
-		portforward.GetPortForwardByID(config.Cache, w, r)
+		contextKey, err := config.getContextKeyForRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		portforward.GetPortForwardByID(config.Cache, contextKey, w, r)
 	}).Methods("GET")
 
 	// Expose user info so the frontend can show the current user in the top bar using the per-cluster auth cookie.

--- a/backend/pkg/portforward/export_test.go
+++ b/backend/pkg/portforward/export_test.go
@@ -21,13 +21,13 @@ import "github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 // StorePortForwardForTest inserts a portForward entry into the cache as
 // StartPortForward would for a dynamic cluster, allowing unit tests to
 // exercise GetPortForwards without a real Kubernetes cluster.
-func StorePortForwardForTest(c cache.Cache[interface{}], clusterName, userID string) error {
+func StorePortForwardForTest(c cache.Cache[interface{}], clusterName, contextKey string) error {
 	pf := portForward{
 		ID:         "test-id-001",
 		Pod:        "test-pod",
 		Namespace:  "default",
 		Cluster:    clusterName,
-		cacheKey:   clusterName + userID,
+		cacheKey:   contextKey,
 		Port:       "8080",
 		TargetPort: "80",
 		Status:     RUNNING,

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -139,6 +139,7 @@ func getFreePort() (int, error) {
 //nolint:funlen
 func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache[interface{}],
 	unsafeUseServiceAccountToken bool,
+	contextKey string,
 	w http.ResponseWriter, r *http.Request,
 ) {
 	var p portForwardRequest
@@ -205,9 +206,9 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		p.Port = strconv.Itoa(freePort)
 	}
 
-	kContext, err := kubeConfigStore.GetContext(clusterName)
+	kContext, err := kubeConfigStore.GetContext(contextKey)
 	if err != nil {
-		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName},
+		logger.Log(logger.LevelError, map[string]string{"cluster": contextKey},
 			err, "getting kubeconfig context")
 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -220,7 +221,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		token, _ = auth.GetTokenFromCookie(r, requestClusterName)
 	}
 
-	err = startPortForward(kContext, cache, p, token, clusterName, requestClusterName)
+	err = startPortForward(kContext, cache, p, token, contextKey, requestClusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "starting portforward")
 
@@ -701,7 +702,9 @@ func (r *stopOrDeletePortForwardRequest) Validate() error {
 }
 
 // StopOrDeletePortForward handles stop or delete port forward request.
-func StopOrDeletePortForward(cache cache.Cache[interface{}], w http.ResponseWriter, r *http.Request) {
+func StopOrDeletePortForward(cache cache.Cache[interface{}], contextKey string,
+	w http.ResponseWriter, r *http.Request,
+) {
 	var p stopOrDeletePortForwardRequest
 
 	err := json.NewDecoder(r.Body).Decode(&p)
@@ -719,14 +722,7 @@ func StopOrDeletePortForward(cache cache.Cache[interface{}], w http.ResponseWrit
 		return
 	}
 
-	userID := r.Header.Get("X-HEADLAMP-USER-ID")
-	clusterName := mux.Vars(r)["clusterName"]
-
-	if userID != "" {
-		clusterName += userID
-	}
-
-	err = stopOrDeletePortForward(cache, clusterName, p.ID, p.StopOrDelete)
+	err = stopOrDeletePortForward(cache, contextKey, p.ID, p.StopOrDelete)
 	if err == nil {
 		if _, err := w.Write([]byte("stopped")); err != nil {
 			logger.Log(logger.LevelError, nil, err, "writing response")
@@ -740,7 +736,9 @@ func StopOrDeletePortForward(cache cache.Cache[interface{}], w http.ResponseWrit
 }
 
 // GetPortForwards handles get port forwards request.
-func GetPortForwards(cache cache.Cache[interface{}], w http.ResponseWriter, r *http.Request) {
+func GetPortForwards(cache cache.Cache[interface{}], contextKey string,
+	w http.ResponseWriter, r *http.Request,
+) {
 	cluster := mux.Vars(r)["clusterName"]
 	if cluster == "" {
 		logger.Log(logger.LevelError, nil, errors.New("cluster is required"), "getting portforwards")
@@ -749,14 +747,7 @@ func GetPortForwards(cache cache.Cache[interface{}], w http.ResponseWriter, r *h
 		return
 	}
 
-	userID := r.Header.Get("X-HEADLAMP-USER-ID")
-	clusterName := cluster
-
-	if userID != "" {
-		clusterName = cluster + userID
-	}
-
-	ports := getPortForwardList(cache, clusterName)
+	ports := getPortForwardList(cache, contextKey)
 
 	w.Header().Set("Content-Type", "application/json")
 
@@ -769,7 +760,9 @@ func GetPortForwards(cache cache.Cache[interface{}], w http.ResponseWriter, r *h
 }
 
 // GetPortForwardByID handles get port forward by id request.
-func GetPortForwardByID(cache cache.Cache[interface{}], w http.ResponseWriter, r *http.Request) {
+func GetPortForwardByID(cache cache.Cache[interface{}], contextKey string,
+	w http.ResponseWriter, r *http.Request,
+) {
 	cluster := mux.Vars(r)["clusterName"]
 	if cluster == "" {
 		logger.Log(logger.LevelError, nil, errors.New("cluster is required"), "getting portforward by id")
@@ -786,14 +779,7 @@ func GetPortForwardByID(cache cache.Cache[interface{}], w http.ResponseWriter, r
 		return
 	}
 
-	userID := r.Header.Get("X-HEADLAMP-USER-ID")
-	clusterName := cluster
-
-	if userID != "" {
-		clusterName = cluster + userID
-	}
-
-	p, err := getPortForwardByID(cache, clusterName, id)
+	p, err := getPortForwardByID(cache, contextKey, id)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "getting portforward by id")
 		http.Error(w, "no portforward running with id "+id, http.StatusNotFound)
@@ -813,7 +799,7 @@ func GetPortForwardByID(cache cache.Cache[interface{}], w http.ResponseWriter, r
 		ID:        p.ID,
 		Pod:       p.Pod,
 		Namespace: p.Namespace,
-		Cluster:   p.Cluster,
+		Cluster:   cluster,
 		Service:   p.Service,
 	}
 

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	streamhttp "k8s.io/streaming/pkg/httpstream"
 )
 
 const (
@@ -293,15 +294,16 @@ func getKubeClientAndConfig(kContext *kubeconfig.Context, token string) (*kubern
 }
 
 // buildPortForwardDialer returns a dialer that performs the port-forward
-// upgrade. It tries WebSocket first (matching kubectl since v1.31) and falls
-// back to SPDY/3.1 over POST when WebSocket negotiation fails — the WebSocket
-// path is also required when the cluster is fronted by a reverse proxy (e.g.
-// Warpgate) that propagates WebSocket upgrades but drops SPDY upgrade headers.
+// upgrade. Direct API endpoints use SPDY, while path-routed proxies try
+// WebSocket first because proxies such as Warpgate can drop SPDY headers.
 func buildPortForwardDialer(
 	rConf *rest.Config, fullURL *url.URL,
 	upgrader spdy.Upgrader, roundTripper http.RoundTripper,
 ) httpstream.Dialer {
 	spdyDialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, fullURL)
+	if strings.HasPrefix(fullURL.Path, "/api/") {
+		return spdyDialer
+	}
 
 	tunnelingDialer, err := portforward.NewSPDYOverWebsocketDialer(fullURL, rConf)
 	if err != nil {
@@ -310,9 +312,13 @@ func buildPortForwardDialer(
 		return spdyDialer
 	}
 
-	return portforward.NewFallbackDialer(tunnelingDialer, spdyDialer, func(err error) bool {
-		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
-	})
+	return portforward.NewFallbackDialer(tunnelingDialer, spdyDialer, shouldFallbackToSPDY)
+}
+
+func shouldFallbackToSPDY(err error) bool {
+	return httpstream.IsUpgradeFailure(err) ||
+		streamhttp.IsUpgradeFailure(err) ||
+		httpstream.IsHTTPSProxyError(err)
 }
 
 // buildPortForwardURL constructs the upstream port-forward URL for a pod,
@@ -322,7 +328,7 @@ func buildPortForwardDialer(
 // `hostURL.ResolveReference(&url.URL{Path: …})` cannot be used here because
 // `ResolveReference` replaces the host path when the reference path is
 // absolute, dropping the prefix.
-func buildPortForwardURL(host, namespace, podName string) (*url.URL, error) {
+func buildPortForwardURL(host, namespace, podName, targetPort string) (*url.URL, error) {
 	hostURL, err := url.Parse(host)
 	if err != nil {
 		return nil, fmt.Errorf("invalid REST config host: %w", err)
@@ -346,6 +352,11 @@ func buildPortForwardURL(host, namespace, podName string) (*url.URL, error) {
 
 	prefix := strings.TrimSuffix(hostURL.Path, "/")
 	hostURL.Path = fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward", prefix, namespace, podName)
+	query := hostURL.Query()
+	// The API server decodes PodPortForwardOptions.ports and forwards each value
+	// to the kubelet's singular port query parameter.
+	query.Set("ports", targetPort)
+	hostURL.RawQuery = query.Encode()
 
 	return hostURL, nil
 }
@@ -353,7 +364,7 @@ func buildPortForwardURL(host, namespace, podName string) (*url.URL, error) {
 // initPortForwarder sets up the SPDY dialer and creates a new port forwarder.
 // It requires a REST config, namespace, pod name, and the port mapping string (e.g., "8080:80").
 // It returns the port forwarder instance, stop/ready channels, output/error buffers, or an error.
-func initPortForwarder(rConf *rest.Config, namespace, podName, portMapping string) (
+func initPortForwarder(rConf *rest.Config, namespace, podName, portMapping, targetPort string) (
 	*portforward.PortForwarder, chan struct{}, chan struct{}, *bytes.Buffer, *bytes.Buffer, error,
 ) {
 	roundTripper, upgrader, err := spdy.RoundTripperFor(rConf)
@@ -361,15 +372,12 @@ func initPortForwarder(rConf *rest.Config, namespace, podName, portMapping strin
 		return nil, nil, nil, nil, nil, fmt.Errorf("failed to create SPDY round tripper: %w", err)
 	}
 
-	fullURL, err := buildPortForwardURL(rConf.Host, namespace, podName)
+	fullURL, err := buildPortForwardURL(rConf.Host, namespace, podName, targetPort)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
-	// Try WebSocket-based port-forward first, fall back to SPDY/3.1 over POST.
-	// This mirrors `kubectl port-forward` behavior since v1.31 and is required
-	// for clusters fronted by reverse proxies (e.g. Warpgate) that handle WS
-	// upgrades but drop SPDY upgrade headers.
+	// Path-routed proxies use WebSocket first; direct API endpoints use SPDY.
 	dialer := buildPortForwardDialer(rConf, fullURL, upgrader, roundTripper)
 
 	stopChan, readyChan := make(chan struct{}), make(chan struct{}, 1)
@@ -639,7 +647,7 @@ func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{
 	)
 
 	forwarder, stopChan, readyChan, outBuffer, errOut, errInit = initPortForwarder(
-		rConf, p.Namespace, p.Pod, portMapping,
+		rConf, p.Namespace, p.Pod, portMapping, p.TargetPort,
 	)
 	if errInit != nil {
 		return fmt.Errorf("failed to initialize port forwarder: %w", errInit)

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -155,20 +155,14 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		p.ID = uuid.New().String()
 	}
 
-	userID := r.Header.Get("X-HEADLAMP-USER-ID")
 	requestClusterName := mux.Vars(r)["clusterName"]
-	clusterName := requestClusterName
-
-	if userID != "" {
-		clusterName += userID
-	}
 
 	// Ensure we don't orphan an existing port-forward by overwriting its cache entry.
 	// This check happens before any resource allocation or blocking code so duplicates short-circuit
 	// deterministically and avoid unnecessary listener churn.
-	if existingPF, err := getPortForwardByID(cache, clusterName, p.ID); err == nil && existingPF.Status == RUNNING {
+	if existingPF, err := getPortForwardByID(cache, contextKey, p.ID); err == nil && existingPF.Status == RUNNING {
 		//nolint:goconst
-		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
+		logger.Log(logger.LevelError, map[string]string{"cluster": contextKey, "id": p.ID},
 			nil, "portforward ID already exists")
 		http.Error(w, "portforward with this ID is already running", http.StatusConflict)
 
@@ -176,9 +170,9 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 	}
 
 	// Reject duplicates before any resource-consuming work (port alloc, kubeconfig lookup).
-	inFlightKey := strings.Join([]string{requestClusterName, userID, p.ID}, "\x00")
+	inFlightKey := strings.Join([]string{contextKey, p.ID}, "\x00")
 	if _, loaded := inFlightPortForwards.LoadOrStore(inFlightKey, struct{}{}); loaded {
-		logger.Log(logger.LevelError, map[string]string{"cluster": clusterName, "id": p.ID},
+		logger.Log(logger.LevelError, map[string]string{"cluster": contextKey, "id": p.ID},
 			nil, "portforward ID is already starting")
 		http.Error(w, "portforward with this ID is already starting", http.StatusConflict)
 

--- a/backend/pkg/portforward/handler_test.go
+++ b/backend/pkg/portforward/handler_test.go
@@ -133,7 +133,7 @@ func TestStartPortForward(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(jsonReq))
 	req.Header.Set("Content-Type", "application/json")
 
-	portforward.StartPortForward(kubeConfigStore, ch, false, resp, req)
+	portforward.StartPortForward(kubeConfigStore, ch, false, minikubeName, resp, req)
 
 	res := resp.Result()
 
@@ -204,7 +204,7 @@ func TestStartPortForward(t *testing.T) {
 	stopReq.Header.Set("Content-Type", "application/json")
 	stopReq = mux.SetURLVars(stopReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.StopOrDeletePortForward(ch, stopResp, stopReq)
+	portforward.StopOrDeletePortForward(ch, minikubeName, stopResp, stopReq)
 
 	stopRes := stopResp.Result()
 
@@ -230,7 +230,7 @@ func TestStartPortForward(t *testing.T) {
 	listReq.URL = &url.URL{}
 	listReq = mux.SetURLVars(listReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.GetPortForwards(ch, listResp, listReq)
+	portforward.GetPortForwards(ch, minikubeName, listResp, listReq)
 
 	listRes := listResp.Result()
 
@@ -280,7 +280,7 @@ func TestStartPortForward(t *testing.T) {
 	getReq.URL.RawQuery = "id=" + id
 	getReq = mux.SetURLVars(getReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.GetPortForwardByID(ch, getResp, getReq)
+	portforward.GetPortForwardByID(ch, minikubeName, getResp, getReq)
 
 	getRes := getResp.Result()
 
@@ -315,7 +315,7 @@ func TestStartPortForward(t *testing.T) {
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteReq = mux.SetURLVars(deleteReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.StopOrDeletePortForward(ch, deleteResp, deleteReq)
+	portforward.StopOrDeletePortForward(ch, minikubeName, deleteResp, deleteReq)
 
 	deleteRes := deleteResp.Result()
 
@@ -359,7 +359,7 @@ func TestGetPortForwardsClusterNameNotExposingUserID(t *testing.T) {
 	listReq.Header.Set("X-HEADLAMP-USER-ID", userID)
 	listReq = mux.SetURLVars(listReq, map[string]string{"clusterName": clusterName})
 
-	portforward.GetPortForwards(ch, listResp, listReq)
+	portforward.GetPortForwards(ch, clusterName+userID, listResp, listReq)
 
 	listRes := listResp.Result()
 	defer func() { _ = listRes.Body.Close() }()

--- a/backend/pkg/portforward/handler_test.go
+++ b/backend/pkg/portforward/handler_test.go
@@ -133,7 +133,7 @@ func TestStartPortForward(t *testing.T) {
 	req.Body = io.NopCloser(bytes.NewReader(jsonReq))
 	req.Header.Set("Content-Type", "application/json")
 
-	portforward.StartPortForward(kubeConfigStore, ch, false, resp, req)
+	portforward.StartPortForward(kubeConfigStore, ch, false, minikubeName, resp, req)
 
 	res := resp.Result()
 
@@ -204,7 +204,7 @@ func TestStartPortForward(t *testing.T) {
 	stopReq.Header.Set("Content-Type", "application/json")
 	stopReq = mux.SetURLVars(stopReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.StopOrDeletePortForward(ch, stopResp, stopReq)
+	portforward.StopOrDeletePortForward(ch, minikubeName, stopResp, stopReq)
 
 	stopRes := stopResp.Result()
 
@@ -230,7 +230,7 @@ func TestStartPortForward(t *testing.T) {
 	listReq.URL = &url.URL{}
 	listReq = mux.SetURLVars(listReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.GetPortForwards(ch, listResp, listReq)
+	portforward.GetPortForwards(ch, minikubeName, listResp, listReq)
 
 	listRes := listResp.Result()
 
@@ -280,7 +280,7 @@ func TestStartPortForward(t *testing.T) {
 	getReq.URL.RawQuery = "id=" + id
 	getReq = mux.SetURLVars(getReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.GetPortForwardByID(ch, getResp, getReq)
+	portforward.GetPortForwardByID(ch, minikubeName, getResp, getReq)
 
 	getRes := getResp.Result()
 
@@ -315,7 +315,7 @@ func TestStartPortForward(t *testing.T) {
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteReq = mux.SetURLVars(deleteReq, map[string]string{"clusterName": minikubeName})
 
-	portforward.StopOrDeletePortForward(ch, deleteResp, deleteReq)
+	portforward.StopOrDeletePortForward(ch, minikubeName, deleteResp, deleteReq)
 
 	deleteRes := deleteResp.Result()
 
@@ -335,20 +335,22 @@ func TestStartPortForward(t *testing.T) {
 // TestGetPortForwardsClusterNameNotExposingUserID verifies that when a dynamic
 // cluster request carries an X-HEADLAMP-USER-ID header, the port forwards
 // returned by GetPortForwards contain the original cluster name and not the
-// internal cache key (clusterName + userID).
+// internal stateless context key.
 func TestGetPortForwardsClusterNameNotExposingUserID(t *testing.T) {
 	t.Parallel()
 
-	const clusterName = "k8s-prod"
-
-	const userID = "f04bd0db261b76f3"
+	const (
+		clusterName = "k8s-prod"
+		userID      = "f04bd0db261b76f3"
+		contextKey  = clusterName + "\x00" + userID
+	)
 
 	ch := cache.New[interface{}]()
 
 	// Simulate what startPortForward does internally: store a portForward
 	// with Cluster set to the original name and cacheKey set to the
 	// userID-suffixed internal key.
-	err := portforward.StorePortForwardForTest(ch, clusterName, userID)
+	err := portforward.StorePortForwardForTest(ch, clusterName, contextKey)
 	require.NoError(t, err)
 
 	listReq := &http.Request{
@@ -359,7 +361,7 @@ func TestGetPortForwardsClusterNameNotExposingUserID(t *testing.T) {
 	listReq.Header.Set("X-HEADLAMP-USER-ID", userID)
 	listReq = mux.SetURLVars(listReq, map[string]string{"clusterName": clusterName})
 
-	portforward.GetPortForwards(ch, listResp, listReq)
+	portforward.GetPortForwards(ch, contextKey, listResp, listReq)
 
 	listRes := listResp.Result()
 	defer func() { _ = listRes.Body.Close() }()

--- a/backend/pkg/portforward/handler_unit_test.go
+++ b/backend/pkg/portforward/handler_unit_test.go
@@ -52,7 +52,7 @@ func TestGetPortForwards_MissingCluster(t *testing.T) {
 	// No clusterName in mux vars — simulates a request without the route parameter.
 	r := newRequestWithVars(http.MethodGet, "/portforward/list", nil, map[string]string{})
 
-	portforward.GetPortForwards(ch, w, r)
+	portforward.GetPortForwards(ch, "", w, r)
 
 	res := w.Result()
 
@@ -74,7 +74,7 @@ func TestGetPortForwards_EmptyList(t *testing.T) {
 		"clusterName": "test-cluster",
 	})
 
-	portforward.GetPortForwards(ch, w, r)
+	portforward.GetPortForwards(ch, "test-cluster", w, r)
 
 	res := w.Result()
 
@@ -99,7 +99,7 @@ func TestGetPortForwards_ContentTypeHeader(t *testing.T) {
 		"clusterName": "any-cluster",
 	})
 
-	portforward.GetPortForwards(ch, w, r)
+	portforward.GetPortForwards(ch, "any-cluster", w, r)
 
 	res := w.Result()
 
@@ -119,7 +119,7 @@ func TestGetPortForwardByID_MissingCluster(t *testing.T) {
 	r := newRequestWithVars(http.MethodGet, "/portforward?id=abc", nil, map[string]string{})
 	r.URL = &url.URL{RawQuery: "id=abc"}
 
-	portforward.GetPortForwardByID(ch, w, r)
+	portforward.GetPortForwardByID(ch, "", w, r)
 
 	res := w.Result()
 
@@ -142,7 +142,7 @@ func TestGetPortForwardByID_MissingID(t *testing.T) {
 	})
 	r.URL = &url.URL{}
 
-	portforward.GetPortForwardByID(ch, w, r)
+	portforward.GetPortForwardByID(ch, "test-cluster", w, r)
 
 	res := w.Result()
 
@@ -165,7 +165,7 @@ func TestGetPortForwardByID_NotFound(t *testing.T) {
 	})
 	r.URL = &url.URL{RawQuery: "id=nonexistent"}
 
-	portforward.GetPortForwardByID(ch, w, r)
+	portforward.GetPortForwardByID(ch, "test-cluster", w, r)
 
 	res := w.Result()
 
@@ -191,7 +191,7 @@ func TestStopOrDeletePortForward_InvalidJSON(t *testing.T) {
 		"clusterName": "test-cluster",
 	})
 
-	portforward.StopOrDeletePortForward(ch, w, r)
+	portforward.StopOrDeletePortForward(ch, "test-cluster", w, r)
 
 	res := w.Result()
 
@@ -200,66 +200,62 @@ func TestStopOrDeletePortForward_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 }
 
-func TestStopOrDeletePortForward_MissingID(t *testing.T) {
+func TestStopOrDeletePortForward_ErrorCases(t *testing.T) {
 	t.Parallel()
 
-	ch := cache.New[interface{}]()
-	w := httptest.NewRecorder()
-
-	payload := map[string]interface{}{
-		"id":           "",
-		"stopOrDelete": true,
+	tests := []struct {
+		name           string
+		id             string
+		wantStatusCode int
+		wantBody       string
+	}{
+		{
+			name:           "missing id",
+			id:             "",
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "id is required",
+		},
+		{
+			name:           "id not found in cache",
+			id:             "does-not-exist",
+			wantStatusCode: http.StatusInternalServerError,
+			wantBody:       "failed to delete port forward",
+		},
 	}
 
-	jsonPayload, err := json.Marshal(payload)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		tt := tt
 
-	body := bytes.NewReader(jsonPayload)
-	r := newRequestWithVars(http.MethodDelete, "/portforward", body, map[string]string{
-		"clusterName": "test-cluster",
-	})
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	portforward.StopOrDeletePortForward(ch, w, r)
+			ch := cache.New[interface{}]()
+			w := httptest.NewRecorder()
 
-	res := w.Result()
+			payload := map[string]interface{}{
+				"id":           tt.id,
+				"stopOrDelete": true,
+			}
 
-	defer func() { _ = res.Body.Close() }()
+			jsonPayload, err := json.Marshal(payload)
+			require.NoError(t, err)
 
-	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+			body := bytes.NewReader(jsonPayload)
+			r := newRequestWithVars(http.MethodDelete, "/portforward", body, map[string]string{
+				"clusterName": "test-cluster",
+			})
 
-	respBody, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	assert.Contains(t, string(respBody), "id is required")
-}
+			portforward.StopOrDeletePortForward(ch, "test-cluster", w, r)
 
-func TestStopOrDeletePortForward_NotFoundInCache(t *testing.T) {
-	t.Parallel()
+			res := w.Result()
 
-	ch := cache.New[interface{}]()
-	w := httptest.NewRecorder()
+			defer func() { _ = res.Body.Close() }()
 
-	payload := map[string]interface{}{
-		"id":           "does-not-exist",
-		"stopOrDelete": true,
+			assert.Equal(t, tt.wantStatusCode, res.StatusCode)
+
+			respBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(respBody), tt.wantBody)
+		})
 	}
-
-	jsonPayload, err := json.Marshal(payload)
-	require.NoError(t, err)
-
-	body := bytes.NewReader(jsonPayload)
-	r := newRequestWithVars(http.MethodDelete, "/portforward", body, map[string]string{
-		"clusterName": "test-cluster",
-	})
-
-	portforward.StopOrDeletePortForward(ch, w, r)
-
-	res := w.Result()
-
-	defer func() { _ = res.Body.Close() }()
-
-	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
-
-	respBody, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	assert.Contains(t, string(respBody), "failed to delete port forward")
 }

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -532,7 +532,7 @@ func TestGetPortForwardByID_UserIDKeyIsolation(t *testing.T) {
 }
 
 // TestGetPortForwardsHandler_UserIDKeyIsolation uses the exported HTTP handler
-// to verify that the X-HEADLAMP-USER-ID header causes a different cache lookup.
+// to verify that a different context key causes a different cache lookup.
 func TestGetPortForwardsHandler_UserIDKeyIsolation(t *testing.T) {
 	c := cache.New[interface{}]()
 
@@ -540,12 +540,12 @@ func TestGetPortForwardsHandler_UserIDKeyIsolation(t *testing.T) {
 	pf := portForward{ID: "pf-3", Cluster: "cluster", Pod: "nginx", Namespace: "default", Status: RUNNING}
 	portforwardstore(c, pf)
 
-	// Request WITHOUT user ID header — should return the seeded entry.
+	// Request with the base cluster context key — should return the seeded entry.
 	w := httptest.NewRecorder()
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward/list", nil)
 	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
 
-	GetPortForwards(c, w, r)
+	GetPortForwards(c, "cluster", w, r)
 
 	res := w.Result()
 
@@ -557,13 +557,12 @@ func TestGetPortForwardsHandler_UserIDKeyIsolation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "pf-3")
 
-	// Request WITH user ID header — should return empty list.
+	// Request with a user-specific context key — should return empty list.
 	w2 := httptest.NewRecorder()
 	r2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward/list", nil)
 	r2 = mux.SetURLVars(r2, map[string]string{"clusterName": "cluster"})
-	r2.Header.Set("X-HEADLAMP-USER-ID", "user999")
 
-	GetPortForwards(c, w2, r2)
+	GetPortForwards(c, "clusteruser999", w2, r2)
 
 	res2 := w2.Result()
 
@@ -577,7 +576,7 @@ func TestGetPortForwardsHandler_UserIDKeyIsolation(t *testing.T) {
 }
 
 // TestGetPortForwardByIDHandler_UserIDKeyIsolation uses the exported HTTP handler
-// to verify that the X-HEADLAMP-USER-ID header causes a different cache lookup.
+// to verify that a different context key causes a different cache lookup.
 func TestGetPortForwardByIDHandler_UserIDKeyIsolation(t *testing.T) {
 	c := cache.New[interface{}]()
 
@@ -585,13 +584,13 @@ func TestGetPortForwardByIDHandler_UserIDKeyIsolation(t *testing.T) {
 	pf := portForward{ID: "pf-4", Cluster: "cluster", Pod: "redis", Namespace: "cache", Status: RUNNING}
 	portforwardstore(c, pf)
 
-	// Request WITHOUT user ID header — should find the entry.
+	// Request with the base cluster context key — should find the entry.
 	w := httptest.NewRecorder()
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward?id=pf-4", nil)
 	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
 	r.URL = &url.URL{RawQuery: "id=pf-4"}
 
-	GetPortForwardByID(c, w, r)
+	GetPortForwardByID(c, "cluster", w, r)
 
 	res := w.Result()
 
@@ -599,14 +598,13 @@ func TestGetPortForwardByIDHandler_UserIDKeyIsolation(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 
-	// Request WITH user ID header — should NOT find it.
+	// Request with a user-specific context key — should NOT find it.
 	w2 := httptest.NewRecorder()
 	r2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward?id=pf-4", nil)
 	r2 = mux.SetURLVars(r2, map[string]string{"clusterName": "cluster"})
 	r2.URL = &url.URL{RawQuery: "id=pf-4"}
-	r2.Header.Set("X-HEADLAMP-USER-ID", "user999")
 
-	GetPortForwardByID(c, w2, r2)
+	GetPortForwardByID(c, "clusteruser999", w2, r2)
 
 	res2 := w2.Result()
 
@@ -616,8 +614,38 @@ func TestGetPortForwardByIDHandler_UserIDKeyIsolation(t *testing.T) {
 		"user-specific lookup must not find entries under base cluster key")
 }
 
+func TestGetPortForwardByIDHandler_ReturnsRouteClusterName(t *testing.T) {
+	c := cache.New[interface{}]()
+	contextKey := "cluster\x00user"
+
+	pf := portForward{
+		ID: "pf-context-key", Cluster: contextKey, cacheKey: contextKey,
+		Pod: "redis", Namespace: "cache", Status: RUNNING,
+	}
+	portforwardstore(c, pf)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portforward?id=pf-context-key", nil)
+	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
+	r.URL = &url.URL{RawQuery: "id=pf-context-key"}
+
+	GetPortForwardByID(c, contextKey, w, r)
+
+	res := w.Result()
+	defer func() { _ = res.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var response struct {
+		Cluster string `json:"cluster"`
+	}
+
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&response))
+	assert.Equal(t, "cluster", response.Cluster)
+}
+
 // TestStopOrDeletePortForwardHandler_UserIDKeyIsolation verifies that
-// StopOrDeletePortForward uses cluster+userID as the cache key.
+// StopOrDeletePortForward uses the provided context key as the cache key.
 func TestStopOrDeletePortForwardHandler_UserIDKeyIsolation(t *testing.T) {
 	c := cache.New[interface{}]()
 
@@ -626,16 +654,15 @@ func TestStopOrDeletePortForwardHandler_UserIDKeyIsolation(t *testing.T) {
 	pf := portForward{ID: "pf-5", Cluster: "cluster", Pod: "app", Namespace: "ns", Status: RUNNING, closeChan: ch}
 	portforwardstore(c, pf)
 
-	// Try to stop with a user ID header — should fail because the key is different.
+	// Try to stop with a user-specific context key — should fail because the key is different.
 	payload, err := json.Marshal(map[string]interface{}{"id": "pf-5", "stopOrDelete": true})
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/portforward", bytes.NewReader(payload))
 	r = mux.SetURLVars(r, map[string]string{"clusterName": "cluster"})
-	r.Header.Set("X-HEADLAMP-USER-ID", "user999")
 
-	StopOrDeletePortForward(c, w, r)
+	StopOrDeletePortForward(c, "clusteruser999", w, r)
 
 	res := w.Result()
 
@@ -674,7 +701,7 @@ func TestStartPortForward_DuplicateIDConflict(t *testing.T) {
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/portforward", bytes.NewReader(jsonReq))
 	r = mux.SetURLVars(r, map[string]string{"clusterName": "test-cluster"})
 
-	StartPortForward(kubeConfigStore, c, false, w, r)
+	StartPortForward(kubeConfigStore, c, false, "test-cluster", w, r)
 
 	res := w.Result()
 
@@ -728,7 +755,7 @@ func TestStartPortForward_ConcurrentRequests(t *testing.T) {
 		r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/portforward", bytes.NewReader(body))
 		r = mux.SetURLVars(r, map[string]string{"clusterName": "test-cluster"})
 
-		StartPortForward(store, c, false, w, r)
+		StartPortForward(store, c, false, "test-cluster", w, r)
 
 		return w
 	}

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,8 +35,10 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/httpstream" //nolint:staticcheck // Cover the legacy client-go fallback error.
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
+	streamhttp "k8s.io/streaming/pkg/httpstream"
 )
 
 // TestHandlePortForwardReadiness tests handlePortForwardReadiness function.
@@ -242,62 +245,71 @@ func TestPortForwardRequestValidate(t *testing.T) {
 // TestBuildPortForwardURL ensures the upstream port-forward URL preserves the
 // kubeconfig server's path prefix (relevant when the cluster is fronted by a
 // path-routing reverse proxy such as Warpgate).
-func TestBuildPortForwardURL(t *testing.T) {
-	tests := []struct {
-		name      string
-		host      string
-		namespace string
-		podName   string
-		want      string
-	}{
-		{
-			name:      "no path prefix",
-			host:      "https://kubernetes.default.svc:443",
-			namespace: "default",
-			podName:   "my-pod",
-			want:      "https://kubernetes.default.svc:443/api/v1/namespaces/default/pods/my-pod/portforward",
-		},
-		{
-			name:      "single segment path prefix",
-			host:      "https://example.com/k8s",
-			namespace: "default",
-			podName:   "my-pod",
-			want:      "https://example.com/k8s/api/v1/namespaces/default/pods/my-pod/portforward",
-		},
-		{
-			name:      "trailing slash path prefix",
-			host:      "https://example.com/k8s/",
-			namespace: "default",
-			podName:   "my-pod",
-			want:      "https://example.com/k8s/api/v1/namespaces/default/pods/my-pod/portforward",
-		},
-		{
-			name:      "Warpgate-style multi-segment prefix",
-			host:      "https://k8s.example.com:443/proxy-routed-cluster",
-			namespace: "kube-system",
-			podName:   "traefik-69fpr",
-			want: "https://k8s.example.com:443/proxy-routed-cluster" +
-				"/api/v1/namespaces/kube-system/pods/traefik-69fpr/portforward",
-		},
-		{
-			name:      "missing scheme defaults to https",
-			host:      "kubernetes.default.svc:443",
-			namespace: "default",
-			podName:   "my-pod",
-			want:      "https://kubernetes.default.svc:443/api/v1/namespaces/default/pods/my-pod/portforward",
-		},
-		{
-			name:      "bare hostname defaults to https",
-			host:      "example.com",
-			namespace: "default",
-			podName:   "my-pod",
-			want:      "https://example.com/api/v1/namespaces/default/pods/my-pod/portforward",
-		},
-	}
+var buildPortForwardURLTests = []struct {
+	name      string
+	host      string
+	namespace string
+	podName   string
+	want      string
+}{
+	{
+		name:      "no path prefix",
+		host:      "https://kubernetes.default.svc:443",
+		namespace: "default",
+		podName:   "my-pod",
+		want:      "https://kubernetes.default.svc:443/api/v1/namespaces/default/pods/my-pod/portforward?ports=4466",
+	},
+	{
+		name:      "single segment path prefix",
+		host:      "https://example.com/k8s",
+		namespace: "default",
+		podName:   "my-pod",
+		want:      "https://example.com/k8s/api/v1/namespaces/default/pods/my-pod/portforward?ports=4466",
+	},
+	{
+		name:      "trailing slash path prefix",
+		host:      "https://example.com/k8s/",
+		namespace: "default",
+		podName:   "my-pod",
+		want:      "https://example.com/k8s/api/v1/namespaces/default/pods/my-pod/portforward?ports=4466",
+	},
+	{
+		name:      "Warpgate-style multi-segment prefix",
+		host:      "https://k8s.example.com:443/proxy-routed-cluster",
+		namespace: "kube-system",
+		podName:   "traefik-69fpr",
+		want: "https://k8s.example.com:443/proxy-routed-cluster" +
+			"/api/v1/namespaces/kube-system/pods/traefik-69fpr/portforward?ports=4466",
+	},
+	{
+		name:      "missing scheme defaults to https",
+		host:      "kubernetes.default.svc:443",
+		namespace: "default",
+		podName:   "my-pod",
+		want:      "https://kubernetes.default.svc:443/api/v1/namespaces/default/pods/my-pod/portforward?ports=4466",
+	},
+	{
+		name:      "bare hostname defaults to https",
+		host:      "example.com",
+		namespace: "default",
+		podName:   "my-pod",
+		want:      "https://example.com/api/v1/namespaces/default/pods/my-pod/portforward?ports=4466",
+	},
+	{
+		name:      "existing query parameter is preserved",
+		host:      "https://example.com/k8s?tenant=demo",
+		namespace: "default",
+		podName:   "my-pod",
+		want:      "https://example.com/k8s/api/v1/namespaces/default/pods/my-pod/portforward?ports=4466&tenant=demo",
+	},
+}
 
-	for _, tt := range tests {
+func TestBuildPortForwardURL(t *testing.T) {
+	const targetPort = "4466"
+
+	for _, tt := range buildPortForwardURLTests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildPortForwardURL(tt.host, tt.namespace, tt.podName)
+			got, err := buildPortForwardURL(tt.host, tt.namespace, tt.podName, targetPort)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got.String())
 		})
@@ -318,27 +330,30 @@ func TestBuildPortForwardURLInvalidHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := buildPortForwardURL(tt.host, "ns", "pod")
+			_, err := buildPortForwardURL(tt.host, "ns", "pod", "4466")
 			assert.Error(t, err)
 		})
 	}
 }
 
-// TestBuildPortForwardDialer verifies dialer selection: with a valid REST
-// config we get a WebSocket-first FallbackDialer (which itself falls back to
-// SPDY on upgrade failures); when the WebSocket dialer cannot be created we
-// fall back to a SPDY-only dialer rather than erroring.
+// TestBuildPortForwardDialer verifies direct API endpoints use SPDY while
+// path-routed proxies use WebSocket first and fall back to SPDY.
 func TestBuildPortForwardDialer(t *testing.T) {
-	fullURL, err := url.Parse("https://example.com/api/v1/namespaces/default/pods/p/portforward")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name         string
+		url          string
 		rConf        *rest.Config
 		wantFallback bool
 	}{
 		{
-			name:         "websocket dialer available, wraps in FallbackDialer",
+			name:         "direct API endpoint uses SPDY",
+			url:          "https://example.com/api/v1/namespaces/default/pods/p/portforward",
+			rConf:        &rest.Config{Host: "https://example.com"},
+			wantFallback: false,
+		},
+		{
+			name:         "path-routed proxy uses WebSocket fallback dialer",
+			url:          "https://example.com/proxy/api/v1/namespaces/default/pods/p/portforward",
 			rConf:        &rest.Config{Host: "https://example.com"},
 			wantFallback: true,
 		},
@@ -346,6 +361,7 @@ func TestBuildPortForwardDialer(t *testing.T) {
 			// Insecure + CAData makes TLSConfigFor (called by
 			// websocket.RoundTripperFor) fail, exercising the SPDY-only path.
 			name: "websocket dialer unavailable, returns SPDY-only dialer",
+			url:  "https://example.com/proxy/api/v1/namespaces/default/pods/p/portforward",
 			rConf: &rest.Config{
 				Host: "https://example.com",
 				TLSClientConfig: rest.TLSClientConfig{
@@ -359,11 +375,49 @@ func TestBuildPortForwardDialer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			fullURL, err := url.Parse(tt.url)
+			require.NoError(t, err)
+
 			d := buildPortForwardDialer(tt.rConf, fullURL, nil, nil)
 			require.NotNil(t, d)
 
 			_, isFallback := d.(*portforward.FallbackDialer)
 			assert.Equal(t, tt.wantFallback, isFallback)
+		})
+	}
+}
+
+func TestShouldFallbackToSPDY(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "legacy upgrade failure",
+			err:  &httpstream.UpgradeFailureError{Cause: errors.New("legacy upgrade failed")},
+			want: true,
+		},
+		{
+			name: "streaming upgrade failure",
+			err:  &streamhttp.UpgradeFailureError{Cause: errors.New("websocket upgrade failed")},
+			want: true,
+		},
+		{
+			name: "HTTPS proxy failure",
+			err:  errors.New("proxy: unknown scheme: https"),
+			want: true,
+		},
+		{
+			name: "other failure",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldFallbackToSPDY(tt.err))
 		})
 	}
 }

--- a/backend/pkg/portforward/internal_test.go
+++ b/backend/pkg/portforward/internal_test.go
@@ -675,13 +675,19 @@ func TestStopOrDeletePortForwardHandler_UserIDKeyIsolation(t *testing.T) {
 // TestStartPortForward_DuplicateIDConflict verifies that StartPortForward
 // returns a 409 Conflict if a port-forward with the same ID is already running.
 func TestStartPortForward_DuplicateIDConflict(t *testing.T) {
+	const (
+		clusterName = "test-cluster"
+		contextKey  = clusterName + "\x00user"
+	)
+
 	c := cache.New[interface{}]()
 	kubeConfigStore := kubeconfig.NewContextStore()
 
 	// Seed a running port-forward in the cache
 	pf := portForward{
 		ID:        "duplicate-id",
-		Cluster:   "test-cluster",
+		Cluster:   clusterName,
+		cacheKey:  contextKey,
 		Pod:       "some-pod",
 		Namespace: "default",
 		Status:    RUNNING,
@@ -699,9 +705,10 @@ func TestStartPortForward_DuplicateIDConflict(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/portforward", bytes.NewReader(jsonReq))
-	r = mux.SetURLVars(r, map[string]string{"clusterName": "test-cluster"})
+	r.Header.Set("X-HEADLAMP-USER-ID", "user")
+	r = mux.SetURLVars(r, map[string]string{"clusterName": clusterName})
 
-	StartPortForward(kubeConfigStore, c, false, "test-cluster", w, r)
+	StartPortForward(kubeConfigStore, c, false, contextKey, w, r)
 
 	res := w.Result()
 

--- a/e2e-tests/tests/dynamicCluster.spec.ts
+++ b/e2e-tests/tests/dynamicCluster.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { HeadlampPage } from './headlampPage';
 const yaml = require('yaml');
 const fs = require('fs').promises;
@@ -130,6 +130,74 @@ test('stateless cluster loads without errors after storing kubeconfig', async ({
     'button:has-text("Our Cluster Chooser button. Cluster: dummy")',
     'Our Cluster Chooser button. Cluster: dummy'
   );
+});
+
+test('stateless cluster can start a port forward', async ({ page }) => {
+  const clusterName = 'dummy';
+  const userID = 'port-forward-e2e-user';
+  const portForwardID = `stateless-port-forward-${Date.now()}`;
+  const base64EncodedKubeconfig = await getBase64EncodedKubeconfig(clusterName);
+
+  if (!base64EncodedKubeconfig) {
+    throw new Error('Failed to generate a kubeconfig for the port-forward test');
+  }
+
+  const result = await page.evaluate(
+    async ({ cluster, kubeconfig, id, user }) => {
+      const headers = {
+        'Content-Type': 'application/json',
+        KUBECONFIG: kubeconfig,
+        'X-HEADLAMP-USER-ID': user,
+      };
+      const podResponse = await fetch(
+        `/clusters/${cluster}/api/v1/namespaces/kube-system/pods?labelSelector=app.kubernetes.io%2Fname%3Dheadlamp`,
+        { headers }
+      );
+      const podResponseBody = await podResponse.text();
+
+      if (!podResponse.ok) {
+        return { status: podResponse.status, body: podResponseBody };
+      }
+
+      const pods = JSON.parse(podResponseBody);
+      const podName = pods.items?.[0]?.metadata?.name;
+      if (!podName) {
+        return { status: 404, body: 'Headlamp pod not found' };
+      }
+
+      const startResponse = await fetch(`/clusters/${cluster}/portforward`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          id,
+          namespace: 'kube-system',
+          pod: podName,
+          service: '',
+          serviceNamespace: '',
+          targetPort: '4466',
+        }),
+      });
+      const startResponseBody = await startResponse.text();
+
+      if (startResponse.ok) {
+        await fetch(`/clusters/${cluster}/portforward`, {
+          method: 'DELETE',
+          headers,
+          body: JSON.stringify({ id, stopOrDelete: false }),
+        });
+      }
+
+      return { status: startResponse.status, body: startResponseBody };
+    },
+    {
+      cluster: clusterName,
+      kubeconfig: base64EncodedKubeconfig,
+      id: portForwardID,
+      user: userID,
+    }
+  );
+
+  expect(result.status, result.body).toBe(200);
 });
 
 test('reload does not trigger stateless parsing when IndexedDB is empty', async ({ page }) => {
@@ -260,8 +328,7 @@ const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
   // Use kubectl command-line tool to get the kubeconfig
   const { stdout, stderr } = await exec('kubectl config view --output json');
   if (stderr) {
-    console.error('Error fetching Minikube kubeconfig:', stderr);
-    return;
+    throw new Error(`Error fetching Minikube kubeconfig: ${stderr}`);
   }
 
   // Parse the kubeconfig JSON
@@ -309,7 +376,7 @@ const getBase64EncodedKubeconfig = async (clusterName: string = 'dummy') => {
   return Buffer.from(kubeconfigYaml).toString('base64');
 };
 
-const saveKubeconfigToIndexDB = async (page, base64EncodedKubeconfig) => {
+const saveKubeconfigToIndexDB = async (page: Page, base64EncodedKubeconfig: string) => {
   await page.evaluate(base64EncodedKubeconfig => {
     return new Promise<void>((resolve, reject) => {
       // Open or create an IndexDB database
@@ -365,9 +432,9 @@ const saveKubeconfigToIndexDB = async (page, base64EncodedKubeconfig) => {
   }, base64EncodedKubeconfig);
 };
 
-const getKubeconfigFromIndexDB = async page => {
+const getKubeconfigFromIndexDB = async (page: Page) => {
   const storedKubeconfig = await page.evaluate(() => {
-    return new Promise((resolve, reject) => {
+    return new Promise<string | null>((resolve, reject) => {
       const request = indexedDB.open('kubeconfigs', 1);
 
       request.onsuccess = (event: any) => {
@@ -404,7 +471,7 @@ const getKubeconfigFromIndexDB = async page => {
   return storedKubeconfig;
 };
 
-const clearKubeconfigsFromIndexDB = async page => {
+const clearKubeconfigsFromIndexDB = async (page: Page) => {
   await page.evaluate(() => {
     return new Promise<void>((resolve, reject) => {
       const request = indexedDB.open('kubeconfigs', 1);


### PR DESCRIPTION
## Summary

Port forwarding broke in 0.43 with "Unreachable" for some clusters. The port forward handler builds the cluster lookup key differently from the rest of the backend, so in some setups it looks for the cluster under a key that was never stored and fails.

This PR changes the port forward handlers to use the same key logic as the rest of the backend instead of building the key themselves.

It also passes Kubernetes API `ports` options for WebSocket port forwarding and keeps direct API endpoints on SPDY. This lets path-routed proxies use WebSocket fallback without dropping the remote port before the request reaches the kubelet.

## Related Issue

Fixes #6069

## Steps to Test

1. Use a cluster setup where port forwarding currently fails with "Unreachable"
2. Try to port forward a pod or service

I reproduced the issue locally and confirmed the same request fails before the change and succeeds after.

## Notes for the Reviewer

The existing port forward tests were updated for the new function signatures.

Validation:

- `go test ./pkg/portforward -count=1`
- `make backend-test`
- `make backend-lint`
- [`build discover and deploy`](https://github.com/kubernetes-sigs/headlamp/actions/runs/32266728308) passed, including stateless-cluster port forwarding
