### PR TITLE
backend: cmd: Isolate TestDynamicClustersKubeConfig from real Headlamp config dir

### DIFF
--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -364,6 +364,10 @@ func TestDynamicClusters(t *testing.T) {
 }
 
 func TestDynamicClustersKubeConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("APPDATA", t.TempDir())
+
 	kubeConfigByte, err := os.ReadFile("./headlamp_testdata/kubeconfig")
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
This PR fixes `TestDynamicClustersKubeConfig` writing to the real `~/.config/Headlamp/kubeconfigs/config` file by isolating the test's config directory using `t.Setenv` on `HOME`, `XDG_CONFIG_HOME`, and `APPDATA`, preventing test runs from polluting the user's actual Headlamp configuration.
## Related Issue
Fixes #6134
## Changes
- Added `t.Setenv("HOME", t.TempDir())`, `t.Setenv("XDG_CONFIG_HOME", t.TempDir())`, and `t.Setenv("APPDATA", t.TempDir())` at the start of `TestDynamicClustersKubeConfig` in `backend/cmd/headlamp_test.go`
- Redirected `os.UserConfigDir()` resolution (used by `defaultHeadlampKubeConfigFile()` and `cfg.MakeHeadlampKubeConfigsDir()`) to a temp directory for the duration of the test
## Steps to Test
1. Run `rm -f ~/.config/Headlamp/kubeconfigs/config` to remove any existing dynamic cluster config
2. Run `cd backend && go test ./cmd/ -run TestDynamicClustersKubeConfig -v` and confirm it passes
3. Run `cat ~/.config/Headlamp/kubeconfigs/config` and confirm the file was not created or modified
## Screenshots 
<img width="1497" height="606" alt="image" src="https://github.com/user-attachments/assets/82c08295-4abf-49b7-9a33-eff260ce3dce" />

## Notes for the Reviewer
- This follows the same `t.Setenv` isolation pattern already used in `TestCreateHeadlampHandlerSkipsInClusterContextWhenConfigUnavailable` in the same file
- No production code changes were needed, the bug was purely missing test isolation setup