### PR TITLE
frontend: k8s: Extract KubeObject hooks into standalone hook functions

### DIFF
--- a/frontend/src/lib/k8s/KubeObject.hooks.test.tsx
+++ b/frontend/src/lib/k8s/KubeObject.hooks.test.tsx
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the k8s barrel, event module, Redux store, and router functions to prevent circular initialization issues.
+// KubeObject.ts imports createRouteURL, which imports getRoutePath, which imports
+// router/index, which imports deployment.ts and loads all resources.
+vi.mock('.', () => ({}));
+vi.mock('./event', () => ({}));
+vi.mock('../router/createRouteURL', () => ({
+  createRouteURL: vi.fn(),
+}));
+vi.mock('../../redux/stores/store', () => ({
+  default: {
+    getState: () => ({}),
+    dispatch: () => {},
+    subscribe: () => () => {},
+  },
+}));
+
+// Mock dependencies before importing the hooks under test.
+const mockUseKubeObjectList = vi.fn().mockReturnValue({
+  data: null,
+  items: null,
+  error: null,
+  isError: false,
+  isLoading: true,
+  isFetching: true,
+  isSuccess: false,
+  status: 'pending',
+  clusterResults: {},
+  errors: null,
+});
+const mockMakeListRequests = vi.fn().mockReturnValue([{ cluster: '', namespaces: [] }]);
+
+vi.mock('./api/v2/useKubeObjectList', () => ({
+  useKubeObjectList: (...args: any[]) => mockUseKubeObjectList(...args),
+  makeListRequests: (...args: any[]) => mockMakeListRequests(...args),
+}));
+
+const mockUseKubeObject = vi.fn().mockReturnValue(
+  Object.assign([null, null], {
+    data: null,
+    error: null,
+    isError: false,
+    isLoading: true,
+    isFetching: true,
+    isSuccess: false,
+    status: 'pending',
+  })
+);
+
+vi.mock('./api/v2/hooks', () => ({
+  useKubeObject: (...args: any[]) => mockUseKubeObject(...args),
+}));
+
+const mockUseConnectApi = vi.fn();
+const mockUseSelectedClusters = vi.fn().mockReturnValue(['test-cluster']);
+
+vi.mock('./api/v1/hooks', () => ({
+  useConnectApi: (...args: any[]) => mockUseConnectApi(...args),
+  useSelectedClusters: (...args: any[]) => mockUseSelectedClusters(...args),
+}));
+
+import { useKubeApiGet, useKubeApiList, useKubeGet, useKubeList } from './KubeObject';
+
+// A minimal mock class that satisfies the KubeObject type constraints
+const MockKubeClass = class {
+  static apiVersion = 'v1';
+  static apiName = 'pods';
+  static kind = 'Pod';
+  static isNamespaced = true;
+
+  static apiEndpoint = {
+    apiInfo: [{ group: '', resource: 'pods', version: 'v1' }],
+  };
+
+  static apiList = vi.fn().mockReturnValue(() => Promise.resolve(() => {}));
+  static apiGet = vi.fn().mockReturnValue(() => Promise.resolve(() => {}));
+
+  constructor(public jsonData: any) {}
+} as any;
+
+const MockClusterScopedClass = class {
+  static apiVersion = 'v1';
+  static apiName = 'nodes';
+  static kind = 'Node';
+  static isNamespaced = false;
+
+  static apiEndpoint = {
+    apiInfo: [{ group: '', resource: 'nodes', version: 'v1' }],
+  };
+
+  static apiList = vi.fn().mockReturnValue(() => Promise.resolve(() => {}));
+  static apiGet = vi.fn().mockReturnValue(() => Promise.resolve(() => {}));
+
+  constructor(public jsonData: any) {}
+} as any;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useKubeList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSelectedClusters.mockReturnValue(['test-cluster']);
+  });
+
+  it('should call makeListRequests and useKubeObjectList with correct params', () => {
+    renderHook(() => useKubeList(MockKubeClass, { namespace: 'default' }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockMakeListRequests).toHaveBeenCalled();
+    expect(mockUseKubeObjectList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kubeObjectClass: MockKubeClass,
+      })
+    );
+  });
+
+  it('should use the provided cluster when specified', () => {
+    renderHook(() => useKubeList(MockKubeClass, { cluster: 'my-cluster' }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockMakeListRequests).toHaveBeenCalledWith(
+      ['my-cluster'],
+      expect.any(Function),
+      true,
+      undefined
+    );
+  });
+
+  it('should use the provided clusters array when specified', () => {
+    renderHook(() => useKubeList(MockKubeClass, { clusters: ['cluster-a', 'cluster-b'] }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockMakeListRequests).toHaveBeenCalledWith(
+      ['cluster-a', 'cluster-b'],
+      expect.any(Function),
+      true,
+      undefined
+    );
+  });
+
+  it('should fall back to selected clusters when no cluster is specified', () => {
+    mockUseSelectedClusters.mockReturnValue(['fallback-a', 'fallback-b']);
+
+    renderHook(() => useKubeList(MockKubeClass, {}), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockMakeListRequests).toHaveBeenCalledWith(
+      ['fallback-a', 'fallback-b'],
+      expect.any(Function),
+      true,
+      undefined
+    );
+  });
+
+  it('should handle a single namespace string', () => {
+    renderHook(() => useKubeList(MockKubeClass, { namespace: 'kube-system' }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockMakeListRequests).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Function),
+      true,
+      ['kube-system']
+    );
+  });
+
+  it('should handle a namespace array', () => {
+    renderHook(() => useKubeList(MockKubeClass, { namespace: ['ns-a', 'ns-b'] }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockMakeListRequests).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Function),
+      true,
+      ['ns-a', 'ns-b']
+    );
+  });
+
+  it('should pass refetchInterval to useKubeObjectList', () => {
+    renderHook(() => useKubeList(MockKubeClass, { refetchInterval: 5000 }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockUseKubeObjectList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refetchInterval: 5000,
+      })
+    );
+  });
+});
+
+describe('useKubeGet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delegate to useKubeObject with correct params', () => {
+    renderHook(() => useKubeGet(MockKubeClass, 'my-pod', 'default'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockUseKubeObject).toHaveBeenCalledWith({
+      kubeObjectClass: MockKubeClass,
+      name: 'my-pod',
+      namespace: 'default',
+      cluster: undefined,
+      queryParams: undefined,
+    });
+  });
+
+  it('should pass optional cluster and queryParams', () => {
+    renderHook(
+      () =>
+        useKubeGet(MockKubeClass, 'my-pod', 'default', {
+          cluster: 'my-cluster',
+          queryParams: { labelSelector: 'app=test' },
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(mockUseKubeObject).toHaveBeenCalledWith({
+      kubeObjectClass: MockKubeClass,
+      name: 'my-pod',
+      namespace: 'default',
+      cluster: 'my-cluster',
+      queryParams: { labelSelector: 'app=test' },
+    });
+  });
+
+  it('should work without namespace for cluster-scoped resources', () => {
+    renderHook(() => useKubeGet(MockClusterScopedClass, 'my-node'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockUseKubeObject).toHaveBeenCalledWith({
+      kubeObjectClass: MockClusterScopedClass,
+      name: 'my-node',
+      namespace: undefined,
+      cluster: undefined,
+      queryParams: undefined,
+    });
+  });
+});
+
+describe('useKubeApiList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockKubeClass.apiList.mockReturnValue(() => Promise.resolve(() => {}));
+    MockClusterScopedClass.apiList.mockReturnValue(() => Promise.resolve(() => {}));
+  });
+
+  it('should call useConnectApi', () => {
+    const onList = vi.fn();
+
+    renderHook(() => useKubeApiList(MockClusterScopedClass, onList), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockUseConnectApi).toHaveBeenCalled();
+  });
+
+  it('should create a single API call for cluster-scoped resources', () => {
+    const onList = vi.fn();
+
+    renderHook(() => useKubeApiList(MockClusterScopedClass, onList), {
+      wrapper: createWrapper(),
+    });
+
+    expect(MockClusterScopedClass.apiList).toHaveBeenCalledTimes(1);
+    expect(MockClusterScopedClass.apiList).toHaveBeenCalledWith(
+      onList,
+      undefined,
+      expect.objectContaining({ cluster: undefined })
+    );
+  });
+
+  it('should create per-namespace API calls for namespaced resources with explicit namespaces', () => {
+    const onList = vi.fn();
+
+    renderHook(
+      () =>
+        useKubeApiList(MockKubeClass, onList, undefined, {
+          namespace: ['ns-a', 'ns-b'],
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(MockKubeClass.apiList).toHaveBeenCalledTimes(2);
+    expect(MockKubeClass.apiList).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      expect.objectContaining({ namespace: 'ns-a' })
+    );
+    expect(MockKubeClass.apiList).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      expect.objectContaining({ namespace: 'ns-b' })
+    );
+  });
+
+  it('should handle a single namespace string', () => {
+    const onList = vi.fn();
+
+    renderHook(
+      () =>
+        useKubeApiList(MockKubeClass, onList, undefined, {
+          namespace: 'kube-system',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(MockKubeClass.apiList).toHaveBeenCalledTimes(1);
+    expect(MockKubeClass.apiList).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      expect.objectContaining({ namespace: 'kube-system' })
+    );
+  });
+
+  it('should pass cluster option through', () => {
+    const onList = vi.fn();
+
+    renderHook(
+      () =>
+        useKubeApiList(MockKubeClass, onList, undefined, {
+          namespace: 'default',
+          cluster: 'my-cluster',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(MockKubeClass.apiList).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      expect.objectContaining({ cluster: 'my-cluster' })
+    );
+  });
+
+  it('should pass the error callback', () => {
+    const onList = vi.fn();
+    const onError = vi.fn();
+
+    renderHook(() => useKubeApiList(MockClusterScopedClass, onList, onError), {
+      wrapper: createWrapper(),
+    });
+
+    expect(MockClusterScopedClass.apiList).toHaveBeenCalledWith(
+      onList,
+      onError,
+      expect.any(Object)
+    );
+  });
+});
+
+describe('useKubeApiGet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockKubeClass.apiGet.mockReturnValue(() => Promise.resolve(() => {}));
+  });
+
+  it('should call useConnectApi with apiGet result', () => {
+    const onGet = vi.fn();
+
+    renderHook(() => useKubeApiGet(MockKubeClass, onGet, 'my-pod', 'default'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(MockKubeClass.apiGet).toHaveBeenCalledWith(
+      onGet,
+      'my-pod',
+      'default',
+      undefined,
+      undefined
+    );
+    expect(mockUseConnectApi).toHaveBeenCalled();
+  });
+
+  it('should pass error callback and options', () => {
+    const onGet = vi.fn();
+    const onError = vi.fn();
+    const opts = { cluster: 'my-cluster', queryParams: { labelSelector: 'app=test' } };
+
+    renderHook(() => useKubeApiGet(MockKubeClass, onGet, 'my-pod', 'default', onError, opts), {
+      wrapper: createWrapper(),
+    });
+
+    expect(MockKubeClass.apiGet).toHaveBeenCalledWith(onGet, 'my-pod', 'default', onError, opts);
+  });
+
+  it('should work without namespace for cluster-scoped resources', () => {
+    const onGet = vi.fn();
+
+    renderHook(() => useKubeApiGet(MockClusterScopedClass, onGet, 'my-node', undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(MockClusterScopedClass.apiGet).toHaveBeenCalledWith(
+      onGet,
+      'my-node',
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+});

--- a/frontend/src/lib/k8s/KubeObject.hooks.test.tsx
+++ b/frontend/src/lib/k8s/KubeObject.hooks.test.tsx
@@ -18,7 +18,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the k8s barrel, event module, Redux store, and router functions to prevent circular initialization issues.
 // KubeObject.ts imports createRouteURL, which imports getRoutePath, which imports

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -895,7 +895,7 @@ export function useKubeApiList<K extends KubeObject>(
   // If the request itself has no namespaces set, we check whether to apply the
   // allowed namespaces.
   if (namespaces.length === 0 && kubeObjectClass.isNamespaced) {
-    namespaces = getAllowedNamespaces(cluster ?? getCluster());
+    namespaces = getAllowedNamespaces(getCluster());
   }
 
   if (namespaces.length > 0) {
@@ -903,6 +903,7 @@ export function useKubeApiList<K extends KubeObject>(
     // namespace and then set the objects once we have all of the responses.
     for (const namespace of namespaces) {
       listCalls.push(
+        // eslint-disable-next-line react-hooks/refs
         kubeObjectClass.apiList(objList => onObjs(namespace, objList as K[]), onError, {
           namespace,
           queryParams,

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -749,6 +749,7 @@ export function useKubeList<K extends KubeObject>(
     refetchInterval?: number;
   } & QueryParameters = {}
 ) {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const fallbackClusters = useSelectedClusters();
 
   // Create requests for each cluster and namespace
@@ -773,6 +774,7 @@ export function useKubeList<K extends KubeObject>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cluster, clusters, fallbackClusters, namespace, kubeObjectClass.isNamespaced]);
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const result = useKubeObjectList<K>({
     queryParams: queryParams,
     kubeObjectClass: kubeObjectClass,
@@ -798,6 +800,7 @@ export function useKubeGet<K extends KubeObject>(
     cluster?: string;
   }
 ) {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useKubeObject<K>({
     kubeObjectClass: kubeObjectClass,
     name: name,
@@ -858,6 +861,7 @@ export function useKubeApiList<K extends KubeObject>(
     // namespace and then set the objects once we have all of the responses.
     for (const namespace of namespaces) {
       listCalls.push(
+        // eslint-disable-next-line react-hooks/refs
         kubeObjectClass.apiList(objList => onObjs(namespace, objList as K[]), onError, {
           namespace,
           queryParams,
@@ -871,6 +875,7 @@ export function useKubeApiList<K extends KubeObject>(
     listCalls.push(kubeObjectClass.apiList(listCallback, onError, { queryParams, cluster }));
   }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useConnectApi(...listCalls);
 }
 
@@ -891,5 +896,6 @@ export function useKubeApiGet<K extends KubeObject>(
   // We do the type conversion here because we want to be able to use hooks that may not have
   // the exact signature as get callbacks.
   const getCallback = onGet as (item: K) => void;
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useConnectApi(kubeObjectClass.apiGet(getCallback, name, namespace, onError, opts));
 }

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -850,7 +850,7 @@ export function useKubeApiList<K extends KubeObject>(
   // If the request itself has no namespaces set, we check whether to apply the
   // allowed namespaces.
   if (namespaces.length === 0 && kubeObjectClass.isNamespaced) {
-    namespaces = getAllowedNamespaces(cluster);
+    namespaces = getAllowedNamespaces(cluster ?? getCluster());
   }
 
   if (namespaces.length > 0) {

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -17,7 +17,7 @@
 import { JSONPath } from 'jsonpath-plus';
 import cloneDeep from 'lodash/cloneDeep';
 import unset from 'lodash/unset';
-import React, { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { loadClusterSettings } from '../../helpers/clusterSettings';
 import { formatClusterPathParam, getCluster, getSelectedClusters } from '../cluster';
 import { createRouteURL } from '../router/createRouteURL';
@@ -301,6 +301,9 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     return this.apiEndpoint.list.bind(null, ...args);
   }
 
+  /**
+   * @deprecated Use the standalone {@link useKubeApiList} hook instead.
+   */
   static useApiList<K extends KubeObject>(
     this: (new (...args: any) => K) & typeof KubeObject<any>,
     onList: (...arg: any[]) => any,
@@ -308,79 +311,25 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     opts?: ApiListOptions
   ) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [objs, setObjs] = React.useState<{ [key: string]: K[] }>({});
-    const listCallback = onList as (arg: any[]) => void;
-
-    function onObjs(namespace: string, objList: K[]) {
-      let newObjs: typeof objs = {};
-      // Set the objects so we have them for the next API response...
-      setObjs(previousObjs => {
-        newObjs = { ...previousObjs, [namespace || '']: objList };
-        return newObjs;
-      });
-
-      let allObjs: K[] = [];
-      Object.values(newObjs).map(currentObjs => {
-        allObjs = allObjs.concat(currentObjs);
-      });
-
-      listCallback(allObjs);
-    }
-
-    const listCalls = [];
-    const queryParams = cloneDeep(opts);
-    let namespaces: string[] = [];
-    unset(queryParams, 'namespace');
-
-    const cluster = opts?.cluster;
-
-    if (!!opts?.namespace) {
-      if (typeof opts.namespace === 'string') {
-        namespaces = [opts.namespace];
-      } else if (Array.isArray(opts.namespace)) {
-        namespaces = opts.namespace as string[];
-      } else {
-        throw Error('namespace should be a string or array of strings');
-      }
-    }
-
-    // If the request itself has no namespaces set, we check whether to apply the
-    // allowed namespaces.
-    if (namespaces.length === 0 && this.isNamespaced) {
-      namespaces = getAllowedNamespaces();
-    }
-
-    if (namespaces.length > 0) {
-      // If we have a namespace set, then we have to make an API call for each
-      // namespace and then set the objects once we have all of the responses.
-      for (const namespace of namespaces) {
-        listCalls.push(
-          this.apiList(objList => onObjs(namespace, objList as K[]), onError, {
-            namespace,
-            queryParams,
-            cluster,
-          })
-        );
-      }
-    } else {
-      // If we don't have a namespace set, then we only have one API call
-      // response to set and we return it right away.
-      listCalls.push(this.apiList(listCallback, onError, { queryParams, cluster }));
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(...listCalls);
+    return useKubeApiList<K>(this, onList, onError, opts);
   }
 
+  /**
+   * @deprecated Use the standalone {@link useKubeList} hook instead.
+   *
+   * @example
+   * ```tsx
+   * // Before:
+   * const [pods] = Pod.useList({ namespace: 'default' });
+   *
+   * // After:
+   * import { useKubeList } from '../lib/k8s/KubeObject';
+   * const [pods] = useKubeList(Pod, { namespace: 'default' });
+   * ```
+   */
   static useList<K extends KubeObject>(
     this: (new (...args: any) => K) & typeof KubeObject<any>,
-    {
-      cluster,
-      clusters,
-      namespace,
-      refetchInterval,
-      ...queryParams
-    }: {
+    opts: {
       cluster?: string;
       clusters?: string[];
       namespace?: string | string[];
@@ -389,44 +338,24 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     } & QueryParameters = {}
   ) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const fallbackClusters = useSelectedClusters();
-
-    // Create requests for each cluster and namespace
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const requests = useMemo(() => {
-      const clusterList = cluster
-        ? [cluster]
-        : clusters || (fallbackClusters.length === 0 ? [''] : fallbackClusters);
-
-      const namespacesFromParams =
-        typeof namespace === 'string'
-          ? [namespace]
-          : Array.isArray(namespace)
-          ? namespace
-          : undefined;
-
-      return makeListRequests(
-        clusterList,
-        getAllowedNamespaces,
-        this.isNamespaced,
-        namespacesFromParams
-      );
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [cluster, clusters, fallbackClusters, namespace, this.isNamespaced]);
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const result = useKubeObjectList<K>({
-      queryParams: queryParams,
-      kubeObjectClass: this,
-      requests,
-      refetchInterval,
-    });
-
-    return result;
+    return useKubeList<K>(this, opts);
   }
 
+  /**
+   * @deprecated Use the standalone {@link useKubeGet} hook instead.
+   *
+   * @example
+   * ```tsx
+   * // Before:
+   * const [secret, error] = Secret.useGet(name, namespace);
+   *
+   * // After:
+   * import { useKubeGet } from '../lib/k8s/KubeObject';
+   * const [secret, error] = useKubeGet(Secret, name, namespace);
+   * ```
+   */
   static useGet<K extends KubeObject>(
-    this: new (...args: any) => K,
+    this: (new (...args: any) => K) & typeof KubeObject<any>,
     name: string,
     namespace?: string,
     opts?: {
@@ -435,13 +364,7 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     }
   ) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useKubeObject<K>({
-      kubeObjectClass: this as (new (...args: any) => K) & typeof KubeObject<any>,
-      name: name,
-      namespace: namespace,
-      cluster: opts?.cluster,
-      queryParams: opts?.queryParams,
-    });
+    return useKubeGet<K>(this, name, namespace, opts);
   }
 
   static create<Args extends any[], T extends KubeObject>(
@@ -487,11 +410,8 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
       cluster?: string;
     }
   ) {
-    // We do the type conversion here because we want to be able to use hooks that may not have
-    // the exact signature as get callbacks.
-    const getCallback = onGet as (item: K) => void;
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(this.apiGet(getCallback, name, namespace, onError, opts));
+    return useKubeApiGet<K>(this, onGet, name, namespace, onError, opts);
   }
 
   _class() {
@@ -834,4 +754,180 @@ export interface AuthRequestResourceAttrs {
   version?: string;
   group?: string;
   verb?: string;
+}
+
+/**
+ * Hook to get a list of Kubernetes objects.
+ *
+ * Replaces the static `KubeObjectClass.useList()` pattern with a proper
+ * standalone hook that follows React's rules of hooks.
+ */
+export function useKubeList<K extends KubeObject>(
+  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
+  {
+    cluster,
+    clusters,
+    namespace,
+    refetchInterval,
+    ...queryParams
+  }: {
+    cluster?: string;
+    clusters?: string[];
+    namespace?: string | string[];
+    /** How often to refetch the list. Won't refetch by default. Disables watching if set. */
+    refetchInterval?: number;
+  } & QueryParameters = {}
+) {
+  const fallbackClusters = useSelectedClusters();
+
+  // Create requests for each cluster and namespace
+  const requests = useMemo(() => {
+    const clusterList = cluster
+      ? [cluster]
+      : clusters || (fallbackClusters.length === 0 ? [''] : fallbackClusters);
+
+    const namespacesFromParams =
+      typeof namespace === 'string'
+        ? [namespace]
+        : Array.isArray(namespace)
+        ? namespace
+        : undefined;
+
+    return makeListRequests(
+      clusterList,
+      getAllowedNamespaces,
+      kubeObjectClass.isNamespaced,
+      namespacesFromParams
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cluster, clusters, fallbackClusters, namespace, kubeObjectClass.isNamespaced]);
+
+  const result = useKubeObjectList<K>({
+    queryParams: queryParams,
+    kubeObjectClass: kubeObjectClass,
+    requests,
+    refetchInterval,
+  });
+
+  return result;
+}
+
+/**
+ * Hook to get a single Kubernetes object by name.
+ *
+ * Replaces the static `KubeObjectClass.useGet()` pattern with a proper
+ * standalone hook that follows React's rules of hooks.
+ */
+export function useKubeGet<K extends KubeObject>(
+  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
+  name: string,
+  namespace?: string,
+  opts?: {
+    queryParams?: QueryParameters;
+    cluster?: string;
+  }
+) {
+  return useKubeObject<K>({
+    kubeObjectClass: kubeObjectClass,
+    name: name,
+    namespace: namespace,
+    cluster: opts?.cluster,
+    queryParams: opts?.queryParams,
+  });
+}
+
+/**
+ * Hook to get a list of Kubernetes objects via list callback.
+ *
+ * @deprecated Use `useKubeList` instead.
+ */
+export function useKubeApiList<K extends KubeObject>(
+  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
+  onList: (...arg: any[]) => any,
+  onError?: (err: ApiError, cluster?: string) => void,
+  opts?: ApiListOptions
+) {
+  const [objs, setObjs] = useState<{ [key: string]: K[] }>({});
+  const listCallback = onList as (arg: any[]) => void;
+
+  function onObjs(namespace: string, objList: K[]) {
+    let newObjs: typeof objs = {};
+    // Set the objects so we have them for the next API response...
+    setObjs(previousObjs => {
+      newObjs = { ...previousObjs, [namespace || '']: objList };
+      return newObjs;
+    });
+
+    let allObjs: K[] = [];
+    Object.values(newObjs).map(currentObjs => {
+      allObjs = allObjs.concat(currentObjs);
+    });
+
+    listCallback(allObjs);
+  }
+
+  const listCalls = [];
+  const queryParams = cloneDeep(opts);
+  let namespaces: string[] = [];
+  unset(queryParams, 'namespace');
+
+  const cluster = opts?.cluster;
+
+  if (!!opts?.namespace) {
+    if (typeof opts.namespace === 'string') {
+      namespaces = [opts.namespace];
+    } else if (Array.isArray(opts.namespace)) {
+      namespaces = opts.namespace as string[];
+    } else {
+      throw Error('namespace should be a string or array of strings');
+    }
+  }
+
+  // If the request itself has no namespaces set, we check whether to apply the
+  // allowed namespaces.
+  if (namespaces.length === 0 && kubeObjectClass.isNamespaced) {
+    namespaces = getAllowedNamespaces(cluster);
+  }
+
+  if (namespaces.length > 0) {
+    // If we have a namespace set, then we have to make an API call for each
+    // namespace and then set the objects once we have all of the responses.
+    for (const namespace of namespaces) {
+      listCalls.push(
+        kubeObjectClass.apiList(objList => onObjs(namespace, objList as K[]), onError, {
+          namespace,
+          queryParams,
+          cluster,
+        })
+      );
+    }
+  } else {
+    // If we don't have a namespace set, then we only have one API call
+    // response to set and we return it right away.
+    listCalls.push(kubeObjectClass.apiList(listCallback, onError, { queryParams, cluster }));
+  }
+
+  useConnectApi(...listCalls);
+}
+
+/**
+ * Hook to get a single Kubernetes object by name via get callback.
+ *
+ * @deprecated Use `useKubeGet` instead.
+ */
+export function useKubeApiGet<K extends KubeObject>(
+  kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
+  onGet: (item: K | null) => any,
+  name: string,
+  namespace?: string,
+  onError?: (err: ApiError | null, cluster?: string) => void,
+  opts?: {
+    queryParams?: QueryParameters;
+    cluster?: string;
+  }
+) {
+  // We do the type conversion here because we want to be able to use hooks that may not have
+  // the exact signature as get callbacks.
+  const getCallback = onGet as (item: K) => void;
+  useConnectApi(kubeObjectClass.apiGet(getCallback, name, namespace, onError, opts));
 }

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -31,7 +31,7 @@ import type {
   RecursivePartial,
 } from './api/v1/factories';
 import { apiFactory, apiFactoryWithNamespace } from './api/v1/factories';
-import { useConnectApi, useSelectedClusters } from './api/v1/hooks';
+import { type CancellablePromise, useConnectApi, useSelectedClusters } from './api/v1/hooks';
 import type { QueryParameters } from './api/v1/queryParameters';
 import type { ApiError } from './api/v2/ApiError';
 import { useKubeObject } from './api/v2/hooks';
@@ -746,9 +746,9 @@ export interface AuthRequestResourceAttrs {
  *
  * @example
  * ```tsx
- * const [pods, error] = Pod.useList({ namespace: 'default' });
+ * const { items: pods, error } = Pod.useList({ namespace: 'default' });
  * // or as a standalone hook:
- * const result = useKubeList(Pod, { namespace: 'default' });
+ * const { items: pods, error } = useKubeList(Pod, { namespace: 'default' });
  * ```
  */
 export function useKubeList<K extends KubeObject>(
@@ -769,7 +769,6 @@ export function useKubeList<K extends KubeObject>(
 ) {
   const fallbackClusters = useSelectedClusters();
 
-  // Create requests for each cluster and namespace
   const requests = useMemo(() => {
     const clusterList = cluster
       ? [cluster]
@@ -788,8 +787,7 @@ export function useKubeList<K extends KubeObject>(
       kubeObjectClass.isNamespaced,
       namespacesFromParams
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cluster, clusters, fallbackClusters, namespace, kubeObjectClass.isNamespaced]);
+  }, [cluster, clusters, fallbackClusters, namespace, kubeObjectClass]);
 
   const result = useKubeObjectList<K>({
     queryParams: queryParams,
@@ -877,7 +875,7 @@ export function useKubeApiList<K extends KubeObject>(
     listCallback(allObjs);
   }
 
-  const listCalls = [];
+  const listCalls: (() => CancellablePromise)[] = [];
   const queryParams = cloneDeep(opts);
   let namespaces: string[] = [];
   unset(queryParams, 'namespace');
@@ -905,7 +903,6 @@ export function useKubeApiList<K extends KubeObject>(
     // namespace and then set the objects once we have all of the responses.
     for (const namespace of namespaces) {
       listCalls.push(
-        // eslint-disable-next-line react-hooks/refs
         kubeObjectClass.apiList(objList => onObjs(namespace, objList as K[]), onError, {
           namespace,
           queryParams,

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -856,6 +856,18 @@ export function useKubeApiList<K extends KubeObject>(
     namespaces = getAllowedNamespaces(cluster);
   }
 
+  // Prevent stale results from previous namespace sets from leaking into the aggregated callback.
+  if (namespaces.length === 0) {
+    objsRef.current = {};
+  } else {
+    const allowedKeys = new Set(namespaces.map(ns => ns || ''));
+    for (const key of Object.keys(objsRef.current)) {
+      if (!allowedKeys.has(key)) {
+        delete objsRef.current[key];
+      }
+    }
+  }
+
   if (namespaces.length > 0) {
     // If we have a namespace set, then we have to make an API call for each
     // namespace and then set the objects once we have all of the responses.

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -17,7 +17,7 @@
 import { JSONPath } from 'jsonpath-plus';
 import cloneDeep from 'lodash/cloneDeep';
 import unset from 'lodash/unset';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import { loadClusterSettings } from '../../helpers/clusterSettings';
 import { formatClusterPathParam, getCluster, getSelectedClusters } from '../cluster';
 import { createRouteURL } from '../router/createRouteURL';
@@ -301,9 +301,6 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     return this.apiEndpoint.list.bind(null, ...args);
   }
 
-  /**
-   * @deprecated Use the standalone {@link useKubeApiList} hook instead.
-   */
   static useApiList<K extends KubeObject>(
     this: (new (...args: any) => K) & typeof KubeObject<any>,
     onList: (...arg: any[]) => any,
@@ -314,19 +311,6 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     return useKubeApiList<K>(this, onList, onError, opts);
   }
 
-  /**
-   * @deprecated Use the standalone {@link useKubeList} hook instead.
-   *
-   * @example
-   * ```tsx
-   * // Before:
-   * const [pods] = Pod.useList({ namespace: 'default' });
-   *
-   * // After:
-   * import { useKubeList } from '../lib/k8s/KubeObject';
-   * const [pods] = useKubeList(Pod, { namespace: 'default' });
-   * ```
-   */
   static useList<K extends KubeObject>(
     this: (new (...args: any) => K) & typeof KubeObject<any>,
     opts: {
@@ -341,19 +325,6 @@ export class KubeObject<T extends KubeObjectInterface | KubeEvent = any> {
     return useKubeList<K>(this, opts);
   }
 
-  /**
-   * @deprecated Use the standalone {@link useKubeGet} hook instead.
-   *
-   * @example
-   * ```tsx
-   * // Before:
-   * const [secret, error] = Secret.useGet(name, namespace);
-   *
-   * // After:
-   * import { useKubeGet } from '../lib/k8s/KubeObject';
-   * const [secret, error] = useKubeGet(Secret, name, namespace);
-   * ```
-   */
   static useGet<K extends KubeObject>(
     this: (new (...args: any) => K) & typeof KubeObject<any>,
     name: string,
@@ -838,8 +809,6 @@ export function useKubeGet<K extends KubeObject>(
 
 /**
  * Hook to get a list of Kubernetes objects via list callback.
- *
- * @deprecated Use `useKubeList` instead.
  */
 export function useKubeApiList<K extends KubeObject>(
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
@@ -847,19 +816,14 @@ export function useKubeApiList<K extends KubeObject>(
   onError?: (err: ApiError, cluster?: string) => void,
   opts?: ApiListOptions
 ) {
-  const [objs, setObjs] = useState<{ [key: string]: K[] }>({});
+  const objsRef = useRef<{ [key: string]: K[] }>({});
   const listCallback = onList as (arg: any[]) => void;
 
   function onObjs(namespace: string, objList: K[]) {
-    let newObjs: typeof objs = {};
-    // Set the objects so we have them for the next API response...
-    setObjs(previousObjs => {
-      newObjs = { ...previousObjs, [namespace || '']: objList };
-      return newObjs;
-    });
+    objsRef.current = { ...objsRef.current, [namespace || '']: objList };
 
     let allObjs: K[] = [];
-    Object.values(newObjs).map(currentObjs => {
+    Object.values(objsRef.current).forEach(currentObjs => {
       allObjs = allObjs.concat(currentObjs);
     });
 
@@ -912,8 +876,6 @@ export function useKubeApiList<K extends KubeObject>(
 
 /**
  * Hook to get a single Kubernetes object by name via get callback.
- *
- * @deprecated Use `useKubeGet` instead.
  */
 export function useKubeApiGet<K extends KubeObject>(
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -749,7 +749,6 @@ export function useKubeList<K extends KubeObject>(
     refetchInterval?: number;
   } & QueryParameters = {}
 ) {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const fallbackClusters = useSelectedClusters();
 
   // Create requests for each cluster and namespace
@@ -774,7 +773,6 @@ export function useKubeList<K extends KubeObject>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cluster, clusters, fallbackClusters, namespace, kubeObjectClass.isNamespaced]);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const result = useKubeObjectList<K>({
     queryParams: queryParams,
     kubeObjectClass: kubeObjectClass,
@@ -800,7 +798,6 @@ export function useKubeGet<K extends KubeObject>(
     cluster?: string;
   }
 ) {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useKubeObject<K>({
     kubeObjectClass: kubeObjectClass,
     name: name,
@@ -856,18 +853,6 @@ export function useKubeApiList<K extends KubeObject>(
     namespaces = getAllowedNamespaces(cluster);
   }
 
-  // Prevent stale results from previous namespace sets from leaking into the aggregated callback.
-  if (namespaces.length === 0) {
-    objsRef.current = {};
-  } else {
-    const allowedKeys = new Set(namespaces.map(ns => ns || ''));
-    for (const key of Object.keys(objsRef.current)) {
-      if (!allowedKeys.has(key)) {
-        delete objsRef.current[key];
-      }
-    }
-  }
-
   if (namespaces.length > 0) {
     // If we have a namespace set, then we have to make an API call for each
     // namespace and then set the objects once we have all of the responses.
@@ -887,7 +872,6 @@ export function useKubeApiList<K extends KubeObject>(
     listCalls.push(kubeObjectClass.apiList(listCallback, onError, { queryParams, cluster }));
   }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useConnectApi(...listCalls);
 }
 
@@ -908,6 +892,5 @@ export function useKubeApiGet<K extends KubeObject>(
   // We do the type conversion here because we want to be able to use hooks that may not have
   // the exact signature as get callbacks.
   const getCallback = onGet as (item: K) => void;
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useConnectApi(kubeObjectClass.apiGet(getCallback, name, namespace, onError, opts));
 }

--- a/frontend/src/lib/k8s/KubeObject.ts
+++ b/frontend/src/lib/k8s/KubeObject.ts
@@ -731,7 +731,25 @@ export interface AuthRequestResourceAttrs {
  * Hook to get a list of Kubernetes objects.
  *
  * Replaces the static `KubeObjectClass.useList()` pattern with a proper
- * standalone hook that follows React's rules of hooks.
+ * standalone hook that follows React's rules of hooks. Builds list requests
+ * for each cluster/namespace combination and delegates to {@link useKubeObjectList}.
+ *
+ * @param kubeObjectClass - The KubeObject subclass to list (e.g. `Pod`, `Deployment`).
+ * @param opts - Options controlling which clusters, namespaces, and query parameters to use.
+ * @param opts.cluster - A single cluster to list from. Overrides `clusters` if set.
+ * @param opts.clusters - An array of clusters to list from. Falls back to the currently
+ *   selected clusters if not provided.
+ * @param opts.namespace - Namespace(s) to filter by. Can be a single string or an array.
+ * @param opts.refetchInterval - Polling interval in milliseconds. Disables watching if set.
+ * @returns A {@link QueryListResponse} containing the list of objects, loading/error state,
+ *   and per-cluster results.
+ *
+ * @example
+ * ```tsx
+ * const [pods, error] = Pod.useList({ namespace: 'default' });
+ * // or as a standalone hook:
+ * const result = useKubeList(Pod, { namespace: 'default' });
+ * ```
  */
 export function useKubeList<K extends KubeObject>(
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
@@ -787,7 +805,24 @@ export function useKubeList<K extends KubeObject>(
  * Hook to get a single Kubernetes object by name.
  *
  * Replaces the static `KubeObjectClass.useGet()` pattern with a proper
- * standalone hook that follows React's rules of hooks.
+ * standalone hook that follows React's rules of hooks. Delegates to
+ * {@link useKubeObject} from the v2 API hooks.
+ *
+ * @param kubeObjectClass - The KubeObject subclass to fetch (e.g. `Pod`, `Deployment`).
+ * @param name - The name of the Kubernetes object to retrieve.
+ * @param namespace - The namespace of the object. Optional for cluster-scoped resources.
+ * @param opts - Additional options.
+ * @param opts.queryParams - Extra query parameters to include in the API request.
+ * @param opts.cluster - The cluster to fetch from. Defaults to the currently active cluster.
+ * @returns A tuple `[object, error]` that also implements {@link QueryResponse},
+ *   providing `isLoading`, `isError`, `isSuccess`, and `status` fields.
+ *
+ * @example
+ * ```tsx
+ * const [pod, error] = Pod.useGet('my-pod', 'default');
+ * // or as a standalone hook:
+ * const [pod, error] = useKubeGet(Pod, 'my-pod', 'default');
+ * ```
  */
 export function useKubeGet<K extends KubeObject>(
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
@@ -808,7 +843,19 @@ export function useKubeGet<K extends KubeObject>(
 }
 
 /**
- * Hook to get a list of Kubernetes objects via list callback.
+ * Hook to list Kubernetes objects using the legacy callback-based (v1) API.
+ *
+ * Sets up streaming API connections via {@link useConnectApi}. For namespaced
+ * resources, creates one API call per namespace and aggregates results before
+ * invoking the callback. Automatically applies allowed-namespace filtering
+ * from cluster settings when no explicit namespaces are provided.
+ *
+ * @param kubeObjectClass - The KubeObject subclass to list (e.g. `Pod`, `Deployment`).
+ * @param onList - Callback invoked with the aggregated array of objects whenever
+ *   results are updated.
+ * @param onError - Optional error callback invoked if any API call fails.
+ * @param opts - Options matching {@link ApiListOptions}, including `namespace`,
+ *   `cluster`, and `queryParams`.
  */
 export function useKubeApiList<K extends KubeObject>(
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,
@@ -876,7 +923,19 @@ export function useKubeApiList<K extends KubeObject>(
 }
 
 /**
- * Hook to get a single Kubernetes object by name via get callback.
+ * Hook to get a single Kubernetes object using the legacy callback-based (v1) API.
+ *
+ * Sets up a streaming API connection via {@link useConnectApi} that invokes the
+ * callback whenever the object is updated.
+ *
+ * @param kubeObjectClass - The KubeObject subclass to fetch (e.g. `Pod`, `Deployment`).
+ * @param onGet - Callback invoked with the object whenever it is fetched or updated.
+ * @param name - The name of the Kubernetes object to retrieve.
+ * @param namespace - The namespace of the object. Optional for cluster-scoped resources.
+ * @param onError - Optional error callback invoked if the API call fails.
+ * @param opts - Additional options.
+ * @param opts.queryParams - Extra query parameters to include in the API request.
+ * @param opts.cluster - The cluster to fetch from. Defaults to the currently active cluster.
  */
 export function useKubeApiGet<K extends KubeObject>(
   kubeObjectClass: (new (...args: any) => K) & typeof KubeObject<any>,

--- a/frontend/src/lib/k8s/index.ts
+++ b/frontend/src/lib/k8s/index.ts
@@ -383,6 +383,8 @@ export function useClustersVersion(clusters: Cluster[]) {
   }, [versions]);
 }
 
+export { useKubeList, useKubeGet, useKubeApiList, useKubeApiGet } from './KubeObject';
+
 // Other exports that can be used by plugins:
 export * as cluster from './cluster';
 export * as clusterRole from './clusterRole';

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -551,6 +551,10 @@
     "useClustersConf": [Function],
     "useClustersVersion": [Function],
     "useConnectApi": [Function],
+    "useKubeApiGet": [Function],
+    "useKubeApiList": [Function],
+    "useKubeGet": [Function],
+    "useKubeList": [Function],
     "useSelectedClusters": [Function],
     "volumeAttributesClass": {
       "default": [Function],


### PR DESCRIPTION
## Summary

This PR fixes a React rules-of-hooks violation in KubeObject static class methods by refactoring the hook implementations to standalone hook functions outside of the class.

## Related Issue

Fixes #5242

## Changes

- **Standalone Hooks:** Refactored the core hook logic from `KubeObject` class methods into proper standalone hook functions (`useKubeList`, `useKubeGet`, `useKubeApiList`, `useKubeApiGet`) in `KubeObject.ts`.
- **Legacy Wrappers:** Refactored the class static methods (`useList`, `useGet`, `useApiList`, `useApiGet`) to serve as clean, fully-supported wrapper methods that delegate to the new standalone hooks.
- **JSDoc Documentation:** Added detailed JSDoc documentation with `@param` and `@returns` tags for all standalone hook functions to improve API clarity.
- **Unit Tests:** Created a new unit test suite `KubeObject.hooks.test.tsx` verifying logic pathways, single/multiple namespace queries, error callbacks, and parameter mapping.
- **CI-Lint Alignment:** Added ESLint directive markers inside the standalone hooks to satisfy the strict rules defined in `.eslintrc.ci.cjs` for rules-of-hooks and refs warnings.
- **Exports:** Exported the new standalone hooks from the barrel file `index.ts`.
- **Snapshot Tests:** Updated `pluginLib.snapshot` to reflect the new exported hook symbols.

## Steps to Test

1. Verify that the frontend compiles successfully:
```
npm run frontend:tsc
```
3. Verify that there are no style or linting issues:
```
npm run frontend:lint
```
4. Run the unit tests to confirm everything functions correctly:
```
npm run frontend:test
```
## Notes for the Reviewer
To prevent code churn and breaking changes for plugins and example guides, we decided not to deprecate the legacy static class methods. They will remain fully supported under the hood as thin wrapper methods.