### PR TITLE
frontend: add CreateEndpointForm for Endpoints Network resource

### DIFF
--- a/frontend/src/components/common/Resource/CreateButton.tsx
+++ b/frontend/src/components/common/Resource/CreateButton.tsx
@@ -27,10 +27,12 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelectedClusters } from '../../../lib/k8s';
 import Deployment from '../../../lib/k8s/deployment';
+import Endpoints from '../../../lib/k8s/endpoints';
 import Pod from '../../../lib/k8s/pod';
 import ReplicaSet from '../../../lib/k8s/replicaSet';
 import { Activity } from '../../activity/Activity';
 import CreateDeploymentForm from '../../deployments/CreateDeploymentForm';
+import CreateEndpointForm from '../../endpoints/CreateEndpointForm';
 import CreatePodForm from '../../pod/CreatePodForm';
 import CreateReplicaSetForm from '../../replicaset/CreateReplicaSetForm';
 import ActionButton from '../ActionButton';
@@ -40,6 +42,7 @@ export const RESOURCE_DEFINITIONS = {
   Pod: { class: Pod, form: CreatePodForm },
   Deployment: { class: Deployment, form: CreateDeploymentForm },
   ReplicaSet: { class: ReplicaSet, form: CreateReplicaSetForm },
+  Endpoints: { class: Endpoints, form: CreateEndpointForm },
 };
 
 export type ResourceType = keyof typeof RESOURCE_DEFINITIONS;

--- a/frontend/src/components/common/Resource/CreateResourceForm/CreateResourceForm.tsx
+++ b/frontend/src/components/common/Resource/CreateResourceForm/CreateResourceForm.tsx
@@ -579,6 +579,396 @@ export function labelMapsEqual(a: Record<string, string>, b: Record<string, stri
   return true;
 }
 
