### PR TITLE
fix: move sidebar toggle button up to avoid OS taskbar overlap

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -137,6 +137,7 @@ const DefaultLinkArea = memo((props: { sidebarName: string; isOpen: boolean }) =
         alignItems="center"
         flexDirection={isOpen ? 'row' : 'column'}
         p={1}
+        sx={{ marginBottom: '40px' }}
       >
         <Box>{isElectron() && <AddClusterButton />}</Box>
         <Box>
@@ -155,6 +156,7 @@ const DefaultLinkArea = memo((props: { sidebarName: string; isOpen: boolean }) =
         alignItems="center"
         flexDirection={isOpen ? 'row' : 'column'}
         p={1}
+        sx={{ marginBottom: '40px' }}
       >
         <Box>
           <VersionButton />

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -178,7 +178,7 @@
                 class="MuiBox-root css-xi606m"
               >
                 <div
-                  class="MuiBox-root css-1h413jj"
+                  class="MuiBox-root css-9c2sar"
                 >
                   <div
                     class="MuiBox-root css-0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
@@ -196,7 +196,7 @@
                 class="MuiBox-root css-xi606m"
               >
                 <div
-                  class="MuiBox-root css-phsv6y"
+                  class="MuiBox-root css-dsmt5k"
                 >
                   <div
                     class="MuiBox-root css-0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -1422,7 +1422,7 @@
                     />
                   </button>
                   <div
-                    class="MuiBox-root css-1h413jj"
+                    class="MuiBox-root css-9c2sar"
                   >
                     <div
                       class="MuiBox-root css-0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -1484,7 +1484,7 @@
                     />
                   </button>
                   <div
-                    class="MuiBox-root css-phsv6y"
+                    class="MuiBox-root css-dsmt5k"
                   >
                     <div
                       class="MuiBox-root css-0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -1484,7 +1484,7 @@
                     />
                   </button>
                   <div
-                    class="MuiBox-root css-phsv6y"
+                    class="MuiBox-root css-dsmt5k"
                   >
                     <div
                       class="MuiBox-root css-0"


### PR DESCRIPTION
## Summary

This PR fixes the sidebar toggle button becoming unclickable when the OS taskbar auto-hides and pops up over the sidebar, by adding a 40px bottom margine to push the toggle controls up from the bottom edge.

## Related Issue

Fixes #1287 

## Changes

- Added 'marginBottom: '40px' to the Box containing sidebarToggleButton in both the Home sidebar and regular sidebar layouts in Sidebar.tsx
- Updated storybook snapshots to reflect the new spacing

## Steps to Test

1. Enable Windows taskbar auto-hide (Taskbar settings -> Taskbar behaviors -> Automatically hide the taskbar).
2. Open Headlamp and let the taskbar pop up (move mouse to bottom of screen or trigger a notification).
3. Verify the sidebar toggle button is now visible and clickable, no longer behind the taskbar.

## Screenshots (if applicable)
- Before : <img width="815" height="1032" alt="Screenshot 2026-06-21 141422" src="https://github.com/user-attachments/assets/236edcfe-e394-4c27-a8ca-72bf0c8960f9" />
- After: 
<img width="667" height="962" alt="Screenshot 2026-06-21 141548" src="https://github.com/user-attachments/assets/86508bba-cc73-4241-877b-cb825e246a5c" />

## Notes for the Reviewer

-This is a minimal CSS fix that adds spacing without changing any sidebar functionality. All existing tests pass with updated snapshots reflecting the new layout.
