### PR TITLE
charts: Allow disabling the bundled Prometheus / static plugins

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -133,6 +133,7 @@ config:
 | config.unsafeUseServiceAccountToken | bool | `false` | UNSAFE: authenticate every user as the pod's service account when running in-cluster. Only safe behind an auth proxy |
 | config.serviceAccountTokenPath | string | `""` | Path to the service account token file. Used only when `unsafeUseServiceAccountToken` is true |
 | config.pluginsDir  | string | `"/headlamp/plugins"` | Directory to load Headlamp plugins from                                   |
+| config.staticPlugins.enabled | bool | `true` | Serve the bundled static plugins shipped in the image (e.g. the Prometheus "Show Prometheus metrics" plugin). Set to false to disable them |
 | config.enableHelm  | bool   | `false`               | Enable Helm operations like install, upgrade and uninstall of Helm charts |
 | config.podDebugImage | string | `""`                | Default image to use when creating pod debug containers                    |
 | config.nodeShellImage | string | `""`               | Default image to use when creating node shell pods                         |

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -1,6 +1,12 @@
 {{- $oidc := .Values.config.oidc }}
 {{- $env := .Values.env }}
 
+{{- /* Disable the bundled static plugins (e.g. Prometheus) by clearing
+       HEADLAMP_STATIC_PLUGINS_DIR. `hasKey` guards against false being treated
+       as empty by `default`, and an unset value defaults to serving them. */}}
+{{- $staticPlugins := .Values.config.staticPlugins | default dict }}
+{{- $staticPluginsDisabled := and (hasKey $staticPlugins "enabled") (not $staticPlugins.enabled) }}
+
 {{- $clientID := "" }}
 {{- $clientSecret := "" }}
 {{- $issuerURL := "" }}
@@ -114,15 +120,21 @@ spec:
             {{- end }}
           image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{ if or $oidc .Values.env }}
+          {{ if or $oidc .Values.env $staticPluginsDisabled }}
           {{- if $oidc.externalSecret.enabled }}
           # Check if externalSecret is enabled
           envFrom:
           - secretRef:
               name: {{ $oidc.externalSecret.name }}
-          {{- if .Values.env }}
+          {{- if or .Values.env $staticPluginsDisabled }}
           env:
-            {{- toYaml .Values.env | nindent 12 }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if $staticPluginsDisabled }}
+            - name: HEADLAMP_STATIC_PLUGINS_DIR
+              value: ""
+            {{- end }}
           {{- end }}
           {{- else }}
           env:
@@ -241,6 +253,10 @@ spec:
             {{- end }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
+            {{- end }}
+            {{- if $staticPluginsDisabled }}
+            - name: HEADLAMP_STATIC_PLUGINS_DIR
+              value: ""
             {{- end }}
           {{- end }}
           {{- end }}

--- a/charts/headlamp/tests/expected_templates/disable-static-plugins.yaml
+++ b/charts/headlamp/tests/expected_templates/disable-static-plugins.yaml
@@ -1,0 +1,144 @@
+---
+# Source: headlamp/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc
+  namespace: default
+type: Opaque
+data:
+---
+# Source: headlamp/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: headlamp
+  namespace: default
+---
+# Source: headlamp/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+---
+# Source: headlamp/templates/deployment.yaml
+# This block of code is used to extract the values from the env.
+# This is done to check if the values are non-empty and if they are, they are used in the deployment.yaml.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: headlamp
+  namespace: default
+  labels:
+    helm.sh/chart: headlamp-0.43.0
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/instance: headlamp
+    app.kubernetes.io/version: "0.43.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: headlamp
+      app.kubernetes.io/instance: headlamp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headlamp
+        app.kubernetes.io/instance: headlamp
+    spec:
+      serviceAccountName: headlamp
+      automountServiceAccountToken: true
+      hostUsers: true
+      securityContext:
+        {}
+      containers:
+        - name: headlamp
+          securityContext:
+            privileged: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 100
+          image: "ghcr.io/headlamp-k8s/headlamp:v0.43.0"
+          imagePullPolicy: IfNotPresent
+          
+          env:
+            - name: HEADLAMP_STATIC_PLUGINS_DIR
+              value: ""
+          args:
+            - "-in-cluster"
+            - "-in-cluster-context-name=main"
+            - "-plugins-dir=/headlamp/plugins"
+            - "-session-ttl=86400"
+            # Check if externalSecret is disabled
+          ports:
+            - name: http
+              containerPort: 4466
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {}

--- a/charts/headlamp/tests/test_cases/disable-static-plugins.yaml
+++ b/charts/headlamp/tests/test_cases/disable-static-plugins.yaml
@@ -1,0 +1,7 @@
+# Test case for disabling the bundled static plugins (e.g. the Prometheus
+# "Show Prometheus metrics" plugin). With staticPlugins.enabled set to false the
+# deployment should set HEADLAMP_STATIC_PLUGINS_DIR to an empty string so the
+# backend skips serving them.
+config:
+  staticPlugins:
+    enabled: false

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -258,6 +258,18 @@
           "type": "string",
           "description": "Directory to load plugins from"
         },