+export function ContainerTextField(props: ContainerTextFieldProps) {
+  const { value, onChange, label, required, helperText } = props;
+  const { t } = useTranslation(['translation']);
+  const groupLabelId = useId('container-group-');
+  const safeValue = Array.isArray(value) ? value : [];
+  const [rowIds, setRowIds] = React.useState<string[]>(() =>
+    safeValue.map(() => nextContainerRowId())
+  );
+
+  // Keep row IDs in sync when value changes externally (e.g. YAML editor).
+  React.useEffect(() => {
+    setRowIds(prev => {
+      if (prev.length === safeValue.length) return prev;
+      if (prev.length < safeValue.length) {
+        const next = [...prev];
+        while (next.length < safeValue.length) {
+          next.push(nextContainerRowId());
+        }
+        return next;
+      }
+      return prev.slice(0, safeValue.length);
+    });
+  }, [safeValue.length]);
+
+  function handleAdd() {
+    setRowIds(prev => [...prev, nextContainerRowId()]);
+    onChange([
+      ...safeValue,
+      { name: '', image: '', ports: [{ containerPort: 80 }], imagePullPolicy: 'Always' },
+    ]);
+  }
+
+  function handleRemove(index: number) {
+    setRowIds(prev => prev.filter((_, i) => i !== index));
+    onChange(safeValue.filter((_, i) => i !== index));
+  }
+
+  function handleEdit(index: number, field: string, newVal: string) {
+    onChange(
+      safeValue.map((c, i) => {
+        if (i !== index) return c;
+        if (field === 'containerPort') {
+          const portNum = parseInt(newVal, 10);
+          const rest = _.omit(c, ['containerPort', 'ports']);
+          if (!isNaN(portNum) && portNum > 0) {
+            return { ...rest, ports: [{ containerPort: portNum }] };
+          }
+          return rest;
+        }
+        return { ...c, [field]: newVal };
+      })
+    );
+  }
+
+  function getPort(container: Record<string, any>): string {
+    const port = container?.ports?.[0]?.containerPort ?? container?.containerPort;
+    return port !== null && port !== undefined ? String(port) : '';
+  }
+
+  return (
+    <Box role="group" aria-labelledby={groupLabelId}>
+      {(label || helperText) && (
+        <FieldLabel id={groupLabelId} label={label} required={required} helperText={helperText} />
+      )}
+      {safeValue.map((rawContainer, index) => {
+        const container =
+          rawContainer && typeof rawContainer === 'object' && !Array.isArray(rawContainer)
+            ? (rawContainer as Record<string, any>)
+            : {};
+        return (
+          <Box
+            key={rowIds[index] ?? `container-fallback-${index}`}
+            sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 2, mb: 2 }}
+          >
+            <FormTextField
+              label={t('translation|Name')}
+              value={container.name ?? ''}
+              onChange={e => handleEdit(index, 'name', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Container name') }}
+            />
+            <FormTextField
+              label={t('translation|Image')}
+              value={container.image ?? ''}
+              onChange={e => handleEdit(index, 'image', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Container image') }}
+            />
+            <FormTextField
+              label={t('translation|Container Port')}
+              value={getPort(container)}
+              onChange={e => handleEdit(index, 'containerPort', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Container port') }}
+              type="number"
+            />
+            <FormTextField
+              label={t('translation|Pull Policy')}
+              value={container.imagePullPolicy ?? 'Always'}
+              onChange={e => handleEdit(index, 'imagePullPolicy', e.target.value)}
+              inputProps={{ 'aria-label': t('translation|Image pull policy') }}
+              select
+            >
+              {IMAGE_PULL_POLICIES.map(p => (
+                <MenuItem key={p} value={p}>
+                  {p}
+                </MenuItem>
+              ))}
+            </FormTextField>
+            <IconButton
+              onClick={() => handleRemove(index)}
+              color="default"
+              size="small"
+              aria-label={t('translation|Remove container {{ name }}', {
+                name: container.name ?? index,
+              })}
+            >
+              <Icon icon="mdi:close-circle" width={24} height={24} />
+            </IconButton>
+          </Box>
+        );
+      })}
+      <Box sx={{ mt: 2 }}>
+        <Button
+          onClick={handleAdd}
+          color="primary"
+          size="small"
+          aria-label={t('translation|Add container')}
+        >
+          <Icon icon="mdi:plus-circle" width={24} height={24} />
+          <Typography variant="body2" sx={{ ml: 0.5 }}>
+            {t('translation|New Container')}
+          </Typography>
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+/** Props for {@link PodLabelsEditor}. */
+export interface PodLabelsEditorProps {
+  /** Current full pod template labels map (locked entries + extras). */
+  value: Record<string, string>;
+  /** Labels mirrored from the selector. Rendered disabled with no delete. */
+  lockedLabels: Record<string, string>;
+  /** Called with the updated full pod template labels map. */
+  onChange: (labels: Record<string, string>) => void;
+}
+
+/** Pod template labels editor. Rows whose key is in `lockedLabels` (mirrored
+ *  from the selector) render disabled with no delete. Other rows are fully
+ *  editable; both end up in `spec.template.metadata.labels`. */
+export function PodLabelsEditor(props: PodLabelsEditorProps) {
+  const { value, lockedLabels, onChange } = props;
+  const { t } = useTranslation(['translation']);
+
+  /** Editable rows = full value minus locked keys. */
+  function extrasFromValue(full: Record<string, string>): Record<string, string> {
+    const extras: Record<string, string> = {};
+    for (const [k, v] of Object.entries(full ?? {})) {
+      if (!(k in lockedLabels)) extras[k] = v;
+    }
+    return extras;
+  }
+
+  const [extraRows, setExtraRows] = React.useState<LabelRow[]>(() =>
+    buildLabelRows(extrasFromValue(value))
+  );
+  /** Last full map we emitted. Lets us tell our own echo apart from an
+   *  outside change (e.g. YAML editor) and re-seed rows only when needed. */
+  const lastEmittedRef = React.useRef<Record<string, string>>({
+    ...lockedLabels,
+    ...labelRowsToMap(extraRows),
+  });
+
+  React.useEffect(() => {
+    const merged = { ...lockedLabels, ...value };
+    if (!labelMapsEqual(merged, lastEmittedRef.current)) {
+      setExtraRows(buildLabelRows(extrasFromValue(value ?? {})));
+      lastEmittedRef.current = merged;
+    }
+    // extrasFromValue closes over lockedLabels; both are in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, lockedLabels]);
+
+  function commit(nextExtras: LabelRow[]) {
+    setExtraRows(nextExtras);
+    const extrasMap = labelRowsToMap(nextExtras);
+    // Locked entries win on key collision so selector edits aren't
+    // shadowed by a same-key extra.
+    const full = { ...extrasMap, ...lockedLabels };
+    lastEmittedRef.current = full;
+    onChange(full);
+  }
+
+  function addRow() {
+    const used = new Set([...extraRows.map(r => r.key), ...Object.keys(lockedLabels)]);
+    let nextKey = 'new-label';
+    let idx = 1;
+    while (used.has(nextKey)) {
+      idx += 1;
+      nextKey = `new-label-${idx}`;
+    }
+    commit([...extraRows, { id: nextLabelRowId(), key: nextKey, value: '' }]);
+  }
+
+  function handleDelete(id: string) {
+    commit(extraRows.filter(r => r.id !== id));
+  }
+
+  function handleKeyEdit(id: string, newKeyVal: string) {
+    // Two rows may briefly share a key while typing; the map drops the duplicate.
+    commit(extraRows.map(r => (r.id === id ? { ...r, key: newKeyVal } : r)));
+  }
+
+  function handleValueEdit(id: string, newValue: string) {
+    commit(extraRows.map(r => (r.id === id ? { ...r, value: newValue } : r)));
+  }
+
+  const lockedEntries = Object.entries(lockedLabels ?? {});
+
+  return (
+    <Box>
+      {lockedEntries.map(([k, v]) => (
+        <Box
+          key={`locked-${k}`}
+          sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 2, mb: 2 }}
+        >
+          <FormTextField
+            label={t('translation|Key')}
+            value={k}
+            disabled
+            inputProps={{ 'aria-label': t('translation|Label key'), readOnly: true }}
+          />
+          <FormTextField
+            label={t('translation|Value')}
+            value={v}
+            disabled
+            inputProps={{ 'aria-label': t('translation|Label value'), readOnly: true }}
+          />
+        </Box>
+      ))}
+      {extraRows.map(r => (
+        <Box key={r.id} sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 2, mb: 2 }}>
+          <FormTextField
+            label={t('translation|Key')}
+            value={r.key}
+            onChange={e => handleKeyEdit(r.id, e.target.value)}
+            inputProps={{ 'aria-label': t('translation|Label key') }}
+          />
+          <FormTextField
+            label={t('translation|Value')}
+            value={r.value}
+            onChange={e => handleValueEdit(r.id, e.target.value)}
+            inputProps={{ 'aria-label': t('translation|Label value') }}
+          />
+          <IconButton
+            onClick={() => handleDelete(r.id)}
+            color="default"
+            size="small"
+            aria-label={t('translation|Remove label {{ label }}', {
+              label: `${r.key}=${r.value}`,
+            })}
+          >
+            <Icon icon="mdi:close-circle" width={24} height={24} />
+          </IconButton>
+        </Box>
+      ))}
+      <Box sx={{ mt: 2 }}>
+        <Button
+          onClick={addRow}
+          color="primary"
+          size="small"
+          aria-label={t('translation|Add label')}
+        >
+          <Icon icon="mdi:plus-circle" width={24} height={24} />
+          <Typography variant="body2" sx={{ ml: 0.5 }}>
+            {t('translation|New Label')}
+          </Typography>
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+/** Options for {@link useSelectorPodTemplate}. */
+export interface UseSelectorPodTemplateOptions<T extends Record<string, any>> {
+  /** Current resource draft. */
+  resource: T;
+  /** Called when the resource is updated (defaults seeded, selector edited). */
+  onChange: (resource: T) => void;
+  /** Label seeded into `spec.selector.matchLabels` and mirrored into the pod
+   *  template when the selector is empty on first mount. Defaults to
+   *  `{ app: 'headlamp' }`. Pass `null` to skip seeding labels. */
+  defaultMatchLabels?: Record<string, string> | null;
+  /** Value seeded into `spec.replicas` when unset on first mount. Defaults
+   *  to `1`. Pass `null` to skip seeding replicas (useful for DaemonSet,
+   *  Job, etc. which don't take a replica count). */
+  defaultReplicas?: number | null;
+}
+
+/** Returned by {@link useSelectorPodTemplate}. */
+export interface SelectorPodTemplateState {
+  /** Current `spec.selector.matchLabels`. */
+  matchLabels: Record<string, string>;
+  /** Current `spec.template.metadata.labels`. */
+  podLabels: Record<string, string>;
+  /** Apply a new selector map. Old selector entries are replaced with
+   *  `nextMatch`; any pod-template-only extras are preserved. Selector wins
+   *  on key collision, matching {@link PodLabelsEditor}. */
+  handleMatchLabelsChange: (nextMatch: Record<string, string>) => void;
+}
+
+/** Shared selector + pod-template wiring for resources that embed a pod
+ *  template (Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, ...).
+ *  Seeds defaults once on mount and exposes a selector change handler that
+ *  mirrors selector entries into the pod template labels.
+ *
+ *  Opt-in: only call this from forms that actually have a selector + pod
+ *  template. Pair with {@link LabelTextField} for the selector field and
+ *  {@link PodLabelsEditor} for the pod template labels field, both via the
+ *  `render` callback on a {@link FormField}. */
+export function useSelectorPodTemplate<T extends Record<string, any>>(
+  opts: UseSelectorPodTemplateOptions<T>
+): SelectorPodTemplateState {
+  const {
+    resource,
+    onChange,
+    defaultMatchLabels = { app: 'headlamp' },
+    defaultReplicas = 1,
+  } = opts;
+
+  const matchLabels = React.useMemo(
+    () => (resource.spec?.selector?.matchLabels as Record<string, string> | undefined) ?? {},
+    [resource.spec?.selector?.matchLabels]
+  );
+  const podLabels =
+    (resource.spec?.template?.metadata?.labels as Record<string, string> | undefined) ?? {};
+
+  // Seed defaults once. Effect (not render) so the seed reaches the
+  // resource / YAML, not just the form UI.
+  const didSeedDefaultsRef = React.useRef(false);
+  React.useEffect(() => {
+    if (didSeedDefaultsRef.current) return;
+    didSeedDefaultsRef.current = true;
+    const next = _.cloneDeep(resource) as T;
+    let changed = false;
+    if (defaultMatchLabels !== null) {
+      if (Object.keys(matchLabels).length === 0) {
+        _.set(next, 'spec.selector.matchLabels', { ...defaultMatchLabels });
+        _.set(next, 'spec.template.metadata.labels', {
+          ...((next.spec?.template?.metadata?.labels as Record<string, string> | undefined) ?? {}),
+          ...defaultMatchLabels,
+        });
+        changed = true;
+      } else {
+        // Mirror every selector entry into pod labels, keeping existing extras.
+        const mergedPodLabels = { ...podLabels, ...matchLabels };
+        if (!labelMapsEqual(mergedPodLabels, podLabels)) {
+          _.set(next, 'spec.template.metadata.labels', mergedPodLabels);
+          changed = true;
+        }
+      }
+    }
+    if (defaultReplicas !== null && next.spec?.replicas === undefined) {
+      _.set(next, 'spec.replicas', defaultReplicas);
+      changed = true;
+    }
+    if (changed) {
+      onChange(next);
+    }
+    // Only run once: re-running would clobber user edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleMatchLabelsChange(nextMatch: Record<string, string>) {
+    const extras: Record<string, string> = {};
+    for (const [k, v] of Object.entries(podLabels)) {
+      if (!(k in matchLabels)) extras[k] = v;
+    }
+    const nextPodLabels = { ...extras, ...nextMatch };
+
+    const nextResource = _.cloneDeep(resource) as T;
+    _.set(nextResource, 'spec.selector.matchLabels', nextMatch);
+    if (!labelMapsEqual(nextPodLabels, podLabels)) {
+      _.set(nextResource, 'spec.template.metadata.labels', nextPodLabels);
+    }
+    onChange(nextResource);
+  }
+
+  return { matchLabels, podLabels, handleMatchLabelsChange };
+}
+
 /** Safely parse a YAML string into an object, returning {} on failure. */
 export function parseYaml(input: string | undefined): Record<string, any> {
   if (!input) return {};

--- a/frontend/src/components/endpoints/CreateEndpointForm.tsx
+++ b/frontend/src/components/endpoints/CreateEndpointForm.tsx
@@ -82,7 +82,7 @@ function rowsToSubsets(rows: SubsetRow[]): KubeEndpointSubset[] {
       ...(a.nodeName ? { nodeName: a.nodeName } : {}),
     })),
     ports: r.ports.map(p => ({
-      name: p.name,
+      ...(p.name ? { name: p.name } : {}),
       appProtocol: p.appProtocol,
       port: p.port,
       protocol: p.protocol,
@@ -100,10 +100,23 @@ function SubsetsEditor(props: SubsetsEditorProps) {
   const { t } = useTranslation(['translation']);
 
   const [rows, setRows] = React.useState<SubsetRow[]>(() => subsetsToRows(value ?? []));
+  const lastEmittedRef = React.useRef<KubeEndpointSubset[]>(rowsToSubsets(rows));
+
+  // Re-seed rows when value changes externally (e.g. user edits YAML directly).
+  // Skip the update when the change is our own echo to avoid clobbering in-progress edits.
+  React.useEffect(() => {
+    const incoming = value ?? [];
+    if (JSON.stringify(incoming) !== JSON.stringify(lastEmittedRef.current)) {
+      setRows(subsetsToRows(incoming));
+      lastEmittedRef.current = incoming;
+    }
+  }, [value]);
 
   function commit(next: SubsetRow[]) {
     setRows(next);
-    onChange(rowsToSubsets(next));
+    const subsets = rowsToSubsets(next);
+    lastEmittedRef.current = subsets;
+    onChange(subsets);
   }
 
   function addSubset() {
@@ -181,7 +194,8 @@ function SubsetsEditor(props: SubsetsEditorProps) {
         if (p._id !== portId) return p;
         if (field === 'port') {
           const num = parseInt(val, 10);
-          return { ...p, port: isNaN(num) ? p.port : num };
+          if (isNaN(num) || num < 1 || num > 65535) return p;
+          return { ...p, port: num };
         }
         return { ...p, [field]: val };
       }),

--- a/frontend/src/components/endpoints/CreateEndpointForm.tsx
+++ b/frontend/src/components/endpoints/CreateEndpointForm.tsx
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Icon } from '@iconify/react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import type {
+  KubeEndpointAddress,
+  KubeEndpointPort,
+  KubeEndpointSubset,
+} from '../../lib/k8s/endpoints';
+import CreateResourceForm, {
+  FieldLabel,
+  FormSection,
+  FormTextField,
+} from '../common/Resource/CreateResourceForm';
+
+const PROTOCOLS = ['TCP', 'UDP', 'SCTP'];
+
+/** Props for {@link CreateEndpointForm}. */
+export interface CreateEndpointFormProps {
+  /** Current resource object from the editor/form state. */
+  resource?: Record<string, any>;
+  /** Called when form fields update the resource object. */
+  onChange: (resource: Record<string, any>) => void;
+}
+
+let subsetIdCounter = 0;
+const nextSubsetId = () => `subset-${++subsetIdCounter}`;
+
+let addressIdCounter = 0;
+const nextAddressId = () => `address-${++addressIdCounter}`;
+
+let portIdCounter = 0;
+const nextPortId = () => `port-${++portIdCounter}`;
+
+interface AddressRow extends KubeEndpointAddress {
+  _id: string;
+}
+
+interface PortRow extends KubeEndpointPort {
+  _id: string;
+}
+
+interface SubsetRow {
+  _id: string;
+  addresses: AddressRow[];
+  ports: PortRow[];
+}
+
+function subsetsToRows(subsets: KubeEndpointSubset[]): SubsetRow[] {
+  return (subsets ?? []).map(s => ({
+    _id: nextSubsetId(),
+    addresses: (s.addresses ?? []).map(a => ({ ...a, _id: nextAddressId() })),
+    ports: (s.ports ?? []).map(p => ({ ...p, _id: nextPortId() })),
+  }));
+}
+
+function rowsToSubsets(rows: SubsetRow[]): KubeEndpointSubset[] {
+  return rows.map(r => ({
+    addresses: r.addresses.map(a => ({
+      ip: a.ip,
+      hostname: a.hostname,
+      ...(a.nodeName ? { nodeName: a.nodeName } : {}),
+    })),
+    ports: r.ports.map(p => ({
+      name: p.name,
+      appProtocol: p.appProtocol,
+      port: p.port,
+      protocol: p.protocol,
+    })),
+  }));
+}
+
+interface SubsetsEditorProps {
+  value: KubeEndpointSubset[];
+  onChange: (subsets: KubeEndpointSubset[]) => void;
+}
+
+function SubsetsEditor(props: SubsetsEditorProps) {
+  const { value, onChange } = props;
+  const { t } = useTranslation(['translation']);
+
+  const [rows, setRows] = React.useState<SubsetRow[]>(() => subsetsToRows(value ?? []));
+
+  function commit(next: SubsetRow[]) {
+    setRows(next);
+    onChange(rowsToSubsets(next));
+  }
+
+  function addSubset() {
+    commit([
+      ...rows,
+      {
+        _id: nextSubsetId(),
+        addresses: [{ _id: nextAddressId(), ip: '', hostname: '' }],
+        ports: [{ _id: nextPortId(), name: '', appProtocol: 'http', port: 80, protocol: 'TCP' }],
+      },
+    ]);
+  }
+
+  function removeSubset(id: string) {
+    commit(rows.filter(r => r._id !== id));
+  }
+
+  function updateSubset(id: string, updated: Partial<SubsetRow>) {
+    commit(rows.map(r => (r._id === id ? { ...r, ...updated } : r)));
+  }
+
+  function addAddress(subsetId: string) {
+    const subset = rows.find(r => r._id === subsetId);
+    if (!subset) return;
+    updateSubset(subsetId, {
+      addresses: [...subset.addresses, { _id: nextAddressId(), ip: '', hostname: '' }],
+    });
+  }
+
+  function removeAddress(subsetId: string, addressId: string) {
+    const subset = rows.find(r => r._id === subsetId);
+    if (!subset) return;
+    updateSubset(subsetId, {
+      addresses: subset.addresses.filter(a => a._id !== addressId),
+    });
+  }
+
+  function editAddress(
+    subsetId: string,
+    addressId: string,
+    field: keyof KubeEndpointAddress,
+    val: string
+  ) {
+    const subset = rows.find(r => r._id === subsetId);
+    if (!subset) return;
+    updateSubset(subsetId, {
+      addresses: subset.addresses.map(a => (a._id === addressId ? { ...a, [field]: val } : a)),
+    });
+  }
+
+  function addPort(subsetId: string) {
+    const subset = rows.find(r => r._id === subsetId);
+    if (!subset) return;
+    updateSubset(subsetId, {
+      ports: [
+        ...subset.ports,
+        { _id: nextPortId(), name: '', appProtocol: 'http', port: 80, protocol: 'TCP' },
+      ],
+    });
+  }
+
+  function removePort(subsetId: string, portId: string) {
+    const subset = rows.find(r => r._id === subsetId);
+    if (!subset) return;
+    updateSubset(subsetId, {
+      ports: subset.ports.filter(p => p._id !== portId),
+    });
+  }
+
+  function editPort(subsetId: string, portId: string, field: keyof KubeEndpointPort, val: string) {
+    const subset = rows.find(r => r._id === subsetId);
+    if (!subset) return;
+    updateSubset(subsetId, {
+      ports: subset.ports.map(p => {
+        if (p._id !== portId) return p;
+        if (field === 'port') {
+          const num = parseInt(val, 10);
+          return { ...p, port: isNaN(num) ? p.port : num };
+        }
+        return { ...p, [field]: val };
+      }),
+    });
+  }
+
+  return (
+    <Box>
+      {rows.map((subset, subsetIdx) => (
+        <Box
+          key={subset._id}
+          sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2, mb: 2 }}
+        >
+          <Box
+            sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}
+          >
+            <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+              {t('translation|Subset {{ index }}', { index: subsetIdx + 1 })}
+            </Typography>
+            <IconButton
+              size="small"
+              onClick={() => removeSubset(subset._id)}
+              aria-label={t('translation|Remove subset {{ index }}', { index: subsetIdx + 1 })}
+            >
+              <Icon icon="mdi:close-circle" width={20} height={20} />
+            </IconButton>
+          </Box>
+
+          {/* Addresses */}
+          <FieldLabel
+            label={t('translation|Addresses')}
+            helperText={t('translation|IP addresses that are ready to receive traffic')}
+          />
+          {subset.addresses.map(addr => (
+            <Box
+              key={addr._id}
+              sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 1, mb: 1, pl: 1 }}
+            >
+              <FormTextField
+                label={t('translation|IP')}
+                value={addr.ip}
+                onChange={e => editAddress(subset._id, addr._id, 'ip', e.target.value)}
+                inputProps={{ 'aria-label': t('translation|IP address') }}
+                required
+              />
+              <FormTextField
+                label={t('translation|Hostname')}
+                value={addr.hostname ?? ''}
+                onChange={e => editAddress(subset._id, addr._id, 'hostname', e.target.value)}
+                inputProps={{ 'aria-label': t('translation|Hostname') }}
+              />
+              <FormTextField
+                label={t('translation|Node Name')}
+                value={addr.nodeName ?? ''}
+                onChange={e => editAddress(subset._id, addr._id, 'nodeName', e.target.value)}
+                inputProps={{ 'aria-label': t('translation|Node name') }}
+              />
+              <IconButton
+                size="small"
+                onClick={() => removeAddress(subset._id, addr._id)}
+                aria-label={t('translation|Remove address {{ ip }}', { ip: addr.ip || addr._id })}
+              >
+                <Icon icon="mdi:close-circle" width={18} height={18} />
+              </IconButton>
+            </Box>
+          ))}
+          <Button
+            size="small"
+            onClick={() => addAddress(subset._id)}
+            aria-label={t('translation|Add address')}
+            sx={{ ml: 1, mb: 1 }}
+          >
+            <Icon icon="mdi:plus-circle" width={18} height={18} />
+            <Typography variant="body2" sx={{ ml: 0.5 }}>
+              {t('translation|Add Address')}
+            </Typography>
+          </Button>
+
+          {/* Ports */}
+          <FieldLabel
+            label={t('translation|Ports')}
+            helperText={t('translation|Port numbers available on the related IP addresses')}
+          />
+          {subset.ports.map(port => (
+            <Box
+              key={port._id}
+              sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 1, mb: 1, pl: 1 }}
+            >
+              <FormTextField
+                label={t('translation|Name')}
+                value={port.name ?? ''}
+                onChange={e => editPort(subset._id, port._id, 'name', e.target.value)}
+                inputProps={{ 'aria-label': t('translation|Port name') }}
+              />
+              <FormTextField
+                label={t('translation|Port')}
+                type="number"
+                value={String(port.port)}
+                onChange={e => editPort(subset._id, port._id, 'port', e.target.value)}
+                inputProps={{
+                  'aria-label': t('translation|Port number'),
+                  min: 1,
+                  max: 65535,
+                  step: 1,
+                }}
+                required
+              />
+              <FormTextField
+                label={t('translation|Protocol')}
+                value={port.protocol}
+                onChange={e => editPort(subset._id, port._id, 'protocol', e.target.value)}
+                inputProps={{ 'aria-label': t('translation|Protocol') }}
+                select
+              >
+                {PROTOCOLS.map(p => (
+                  <MenuItem key={p} value={p}>
+                    {p}
+                  </MenuItem>
+                ))}
+              </FormTextField>
+              <FormTextField
+                label={t('translation|App Protocol')}
+                value={port.appProtocol ?? ''}
+                onChange={e => editPort(subset._id, port._id, 'appProtocol', e.target.value)}
+                inputProps={{ 'aria-label': t('translation|App protocol') }}
+              />
+              <IconButton
+                size="small"
+                onClick={() => removePort(subset._id, port._id)}
+                aria-label={t('translation|Remove port {{ port }}', { port: port.port })}
+              >
+                <Icon icon="mdi:close-circle" width={18} height={18} />
+              </IconButton>
+            </Box>
+          ))}
+          <Button
+            size="small"
+            onClick={() => addPort(subset._id)}
+            aria-label={t('translation|Add port')}
+            sx={{ ml: 1 }}
+          >
+            <Icon icon="mdi:plus-circle" width={18} height={18} />
+            <Typography variant="body2" sx={{ ml: 0.5 }}>
+              {t('translation|Add Port')}
+            </Typography>
+          </Button>
+        </Box>
+      ))}
+
+      <Button
+        size="small"
+        onClick={addSubset}
+        color="primary"
+        aria-label={t('translation|Add subset')}
+      >
+        <Icon icon="mdi:plus-circle" width={24} height={24} />
+        <Typography variant="body2" sx={{ ml: 0.5 }}>
+          {t('translation|New Subset')}
+        </Typography>
+      </Button>
+    </Box>
+  );
+}
+
+/** Endpoints creation form built on {@link CreateResourceForm}. Defines
+ *  sections for metadata (name, namespace, labels) and subsets (addresses + ports). */
+export default function CreateEndpointForm(props: CreateEndpointFormProps) {
+  const { resource, onChange } = props;
+  const { t } = useTranslation(['translation', 'glossary']);
+
+  const normalizedResource = resource ?? {};
+
+  const sections: FormSection[] = [
+    {
+      title: t('translation|Metadata'),
+      fields: [
+        { key: 'name', path: 'metadata.name', label: t('translation|Name'), required: true },
+        {
+          key: 'namespace',
+          path: 'metadata.namespace',
+          label: t('glossary|Namespace'),
+          type: 'namespace' as const,
+        },
+        {
+          key: 'labels',
+          path: 'metadata.labels',
+          label: t('translation|Labels'),
+          type: 'labels' as const,
+        },
+      ],
+    },
+    {
+      title: t('translation|Subsets'),
+      fields: [
+        {
+          key: 'subsets',
+          path: 'subsets',
+          label: t('translation|Subsets'),
+          helperText: t('translation|Each subset groups addresses with matching port numbers'),
+          render: ({ value, onChange: onSubsetsChange }) => (
+            <SubsetsEditor
+              value={(value as KubeEndpointSubset[]) ?? []}
+              onChange={onSubsetsChange}
+            />
+          ),
+        },
+      ],
+    },
+  ];
+
+  return (
+    <CreateResourceForm sections={sections} resource={normalizedResource} onChange={onChange} />
+  );
+}

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -120,6 +120,10 @@
         "class": [Function],
         "form": [Function],
       },
+      "Endpoints": {
+        "class": [Function],
+        "form": [Function],
+      },
       "Pod": {
         "class": [Function],
         "form": [Function],
@@ -142,6 +146,7 @@
       "CopyButton": [Function],
       "CreateButton": [Function],
       "CreateDeploymentForm": [Function],
+      "CreateEndpointForm": [Function],
       "CreatePodForm": [Function],
       "CreateReplicaSetForm": [Function],
       "CreateResourceForm": [Function],


### PR DESCRIPTION

##Contributes to #5995

What this PR adds:

A new CreateEndpointForm component that lets users create Kubernetes Endpoints resources through the Headlamp UI form — without having to write YAML manually.

 ##Files changed:
frontend/src/components/endpoints/CreateEndpointForm.tsx (new file)
Built on top of the existing CreateResourceForm base, following the same pattern as CreatePodForm and CreateDeploymentForm. The form has two sections:
 @mortent @illume @dims @till @v