### PR TITLE
backend: k8cache: purge cache and clientsets when kube context is removed

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2530,6 +2530,7 @@ func newFakeK8sServer(authAllowed bool) *httptest.Server {
 // integration tests do not share clientsets or API response cache entries.
 func resetCacheMiddlewareTestState() {
 	k8cache.ResetForTesting()
+
 	k8sResponseCache = cache.New[string]()
 }
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2531,6 +2531,10 @@ func newFakeK8sServer(authAllowed bool) *httptest.Server {
 func resetCacheMiddlewareTestState() {
 	k8cache.ResetForTesting()
 
+	if k8sResponseCache != nil {
+		_ = k8sResponseCache.Close()
+	}
+
 	k8sResponseCache = cache.New[string]()
 }
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -45,6 +45,7 @@ import (
 	inventorymetadata "github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
@@ -2525,9 +2526,18 @@ func newFakeK8sServer(authAllowed bool) *httptest.Server {
 	}))
 }
 
+// resetCacheMiddlewareTestState clears package-global k8cache state so
+// integration tests do not share clientsets or API response cache entries.
+func resetCacheMiddlewareTestState() {
+	k8cache.ResetForTesting()
+	k8sResponseCache = cache.New[string]()
+}
+
 // newHeadlampConfig create mock HeadlampConfig for testing CacheMiddleware
 // mechanism without creating actual HeadlampConfig.
 func newHeadlampConfig(fakeK8s *httptest.Server, testName string) *HeadlampConfig {
+	resetCacheMiddlewareTestState()
+
 	store := kubeconfig.NewContextStore()
 
 	err := store.AddContext(&kubeconfig.Context{
@@ -2892,6 +2902,8 @@ func TestCacheMiddleware_CacheInvalidation(t *testing.T) {
 //nolint:funlen
 func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 	t.Helper()
+
+	resetCacheMiddlewareTestState()
 
 	kubeConfigPath := os.Getenv("KUBECONFIG")
 	if kubeConfigPath == "" {

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -36,7 +36,6 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/plugins"
-
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/spa"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
@@ -116,6 +115,8 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		TLSKeyPath:                            conf.TLSKeyPath,
 		SessionTTL:                            conf.SessionTTL,
 		PodDebugImage:                         conf.PodDebugImage,
+		NodeShellImage:                        conf.NodeShellImage,
+		NodeShellNamespace:                    conf.NodeShellNamespace,
 		OidcUseCookie:                         conf.OidcUseCookie,
 		DefaultLightTheme:                     conf.DefaultLightTheme,
 		DefaultDarkTheme:                      conf.DefaultDarkTheme,

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/plugins"
+
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/spa"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
@@ -115,8 +116,6 @@ func buildHeadlampCFG(conf *config.Config, kubeConfigStore kubeconfig.ContextSto
 		TLSKeyPath:                            conf.TLSKeyPath,
 		SessionTTL:                            conf.SessionTTL,
 		PodDebugImage:                         conf.PodDebugImage,
-		NodeShellImage:                        conf.NodeShellImage,
-		NodeShellNamespace:                    conf.NodeShellNamespace,
 		OidcUseCookie:                         conf.OidcUseCookie,
 		DefaultLightTheme:                     conf.DefaultLightTheme,
 		DefaultDarkTheme:                      conf.DefaultDarkTheme,
@@ -347,7 +346,7 @@ func handleCacheAuthorization(
 		clearRequestAuthorization(r)
 	}
 
-	isAllowed, authErr := k8cache.IsAllowed(kContext, r)
+	isAllowed, authErr := k8cache.IsAllowed(contextKey, kContext, r)
 	if authErr != nil {
 		k8cache.ServeFromCacheOrForwardToK8s(k8sResponseCache, isAllowed, next, key, w, r, rcw)
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -175,7 +175,7 @@ func setupKubeConfigStoreWatcher(kubeConfigStore kubeconfig.ContextStore) {
 				return
 			}
 
-			k8cache.SyncWatchers(active)
+			k8cache.SyncWatchers(k8sResponseCache, active)
 		})
 	})
 }

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -125,8 +125,8 @@ func evictExpiredClientsets() {
 
 // EvictClientsetsForCluster removes cached authorization clientsets whose keys share
 // the given prefix immediately when a kube context is removed, instead of waiting for
-// TTL expiry. The prefix is the clientset cache key identifier (the part before the
-// NUL separator), not necessarily the Kubernetes cluster name from kubeconfig.
+// TTL expiry. The prefix is the Headlamp context store key (the part before the token
+// separator in clientset cache keys), which includes the user ID for stateless contexts.
 func EvictClientsetsForCluster(clientsetCachePrefix string) {
 	if clientsetCachePrefix == "" {
 		return
@@ -295,8 +295,13 @@ func finishInFlightClientset(cacheKey string, entry *inFlightEntry, cs *kubernet
 // GetClientSet returns *kubernetes.ClientSet and error which is further used for creating
 // SSAR requests to k8s server to authorize user. GetClientSet uses kubeconfig.Context and
 // authentication bearer token which will help to create clientSet based on the user's
-// identity.
-func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, error) {
+// identity. headlampContextKey is the key used in the kubeconfig store (for stateless
+// clusters this includes the user ID, e.g. "cluster\x00userID").
+func GetClientSet(headlampContextKey string, k *kubeconfig.Context, token string) (*kubernetes.Clientset, error) {
+	if headlampContextKey == "" {
+		return nil, fmt.Errorf("empty headlamp context key in getClientSet")
+	}
+
 	contextKey := strings.Split(k.ClusterID, "+")
 	if len(contextKey) < 2 {
 		return nil, fmt.Errorf("unexpected ClusterID format in getClientSet: %q", k.ClusterID)
@@ -304,7 +309,7 @@ func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, e
 
 	startJanitor()
 
-	cacheKey := contextKey[1] + "\x00" + token
+	cacheKey := headlampContextKey + "\x00" + token
 
 	// Check cache first
 	if cs, found := getCachedClientSet(cacheKey); found {
@@ -379,12 +384,13 @@ func GetKindAndVerb(r *http.Request) (string, string) {
 // If the user is authorized and has permission to view the resources, it returns true.
 // Otherwise, it returns false if authorization fails.
 func IsAllowed(
+	headlampContextKey string,
 	k *kubeconfig.Context,
 	r *http.Request,
 ) (bool, error) {
 	token := auth.BearerTokenValue(r.Header.Get("Authorization"))
 
-	clientset, err := GetClientSet(k, token)
+	clientset, err := GetClientSet(headlampContextKey, k, token)
 	if err != nil {
 		return false, err
 	}

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -120,6 +120,38 @@ func evictExpiredClientsets() {
 	}
 }
 
+// EvictClientsetsForCluster removes cached authorization clientsets for a cluster
+// immediately when its kube context is removed, instead of waiting for TTL expiry.
+func EvictClientsetsForCluster(clusterName string) {
+	if clusterName == "" {
+		return
+	}
+
+	prefix := clusterName + "\x00"
+
+	mu.Lock()
+
+	evicted := 0
+
+	for key := range clientsetCache {
+		if strings.HasPrefix(key, prefix) {
+			delete(clientsetCache, key)
+
+			evicted++
+		}
+	}
+
+	remaining := len(clientsetCache)
+
+	mu.Unlock()
+
+	if evicted > 0 {
+		logger.Log(logger.LevelInfo, nil, nil,
+			fmt.Sprintf("evicted %d clientset(s) for removed cluster %s, %d remaining",
+				evicted, redactContextKey(clusterName), remaining))
+	}
+}
+
 // getCachedClientSet retrieves a clientset from the cache if it's valid and not expired.
 func getCachedClientSet(cacheKey string) (*kubernetes.Clientset, bool) {
 	mu.Lock()

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -63,7 +63,7 @@ var (
 	// re-cached after context removal (e.g. while an in-flight GetClientSet completes).
 	blockedClientsetPrefixes = make(map[string]struct{})
 	mu                       sync.Mutex
-	janitorOnce    sync.Once
+	janitorOnce              sync.Once
 
 	// inFlight keeps track of clientsets currently being created to avoid redundant work.
 	inFlight = make(map[string]*inFlightEntry)
@@ -150,13 +150,31 @@ func EvictClientsetsForCluster(clientsetCachePrefix string) {
 
 	remaining := len(clientsetCache)
 
+	unblockClientsetPrefixIfIdleLocked(clientsetCachePrefix)
+
 	mu.Unlock()
 
 	if evicted > 0 {
 		logger.Log(logger.LevelInfo, nil, nil,
-			fmt.Sprintf("evicted %d clientset(s) for removed cluster %s, %d remaining",
+			fmt.Sprintf("evicted %d clientset(s) for removed context %s, %d remaining",
 				evicted, redactContextKey(clientsetCachePrefix), remaining))
 	}
+}
+
+// unblockClientsetPrefixIfIdleLocked removes a blocked clientset prefix when no
+// clientset creation is in flight for that prefix. Caller must hold mu.
+func unblockClientsetPrefixIfIdleLocked(prefix string) {
+	for key := range inFlight {
+		if clientsetCachePrefixFromCacheKey(key) == prefix {
+			return
+		}
+	}
+
+	delete(blockedClientsetPrefixes, prefix)
+}
+
+func clientsetCachePrefixFromCacheKey(cacheKey string) string {
+	return strings.SplitN(cacheKey, "\x00", 2)[0]
 }
 
 // clearBlockedClientsetPrefixesForActiveContexts allows clientset caching again for
@@ -234,7 +252,7 @@ func createAndCacheClientSet(
 		}
 	}
 
-	prefix := strings.SplitN(cacheKey, "\x00", 2)[0]
+	prefix := clientsetCachePrefixFromCacheKey(cacheKey)
 	if _, blocked := blockedClientsetPrefixes[prefix]; blocked {
 		return cs, nil
 	}
@@ -313,6 +331,8 @@ func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, e
 
 	delete(inFlight, cacheKey)
 	close(entry.waitCh)
+
+	unblockClientsetPrefixIfIdleLocked(clientsetCachePrefixFromCacheKey(cacheKey))
 
 	mu.Unlock()
 

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -59,8 +59,9 @@ type inFlightEntry struct {
 
 var (
 	clientsetCache = make(map[string]*CachedClientSet)
-	// blockedClientsetPrefixes holds identifier prefixes whose clientsets must not be
-	// re-cached after context removal (e.g. while an in-flight GetClientSet completes).
+	// blockedClientsetPrefixes holds context keys whose clientsets must not be
+	// re-cached after context removal. Entries are cleared when SyncWatchers sees
+	// the context active again.
 	blockedClientsetPrefixes = make(map[string]struct{})
 	mu                       sync.Mutex
 	janitorOnce              sync.Once
@@ -150,8 +151,6 @@ func EvictClientsetsForCluster(clientsetCachePrefix string) {
 
 	remaining := len(clientsetCache)
 
-	unblockClientsetPrefixIfIdleLocked(clientsetCachePrefix)
-
 	mu.Unlock()
 
 	if evicted > 0 {
@@ -161,20 +160,14 @@ func EvictClientsetsForCluster(clientsetCachePrefix string) {
 	}
 }
 
-// unblockClientsetPrefixIfIdleLocked removes a blocked clientset prefix when no
-// clientset creation is in flight for that prefix. Caller must hold mu.
-func unblockClientsetPrefixIfIdleLocked(prefix string) {
-	for key := range inFlight {
-		if clientsetCachePrefixFromCacheKey(key) == prefix {
-			return
-		}
+// clientsetCachePrefixFromCacheKey returns the Headlamp context store key prefix
+// from a clientset cache key (everything before the final NUL separator).
+func clientsetCachePrefixFromCacheKey(cacheKey string) string {
+	if i := strings.LastIndex(cacheKey, "\x00"); i >= 0 {
+		return cacheKey[:i]
 	}
 
-	delete(blockedClientsetPrefixes, prefix)
-}
-
-func clientsetCachePrefixFromCacheKey(cacheKey string) string {
-	return strings.SplitN(cacheKey, "\x00", 2)[0]
+	return cacheKey
 }
 
 // clearBlockedClientsetPrefixesForActiveContexts allows clientset caching again for
@@ -286,8 +279,6 @@ func finishInFlightClientset(cacheKey string, entry *inFlightEntry, cs *kubernet
 
 	delete(inFlight, cacheKey)
 	close(entry.waitCh)
-
-	unblockClientsetPrefixIfIdleLocked(clientsetCachePrefixFromCacheKey(cacheKey))
 
 	mu.Unlock()
 }

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -156,7 +156,7 @@ func EvictClientsetsForCluster(clientsetCachePrefix string) {
 
 	if evicted > 0 {
 		logger.Log(logger.LevelInfo, nil, nil,
-			fmt.Sprintf("evicted %d clientset(s) for removed context %s, %d remaining",
+			fmt.Sprintf("evicted %d clientset(s) for removed clientset cache prefix %s, %d remaining",
 				evicted, redactContextKey(clientsetCachePrefix), remaining))
 	}
 }
@@ -265,6 +265,33 @@ func createAndCacheClientSet(
 	return cs, nil
 }
 
+func waitForInFlightClientset(entry *inFlightEntry) (*kubernetes.Clientset, error) {
+	hookMu.RLock()
+
+	waitHook := testingInFlightWait
+
+	hookMu.RUnlock()
+
+	waitHook()
+	<-entry.waitCh
+
+	return entry.cs, entry.err
+}
+
+func finishInFlightClientset(cacheKey string, entry *inFlightEntry, cs *kubernetes.Clientset, err error) {
+	mu.Lock()
+
+	entry.cs = cs
+	entry.err = err
+
+	delete(inFlight, cacheKey)
+	close(entry.waitCh)
+
+	unblockClientsetPrefixIfIdleLocked(clientsetCachePrefixFromCacheKey(cacheKey))
+
+	mu.Unlock()
+}
+
 // GetClientSet returns *kubernetes.ClientSet and error which is further used for creating
 // SSAR requests to k8s server to authorize user. GetClientSet uses kubeconfig.Context and
 // authentication bearer token which will help to create clientSet based on the user's
@@ -301,17 +328,7 @@ func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, e
 	if entry, ok := inFlight[cacheKey]; ok {
 		mu.Unlock()
 
-		hookMu.RLock()
-
-		waitHook := testingInFlightWait
-
-		hookMu.RUnlock()
-
-		waitHook()
-		<-entry.waitCh
-
-		// Return the shared result.
-		return entry.cs, entry.err
+		return waitForInFlightClientset(entry)
 	}
 
 	// We are the one to create it.
@@ -324,17 +341,7 @@ func GetClientSet(k *kubeconfig.Context, token string) (*kubernetes.Clientset, e
 
 	cs, err := createAndCacheClientSet(k, token, cacheKey, contextKey)
 
-	mu.Lock()
-
-	entry.cs = cs
-	entry.err = err
-
-	delete(inFlight, cacheKey)
-	close(entry.waitCh)
-
-	unblockClientsetPrefixIfIdleLocked(clientsetCachePrefixFromCacheKey(cacheKey))
-
-	mu.Unlock()
+	finishInFlightClientset(cacheKey, entry, cs, err)
 
 	return cs, err
 }

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -240,13 +240,11 @@ func getCachedClientSet(cacheKey string) (*kubernetes.Clientset, bool) {
 
 	if now.Sub(cs.lastUsed) > clientsetTTL {
 		delete(clientsetCache, cacheKey)
-
-		// Extract cluster name from cacheKey (format: "clusterName\x00token")
-		clusterName := strings.Split(cacheKey, "\x00")[0]
+		redactedContext := redactContextKey(clientsetCachePrefixFromCacheKey(cacheKey))
 		mu.Unlock()
 
 		logger.Log(logger.LevelInfo, nil, nil,
-			fmt.Sprintf("expired clientset for cluster %s was deleted", clusterName))
+			fmt.Sprintf("expired clientset for cluster %s was deleted", redactedContext))
 
 		return nil, false
 	}

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -57,12 +57,17 @@ type inFlightEntry struct {
 	err    error
 }
 
+type blockedPrefixEntry struct {
+	blockedAt time.Time
+}
+
 var (
 	clientsetCache = make(map[string]*CachedClientSet)
 	// blockedClientsetPrefixes holds context keys whose clientsets must not be
 	// re-cached after context removal. Entries are cleared when SyncWatchers sees
-	// the context active again.
-	blockedClientsetPrefixes = make(map[string]struct{})
+	// the context active again, or by the janitor once clientsetTTL has elapsed
+	// and no clientset or in-flight entries remain for the prefix.
+	blockedClientsetPrefixes = make(map[string]blockedPrefixEntry)
 	mu                       sync.Mutex
 	janitorOnce              sync.Once
 
@@ -118,9 +123,43 @@ func evictExpiredClientsets() {
 
 	mu.Unlock()
 
+	pruneBlockedClientsetPrefixes(now)
+
 	if evicted > 0 {
 		logger.Log(logger.LevelInfo, nil, nil,
 			fmt.Sprintf("janitor: evicted %d expired clientset(s), %d remaining", evicted, remaining))
+	}
+}
+
+func hasClientsetActivityForPrefix(prefix string) bool {
+	prefixWithNul := prefix + "\x00"
+
+	for key := range clientsetCache {
+		if strings.HasPrefix(key, prefixWithNul) {
+			return true
+		}
+	}
+
+	for key := range inFlight {
+		if strings.HasPrefix(key, prefixWithNul) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// pruneBlockedClientsetPrefixes drops stale block entries so removed contexts that
+// never return do not accumulate unbounded entries over long process lifetimes.
+func pruneBlockedClientsetPrefixes(now time.Time) {
+	for prefix, entry := range blockedClientsetPrefixes {
+		if hasClientsetActivityForPrefix(prefix) {
+			continue
+		}
+
+		if now.Sub(entry.blockedAt) >= clientsetTTL {
+			delete(blockedClientsetPrefixes, prefix)
+		}
 	}
 }
 
@@ -137,7 +176,7 @@ func EvictClientsetsForCluster(clientsetCachePrefix string) {
 
 	mu.Lock()
 
-	blockedClientsetPrefixes[clientsetCachePrefix] = struct{}{}
+	blockedClientsetPrefixes[clientsetCachePrefix] = blockedPrefixEntry{blockedAt: time.Now()}
 
 	evicted := 0
 
@@ -290,12 +329,12 @@ func finishInFlightClientset(cacheKey string, entry *inFlightEntry, cs *kubernet
 // clusters this includes the user ID, e.g. "cluster\x00userID").
 func GetClientSet(headlampContextKey string, k *kubeconfig.Context, token string) (*kubernetes.Clientset, error) {
 	if headlampContextKey == "" {
-		return nil, fmt.Errorf("empty headlamp context key in getClientSet")
+		return nil, fmt.Errorf("empty headlamp context key in GetClientSet")
 	}
 
 	contextKey := strings.Split(k.ClusterID, "+")
 	if len(contextKey) < 2 {
-		return nil, fmt.Errorf("unexpected ClusterID format in getClientSet: %q", k.ClusterID)
+		return nil, fmt.Errorf("unexpected ClusterID format in GetClientSet: %q", k.ClusterID)
 	}
 
 	startJanitor()

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -66,7 +66,8 @@ var (
 	// blockedClientsetPrefixes holds context keys whose clientsets must not be
 	// re-cached after context removal. Entries are cleared when SyncWatchers sees
 	// the context active again, or by the janitor once clientsetTTL has elapsed
-	// and no clientset or in-flight entries remain for the prefix.
+	// and no clientset or in-flight entries remain for the prefix. The janitor is
+	// started by GetClientSet and EvictClientsetsForCluster.
 	blockedClientsetPrefixes = make(map[string]blockedPrefixEntry)
 	mu                       sync.Mutex
 	janitorOnce              sync.Once
@@ -174,6 +175,8 @@ func EvictClientsetsForCluster(clientsetCachePrefix string) {
 	if clientsetCachePrefix == "" {
 		return
 	}
+
+	startJanitor()
 
 	prefix := clientsetCachePrefix + "\x00"
 

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -107,7 +107,6 @@ func startJanitor() {
 // every entry older than clientsetTTL.
 func evictExpiredClientsets() {
 	mu.Lock()
-	defer mu.Unlock()
 
 	now := time.Now()
 	evicted := 0
@@ -123,6 +122,8 @@ func evictExpiredClientsets() {
 	pruneBlockedClientsetPrefixesLocked(now)
 
 	remaining := len(clientsetCache)
+
+	mu.Unlock()
 
 	if evicted > 0 {
 		logger.Log(logger.LevelInfo, nil, nil,

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -107,6 +107,7 @@ func startJanitor() {
 // every entry older than clientsetTTL.
 func evictExpiredClientsets() {
 	mu.Lock()
+	defer mu.Unlock()
 
 	now := time.Now()
 	evicted := 0
@@ -119,11 +120,9 @@ func evictExpiredClientsets() {
 		}
 	}
 
+	pruneBlockedClientsetPrefixesLocked(now)
+
 	remaining := len(clientsetCache)
-
-	mu.Unlock()
-
-	pruneBlockedClientsetPrefixes(now)
 
 	if evicted > 0 {
 		logger.Log(logger.LevelInfo, nil, nil,
@@ -131,6 +130,8 @@ func evictExpiredClientsets() {
 	}
 }
 
+// hasClientsetActivityForPrefix reports whether any clientset or in-flight entry
+// exists for the given prefix. mu must be held.
 func hasClientsetActivityForPrefix(prefix string) bool {
 	prefixWithNul := prefix + "\x00"
 
@@ -149,9 +150,10 @@ func hasClientsetActivityForPrefix(prefix string) bool {
 	return false
 }
 
-// pruneBlockedClientsetPrefixes drops stale block entries so removed contexts that
+// pruneBlockedClientsetPrefixesLocked drops stale block entries so removed contexts that
 // never return do not accumulate unbounded entries over long process lifetimes.
-func pruneBlockedClientsetPrefixes(now time.Time) {
+// mu must be held.
+func pruneBlockedClientsetPrefixesLocked(now time.Time) {
 	for prefix, entry := range blockedClientsetPrefixes {
 		if hasClientsetActivityForPrefix(prefix) {
 			continue

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -303,8 +303,10 @@ func createAndCacheClientSet(
 	return cs, nil
 }
 
-// waitForInFlightClientset blocks until another goroutine finishes creating the
-// clientset for the same cache key. The caller must not hold mu.
+// waitForInFlightClientset waits for another goroutine to finish creating a
+// clientset for the same cache key. It blocks on entry.waitCh until
+// finishInFlightClientset closes it, then returns the clientset and error
+// stored on entry. The caller must not hold mu.
 func waitForInFlightClientset(entry *inFlightEntry) (*kubernetes.Clientset, error) {
 	hookMu.RLock()
 
@@ -318,9 +320,10 @@ func waitForInFlightClientset(entry *inFlightEntry) (*kubernetes.Clientset, erro
 	return entry.cs, entry.err
 }
 
-// finishInFlightClientset stores the creation result on the in-flight entry,
-// removes it from inFlight, and unblocks waiters by closing entry.waitCh.
-// mu must not be held on entry; this function acquires mu internally.
+// finishInFlightClientset records the clientset creation outcome on entry,
+// removes cacheKey from the inFlight map, and closes entry.waitCh so any
+// goroutines blocked in waitForInFlightClientset can proceed. mu must not be
+// held; this function acquires mu internally.
 func finishInFlightClientset(cacheKey string, entry *inFlightEntry, cs *kubernetes.Clientset, err error) {
 	mu.Lock()
 

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -300,6 +300,8 @@ func createAndCacheClientSet(
 	return cs, nil
 }
 
+// waitForInFlightClientset blocks until another goroutine finishes creating the
+// clientset for the same cache key. The caller must not hold mu.
 func waitForInFlightClientset(entry *inFlightEntry) (*kubernetes.Clientset, error) {
 	hookMu.RLock()
 
@@ -313,6 +315,9 @@ func waitForInFlightClientset(entry *inFlightEntry) (*kubernetes.Clientset, erro
 	return entry.cs, entry.err
 }
 
+// finishInFlightClientset stores the creation result on the in-flight entry,
+// removes it from inFlight, and unblocks waiters by closing entry.waitCh.
+// mu must not be held on entry; this function acquires mu internally.
 func finishInFlightClientset(cacheKey string, entry *inFlightEntry, cs *kubernetes.Clientset, err error) {
 	mu.Lock()
 

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -59,7 +59,10 @@ type inFlightEntry struct {
 
 var (
 	clientsetCache = make(map[string]*CachedClientSet)
-	mu             sync.Mutex
+	// blockedClientsetPrefixes holds identifier prefixes whose clientsets must not be
+	// re-cached after context removal (e.g. while an in-flight GetClientSet completes).
+	blockedClientsetPrefixes = make(map[string]struct{})
+	mu                       sync.Mutex
 	janitorOnce    sync.Once
 
 	// inFlight keeps track of clientsets currently being created to avoid redundant work.
@@ -120,16 +123,20 @@ func evictExpiredClientsets() {
 	}
 }
 
-// EvictClientsetsForCluster removes cached authorization clientsets for a cluster
-// immediately when its kube context is removed, instead of waiting for TTL expiry.
-func EvictClientsetsForCluster(clusterName string) {
-	if clusterName == "" {
+// EvictClientsetsForCluster removes cached authorization clientsets whose keys share
+// the given prefix immediately when a kube context is removed, instead of waiting for
+// TTL expiry. The prefix is the clientset cache key identifier (the part before the
+// NUL separator), not necessarily the Kubernetes cluster name from kubeconfig.
+func EvictClientsetsForCluster(clientsetCachePrefix string) {
+	if clientsetCachePrefix == "" {
 		return
 	}
 
-	prefix := clusterName + "\x00"
+	prefix := clientsetCachePrefix + "\x00"
 
 	mu.Lock()
+
+	blockedClientsetPrefixes[clientsetCachePrefix] = struct{}{}
 
 	evicted := 0
 
@@ -148,7 +155,18 @@ func EvictClientsetsForCluster(clusterName string) {
 	if evicted > 0 {
 		logger.Log(logger.LevelInfo, nil, nil,
 			fmt.Sprintf("evicted %d clientset(s) for removed cluster %s, %d remaining",
-				evicted, redactContextKey(clusterName), remaining))
+				evicted, redactContextKey(clientsetCachePrefix), remaining))
+	}
+}
+
+// clearBlockedClientsetPrefixesForActiveContexts allows clientset caching again for
+// contexts that are currently active (for example after a cluster is re-added).
+func clearBlockedClientsetPrefixesForActiveContexts(activeContexts []string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, contextKey := range activeContexts {
+		delete(blockedClientsetPrefixes, clientsetCachePrefixFromContextKey(contextKey))
 	}
 }
 
@@ -214,6 +232,11 @@ func createAndCacheClientSet(
 
 			return existing.clientset, nil
 		}
+	}
+
+	prefix := strings.SplitN(cacheKey, "\x00", 2)[0]
+	if _, blocked := blockedClientsetPrefixes[prefix]; blocked {
+		return cs, nil
 	}
 
 	clientsetCache[cacheKey] = &CachedClientSet{

--- a/backend/pkg/k8cache/authorization_test.go
+++ b/backend/pkg/k8cache/authorization_test.go
@@ -59,12 +59,12 @@ func (k *MockKubeConfig) ClientConfig() (clientcmd.ClientConfig, error) {
 
 func TestGetClientSet(t *testing.T) {
 	tests := []struct {
-		name                string
-		mockK               MockKubeConfig
-		headlampContextKey  string
-		token               string
-		clientSet           *kubernetes.Clientset
-		expectedError       error
+		name               string
+		mockK              MockKubeConfig
+		headlampContextKey string
+		token              string
+		clientSet          *kubernetes.Clientset
+		expectedError      error
 	}{
 		{
 			name: "valid ClusterID returns cached clientset",
@@ -162,7 +162,6 @@ func TestGetKindAndVerb(t *testing.T) {
 			expectedKind: "deployments",
 			expectedVerb: "get",
 		},
-		
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/pkg/k8cache/authorization_test.go
+++ b/backend/pkg/k8cache/authorization_test.go
@@ -59,11 +59,12 @@ func (k *MockKubeConfig) ClientConfig() (clientcmd.ClientConfig, error) {
 
 func TestGetClientSet(t *testing.T) {
 	tests := []struct {
-		name          string
-		mockK         MockKubeConfig
-		token         string
-		clientSet     *kubernetes.Clientset
-		expectedError error
+		name                string
+		mockK               MockKubeConfig
+		headlampContextKey  string
+		token               string
+		clientSet           *kubernetes.Clientset
+		expectedError       error
 	}{
 		{
 			name: "valid ClusterID returns cached clientset",
@@ -75,8 +76,9 @@ func TestGetClientSet(t *testing.T) {
 					KubeContext: &api.Context{Cluster: "kind-headlamp-admin"},
 				},
 			},
-			token:         "token-1245",
-			expectedError: nil,
+			headlampContextKey: "kind-headlamp-admin",
+			token:              "token-1245",
+			expectedError:      nil,
 		},
 		{
 			name: "return unexpected ClusterID format",
@@ -88,14 +90,15 @@ func TestGetClientSet(t *testing.T) {
 					KubeContext: &api.Context{Cluster: "kind-headlamp-admin"},
 				},
 			},
-			token: "token-54321",
+			headlampContextKey: "kind-headlamp-admin",
+			token:              "token-54321",
 			expectedError: fmt.Errorf("unexpected ClusterID format in getClientSet: " +
 				"\"/home/user/.kubeconfig/kind-headlamp-admin\""),
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cs, err := k8cache.GetClientSet(tc.mockK.Context, tc.token)
+			cs, err := k8cache.GetClientSet(tc.headlampContextKey, tc.mockK.Context, tc.token)
 			if tc.clientSet != nil { // It is difficult to compare the expected clientset with
 				// the returned clientSet as it return nested-struct inside the clientset which
 				// returns only memory references. To check whether the clientset was correct or
@@ -159,6 +162,7 @@ func TestGetKindAndVerb(t *testing.T) {
 			expectedKind: "deployments",
 			expectedVerb: "get",
 		},
+		
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -209,7 +213,7 @@ func TestIsAllowed(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			isAllowed, _ := k8cache.IsAllowed(tc.mockK.Context, r)
+			isAllowed, _ := k8cache.IsAllowed("kind-headlamp-admin", tc.mockK.Context, r)
 			assert.Equal(t, tc.isAllowed, isAllowed)
 		})
 	}

--- a/backend/pkg/k8cache/authorization_test.go
+++ b/backend/pkg/k8cache/authorization_test.go
@@ -92,7 +92,7 @@ func TestGetClientSet(t *testing.T) {
 			},
 			headlampContextKey: "kind-headlamp-admin",
 			token:              "token-54321",
-			expectedError: fmt.Errorf("unexpected ClusterID format in getClientSet: " +
+			expectedError: fmt.Errorf("unexpected ClusterID format in GetClientSet: " +
 				"\"/home/user/.kubeconfig/kind-headlamp-admin\""),
 		},
 	}

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -215,6 +215,8 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 		activeMap[ctx] = true
 	}
 
+	cleaned := make(map[string]struct{})
+
 	contextCancel.Range(func(key, value interface{}) bool {
 		contextKey, ok := key.(string)
 		if !ok {
@@ -228,11 +230,24 @@ func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 				watcherRegistry.Delete(contextKey)
 				contextCancel.Delete(contextKey)
 				cleanupRemovedContext(k8scache, contextKey)
+				cleaned[contextKey] = struct{}{}
 			}
 		}
 
 		return true
 	})
+
+	for contextKey := range collectCachedContextKeys(k8scache) {
+		if activeMap[contextKey] {
+			continue
+		}
+
+		if _, alreadyCleaned := cleaned[contextKey]; alreadyCleaned {
+			continue
+		}
+
+		cleanupRemovedContext(k8scache, contextKey)
+	}
 }
 
 // runWatcher is a long-lived goroutine that sets up and runs Kubernetes informers.

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -204,9 +204,10 @@ func CheckForChanges(
 	go runWatcher(ctx, k8scache, contextKey, kContext)
 }
 
-// SyncWatchers stops watchers for contexts that are no longer active.
+// SyncWatchers stops watchers for contexts that are no longer active and purges
+// their cached API responses and authorization clientsets.
 // activeContexts is a list of currently valid context keys.
-func SyncWatchers(activeContexts []string) {
+func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
 	activeMap := make(map[string]bool, len(activeContexts))
 	for _, ctx := range activeContexts {
 		activeMap[ctx] = true
@@ -224,6 +225,7 @@ func SyncWatchers(activeContexts []string) {
 				cancel()
 				watcherRegistry.Delete(contextKey)
 				contextCancel.Delete(contextKey)
+				cleanupRemovedContext(k8scache, contextKey)
 			}
 		}
 

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -208,6 +208,8 @@ func CheckForChanges(
 // their cached API responses and authorization clientsets.
 // activeContexts is a list of currently valid context keys.
 func SyncWatchers(k8scache cache.Cache[string], activeContexts []string) {
+	clearBlockedClientsetPrefixesForActiveContexts(activeContexts)
+
 	activeMap := make(map[string]bool, len(activeContexts))
 	for _, ctx := range activeContexts {
 		activeMap[ctx] = true

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -873,7 +873,7 @@ func TestSyncWatchers(t *testing.T) {
 	}
 
 	// Sync with only ctx1 and ctx3 active
-	k8cache.SyncWatchers([]string{"ctx1", "ctx3"})
+	k8cache.SyncWatchers(nil, []string{"ctx1", "ctx3"})
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -579,7 +579,7 @@ func TestIsAllowed_EmptyKind(t *testing.T) {
 	)
 	// No mux vars → GetKindAndVerb returns ("", "unknown") →
 	// IsAllowed must return (false, non-nil error).
-	allowed, err := k8cache.IsAllowed(k, req)
+	allowed, err := k8cache.IsAllowed("kind-auth-test", k, req)
 	assert.False(t, allowed)
 	assert.Error(t, err)
 }

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -162,6 +162,24 @@ func ExtractNamespace(rawURL string) (string, string) {
 	return namespace, kind
 }
 
+// escapeCacheKeySegment percent-escapes "%" and "+" so cache key segments can
+// be joined with "+" delimiters without ambiguity. "%" is escaped first so the
+// encoding is injective (see buildCacheKey).
+func escapeCacheKeySegment(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "+", "%2B")
+
+	return s
+}
+
+// unescapeCacheKeySegment reverses escapeCacheKeySegment.
+func unescapeCacheKeySegment(s string) string {
+	s = strings.ReplaceAll(s, "%2B", "+")
+	s = strings.ReplaceAll(s, "%25", "%")
+
+	return s
+}
+
 // buildCacheKey joins apiGroup, kind, namespace, and contextID into a single
 // cache key using "+" as the delimiter. Each field is percent-escaped so
 // that the only "+" characters left in the key are the delimiters
@@ -175,24 +193,12 @@ func ExtractNamespace(rawURL string) (string, string) {
 // namespace stripping in cache invalidation) must stay consistent with this
 // encoding to avoid the two sides silently drifting out of sync.
 func buildCacheKey(apiGroup, kind, namespace, contextID string) string {
-	// Escape "%" first, then "+". This order matters: it makes the encoding
-	// injective, so e.g. "prod+cluster" -> "prod%2Bcluster" and the literal
-	// string "prod%2Bcluster" -> "prod%252Bcluster" never collide. Reversing
-	// the order (or skipping "%") would map both inputs to the same key and
-	// reintroduce the collision class this function exists to prevent.
-	escape := func(s string) string {
-		s = strings.ReplaceAll(s, "%", "%25")
-		s = strings.ReplaceAll(s, "+", "%2B")
-
-		return s
-	}
-
 	return fmt.Sprintf(
 		"%s+%s+%s+%s",
-		escape(apiGroup),
-		escape(kind),
-		escape(namespace),
-		escape(contextID),
+		escapeCacheKeySegment(apiGroup),
+		escapeCacheKeySegment(kind),
+		escapeCacheKeySegment(namespace),
+		escapeCacheKeySegment(contextID),
 	)
 }
 

--- a/backend/pkg/k8cache/concurrency_test.go
+++ b/backend/pkg/k8cache/concurrency_test.go
@@ -74,7 +74,7 @@ func TestGetClientSet_InFlightDedup(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 
-			_, errs[idx] = k8cache.GetClientSet(ctx, "same-token")
+			_, errs[idx] = k8cache.GetClientSet("test-cluster", ctx, "same-token")
 		}(i)
 	}
 
@@ -123,7 +123,7 @@ func TestGetClientSet_InFlightDedupDifferentKeys(t *testing.T) {
 				KubeContext: &api.Context{Cluster: "test-cluster"},
 			}
 
-			_, errs[idx] = k8cache.GetClientSet(ctx, token)
+			_, errs[idx] = k8cache.GetClientSet("test-cluster", ctx, token)
 		}(i, tok)
 	}
 

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+// cacheKeyBelongsToContext reports whether a k8cache entry key belongs to the
+// given Headlamp context. Keys use the format group+resource+namespace+context.
+func cacheKeyBelongsToContext(key, contextKey string) bool {
+	if contextKey == "" {
+		return false
+	}
+
+	parts := strings.SplitN(key, "+", 4)
+	if len(parts) < 4 {
+		return false
+	}
+
+	return parts[3] == contextKey
+}
+
+// PurgeCacheForContext removes all cached API responses for a removed context.
+func PurgeCacheForContext(k8scache cache.Cache[string], contextKey string) {
+	if k8scache == nil || contextKey == "" {
+		return
+	}
+
+	keys, err := k8scache.GetAll(context.Background(), func(key string) bool {
+		return cacheKeyBelongsToContext(key, contextKey)
+	})
+	if err != nil {
+		logger.Log(logger.LevelWarn, nil, err,
+			"failed to list cache keys for context cleanup: "+redactContextKey(contextKey))
+
+		return
+	}
+
+	for key := range keys {
+		if err := k8scache.Delete(context.Background(), key); err != nil {
+			logger.Log(logger.LevelWarn, nil, err,
+				"failed to delete cache key during context cleanup: "+redactCacheKey(key))
+		}
+	}
+
+	if len(keys) > 0 {
+		logger.Log(logger.LevelInfo, nil, nil,
+			fmt.Sprintf("purged %d k8cache entries for removed context %s",
+				len(keys), redactContextKey(contextKey)))
+	}
+}
+
+// cleanupRemovedContext drops cached API responses and auth clientsets for a
+// context that is no longer active.
+func cleanupRemovedContext(k8scache cache.Cache[string], contextKey string) {
+	PurgeCacheForContext(k8scache, contextKey)
+	EvictClientsetsForCluster(contextKey)
+}

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -67,7 +67,42 @@ func PurgeCacheForContext(k8scache cache.Cache[string], contextKey string) {
 	}
 }
 
-// clientsetCachePrefixFromContextKey returns the Headlamp context store key used as
+// collectCachedContextKeys returns Headlamp context keys that still have k8cache
+// or clientset cache entries.
+func collectCachedContextKeys(k8scache cache.Cache[string]) map[string]struct{} {
+	keys := make(map[string]struct{})
+
+	mu.Lock()
+
+	for cacheKey := range clientsetCache {
+		if prefix := clientsetCachePrefixFromCacheKey(cacheKey); prefix != "" {
+			keys[prefix] = struct{}{}
+		}
+	}
+
+	mu.Unlock()
+
+	if k8scache == nil {
+		return keys
+	}
+
+	allKeys, err := k8scache.GetAll(context.Background(), nil)
+	if err != nil {
+		logger.Log(logger.LevelWarn, nil, err, "failed to list cache keys during context cleanup")
+
+		return keys
+	}
+
+	for key := range allKeys {
+		parts := strings.SplitN(key, "+", 4)
+		if len(parts) == 4 && parts[3] != "" {
+			keys[parts[3]] = struct{}{}
+		}
+	}
+
+	return keys
+}
+
 // the prefix for clientset cache keys. For stateless contexts this includes the user
 // ID (e.g. "cluster\x00userID"); for regular contexts it is the cluster name alone.
 func clientsetCachePrefixFromContextKey(contextKey string) string {

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -67,9 +67,10 @@ func PurgeCacheForContext(k8scache cache.Cache[string], contextKey string) {
 	}
 }
 
-// clusterNameFromContextKey returns the cluster portion of a Headlamp context key.
-// Stateless keys use "clusterName\x00userID"; clientset cache keys use "clusterName\x00token".
-func clusterNameFromContextKey(contextKey string) string {
+// clientsetCachePrefixFromContextKey returns the prefix shared by clientset cache keys
+// for a Headlamp context. Stateless context keys use "identifier\x00userID"; clientset
+// cache keys use the same identifier prefix with "\x00token".
+func clientsetCachePrefixFromContextKey(contextKey string) string {
 	return strings.SplitN(contextKey, "\x00", 2)[0]
 }
 
@@ -77,5 +78,5 @@ func clusterNameFromContextKey(contextKey string) string {
 // context that is no longer active.
 func cleanupRemovedContext(k8scache cache.Cache[string], contextKey string) {
 	PurgeCacheForContext(k8scache, contextKey)
-	EvictClientsetsForCluster(clusterNameFromContextKey(contextKey))
+	EvictClientsetsForCluster(clientsetCachePrefixFromContextKey(contextKey))
 }

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -67,11 +67,11 @@ func PurgeCacheForContext(k8scache cache.Cache[string], contextKey string) {
 	}
 }
 
-// clientsetCachePrefixFromContextKey returns the prefix shared by clientset cache keys
-// for a Headlamp context. Stateless context keys use "identifier\x00userID"; clientset
-// cache keys use the same identifier prefix with "\x00token".
+// clientsetCachePrefixFromContextKey returns the Headlamp context store key used as
+// the prefix for clientset cache keys. For stateless contexts this includes the user
+// ID (e.g. "cluster\x00userID"); for regular contexts it is the cluster name alone.
 func clientsetCachePrefixFromContextKey(contextKey string) string {
-	return strings.SplitN(contextKey, "\x00", 2)[0]
+	return contextKey
 }
 
 // cleanupRemovedContext drops cached API responses and auth clientsets for a

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -34,7 +34,7 @@ func cacheKeyBelongsToContext(key, contextKey string) bool {
 		return false
 	}
 
-	return parts[3] == contextKey
+	return parts[3] == escapeCacheKeySegment(contextKey)
 }
 
 // PurgeCacheForContext removes all cached API responses for a removed context.
@@ -102,7 +102,7 @@ func collectCachedContextKeys(k8scache cache.Cache[string]) map[string]struct{} 
 	for key := range allKeys {
 		parts := strings.SplitN(key, "+", 4)
 		if len(parts) == 4 && parts[3] != "" {
-			keys[parts[3]] = struct{}{}
+			keys[unescapeCacheKeySegment(parts[3])] = struct{}{}
 		}
 	}
 

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -67,14 +67,20 @@ func PurgeCacheForContext(k8scache cache.Cache[string], contextKey string) {
 	}
 }
 
-// collectCachedContextKeys returns Headlamp context keys that still have k8cache
-// or clientset cache entries.
+// collectCachedContextKeys returns Headlamp context keys that still have k8cache,
+// clientset cache, or in-flight clientset creation entries.
 func collectCachedContextKeys(k8scache cache.Cache[string]) map[string]struct{} {
 	keys := make(map[string]struct{})
 
 	mu.Lock()
 
 	for cacheKey := range clientsetCache {
+		if prefix := clientsetCachePrefixFromCacheKey(cacheKey); prefix != "" {
+			keys[prefix] = struct{}{}
+		}
+	}
+
+	for cacheKey := range inFlight {
 		if prefix := clientsetCachePrefixFromCacheKey(cacheKey); prefix != "" {
 			keys[prefix] = struct{}{}
 		}
@@ -103,6 +109,7 @@ func collectCachedContextKeys(k8scache cache.Cache[string]) map[string]struct{} 
 	return keys
 }
 
+// clientsetCachePrefixFromContextKey returns the Headlamp context store key used as
 // the prefix for clientset cache keys. For stateless contexts this includes the user
 // ID (e.g. "cluster\x00userID"); for regular contexts it is the cluster name alone.
 func clientsetCachePrefixFromContextKey(contextKey string) string {

--- a/backend/pkg/k8cache/context_cleanup.go
+++ b/backend/pkg/k8cache/context_cleanup.go
@@ -67,9 +67,15 @@ func PurgeCacheForContext(k8scache cache.Cache[string], contextKey string) {
 	}
 }
 
+// clusterNameFromContextKey returns the cluster portion of a Headlamp context key.
+// Stateless keys use "clusterName\x00userID"; clientset cache keys use "clusterName\x00token".
+func clusterNameFromContextKey(contextKey string) string {
+	return strings.SplitN(contextKey, "\x00", 2)[0]
+}
+
 // cleanupRemovedContext drops cached API responses and auth clientsets for a
 // context that is no longer active.
 func cleanupRemovedContext(k8scache cache.Cache[string], contextKey string) {
 	PurgeCacheForContext(k8scache, contextKey)
-	EvictClientsetsForCluster(contextKey)
+	EvictClientsetsForCluster(clusterNameFromContextKey(contextKey))
 }

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -102,6 +102,17 @@ func TestEvictClientsetsForCluster_StatelessScope(t *testing.T) {
 	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
 }
 
+func TestEvictClientsetsForCluster_KeepsPrefixBlocked(t *testing.T) {
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	const removedContext = "minikube\x00user1"
+
+	k8cache.EvictClientsetsForCluster(removedContext)
+
+	assert.True(t, k8cache.ExportedClientsetPrefixBlocked(removedContext))
+}
+
 func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	const (
 		clusterName         = "removed-cluster"

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheKeyBelongsToContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key        string
+		contextKey string
+		want       bool
+	}{
+		{"+pods+default+minikube", "minikube", true},
+		{"apps+deployments+default+minikube", "minikube", true},
+		{"+pods+default+other", "minikube", false},
+		{"malformed", "minikube", false},
+		{"+pods+default+minikube", "", false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, k8cache.ExportedCacheKeyBelongsToContext(tt.key, tt.contextKey))
+	}
+}
+
+func TestPurgeCacheForContext(t *testing.T) {
+	t.Parallel()
+
+	k8scache := cache.New[string]()
+	ctx := context.Background()
+
+	require.NoError(t, k8scache.Set(ctx, "+pods+default+minikube", "pods-data"))
+	require.NoError(t, k8scache.Set(ctx, "apps+deployments+default+minikube", "deploy-data"))
+	require.NoError(t, k8scache.Set(ctx, "+pods+default+other-cluster", "other-data"))
+
+	k8cache.PurgeCacheForContext(k8scache, "minikube")
+
+	_, err := k8scache.Get(ctx, "+pods+default+minikube")
+	assert.Error(t, err)
+
+	_, err = k8scache.Get(ctx, "apps+deployments+default+minikube")
+	assert.Error(t, err)
+
+	val, err := k8scache.Get(ctx, "+pods+default+other-cluster")
+	assert.NoError(t, err)
+	assert.Equal(t, "other-data", val)
+}
+
+func TestEvictClientsetsForCluster(t *testing.T) {
+	t.Parallel()
+
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	k8cache.SeedClientsetCache("minikube\x00token-a", time.Now())
+	k8cache.SeedClientsetCache("minikube\x00token-b", time.Now())
+	k8cache.SeedClientsetCache("other\x00token-c", time.Now())
+
+	assert.Equal(t, 3, k8cache.ClientsetCacheLen())
+
+	k8cache.EvictClientsetsForCluster("minikube")
+
+	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
+}
+
+func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
+	k8cache.ResetRegistries()
+	t.Cleanup(func() { k8cache.ResetRegistries() })
+
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	k8scache := cache.New[string]()
+	ctx := context.Background()
+
+	require.NoError(t, k8scache.Set(ctx, "+pods+default+removed-ctx", "stale-data"))
+	k8cache.SeedClientsetCache("removed-ctx\x00token", time.Now())
+
+	canceled := make(map[string]bool)
+
+	var mu sync.Mutex
+
+	_, cancel := context.WithCancel(context.Background())
+	wrappedCancel := func() {
+		mu.Lock()
+		canceled["removed-ctx"] = true
+		mu.Unlock()
+		cancel()
+	}
+
+	k8cache.StoreTestContextCancel("removed-ctx", wrappedCancel)
+	k8cache.StoreTestRegistry("active-ctx", func() {})
+
+	k8cache.SyncWatchers(k8scache, []string{"active-ctx"})
+
+	mu.Lock()
+	assert.True(t, canceled["removed-ctx"])
+	mu.Unlock()
+
+	_, err := k8scache.Get(ctx, "+pods+default+removed-ctx")
+	assert.Error(t, err)
+	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
+}

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -83,6 +83,25 @@ func TestEvictClientsetsForCluster(t *testing.T) {
 	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
 }
 
+func TestEvictClientsetsForCluster_StatelessScope(t *testing.T) {
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	const (
+		removedUser = "minikube\x00user1"
+		activeUser  = "minikube\x00user2"
+	)
+
+	k8cache.SeedClientsetCache(removedUser+"\x00token-a", time.Now())
+	k8cache.SeedClientsetCache(activeUser+"\x00token-b", time.Now())
+
+	assert.Equal(t, 2, k8cache.ClientsetCacheLen())
+
+	k8cache.EvictClientsetsForCluster(removedUser)
+
+	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
+}
+
 func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	const (
 		clusterName         = "removed-cluster"
@@ -101,7 +120,8 @@ func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, k8scache.Set(ctx, removedCacheDataKey, "stale-data"))
-	k8cache.SeedClientsetCache(clusterName+"\x00token", time.Now())
+	k8cache.SeedClientsetCache(removedContextKey+"\x00token", time.Now())
+	k8cache.SeedClientsetCache(clusterName+"\x00user2\x00other-token", time.Now())
 
 	canceled := make(map[string]bool)
 
@@ -126,5 +146,5 @@ func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 
 	_, err := k8scache.Get(ctx, removedCacheDataKey)
 	assert.Error(t, err)
-	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
+	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
 }

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -86,6 +86,13 @@ func TestEvictClientsetsForCluster(t *testing.T) {
 }
 
 func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
+	const (
+		clusterName         = "removed-cluster"
+		removedContextKey   = clusterName + "\x00user1"
+		activeContextKey    = "active-cluster\x00user2"
+		removedCacheDataKey = "+pods+default+" + removedContextKey
+	)
+
 	k8cache.ResetRegistries()
 	t.Cleanup(func() { k8cache.ResetRegistries() })
 
@@ -95,8 +102,8 @@ func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	k8scache := cache.New[string]()
 	ctx := context.Background()
 
-	require.NoError(t, k8scache.Set(ctx, "+pods+default+removed-ctx", "stale-data"))
-	k8cache.SeedClientsetCache("removed-ctx\x00token", time.Now())
+	require.NoError(t, k8scache.Set(ctx, removedCacheDataKey, "stale-data"))
+	k8cache.SeedClientsetCache(clusterName+"\x00token", time.Now())
 
 	canceled := make(map[string]bool)
 
@@ -105,21 +112,21 @@ func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	_, cancel := context.WithCancel(context.Background())
 	wrappedCancel := func() {
 		mu.Lock()
-		canceled["removed-ctx"] = true
+		canceled[removedContextKey] = true
 		mu.Unlock()
 		cancel()
 	}
 
-	k8cache.StoreTestContextCancel("removed-ctx", wrappedCancel)
-	k8cache.StoreTestRegistry("active-ctx", func() {})
+	k8cache.StoreTestContextCancel(removedContextKey, wrappedCancel)
+	k8cache.StoreTestRegistry(activeContextKey, func() {})
 
-	k8cache.SyncWatchers(k8scache, []string{"active-ctx"})
+	k8cache.SyncWatchers(k8scache, []string{activeContextKey})
 
 	mu.Lock()
-	assert.True(t, canceled["removed-ctx"])
+	assert.True(t, canceled[removedContextKey])
 	mu.Unlock()
 
-	_, err := k8scache.Get(ctx, "+pods+default+removed-ctx")
+	_, err := k8scache.Get(ctx, removedCacheDataKey)
 	assert.Error(t, err)
 	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
 }

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -185,6 +185,29 @@ func TestSyncWatchersPurgesCacheWithoutWatcher(t *testing.T) {
 	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
 }
 
+func TestSyncWatchersPurgesContextWithOnlyInFlightClientset(t *testing.T) {
+	const (
+		removedContextKey = "removed-cluster\x00user1"
+		activeContextKey  = "active-cluster\x00user2"
+	)
+
+	k8cache.ResetRegistries()
+	t.Cleanup(func() { k8cache.ResetRegistries() })
+
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	k8cache.ResetInFlight()
+	t.Cleanup(k8cache.ResetInFlight)
+
+	k8cache.SeedInFlightClientsetKey(removedContextKey + "\x00token")
+	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
+
+	k8cache.SyncWatchers(nil, []string{activeContextKey})
+
+	assert.True(t, k8cache.ExportedClientsetPrefixBlocked(removedContextKey))
+}
+
 func TestPruneBlockedClientsetPrefixes(t *testing.T) {
 	k8cache.ResetClientsetCache()
 	t.Cleanup(k8cache.ResetClientsetCache)

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -115,8 +115,7 @@ func TestEvictClientsetsForCluster_KeepsPrefixBlocked(t *testing.T) {
 
 func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	const (
-		clusterName         = "removed-cluster"
-		removedContextKey   = clusterName + "\x00user1"
+		removedContextKey   = "removed-cluster\x00user1"
 		activeContextKey    = "active-cluster\x00user2"
 		removedCacheDataKey = "+pods+default+" + removedContextKey
 	)
@@ -132,7 +131,7 @@ func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 
 	require.NoError(t, k8scache.Set(ctx, removedCacheDataKey, "stale-data"))
 	k8cache.SeedClientsetCache(removedContextKey+"\x00token", time.Now())
-	k8cache.SeedClientsetCache(clusterName+"\x00user2\x00other-token", time.Now())
+	k8cache.SeedClientsetCache(activeContextKey+"\x00other-token", time.Now())
 
 	canceled := make(map[string]bool)
 
@@ -158,4 +157,44 @@ func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	_, err := k8scache.Get(ctx, removedCacheDataKey)
 	assert.Error(t, err)
 	assert.Equal(t, 1, k8cache.ClientsetCacheLen())
+}
+
+func TestSyncWatchersPurgesCacheWithoutWatcher(t *testing.T) {
+	const (
+		removedContextKey   = "removed-cluster\x00user1"
+		activeContextKey    = "active-cluster\x00user2"
+		removedCacheDataKey = "+pods+default+" + removedContextKey
+	)
+
+	k8cache.ResetRegistries()
+	t.Cleanup(func() { k8cache.ResetRegistries() })
+
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	k8scache := cache.New[string]()
+	ctx := context.Background()
+
+	require.NoError(t, k8scache.Set(ctx, removedCacheDataKey, "stale-data"))
+	k8cache.SeedClientsetCache(removedContextKey+"\x00token", time.Now())
+
+	k8cache.SyncWatchers(k8scache, []string{activeContextKey})
+
+	_, err := k8scache.Get(ctx, removedCacheDataKey)
+	assert.Error(t, err)
+	assert.Equal(t, 0, k8cache.ClientsetCacheLen())
+}
+
+func TestPruneBlockedClientsetPrefixes(t *testing.T) {
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	const removedContext = "minikube\x00user1"
+
+	k8cache.SeedBlockedClientsetPrefix(removedContext, time.Now().Add(-11*time.Minute))
+	assert.True(t, k8cache.ExportedClientsetPrefixBlocked(removedContext))
+
+	k8cache.ManualEvictExpiredClientsets()
+
+	assert.False(t, k8cache.ExportedClientsetPrefixBlocked(removedContext))
 }

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -15,6 +15,7 @@ package k8cache_test
 
 import (
 	"context"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -34,6 +35,9 @@ func TestCacheKeyBelongsToContext(t *testing.T) {
 		want       bool
 	}{
 		{"+pods+default+minikube", "minikube", true},
+		{"+pods+default+prod%2Bcluster", "prod+cluster", true},
+		{"+pods+default+prod%252Bcluster", "prod%2Bcluster", true},
+		{"+pods+default+prod%2Bcluster", "prod%2Bcluster", false},
 		{"apps+deployments+default+minikube", "minikube", true},
 		{"+pods+default+other", "minikube", false},
 		{"malformed", "minikube", false},
@@ -66,6 +70,73 @@ func TestPurgeCacheForContext(t *testing.T) {
 	val, err := k8scache.Get(ctx, "+pods+default+other-cluster")
 	assert.NoError(t, err)
 	assert.Equal(t, "other-data", val)
+}
+
+func TestPurgeCacheForContext_EscapedContextKey(t *testing.T) {
+	t.Parallel()
+
+	const contextKey = "prod+cluster"
+
+	podsURL := url.URL{Path: "/clusters/kind/apis/v1/namespaces/default/pods"}
+	podsKey, err := k8cache.GenerateKey(&podsURL, contextKey)
+	require.NoError(t, err)
+
+	otherURL := url.URL{Path: "/clusters/kind/apis/v1/namespaces/default/pods"}
+	otherKey, err := k8cache.GenerateKey(&otherURL, "other-cluster")
+	require.NoError(t, err)
+
+	k8scache := cache.New[string]()
+	ctx := context.Background()
+
+	require.NoError(t, k8scache.Set(ctx, podsKey, "pods-data"))
+	require.NoError(t, k8scache.Set(ctx, otherKey, "other-data"))
+
+	k8cache.PurgeCacheForContext(k8scache, contextKey)
+
+	_, err = k8scache.Get(ctx, podsKey)
+	assert.Error(t, err)
+
+	val, err := k8scache.Get(ctx, otherKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "other-data", val)
+}
+
+func TestSyncWatchersDoesNotPurgeActiveContextWithPlusInName(t *testing.T) {
+	const (
+		activeContextKey  = "prod+cluster\x00user1"
+		removedContextKey = "removed-cluster\x00user2"
+	)
+
+	podsURL := url.URL{Path: "/clusters/kind/apis/v1/namespaces/default/pods"}
+	activeCacheDataKey, err := k8cache.GenerateKey(&podsURL, activeContextKey)
+	require.NoError(t, err)
+
+	removedCacheDataKey, err := k8cache.GenerateKey(&podsURL, removedContextKey)
+	require.NoError(t, err)
+
+	k8cache.ResetRegistries()
+	t.Cleanup(func() { k8cache.ResetRegistries() })
+
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	k8scache := cache.New[string]()
+	ctx := context.Background()
+
+	require.NoError(t, k8scache.Set(ctx, activeCacheDataKey, "active-data"))
+	require.NoError(t, k8scache.Set(ctx, removedCacheDataKey, "stale-data"))
+	k8cache.SeedClientsetCache(removedContextKey+"\x00token", time.Now())
+
+	k8cache.StoreTestRegistry(activeContextKey, func() {})
+
+	k8cache.SyncWatchers(k8scache, []string{activeContextKey})
+
+	val, err := k8scache.Get(ctx, activeCacheDataKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "active-data", val)
+
+	_, err = k8scache.Get(ctx, removedCacheDataKey)
+	assert.Error(t, err)
 }
 
 func TestEvictClientsetsForCluster(t *testing.T) {

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -69,8 +69,6 @@ func TestPurgeCacheForContext(t *testing.T) {
 }
 
 func TestEvictClientsetsForCluster(t *testing.T) {
-	t.Parallel()
-
 	k8cache.ResetClientsetCache()
 	t.Cleanup(k8cache.ResetClientsetCache)
 

--- a/backend/pkg/k8cache/context_cleanup_test.go
+++ b/backend/pkg/k8cache/context_cleanup_test.go
@@ -184,6 +184,20 @@ func TestEvictClientsetsForCluster_KeepsPrefixBlocked(t *testing.T) {
 	assert.True(t, k8cache.ExportedClientsetPrefixBlocked(removedContext))
 }
 
+func TestEvictClientsetsForCluster_PrunesBlockedPrefixWithoutGetClientSet(t *testing.T) {
+	k8cache.ResetClientsetCache()
+	t.Cleanup(k8cache.ResetClientsetCache)
+
+	const removedContext = "minikube\x00user1"
+
+	k8cache.EvictClientsetsForCluster(removedContext)
+	k8cache.SeedBlockedClientsetPrefix(removedContext, time.Now().Add(-11*time.Minute))
+
+	k8cache.ManualEvictExpiredClientsets()
+
+	assert.False(t, k8cache.ExportedClientsetPrefixBlocked(removedContext))
+}
+
 func TestSyncWatchersPurgesCacheAndClientsetsForRemovedContext(t *testing.T) {
 	const (
 		removedContextKey   = "removed-cluster\x00user1"

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -68,6 +68,7 @@ func ResetClientsetCache() {
 	defer mu.Unlock()
 
 	clientsetCache = make(map[string]*CachedClientSet)
+	blockedClientsetPrefixes = make(map[string]struct{})
 }
 
 // SeedClientsetCache populates the clientset cache with dummy entries for testing.

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -167,3 +167,13 @@ func ExportedInvalidateCacheKeysForResourceEvent(
 func ExportedCacheKeyBelongsToContext(key, contextKey string) bool {
 	return cacheKeyBelongsToContext(key, contextKey)
 }
+
+// ExportedClientsetPrefixBlocked reports whether clientset caching is blocked for a prefix.
+func ExportedClientsetPrefixBlocked(prefix string) bool {
+	mu.Lock()
+	defer mu.Unlock()
+
+	_, blocked := blockedClientsetPrefixes[prefix]
+
+	return blocked
+}

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -112,6 +112,16 @@ func ResetInFlight() {
 	inFlight = make(map[string]*inFlightEntry)
 }
 
+// SeedInFlightClientsetKey registers an in-flight clientset creation for testing.
+func SeedInFlightClientsetKey(cacheKey string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	inFlight[cacheKey] = &inFlightEntry{
+		waitCh: make(chan struct{}),
+	}
+}
+
 // SetClientsetCreator sets a custom clientset creator function for testing.
 // It returns a function to restore the original creator.
 func SetClientsetCreator(fn func(*kubeconfig.Context, string) (*kubernetes.Clientset, error)) func() {

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -161,3 +161,8 @@ func ExportedInvalidateCacheKeysForResourceEvent(
 ) {
 	invalidateCacheKeysForResourceEvent(gvr, namespace, name, contextKey, k8scache)
 }
+
+// ExportedCacheKeyBelongsToContext exposes cacheKeyBelongsToContext for testing.
+func ExportedCacheKeyBelongsToContext(key, contextKey string) bool {
+	return cacheKeyBelongsToContext(key, contextKey)
+}

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -68,7 +68,7 @@ func ResetClientsetCache() {
 	defer mu.Unlock()
 
 	clientsetCache = make(map[string]*CachedClientSet)
-	blockedClientsetPrefixes = make(map[string]struct{})
+	blockedClientsetPrefixes = make(map[string]blockedPrefixEntry)
 }
 
 // SeedClientsetCache populates the clientset cache with dummy entries for testing.
@@ -85,6 +85,14 @@ func SeedClientsetCache(key string, lastUsed time.Time) {
 // ManualEvictExpiredClientsets triggers the eviction logic immediately for testing.
 func ManualEvictExpiredClientsets() {
 	evictExpiredClientsets()
+}
+
+// SeedBlockedClientsetPrefix marks a prefix as blocked at the given time for testing.
+func SeedBlockedClientsetPrefix(prefix string, blockedAt time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	blockedClientsetPrefixes[prefix] = blockedPrefixEntry{blockedAt: blockedAt}
 }
 
 // ClientsetCacheLen returns the current number of entries in the

--- a/backend/pkg/k8cache/testing_reset.go
+++ b/backend/pkg/k8cache/testing_reset.go
@@ -13,6 +13,8 @@
 
 package k8cache
 
+import "context"
+
 // ResetForTesting clears package-global k8cache state between integration tests.
 func ResetForTesting() {
 	mu.Lock()
@@ -23,13 +25,21 @@ func ResetForTesting() {
 
 	mu.Unlock()
 
-	watcherRegistry.Range(func(key, _ interface{}) bool {
-		watcherRegistry.Delete(key)
+	clearWatcherRegistriesForTesting()
+}
+
+func clearWatcherRegistriesForTesting() {
+	contextCancel.Range(func(key, value interface{}) bool {
+		if cancel, ok := value.(context.CancelFunc); ok {
+			cancel()
+		}
+
+		contextCancel.Delete(key)
 
 		return true
 	})
-	contextCancel.Range(func(key, _ interface{}) bool {
-		contextCancel.Delete(key)
+	watcherRegistry.Range(func(key, _ interface{}) bool {
+		watcherRegistry.Delete(key)
 
 		return true
 	})

--- a/backend/pkg/k8cache/testing_reset.go
+++ b/backend/pkg/k8cache/testing_reset.go
@@ -20,7 +20,7 @@ func ResetForTesting() {
 	mu.Lock()
 
 	clientsetCache = make(map[string]*CachedClientSet)
-	blockedClientsetPrefixes = make(map[string]struct{})
+	blockedClientsetPrefixes = make(map[string]blockedPrefixEntry)
 	inFlight = make(map[string]*inFlightEntry)
 
 	mu.Unlock()

--- a/backend/pkg/k8cache/testing_reset.go
+++ b/backend/pkg/k8cache/testing_reset.go
@@ -1,0 +1,36 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8cache
+
+// ResetForTesting clears package-global k8cache state between integration tests.
+func ResetForTesting() {
+	mu.Lock()
+
+	clientsetCache = make(map[string]*CachedClientSet)
+	blockedClientsetPrefixes = make(map[string]struct{})
+	inFlight = make(map[string]*inFlightEntry)
+
+	mu.Unlock()
+
+	watcherRegistry.Range(func(key, _ interface{}) bool {
+		watcherRegistry.Delete(key)
+
+		return true
+	})
+	contextCancel.Range(func(key, _ interface{}) bool {
+		contextCancel.Delete(key)
+
+		return true
+	})
+}


### PR DESCRIPTION
## Problem

When a kube context is removed (for example via dynamic cluster delete), `SyncWatchers` already cancels informers for that context, but:

- Cached k8s API responses in k8cache remain until their TTL expires (~10 minutes)
- Authorization clientsets for the removed cluster remain in the in-memory cache until the janitor evicts them

This can serve stale data or retain clientsets longer than necessary after a cluster is gone.

## Solution

When `SyncWatchers` detects a removed context, it now also:

1. **Purges k8cache entries** for that context via `PurgeCacheForContext` (keys match `group+resource+namespace+context`)
2. **Evicts authorization clientsets** for that cluster via `EvictClientsetsForCluster`

`SyncWatchers` now takes the k8s response cache as an argument; `server.go` passes it through on each sync.

## Changes

- Add `context_cleanup.go` with `PurgeCacheForContext` and `cleanupRemovedContext`
- Extend `SyncWatchers` to call cleanup when canceling a removed context
- Add `EvictClientsetsForCluster` in `authorization.go`
- Wire cache into `SyncWatchers` from `backend/cmd/server.go`
- Add unit tests in `context_cleanup_test.go`

## Screenshots

### 1. Cluster delete via API (PowerShell)

Before delete: `GET /clusters/minikube/api/v1/pods` returns **200 OK** (cluster reachable).


After delete: `DELETE /cluster/minikube` returns **200 OK** with `"clusters":[]` — cluster removed from backend config


<img width="1397" height="930" alt="image" src="https://github.com/user-attachments/assets/7b999a5e-7321-4cd0-9ef7-b5cb327a9ea4" />



### 2. Backend logs — immediate cache purge and clientset eviction

After cluster removal at `11:35:16`, cleanup runs at `11:35:17`:

- `canceling watcher for removed context`
- `purged 2 k8cache entries for removed context`
- `evicted 1 clientset(s) for removed cluster minikube, 0 remaining`
- `Watcher for context ... is shutting down...`

<img width="1875" height="782" alt="image" src="https://github.com/user-attachments/assets/7158a690-4105-408f-b5f6-881344b605cf" />




## Test plan

- [x] `go test ./backend/pkg/k8cache/...`
- [x] Live test on minikube with `-cache-enabled` and dynamic clusters enabled:
  - Confirm pods API returns 200 while cluster is active
  - `DELETE /cluster/minikube` returns 200 with empty `clusters` array
  - Backend logs show immediate purge + clientset eviction (not after TTL expiry)