### PR TITLE
frontend: KubeObject: Safely access nested properties

### DIFF
--- a/frontend/src/lib/k8s/daemonSet.ts
+++ b/frontend/src/lib/k8s/daemonSet.ts
@@ -125,7 +125,7 @@ class DaemonSet extends KubeObject<KubeDaemonSet> {
           namespace: this.getNamespace(),
           cluster: this.cluster,
           queryParams: {
-            labelSelector: this.spec.selector.matchLabels
+            labelSelector: this.spec?.selector?.matchLabels
               ? Object.entries(this.spec.selector.matchLabels)
                   .map(([k, v]) => `${k}=${v}`)
                   .join(',')

--- a/frontend/src/lib/k8s/deployment.ts
+++ b/frontend/src/lib/k8s/deployment.ts
@@ -68,7 +68,7 @@ class Deployment extends KubeObject<KubeDeployment> {
   }
 
   getMatchLabelsList(): string[] {
-    const labels = this.spec.selector.matchLabels || {};
+    const labels = this.spec?.selector?.matchLabels || {};
     return Object.keys(labels).map(key => `${key}=${labels[key]}`);
   }
 

--- a/frontend/src/lib/k8s/hpa.ts
+++ b/frontend/src/lib/k8s/hpa.ts
@@ -209,9 +209,10 @@ class HPA extends KubeObject<KubeHPA> {
 
   metrics(t: Function): HPAMetrics[] {
     const metrics: HPAMetrics[] = [];
-    for (let iter = 0; iter < this.spec.metrics.length; iter++) {
-      const spec = this.spec.metrics[iter];
-      const status = this.status.currentMetrics?.[iter];
+    const specMetrics = this.spec?.metrics || [];
+    for (let iter = 0; iter < specMetrics.length; iter++) {
+      const spec = specMetrics[iter];
+      const status = this.status?.currentMetrics?.[iter];
       switch (spec.type) {
         case 'External':
           {
@@ -221,11 +222,10 @@ class HPA extends KubeObject<KubeHPA> {
                   ? metricValueStatus(status.external.current, t)
                   : t('translation|<unknown>')
               }/${metricTargetValue(spec.external.target)}`;
-              const definition = `"${spec.external.metric.name}" ${defineMetricTarget(
-                spec.external.target
-              )}`;
+              const metricName = spec.external.metric?.name || t('translation|<unknown>');
+              const definition = `"${metricName}" ${defineMetricTarget(spec.external.target)}`;
               metrics.push({
-                name: spec.external.metric.name,
+                name: metricName,
                 definition,
                 value,
                 shortValue: value,
@@ -241,17 +241,18 @@ class HPA extends KubeObject<KubeHPA> {
                   ? metricValueStatus(status.object.current, t)
                   : t('translation|<unknown>')
               }/${metricTargetValue(spec.object.target)}`;
+              const metricName = spec.object.metric?.name || t('translation|<unknown>');
               const definition = t(
                 'translation|"{{metricName}}" on {{objectKind}}/{{objectName}} {{metricTarget}}',
                 {
-                  metricName: spec.object.metric.name,
-                  objectKind: spec.object.describedObject.kind,
-                  objectName: spec.object.describedObject.name,
+                  metricName,
+                  objectKind: spec.object.describedObject?.kind || t('translation|<unknown>'),
+                  objectName: spec.object.describedObject?.name || t('translation|<unknown>'),
                   metricTarget: defineMetricTarget(spec.object.target),
                 }
               );
               metrics.push({
-                name: spec.object.metric.name,
+                name: metricName,
                 definition,
                 value,
                 shortValue: value,
@@ -267,11 +268,12 @@ class HPA extends KubeObject<KubeHPA> {
                   ? metricValueStatus(status.pods.current, t)
                   : t('translation|<unknown>')
               }/${metricTargetValue(spec.pods.target)}`;
+              const metricName = spec.pods.metric?.name || t('translation|<unknown>');
               const definition = t('translation|"{{metricName}}" on pods', {
-                metricName: spec.pods.metric.name,
+                metricName,
               });
               metrics.push({
-                name: spec.pods.metric.name,
+                name: metricName,
                 definition,
                 value,
                 shortValue: value,

--- a/frontend/src/lib/k8s/pod.test.ts
+++ b/frontend/src/lib/k8s/pod.test.ts
@@ -82,6 +82,20 @@ describe('Pod class', () => {
     expect(() => pod.getDetailedStatus()).not.toThrow();
   });
 
+  it('does not throw when spec and status are missing', () => {
+    const dataMissingBoth = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: 'test-pod-missing-fields',
+        namespace: 'default',
+        resourceVersion: '123',
+      },
+    };
+    const pod = new Pod(dataMissingBoth as any);
+    expect(() => pod.getDetailedStatus()).not.toThrow();
+  });
+
   describe('getHealth', () => {
     const makePod = (status: any, metadata: any = {}) =>
       new Pod({

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -423,8 +423,9 @@ class Pod extends KubeObject<KubePod> {
     }
 
     let initializing = false;
-    for (const i in this.status?.initContainerStatuses ?? []) {
-      const container = this.status.initContainerStatuses![i];
+    const initContainerStatuses = this.status?.initContainerStatuses ?? [];
+    for (const i in initContainerStatuses) {
+      const container = initContainerStatuses[i];
       restarts += container.restartCount;
       lastRestartDate = this.getLastRestartDate(container, lastRestartDate);
 

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -414,8 +414,8 @@ class Pod extends KubeObject<KubePod> {
     let reason = this.status?.reason || this.status?.phase;
 
     const initContainers: Record<string, KubeContainer> = {};
-    let totalContainers = (this.spec.containers ?? []).length;
-    for (const ic of this.spec.initContainers ?? []) {
+    let totalContainers = (this.spec?.containers ?? []).length;
+    for (const ic of this.spec?.initContainers ?? []) {
       initContainers[ic.name] = ic;
       if (this.isRestartableInitContainer(ic)) {
         totalContainers++;

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -339,7 +339,7 @@ class Pod extends KubeObject<KubePod> {
     };
 
     // Get current ephemeral containers
-    const currentEphemeralContainers = this.spec.ephemeralContainers || [];
+    const currentEphemeralContainers = this.spec?.ephemeralContainers || [];
 
     // Prepare the patch body
     const patchBody = {
@@ -484,7 +484,7 @@ class Pod extends KubeObject<KubePod> {
           message = container.state.waiting!.message || '';
           break;
         default:
-          reason = `Init:${i}/${(this.spec.initContainers || []).length}`;
+          reason = `Init:${i}/${(this.spec?.initContainers || []).length}`;
           initializing = true;
       }
       break;

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -411,7 +411,7 @@ class Pod extends KubeObject<KubePod> {
     let lastRestartDate = new Date(0);
     let lastRestartableInitContainerRestartDate = new Date(0);
 
-    let reason = this.status?.reason || this.status?.phase;
+    let reason = this.status?.reason || this.status?.phase || 'Unknown';
 
     const initContainers: Record<string, KubeContainer> = {};
     let totalContainers = (this.spec?.containers ?? []).length;

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -411,7 +411,7 @@ class Pod extends KubeObject<KubePod> {
     let lastRestartDate = new Date(0);
     let lastRestartableInitContainerRestartDate = new Date(0);
 
-    let reason = this.status.reason || this.status.phase;
+    let reason = this.status?.reason || this.status?.phase;
 
     const initContainers: Record<string, KubeContainer> = {};
     let totalContainers = (this.spec.containers ?? []).length;
@@ -423,12 +423,15 @@ class Pod extends KubeObject<KubePod> {
     }
 
     let initializing = false;
-    for (const i in this.status.initContainerStatuses ?? []) {
+    for (const i in this.status?.initContainerStatuses ?? []) {
       const container = this.status.initContainerStatuses![i];
       restarts += container.restartCount;
       lastRestartDate = this.getLastRestartDate(container, lastRestartDate);
 
-      if (container.lastState.terminated !== null) {
+      if (
+        container.lastState?.terminated !== null &&
+        container.lastState?.terminated !== undefined
+      ) {
         const terminatedDate = container.lastState.terminated?.finishedAt
           ? new Date(container.lastState.terminated?.finishedAt)
           : undefined;
@@ -439,7 +442,10 @@ class Pod extends KubeObject<KubePod> {
 
       if (this.isRestartableInitContainer(initContainers[container.name])) {
         restartableInitContainerRestarts += container.restartCount;
-        if (container.lastState.terminated !== null) {
+        if (
+          container.lastState?.terminated !== null &&
+          container.lastState?.terminated !== undefined
+        ) {
           const terminatedDate = container.lastState.terminated?.finishedAt
             ? new Date(container.lastState.terminated?.finishedAt)
             : undefined;
@@ -488,7 +494,7 @@ class Pod extends KubeObject<KubePod> {
       lastRestartDate = lastRestartableInitContainerRestartDate;
       let hasRunning = false;
       for (let i = (this.status?.containerStatuses?.length || 0) - 1; i >= 0; i--) {
-        const container = this.status?.containerStatuses[i];
+        const container = this.status?.containerStatuses?.[i];
 
         restarts += container.restartCount;
         lastRestartDate = this.getLastRestartDate(container, lastRestartDate);

--- a/frontend/src/lib/k8s/podDisruptionBudget.ts
+++ b/frontend/src/lib/k8s/podDisruptionBudget.ts
@@ -74,8 +74,10 @@ class PDB extends KubeObject<KubePDB> {
 
   get selectors(): string[] {
     const selectors: string[] = [];
-    Object.keys(this.spec.selector.matchLabels).forEach(key => {
-      selectors.push(`${key}: ${this.spec.selector.matchLabels[key]}`);
+    const matchLabels = this.spec?.selector?.matchLabels;
+    if (!matchLabels) return selectors;
+    Object.keys(matchLabels).forEach(key => {
+      selectors.push(`${key}: ${matchLabels[key]}`);
     });
     return selectors;
   }

--- a/frontend/src/lib/k8s/replicaSet.ts
+++ b/frontend/src/lib/k8s/replicaSet.ts
@@ -89,7 +89,7 @@ class ReplicaSet extends KubeObject<KubeReplicaSet> {
   }
 
   getMatchLabelsList(): string[] {
-    const labels = this.spec.selector.matchLabels || {};
+    const labels = this.spec?.selector?.matchLabels || {};
     return Object.keys(labels).map(key => `${key}=${labels[key]}`);
   }
 }

--- a/frontend/src/lib/k8s/statefulSet.ts
+++ b/frontend/src/lib/k8s/statefulSet.ts
@@ -122,7 +122,7 @@ class StatefulSet extends KubeObject<KubeStatefulSet> {
           namespace: this.getNamespace(),
           cluster: this.cluster,
           queryParams: {
-            labelSelector: this.spec.selector.matchLabels
+            labelSelector: this.spec?.selector?.matchLabels
               ? Object.entries(this.spec.selector.matchLabels)
                   .map(([k, v]) => `${k}=${v}`)
                   .join(',')


### PR DESCRIPTION
Add optional chaining in KubeObject subclasses to safely access nested properties, preventing frontend TypeErrors when instances are initialized with incomplete data.

Several subclasses assume nested fields (like spec.metrics) always exist, causing them to throw runtime TypeErrors if the data is absent.

This change ensures the models safely handle missing data, allowing the UI to degrade gracefully instead of crashing the dashboard completely.

## Summary
This PR fixes potential frontend crashes by adding optional chaining and fallbacks to deeply nested property accesses across several `KubeObject` subclasses. Several subclasses were assuming nested fields (like `spec.selector.matchLabels` or `spec.metrics`) always exist, causing them to throw runtime `TypeErrors` if the data was temporarily absent.

## Related Issue
Fixes #6132

## Changes
- Fixed unsafe accesses to `this.spec` and `this.status` in the `DaemonSet`, `Deployment`, `HPA`, `Pod`, `PodDisruptionBudget`, `ReplicaSet`, and `StatefulSet` classes.
- Added optional chaining (`?.`) and fallbacks (`|| {}`, `|| []`) to prevent `TypeError: Cannot read properties of undefined`.

## Steps to Test
**Programmatic Reproduction:**
1. Construct model instances with missing nested fields in a test environment:
   ```typescript
   const hpa = new HorizontalPodAutoscaler({ spec: {} });
   hpa.metrics(t);
