### PR TITLE
frontend: storybook: Fix startup failure caused by node story helpers

### DIFF
--- a/frontend/src/components/node/storyHelper.ts
+++ b/frontend/src/components/node/storyHelper.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { KubeMetrics } from '../../lib/k8s/cluster';
-import { KubeNode, NODE_POOL_LABEL_KEYS } from '../../lib/k8s/node';
+import type { KubeMetrics } from '../../lib/k8s/cluster';
+import type { KubeNode } from '../../lib/k8s/node';
+import { NODE_POOL_LABEL_KEYS } from '../../lib/k8s/nodeConstants';
 
 const creationTimestamp = new Date('2022-01-01').toISOString();
 

--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -23,6 +23,7 @@ import { KubeNodeSummaryStats, nodeSummaryStats } from './api/v2/nodeSummaryApi'
 import type { KubeCondition, KubeMetrics } from './cluster';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
+import { NODE_POOL_LABEL_KEYS } from './nodeConstants';
 
 export interface KubeNode extends KubeObjectInterface {
   status: {
@@ -62,18 +63,6 @@ export interface KubeNode extends KubeObjectInterface {
     [otherProps: string]: any;
   };
 }
-
-/**
- * The exact label keys checked by {@link Node.getNodePool}.
- * Export this so test helpers and stories can strip them without drifting.
- */
-export const NODE_POOL_LABEL_KEYS = [
-  'cloud.google.com/gke-nodepool',
-  'kubernetes.azure.com/agentpool',
-  'eks.amazonaws.com/nodegroup',
-  'kops.k8s.io/instancegroup',
-  'cluster.x-k8s.io/deployment-name',
-] as const;
 
 class Node extends KubeObject<KubeNode> {
   static kind = 'Node';
@@ -169,5 +158,9 @@ class Node extends KubeObject<KubeNode> {
     return '';
   }
 }
+
+// Re-export for plugin compatibility. Import directly from nodeConstants.ts
+// when only the label keys are needed to avoid loading the Node implementation.
+export { NODE_POOL_LABEL_KEYS };
 
 export default Node;

--- a/frontend/src/lib/k8s/nodeConstants.ts
+++ b/frontend/src/lib/k8s/nodeConstants.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The exact label keys checked by Node.getNodePool().
+ *
+ * Exported separately so stories, tests, and other consumers can use the
+ * same source of truth without importing the full Node implementation.
+ */
+export const NODE_POOL_LABEL_KEYS = [
+  'cloud.google.com/gke-nodepool',
+  'kubernetes.azure.com/agentpool',
+  'eks.amazonaws.com/nodegroup',
+  'kops.k8s.io/instancegroup',
+  'cluster.x-k8s.io/deployment-name',
+] as const;


### PR DESCRIPTION
## Summary

This PR fixes a Storybook startup failure caused by an unnecessary runtime dependency on the Node implementation.

Storybook failed to start and all stories remained stuck loading, with the browser console reporting:

```text
Cannot access 'KubeObject' before initialization
```

Investigation showed that Storybook's `baseMocks` imported `node/storyHelper`, which imported `NODE_POOL_LABEL_KEYS` and type definitions from `node.ts`. Although `storyHelper` only needed a constant and type information, importing from `node.ts` caused the entire Node/KubeObject dependency graph to be evaluated during Storybook startup, leading to the initialization error.

This PR extracts `NODE_POOL_LABEL_KEYS` into a dedicated constants module and updates `storyHelper` to use type-only imports, avoiding the unnecessary runtime dependency while preserving existing public exports.

## Related Issue

Fixes #6125

## Changes

* Added `src/lib/k8s/nodeConstants.ts` and moved `NODE_POOL_LABEL_KEYS` into it.
* Updated `src/components/node/storyHelper.ts` to:

  * Use type-only imports for `KubeNode` and `KubeMetrics`.
  * Import `NODE_POOL_LABEL_KEYS` directly from `nodeConstants.ts`.
* Re-exported `NODE_POOL_LABEL_KEYS` from `src/lib/k8s/node.ts` to preserve plugin and consumer compatibility.
* Added documentation around the re-export explaining its purpose.

## Steps to Test

1. Start Storybook before applying the fix.
2. Observe that Storybook fails to load and the browser console reports:

   ```text
   Cannot access 'KubeObject' before initialization
   ```
3. Apply the changes from this PR.
4. Start Storybook again.
5. Verify that Storybook loads successfully and stories render normally.

Additionally verify:

```bash
npm run tsc
npm run lint
npm test
```

All pass successfully.

## Screenshots

### Before

Storybook failed to load and remained stuck rendering stories. The browser console reported:

```text
Cannot access 'KubeObject' before initialization
```

<p align="center">
  <img width="48%" alt="storybook-loading-spinner-before" src="https://github.com/user-attachments/assets/e4a2d461-03b2-439e-826b-8b864ee9b4d6" />
  <img width="48%" alt="storybook-console-error-before" src="https://github.com/user-attachments/assets/42e5ddee-eaf7-46bb-937c-87988d03fdbb" />
</p>

### After

Storybook starts successfully and stories render normally.

<p align="center">
  <img width="48%" alt="storybook-rendering-success-after" src="https://github.com/user-attachments/assets/5863db91-1834-46d8-aaef-b85a142bceaa" />
  <img width="48%" alt="storybook-console-clean-after" src="https://github.com/user-attachments/assets/225141b1-f714-4e79-9b68-82d41a112312" />
</p>


## Notes for the Reviewer

* The change is intentionally minimal and does not modify Node functionality.
* `NODE_POOL_LABEL_KEYS` continues to be exported from `node.ts` to maintain plugin compatibility and avoid breaking existing consumers.
* The primary goal is to avoid loading the full Node/KubeObject runtime dependency graph when only constants and type information are required.
