### PR TITLE
frontend: fix spelling mistake in headlampEventSlice file

### DIFF
--- a/frontend/src/redux/headlampEventSlice.ts
+++ b/frontend/src/redux/headlampEventSlice.ts
@@ -366,8 +366,8 @@ export const listenerMiddleware =
   createListenerMiddleware<Pick<RootState, 'eventCallbackReducer'>>();
 listenerMiddleware.startListening({
   actionCreator: eventAction,
-  effect: async (action, listernerApi) => {
-    const trackerFuncs = listernerApi.getState()?.eventCallbackReducer?.trackerFuncs;
+  effect: async (action, listenerApi) => {
+    const trackerFuncs = listenerApi.getState()?.eventCallbackReducer?.trackerFuncs;
     for (const trackerFunc of trackerFuncs) {
       try {
         trackerFunc(action.payload);


### PR DESCRIPTION
## Summary

This PR fixes spelling mistake in the code

## Related Issue

Fixes #6130   

## Changes
current text: "listernerApi"
correction: "listenerApi
