### PR TITLE
frontend: workload: Fix Pods overview chart to reflect failing pods

### DIFF
--- a/frontend/src/components/workload/Charts.tsx
+++ b/frontend/src/components/workload/Charts.tsx
@@ -66,6 +66,12 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
   }, [workloadData, categorize]);
 
   function makeData(): ChartDataPoint[] {
+    // Empty state: PercentageCircle divides each segment by total, so returning
+    // any data point here would produce 0/0 = NaN percentages. Return nothing
+    // and let it render the default full "total" ring instead.
+    if (total === 0) {
+      return [];
+    }
     if (counts) {
       // Order around the ring: healthy → degraded → transitional → failed.
       return [

--- a/frontend/src/components/workload/Charts.tsx
+++ b/frontend/src/components/workload/Charts.tsx
@@ -14,26 +14,36 @@
  * limitations under the License.
  */
 
+import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { Workload } from '../../lib/k8s/Workload';
+import type { Workload, WorkloadHealthCategory } from '../../lib/k8s/Workload';
 import { getPercentStr, getReadyReplicas, getTotalReplicas } from '../../lib/util';
-import type { PercentageCircleProps } from '../common/Chart';
+import type { ChartDataPoint, PercentageCircleProps } from '../common/Chart';
 import TileChart from '../common/TileChart';
 
 export interface WorkloadCircleChartProps extends Omit<PercentageCircleProps, 'data'> {
   workloadData: Workload[] | null;
   partialLabel: string;
   totalLabel: string;
+  /**
+   * Optional per-item health classifier. When provided, the chart renders a
+   * multi-segment ring (healthy / degraded / transitional / failed) instead of
+   * the default binary ring. Used for Pods, which have no replica fields and
+   * whose health can't be derived from a ready/total replica mismatch.
+   */
+  categorize?: (item: Workload) => WorkloadHealthCategory;
 }
 
 export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
   const theme = useTheme();
   const { t } = useTranslation();
 
-  const { workloadData, partialLabel = '', totalLabel = '', ...other } = props;
+  const { workloadData, partialLabel = '', totalLabel = '', categorize, ...other } = props;
 
+  // Binary path: a workload counts as "partial" (failed) when its ready replicas
+  // don't match its total replicas. Correct for Deployments, StatefulSets, etc.
   const [total, partial] = useMemo(() => {
     // Total as -1 means it's loading.
     const total = !workloadData ? -1 : workloadData.length;
@@ -43,7 +53,28 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
     return [total, partial];
   }, [workloadData]);
 
-  function makeData() {
+  // Categorized path: bucket every item into a health category.
+  const counts = useMemo(() => {
+    if (!workloadData || !categorize) {
+      return null;
+    }
+    const buckets = { healthy: 0, degraded: 0, transitional: 0, failed: 0 };
+    workloadData.forEach(item => {
+      buckets[categorize(item)]++;
+    });
+    return buckets;
+  }, [workloadData, categorize]);
+
+  function makeData(): ChartDataPoint[] {
+    if (counts) {
+      // Order around the ring: healthy → degraded → transitional → failed.
+      return [
+        { name: 'healthy', value: counts.healthy, fill: theme.palette.success.main },
+        { name: 'degraded', value: counts.degraded, fill: theme.palette.warning.main },
+        { name: 'transitional', value: counts.transitional, fill: theme.palette.grey[500] },
+        { name: 'failed', value: counts.failed, fill: theme.palette.error.main },
+      ];
+    }
     return [
       {
         name: 'failed',
@@ -54,6 +85,9 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
   }
 
   function getLabel() {
+    if (counts) {
+      return total > 0 ? getPercentStr(counts.healthy, total) : '';
+    }
     return total > 0 ? getPercentStr(total - partial, total) : '';
   }
 
@@ -62,8 +96,29 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
       return '…';
     }
     if (total === 0) {
-      return t('translation|0 Running');
+      return `0 ${totalLabel}`;
     }
+
+    if (counts) {
+      // Main line is the healthy count; the secondary line breaks down the rest.
+      const breakdown = [
+        counts.failed && `${counts.failed} ${partialLabel}`,
+        counts.degraded && `${counts.degraded} ${t('translation|Degraded')}`,
+        counts.transitional && `${counts.transitional} ${t('translation|Other')}`,
+      ].filter(Boolean);
+
+      return (
+        <>
+          {`${counts.healthy} ${totalLabel}`}
+          {breakdown.length > 0 && (
+            <Box component="span" sx={{ display: 'block', fontSize: '0.85em', opacity: 0.7 }}>
+              {breakdown.join(' · ')}
+            </Box>
+          )}
+        </>
+      );
+    }
+
     if (partial !== 0) {
       return `${partial} ${partialLabel} / ${total} ${totalLabel}`;
     }

--- a/frontend/src/components/workload/Charts.tsx
+++ b/frontend/src/components/workload/Charts.tsx
@@ -47,11 +47,14 @@ export function WorkloadCircleChart(props: WorkloadCircleChartProps) {
   const [total, partial] = useMemo(() => {
     // Total as -1 means it's loading.
     const total = !workloadData ? -1 : workloadData.length;
-    const partial =
-      workloadData?.filter(item => getReadyReplicas(item) !== getTotalReplicas(item)).length || 0;
+    // The categorized path uses `counts`, not `partial`, so skip the extra pass
+    // (and the replica helpers, irrelevant for Pods) when categorize is set.
+    const partial = categorize
+      ? 0
+      : workloadData?.filter(item => getReadyReplicas(item) !== getTotalReplicas(item)).length || 0;
 
     return [total, partial];
-  }, [workloadData]);
+  }, [workloadData, categorize]);
 
   // Categorized path: bucket every item into a health category.
   const counts = useMemo(() => {

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -135,6 +135,7 @@ export default function Overview() {
                 title={<ChartLink workload={workload} />}
                 partialLabel={t('translation|Failed')}
                 totalLabel={t('translation|Running')}
+                categorize={workload === Pod ? item => (item as Pod).getHealth() : undefined}
               />
             </Grid>
           ))}

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -134,7 +134,7 @@ export default function Overview() {
                 workloadData={workloadsData[workload.className] || null}
                 title={<ChartLink workload={workload} />}
                 partialLabel={t('translation|Failed')}
-                totalLabel={t('translation|Running')}
+                totalLabel={workload === Pod ? t('translation|Healthy') : t('translation|Running')}
                 categorize={workload === Pod ? item => (item as Pod).getHealth() : undefined}
               />
             </Grid>

--- a/frontend/src/components/workload/__snapshots__/Charts.Empty.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.Empty.stories.storyshot
@@ -64,10 +64,6 @@
                   <g
                     class="recharts-layer recharts-pie-sector"
                     tabindex="-1"
-                  />
-                  <g
-                    class="recharts-layer recharts-pie-sector"
-                    tabindex="-1"
                   >
                     <path
                       aria-label="0%"

--- a/frontend/src/components/workload/__snapshots__/Charts.Empty.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Charts.Empty.stories.storyshot
@@ -19,7 +19,7 @@
           <p
             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
           >
-            0 Running
+            0 Total
           </p>
         </div>
         <div

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -51,7 +51,7 @@
                           <p
                             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
                           >
-                            1 Running
+                            1 Healthy
                             <span
                               class="MuiBox-root css-172fsqw"
                             >

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -1001,10 +1001,6 @@
                                   <g
                                     class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
-                                  />
-                                  <g
-                                    class="recharts-layer recharts-pie-sector"
-                                    tabindex="-1"
                                   >
                                     <path
                                       aria-label="0%"

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -51,7 +51,12 @@
                           <p
                             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
                           >
-                            2 Running
+                            1 Running
+                            <span
+                              class="MuiBox-root css-172fsqw"
+                            >
+                              1 Other
+                            </span>
                           </p>
                         </div>
                         <div
@@ -96,31 +101,63 @@
                                   <g
                                     class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
+                                  >
+                                    <path
+                                      aria-label="50 %"
+                                      class="recharts-sector"
+                                      cx="61"
+                                      cy="61"
+                                      d="M 61,16.199999999999996
+    A 44.800000000000004,44.800000000000004,0,
+    0,1,
+    61,105.80000000000001
+  L 61,94.80000000000001
+            A 33.800000000000004,33.800000000000004,0,
+            0,0,
+            61,27.199999999999996 Z"
+                                      fill="#2e7d32"
+                                      name="healthy"
+                                      role="img"
+                                      stroke="#e0e0e0"
+                                      tabindex="-1"
+                                    />
+                                  </g>
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
                                   />
                                   <g
                                     class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
                                   >
                                     <path
-                                      aria-label="100 %"
+                                      aria-label="50 %"
                                       class="recharts-sector"
                                       cx="61"
                                       cy="61"
-                                      d="M 61,16.199999999999996
+                                      d="M 61,105.80000000000001
     A 44.800000000000004,44.800000000000004,0,
-    1,1,
-    60.99921809249515,16.20000000682343
-  L 60.999410078712856,27.200000005148027
+    0,1,
+    60.99999999999999,16.199999999999996
+  L 60.99999999999999,27.199999999999996
             A 33.800000000000004,33.800000000000004,0,
-            1,0,
-            61,27.199999999999996 Z"
-                                      fill="#000"
-                                      name="total"
+            0,0,
+            61,94.80000000000001 Z"
+                                      fill="#9e9e9e"
+                                      name="transitional"
                                       role="img"
                                       stroke="#e0e0e0"
                                       tabindex="-1"
                                     />
                                   </g>
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
                                   <text
                                     class="recharts-text recharts-label"
                                     fill="#808080"
@@ -134,7 +171,7 @@
                                       dy="0.355em"
                                       x="61"
                                     >
-                                      100 %
+                                      50 %
                                     </tspan>
                                   </text>
                                 </g>

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -846,7 +846,7 @@
   "Service: {{namespace}}/{{name}}": "الخدمة: {{namespace}}/{{name}}",
   "Path: {{ path }}:{{ port }}": "المسار: {{ path }}:{{ port }}",
   "Operations": "العمليات",
-  "0 Running": "0 قيد التشغيل",
+  "Other": "",
   "Ready//context:replicas": "جاهز",
   "Up to date//context:replicas": "محدّث",
   "Available//context:replicas": "متاح",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -822,7 +822,7 @@
   "Service: {{namespace}}/{{name}}": "পরিষেবা: {{namespace}}/{{name}}",
   "Path: {{ path }}:{{ port }}": "পথ: {{ path }}:{{ port }}",
   "Operations": "Operations",
-  "0 Running": "0 চলমান",
+  "Other": "",
   "Ready//context:replicas": "প্রস্তুত:replicas",
   "Up to date//context:replicas": "Up to date:replicas",
   "Available//context:replicas": "Available:replicas",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -822,7 +822,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -822,7 +822,7 @@
   "Service: {{namespace}}/{{name}}": "Service: {{namespace}}/{{name}}",
   "Path: {{ path }}:{{ port }}": "Path: {{ path }}:{{ port }}",
   "Operations": "Operations",
-  "0 Running": "0 Running",
+  "Other": "Other",
   "Ready//context:replicas": "Ready",
   "Up to date//context:replicas": "Up to date",
   "Available//context:replicas": "Available",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -828,7 +828,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -828,7 +828,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -828,7 +828,7 @@
   "Service: {{namespace}}/{{name}}": "Service: {{namespace}}/{{name}}",
   "Path: {{ path }}:{{ port }}": "Path: {{ path }}:{{ port }}",
   "Operations": "Operations",
-  "0 Running": "0 Running",
+  "Other": "",
   "Ready//context:replicas": "Ready",
   "Up to date//context:replicas": "Up to date",
   "Available//context:replicas": "Available",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -822,7 +822,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -828,7 +828,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -816,7 +816,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -816,7 +816,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -828,7 +828,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -834,7 +834,7 @@
   "Service: {{namespace}}/{{name}}": "Сервис: {{namespace}}/{{name}}",
   "Path: {{ path }}:{{ port }}": "Путь: {{ path }}:{{ port }}",
   "Operations": "Операции",
-  "0 Running": "0 работает",
+  "Other": "",
   "Ready//context:replicas": "Готовые",
   "Up to date//context:replicas": "Актуальные",
   "Available//context:replicas": "Доступные",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -822,7 +822,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -822,7 +822,7 @@
   "Service: {{namespace}}/{{name}}": "سروس: {{namespace}}/{{name}}",
   "Path: {{ path }}:{{ port }}": "پاتھ: {{ path }}:{{ port }}",
   "Operations": "عملیات",
-  "0 Running": "0 چل رہے ہیں",
+  "Other": "",
   "Ready//context:replicas": "تیار",
   "Up to date//context:replicas": "تازہ ترین",
   "Available//context:replicas": "دستیاب",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -816,7 +816,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -816,7 +816,7 @@
   "Service: {{namespace}}/{{name}}": "",
   "Path: {{ path }}:{{ port }}": "",
   "Operations": "",
-  "0 Running": "",
+  "Other": "",
   "Ready//context:replicas": "",
   "Up to date//context:replicas": "",
   "Available//context:replicas": "",

--- a/frontend/src/lib/k8s/Workload.ts
+++ b/frontend/src/lib/k8s/Workload.ts
@@ -23,6 +23,14 @@ import type Pod from './pod';
 import type ReplicaSet from './replicaSet';
 import type StatefulSet from './statefulSet';
 
+/**
+ * Coarse health category for a workload item, used by the Workloads overview
+ * chart. Replica-based workloads only use the binary healthy/failed distinction,
+ * but item-based workloads (Pods) also need to tell genuine failures apart from
+ * transitional states (Pending, Terminating) and degraded-but-running items.
+ */
+export type WorkloadHealthCategory = 'healthy' | 'degraded' | 'transitional' | 'failed';
+
 export type Workload =
   | Pod
   | DaemonSet

--- a/frontend/src/lib/k8s/pod.test.ts
+++ b/frontend/src/lib/k8s/pod.test.ts
@@ -140,6 +140,16 @@ describe('Pod class', () => {
       expect(pod.getHealth()).toBe('failed');
     });
 
+    it('classifies a terminated container with a non-zero exitCode and empty reason as failed', () => {
+      const pod = makePod({
+        phase: 'Pending',
+        initContainerStatuses: [
+          { name: 'init', state: { terminated: { exitCode: 1, reason: '' } } },
+        ],
+      });
+      expect(pod.getHealth()).toBe('failed');
+    });
+
     it('classifies a Failed pod as failed', () => {
       const pod = makePod({ phase: 'Failed' });
       expect(pod.getHealth()).toBe('failed');

--- a/frontend/src/lib/k8s/pod.test.ts
+++ b/frontend/src/lib/k8s/pod.test.ts
@@ -81,4 +81,73 @@ describe('Pod class', () => {
     const pod = new Pod(data);
     expect(() => pod.getDetailedStatus()).not.toThrow();
   });
+
+  describe('getHealth', () => {
+    const makePod = (status: any, metadata: any = {}) =>
+      new Pod({
+        ...mockPodData,
+        metadata: { ...mockPodData.metadata, ...metadata },
+        status,
+      } as any);
+
+    it('classifies a Running and Ready pod as healthy', () => {
+      const pod = makePod({
+        phase: 'Running',
+        conditions: [{ type: 'Ready', status: 'True' }],
+      });
+      expect(pod.getHealth()).toBe('healthy');
+    });
+
+    it('classifies a Running but NotReady pod as degraded', () => {
+      const pod = makePod({
+        phase: 'Running',
+        conditions: [{ type: 'Ready', status: 'False' }],
+      });
+      expect(pod.getHealth()).toBe('degraded');
+    });
+
+    it('classifies a Pending pod as transitional', () => {
+      const pod = makePod({ phase: 'Pending' });
+      expect(pod.getHealth()).toBe('transitional');
+    });
+
+    it('classifies a terminating (deletionTimestamp) pod as transitional', () => {
+      const pod = makePod({ phase: 'Running' }, { deletionTimestamp: '2020-01-01T00:00:00Z' });
+      expect(pod.getHealth()).toBe('transitional');
+    });
+
+    it('classifies a lost node (NodeLost) pod as failed', () => {
+      const pod = makePod(
+        { phase: 'Running', reason: 'NodeLost' },
+        { deletionTimestamp: '2020-01-01T00:00:00Z' }
+      );
+      expect(pod.getHealth()).toBe('failed');
+    });
+
+    it('classifies a pod with a CrashLoopBackOff container as failed', () => {
+      const pod = makePod({
+        phase: 'Running',
+        containerStatuses: [{ name: 'c', state: { waiting: { reason: 'CrashLoopBackOff' } } }],
+      });
+      expect(pod.getHealth()).toBe('failed');
+    });
+
+    it('classifies a pod with an ImagePullBackOff container as failed', () => {
+      const pod = makePod({
+        phase: 'Pending',
+        containerStatuses: [{ name: 'c', state: { waiting: { reason: 'ImagePullBackOff' } } }],
+      });
+      expect(pod.getHealth()).toBe('failed');
+    });
+
+    it('classifies a Failed pod as failed', () => {
+      const pod = makePod({ phase: 'Failed' });
+      expect(pod.getHealth()).toBe('failed');
+    });
+
+    it('classifies a Succeeded pod as healthy', () => {
+      const pod = makePod({ phase: 'Succeeded' });
+      expect(pod.getHealth()).toBe('healthy');
+    });
+  });
 });

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -21,6 +21,23 @@ import { stream } from './api/v1/streamingApi';
 import type { KubeCondition, KubeContainer, KubeContainerStatus, Time } from './cluster';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
+import type { WorkloadHealthCategory } from './Workload';
+
+/** Container waiting/terminated reasons that represent a genuine failure rather than normal startup. */
+const POD_FAILED_CONTAINER_REASONS = [
+  'CrashLoopBackOff',
+  'ImagePullBackOff',
+  'ErrImagePull',
+  'ErrImageNeverPull',
+  'InvalidImageName',
+  'CreateContainerError',
+  'CreateContainerConfigError',
+  'RunContainerError',
+  'OOMKilled',
+  'Error',
+  'ContainerCannotRun',
+  'DeadlineExceeded',
+];
 
 export interface KubeVolume {
   name: string;
@@ -530,6 +547,58 @@ class Pod extends KubeObject<KubePod> {
 
     return newDetails;
   }
+
+  /**
+   * Classifies the pod into a coarse health category for the Workloads overview
+   * chart. Pods have no replica fields, so the replica-mismatch logic used for
+   * other workloads can't apply. This relies on the same signals the Pods list
+   * shows (phase, readiness, container state, deletionTimestamp) so the chart
+   * and the list can't disagree. Terminating and Pending pods are treated as
+   * transitional rather than failures.
+   */
+  getHealth(): WorkloadHealthCategory {
+    // A lost node is reported as Unknown (unhealthy), matching getDetailedStatus.
+    if (this.metadata.deletionTimestamp) {
+      return this.status?.reason === 'NodeLost' ? 'failed' : 'transitional';
+    }
+
+    const phase = this.status?.phase;
+    if (phase === 'Succeeded') {
+      return 'healthy';
+    }
+
+    const containerStatuses = [
+      ...(this.status?.containerStatuses || []),
+      ...(this.status?.initContainerStatuses || []),
+    ];
+    // Failures surface either as a waiting reason (CrashLoopBackOff, ImagePull…)
+    // or as the current terminated reason (Error, OOMKilled…). lastState is
+    // intentionally ignored so a container that already recovered isn't flagged.
+    const hasFailingContainer = containerStatuses.some(cs => {
+      const reason = cs.state?.waiting?.reason || cs.state?.terminated?.reason;
+      return !!reason && POD_FAILED_CONTAINER_REASONS.includes(reason);
+    });
+    if (phase === 'Failed' || hasFailingContainer) {
+      return 'failed';
+    }
+
+    // Pending without a failing container is still starting up (scheduling,
+    // ContainerCreating, PodInitializing, …).
+    if (phase === 'Pending') {
+      return 'transitional';
+    }
+
+    const isReady = (this.status?.conditions || []).some(
+      condition => condition.type === 'Ready' && condition.status === 'True'
+    );
+    if (phase === 'Running') {
+      return isReady ? 'healthy' : 'degraded';
+    }
+
+    // Unknown / NodeLost and anything else we can't place is treated as failed.
+    return 'failed';
+  }
+
   static getBaseObject(): KubePod {
     const baseObject = super.getBaseObject() as KubePod;
     baseObject.metadata = {

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -575,7 +575,14 @@ class Pod extends KubeObject<KubePod> {
     // or as the current terminated reason (Error, OOMKilled…). lastState is
     // intentionally ignored so a container that already recovered isn't flagged.
     const hasFailingContainer = containerStatuses.some(cs => {
-      const reason = cs.state?.waiting?.reason || cs.state?.terminated?.reason;
+      const terminated = cs.state?.terminated;
+      // A container terminated with a non-zero exit code or signal is a failure
+      // even when the reason is empty/unspecified, mirroring the ExitCode:/Signal:
+      // handling in getDetailedStatus.
+      if (terminated && (terminated.exitCode || terminated.signal)) {
+        return true;
+      }
+      const reason = cs.state?.waiting?.reason || terminated?.reason;
       return !!reason && POD_FAILED_CONTAINER_REASONS.includes(reason);
     });
     if (phase === 'Failed' || hasFailingContainer) {


### PR DESCRIPTION
## What this fixes

Fixes #6090.

On the Workloads overview, the **Pods** status chart always reported `100% / "N Running"`, even when pods were in `Error`, `CrashLoopBackOff`, `ImagePullBackOff`, `Pending`, etc. — it was structurally incapable of ever showing an unhealthy pod.

### Root cause

`WorkloadCircleChart` computes the failed count with a replica-mismatch check:

```ts
workloadData?.filter(item => getReadyReplicas(item) !== getTotalReplicas(item)).length
```

`getReadyReplicas`/`getTotalReplicas` only read replica fields (`status.readyReplicas`, `status.numberReady`, `spec.replicas`, `status.currentNumberScheduled`, `status.desiredNumberScheduled`). A Pod has **none** of these, so both helpers return `0`, the check is always `0 !== 0` → `false`, and the Pods tile can only ever render `100%`. This is correct for replica-based kinds (Deployment/StatefulSet/DaemonSet/ReplicaSet) but wrong for Pods.

## Approach

- Add an optional `categorize()` classifier to `WorkloadCircleChart`. When provided (Pods only), the chart renders a **multi-segment health ring** instead of the binary one:
  - 🟢 **healthy** — Running & Ready, or Succeeded
  - 🟡 **degraded** — Running but not Ready
  - ⚪ **transitional** — Pending / Terminating (not failures)
  - 🔴 **failed** — Failed phase, or a container in CrashLoopBackOff / ImagePullBackOff / etc.
- Replica-based tiles keep their existing **binary behavior unchanged**.
- `getPodHealth()` derives the category from the **same signals the Pods list already shows** (phase, readiness, container waiting reason, `deletionTimestamp`), so the chart and the list can't disagree. Notably, **Terminating and Pending pods are transitional, not failures**, which avoids a false-alarm red arc.

## Before / after

On a cluster with 89 pods (50 Running&Ready, 13 not-ready, 19 Pending/Terminating, 7 genuinely failing):

| | Center | Legend |
|---|---|---|
| Before | `100%` | `89 Running` |
| After | `56.2%` | `50 Running` · `7 Failed · 13 Degraded · 19 Other` |

## Testing

- Updated the `Overview` storyshot (Pods tile now reflects real health instead of a flat 100%).
- Charts storyshots for the replica-based tiles are unchanged (binary path untouched).
- `tsc` and `eslint` clean; i18n strings extracted.
