### PR TITLE
frontend: PluginSettings: Fix User-installed chip contrast

### DIFF
--- a/frontend/src/components/App/PluginSettings/PluginSettings.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.tsx
@@ -16,9 +16,9 @@
 
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
+import Chip, { ChipProps } from '@mui/material/Chip';
 import Link from '@mui/material/Link';
-import { useTheme } from '@mui/material/styles';
+import { SxProps, Theme, useTheme } from '@mui/material/styles';
 import { SwitchProps } from '@mui/material/Switch';
 import Switch from '@mui/material/Switch';
 import Tooltip from '@mui/material/Tooltip';
@@ -298,7 +298,10 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
               header: t('translation|Type'),
               accessorFn: (plugin: PluginInfo) => plugin.type || 'unknown',
               Cell: ({ row: { original: plugin } }: { row: MRT_Row<PluginInfo> }) => {
-                const typeLabels: Record<string, { label: string; color: any }> = {
+                const typeLabels: Record<
+                  string,
+                  { label: string; color: ChipProps['color']; sx?: SxProps<Theme> }
+                > = {
                   development: {
                     label: t('translation|Development'),
                     color: 'primary',
@@ -306,6 +309,13 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                   user: {
                     label: t('translation|User-installed'),
                     color: 'info',
+                    // info.main is a light blue whose default white text only
+                    // reaches 3.85:1. Use dark text so the chip meets the WCAG
+                    // AA 4.5:1 minimum (5.44:1 on light, 9.1:1 on dark themes).
+                    sx: (theme: Theme) => ({
+                      backgroundColor: theme.palette.info.main,
+                      color: theme.palette.common.black,
+                    }),
                   },
                   shipped: {
                     label: t('translation|Shipped'),
@@ -313,7 +323,14 @@ export function PluginSettingsPure(props: PluginSettingsPureProps) {
                   },
                 };
                 const typeInfo = typeLabels[plugin.type || 'shipped'];
-                return <Chip label={typeInfo.label} size="small" color={typeInfo.color} />;
+                return (
+                  <Chip
+                    label={typeInfo.label}
+                    size="small"
+                    color={typeInfo.color}
+                    sx={typeInfo.sx}
+                  />
+                );
               },
             },
             {

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MigrationScenario.stories.storyshot
@@ -416,7 +416,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-17z0rci-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -479,7 +479,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-17z0rci-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"

--- a/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
+++ b/frontend/src/components/App/PluginSettings/__snapshots__/PluginSettings.MultipleLocations.stories.storyshot
@@ -497,7 +497,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-17z0rci-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -645,7 +645,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-17z0rci-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -845,7 +845,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-17z0rci-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
@@ -1052,7 +1052,7 @@
                   class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qzqemr-MuiTableCell-root"
                 >
                   <div
-                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-17z0rci-MuiChip-root"
                   >
                     <span
                       class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"


### PR DESCRIPTION
The "User-installed" plugin chip rendered white text on the info blue (#0288d1), which is 3.85:1 and fails the WCAG AA minimum of 4.5:1 for normal text.

Fix: keep the info background and set the chip text to a dark color, scoped to this chip in PluginSettings so the theme is not changed globally. I checked it across themes: dark text on info.main is 5.44:1 on the light theme and 9.1:1 on the dark theme (info.main #29b6f6), both above 4.5:1. getContrastText is not used here because at our default contrastThreshold it returns white for info.main and would not reach AA.

The typeLabels map is now typed with ChipProps and SxProps instead of any.

## Testing
- tsc, eslint (ci config) and prettier pass.
- The PluginSettings story tests pass. Snapshots for the MultipleLocations and MigrationScenario stories are updated for the new chip style.

## Screenshots
The change only affects the text color of the "User-installed" chip. Before: white text on #0288d1 (3.85:1). After: dark text on the same blue (5.44:1 light, 9.1:1 dark). Happy to attach a before/after image if useful.

Fixes #4592