+        "staticPlugins": {
+          "type": "object",
+          "description": "Bundled (static) plugins shipped in the Headlamp image, such as the Prometheus plugin",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Serve the bundled static plugins. Set to false to disable them (e.g. the \"Show Prometheus metrics\" button)",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
          "tlsCertPath": {
           "type": "string",
           "description": "Path of certificate file for TLS"

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -123,6 +123,13 @@ config:
 
   # -- directory to look for plugins
   pluginsDir: "/headlamp/plugins"
+  # Bundled (static) plugins that ship inside the Headlamp image, such as the
+  # Prometheus plugin (the "Show Prometheus metrics" UI).
+  staticPlugins:
+    # -- Serve the bundled static plugins. Set to false to disable them (e.g. to
+    # hide the "Show Prometheus metrics" button) without relying on internal
+    # image paths; this sets HEADLAMP_STATIC_PLUGINS_DIR to an empty string so the backend skips them.
+    enabled: true
   enableHelm: false
   watchPlugins: false
   # -- Default image to use when creating pod debug containers. If empty, Headlamp uses its built-in default.


### PR DESCRIPTION


## Summary
This PR adds Helm chart support for disabling bundled static plugins (including Prometheus) by introducing a new `config.staticPlugins.enabled` value, allowing users to suppress the Prometheus plugin without relying on undocumented workarounds.

## Related Issue
Fixes #6083

## Changes
- Added `config.staticPlugins.enabled` (default `true`) to `values.yaml`
- Updated `templates/deployment.yaml` to emit `HEADLAMP_STATIC_PLUGINS_DIR=""` env var when `staticPlugins.enabled` is set to `false`
- Updated `values.schema.json` with schema definition for the new value
- Updated `README.md` to document the new chart value
- Added `disable-static-plugins` test case and expected template under `tests/`

## Steps to Test
1. Run `helm template` with default values → confirm `HEADLAMP_STATIC_PLUGINS_DIR` is **not** rendered (bundled plugins remain active)
2. Run `helm template` with `config.staticPlugins.enabled: false` → confirm `HEADLAMP_STATIC_PLUGINS_DIR=""` is present in the deployment env vars
3. Deploy to a cluster with `staticPlugins.enabled: false` and verify the "Show Prometheus metrics" button and "Couldn't detect Prometheus" prompt no longer appear in the UI.

## Notes for the Reviewer
- Default behavior is fully preserved: when `staticPlugins.enabled` is not set (or `true`), no extra env var is injected, so existing deployments are unaffected.
- This relies entirely on the backend's existing env contract (`HEADLAMP_STATIC_PLUGINS_DIR`), not on internal image paths — making it stable across image versions.
- The backend already handles an empty string for this env var as "serve no static plugins" (`backend/cmd/headlamp.go`, `backend/pkg/plugins/plugins.go`), so no backend changes are needed.
