### PR TITLE
frontend: limitRange: Show maxLimitRequestRatio in detail view

### DIFF
--- a/frontend/src/components/limitRange/Details.tsx
+++ b/frontend/src/components/limitRange/Details.tsx
@@ -55,6 +55,14 @@ export function LimitRangeDetails(props: { name?: string; namespace?: string; cl
                   <Typography variant="h6">{t('translation|Min')}</Typography>
                   <MetadataDictGrid dict={item?.jsonData?.spec?.limits?.[0]?.min} />
                 </Box>
+                {item?.jsonData?.spec?.limits?.[0]?.maxLimitRequestRatio && (
+                  <Box m={1}>
+                    <Typography variant="h6">{t('translation|Max Limit/Request Ratio')}</Typography>
+                    <MetadataDictGrid
+                      dict={item?.jsonData?.spec?.limits?.[0]?.maxLimitRequestRatio}
+                    />
+                  </Box>
+                )}
               </>
             ),
           },

--- a/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
+++ b/frontend/src/components/limitRange/__snapshots__/Details.LimitRangeDetail.stories.storyshot
@@ -293,6 +293,33 @@
                         </div>
                       </div>
                     </div>
+                    <div
+                      class="MuiBox-root css-1ynyhby"
+                    >
+                      <h6
+                        class="MuiTypography-root MuiTypography-h6 css-k6p83p-MuiTypography-root"
+                      >
+                        Max Limit/Request Ratio
+                      </h6>
+                      <div
+                        class="MuiBox-root css-0"
+                      >
+                        <div
+                          class="MuiBox-root css-yi3mkw"
+                        >
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                          >
+                            cpu: 2
+                          </p>
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 css-1on669h-MuiTypography-root"
+                          >
+                            memory: 1.5
+                          </p>
+                        </div>
+                      </div>
+                    </div>
                   </dd>
                 </dl>
               </div>

--- a/frontend/src/components/limitRange/storyHelper.ts
+++ b/frontend/src/components/limitRange/storyHelper.ts
@@ -41,6 +41,10 @@ export const LIMIT_RANGE_DUMMY_DATA = [
             cpu: '500m',
             memory: '1Gi',
           },
+          maxLimitRequestRatio: {
+            cpu: '2',
+            memory: '1.5',
+          },
           min: {
             cpu: '10m',
             memory: '4Mi',

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -657,6 +657,7 @@
   "Default Request": "الطلب الافتراضي",
   "Max": "الحد الأقصى",
   "Min": "الحد الأدنى",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "يوجد نطاق بهذا الاسم بالفعل",
   "Namespaces must be under 64 characters.": "يجب أن يكون اسم النطاق أقل من 64 حرفًا",
   "Create Namespace": "إنشاء نطاق",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -637,6 +637,7 @@
   "Default Request": "Default অনুরোধ",
   "Max": "সর্বোচ্চ",
   "Min": "সর্বনিম্ন",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "এই নাম সহ একটি namespace ইতিমধ্যে বিদ্যমান।",
   "Namespaces must be under 64 characters.": "namespace গুলি অবশ্যই 64 টি অক্ষরের অধীনে থাকতে হবে।",
   "Create Namespace": "namespace Create করুন",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -637,6 +637,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -637,6 +637,7 @@
   "Default Request": "Default Request",
   "Max": "Max",
   "Min": "Min",
+  "Max Limit/Request Ratio": "Max Limit/Request Ratio",
   "A namespace with this name already exists.": "A namespace with this name already exists.",
   "Namespaces must be under 64 characters.": "Namespaces must be under 64 characters.",
   "Create Namespace": "Create Namespace",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -642,6 +642,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -642,6 +642,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -642,6 +642,7 @@
   "Default Request": "Default Request",
   "Max": "Max",
   "Min": "Min",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "A namespace with this name already exists.",
   "Namespaces must be under 64 characters.": "Namespaces must be under 64 characters.",
   "Create Namespace": "Create Namespace",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -637,6 +637,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -642,6 +642,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -632,6 +632,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -632,6 +632,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -642,6 +642,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -647,6 +647,7 @@
   "Default Request": "Запрос по умолчанию",
   "Max": "Макс",
   "Min": "Мин",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "Пространство имён с таким именем уже существует.",
   "Namespaces must be under 64 characters.": "Пространства имён должны содержать менее 64 символов.",
   "Create Namespace": "Создать пространство имён",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -637,6 +637,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -637,6 +637,7 @@
   "Default Request": "ڈیفالٹ درخواست",
   "Max": "زیادہ سے زیادہ",
   "Min": "کم سے کم",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "اس نام کا نیم اسپیس پہلے سے موجود ہے",
   "Namespaces must be under 64 characters.": "نیم اسپیس 64 حروف سے کم ہونا چاہیے",
   "Create Namespace": "نیم اسپیس بنائیں",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -632,6 +632,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -632,6 +632,7 @@
   "Default Request": "",
   "Max": "",
   "Min": "",
+  "Max Limit/Request Ratio": "",
   "A namespace with this name already exists.": "",
   "Namespaces must be under 64 characters.": "",
   "Create Namespace": "",

--- a/frontend/src/lib/k8s/limitRange.tsx
+++ b/frontend/src/lib/k8s/limitRange.tsx
@@ -31,6 +31,9 @@ export interface LimitRangeSpec {
       cpu: string;
       memory: string;
     };
+    maxLimitRequestRatio?: {
+      [resourceName: string]: string;
+    };
     min: {
       cpu: string;
       memory: string;


### PR DESCRIPTION
## Summary

Issue #6115 

Adds `maxLimitRequestRatio` display to the LimitRange detail view alongside existing LimitRange constraints.

## Changes

* Added `maxLimitRequestRatio` to the `LimitRangeItem` type in `frontend/src/lib/k8s/limitRange.tsx`
* Added conditional rendering of `maxLimitRequestRatio` in `frontend/src/components/limitRange/Details.tsx`
* Extended Storybook fixtures to include a scenario with `maxLimitRequestRatio`
* Updated Storybook snapshot
* Added translation entries for the new label across all 17 locales

## Notes for Reviewers

- `maxLimitRequestRatio` renders only when present in the LimitRange item.
  Other constraint sections (`max`, `min`, `default`, `defaultRequest`)
  are unchanged and continue to render unconditionally.
* The change is limited to the details view and associated Storybook/i18n updates.
* Existing rendering for `max`, `min`, `default`, and `defaultRequest` is unchanged.
* Storybook fixtures include an example that exercises the new UI section.
