### PR TITLE
backend: fix typo in node drain status error

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -3102,7 +3102,7 @@ func (c *HeadlampConfig) handleNodeDrainStatus(w http.ResponseWriter, r *http.Re
 	c.TelemetryHandler.RecordEvent(span, "Drain status found", attribute.String("cache.key", cacheKey))
 
 	if err = json.NewEncoder(w).Encode(responsePayload); err != nil {
-		c.handleError(w, ctx, span, err, "failed to encode repsone", http.StatusInternalServerError)
+		c.handleError(w, ctx, span, err, "failed to encode response", http.StatusInternalServerError)
 
 		return
 	}


### PR DESCRIPTION
## Summary

This PR fixes a minor typo in the backend node drain status error message ("repsone" -> "response").

## Related Issue

Fixes #6140

## Changes

- Fixed a typo in `backend/cmd/headlamp.go` line 3105.

## Steps to Test

1. Navigate to the `backend/` directory.
2. Run backend tests specifically for the command package to verify everything compiles and passes:
   ```bash
   go test -v ./cmd
