### PR TITLE
backend: k8cache: percent-encode '+' in cache key fields to avoid delimiter collision

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -22,7 +22,6 @@ package k8cache
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -342,7 +341,7 @@ func handleKeyGenerationAndDeletion(obj interface{}, gvr schema.GroupVersionReso
 	}
 
 	namespace := unstructuredObj.GetNamespace()
-	key := fmt.Sprintf("%s+%s+%s+%s", gvr.Group, gvr.Resource, namespace, contextKey)
+	key := buildCacheKey(gvr.Group, gvr.Resource, namespace, contextKey)
 
 	logger.Log(logger.LevelInfo, nil, nil, redactCacheKey(key)+" will be deleted from the cache")
 

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -162,6 +162,40 @@ func ExtractNamespace(rawURL string) (string, string) {
 	return namespace, kind
 }
 
+// buildCacheKey joins apiGroup, kind, namespace, and contextID into a single
+// cache key using "+" as the delimiter. Each field is percent-escaped so
+// that the only "+" characters left in the key are the delimiters
+// themselves and the encoding round-trips uniquely back to its inputs.
+// This matters most for the context field, since kubeconfig context names
+// are not restricted by Kubernetes naming rules and may legitimately
+// contain "+" (or "%").
+//
+// This function is the single source of truth for constructing cache keys.
+// Any code that parses or otherwise manipulates the key format (e.g. the
+// namespace stripping in cache invalidation) must stay consistent with this
+// encoding to avoid the two sides silently drifting out of sync.
+func buildCacheKey(apiGroup, kind, namespace, contextID string) string {
+	// Escape "%" first, then "+". This order matters: it makes the encoding
+	// injective, so e.g. "prod+cluster" -> "prod%2Bcluster" and the literal
+	// string "prod%2Bcluster" -> "prod%252Bcluster" never collide. Reversing
+	// the order (or skipping "%") would map both inputs to the same key and
+	// reintroduce the collision class this function exists to prevent.
+	escape := func(s string) string {
+		s = strings.ReplaceAll(s, "%", "%25")
+		s = strings.ReplaceAll(s, "+", "%2B")
+
+		return s
+	}
+
+	return fmt.Sprintf(
+		"%s+%s+%s+%s",
+		escape(apiGroup),
+		escape(kind),
+		escape(namespace),
+		escape(contextID),
+	)
+}
+
 // GenerateKey function helps to generate a unique key based on the request from the client
 // The function accepts url( which includes all the information of request ) and contextID which
 // helps to differentiate in multiple contexts.
@@ -179,10 +213,7 @@ func GenerateKey(url *url.URL, contextID string) (string, error) {
 		Context:   contextID,
 	}
 
-	// Create a stable representation
-	raw := fmt.Sprintf("%s+%s+%s+%s", apiGroup, k.Kind, k.Namespace, k.Context)
-
-	return raw, nil
+	return buildCacheKey(apiGroup, k.Kind, k.Namespace, k.Context), nil
 }
 
 // SetHeader function help to serve response from cache to ensure the client

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -497,6 +497,23 @@ func TestGenerateKey(t *testing.T) {
 			expectedKey: "",
 			expectedErr: errors.New("invalid url format"),
 		},
+		{
+			name:        "context key containing a literal plus is escaped, not treated as delimiter",
+			urlPath:     url.URL{Path: "/clusters/kind-kind/apis/apps/v1/namespaces/default/deployments"},
+			contextKey:  "prod+cluster",
+			expectedKey: "apps+deployments+default+prod%2Bcluster",
+			expectedErr: nil,
+		},
+		{
+			// Regression: ensures the escape is injective. If "%" weren't
+			// escaped first, this input would collide with "prod+cluster"
+			// above and both would produce the same cache key.
+			name:        "context key containing a literal percent sequence does not collide with the plus-escaped form",
+			urlPath:     url.URL{Path: "/clusters/kind-kind/apis/apps/v1/namespaces/default/deployments"},
+			contextKey:  "prod%2Bcluster",
+			expectedKey: "apps+deployments+default+prod%252Bcluster",
+			expectedErr: nil,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR fixes a cache-key collision bug by percent-encoding any literal `+` character in the fields used to build k8cache keys, so the `+` delimiter can no longer be ambiguous with field content.

## Related Issue
Fixes #6123

## Changes
-> Updated `GenerateKey` in `backend/pkg/k8cache/cacheStore.go` to escape literal `+` to `%2B` in `apiGroup`, `kind`, `namespace`, and `contextID` before joining them with `+` to form the cache key
-> Added a regression test case to `TestGenerateKey` in `backend/pkg/k8cache/cacheStore_test.go` covering a context name containing `+`

## Steps to Test
1. Use a kubeconfig context whose name contains a `+`, e.g. `prod+cluster`
2. Call `GenerateKey` with a request URL and that context name
3. Before this fix: the resulting key has more than 4 `+`-delimited segments (e.g.`apps+deployments+default+prod+cluster`), which breaks`DeleteKeys`'s positional namespace-stripping (`keyPart[2] = ""`) andcan cause cache invalidation to target the wrong key
4. After this fix: the `+` in the context name is escaped to `%2B` (`apps+deployments+default+prod%2Bcluster`), so the key always has exactly 4 segments and `DeleteKeys` parses it correctly
5. Run `go test ./pkg/k8cache/...` - all existing tests pass unchanged, plus the new regression test

## Screenshots (if applicable)
N/A  (backend logic fix, no UI changes)

## Notes for the Reviewer
-> Both `GenerateKey` and `cacheInvalidation.go` now route through `buildCacheKey` instead of duplicating the `fmt.Sprintf("%s+%s+%s+%s", ...)` format string, addressing the earlier Copilot concern about format drift between the two sides
-> **Behavior change:** the escape covers both `+` *and* `%`, not just `+`, so cache keys for context names containing literal `%` will also change after this update. This is intentional escaping only `+` would leave the encoding non-injective.
-> No existing test fixtures use `+` or `%` in any field, so this change is backward compatible for typical kubeconfig contexts
-> `gofmt`, `go vet`, and backend tests under `-race` all pass clean