### PR TITLE
frontend: plugins: Guard localStorage parsing against corrupt JSON

### DIFF
--- a/frontend/src/plugin/pluginConfigSlice.ts
+++ b/frontend/src/plugin/pluginConfigSlice.ts
@@ -30,10 +30,13 @@ const PLUGIN_CONFIG_KEY = 'pluginConfigs';
 
 // Load from local storage, falling back to empty if unavailable, missing or invalid.
 function loadInitialState(): PluginConfigState {
-  if (typeof localStorage === 'undefined') {
-    return {};
-  }
   try {
+    // Accessing localStorage can itself throw in restricted contexts (e.g. a
+    // SecurityError from a throwing getter), so keep the availability check
+    // inside the try so every failure path falls back to empty.
+    if (typeof localStorage === 'undefined') {
+      return {};
+    }
     const parsed: unknown = JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}');
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       console.warn('Stored plugin configs are not an object, falling back to empty:', parsed);
@@ -41,7 +44,7 @@ function loadInitialState(): PluginConfigState {
     }
     return parsed as PluginConfigState;
   } catch (error) {
-    console.warn('Failed to parse stored plugin configs, falling back to empty:', error);
+    console.warn('Failed to read stored plugin configs, falling back to empty:', error);
     return {};
   }
 }

--- a/frontend/src/plugin/pluginConfigSlice.ts
+++ b/frontend/src/plugin/pluginConfigSlice.ts
@@ -42,7 +42,7 @@ function loadInitialState(): PluginConfigState {
       // Avoid logging the value itself: plugin configs may hold sensitive data.
       console.warn(
         `Stored plugin configs are not an object (got ${
-          Array.isArray(parsed) ? 'array' : typeof parsed
+          parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed
         }), falling back to empty.`
       );
       return {};

--- a/frontend/src/plugin/pluginConfigSlice.ts
+++ b/frontend/src/plugin/pluginConfigSlice.ts
@@ -39,7 +39,12 @@ function loadInitialState(): PluginConfigState {
     }
     const parsed: unknown = JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}');
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      console.warn('Stored plugin configs are not an object, falling back to empty:', parsed);
+      // Avoid logging the value itself: plugin configs may hold sensitive data.
+      console.warn(
+        `Stored plugin configs are not an object (got ${
+          Array.isArray(parsed) ? 'array' : typeof parsed
+        }), falling back to empty.`
+      );
       return {};
     }
     return parsed as PluginConfigState;

--- a/frontend/src/plugin/pluginConfigSlice.ts
+++ b/frontend/src/plugin/pluginConfigSlice.ts
@@ -28,8 +28,11 @@ export interface PluginConfigState {
 // Key used for local storage to persist plugin configurations.
 const PLUGIN_CONFIG_KEY = 'pluginConfigs';
 
-// Load from local storage, falling back to empty if missing or invalid.
+// Load from local storage, falling back to empty if unavailable, missing or invalid.
 function loadInitialState(): PluginConfigState {
+  if (typeof localStorage === 'undefined') {
+    return {};
+  }
   try {
     return JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}');
   } catch (error) {

--- a/frontend/src/plugin/pluginConfigSlice.ts
+++ b/frontend/src/plugin/pluginConfigSlice.ts
@@ -28,8 +28,17 @@ export interface PluginConfigState {
 // Key used for local storage to persist plugin configurations.
 const PLUGIN_CONFIG_KEY = 'pluginConfigs';
 
-// Initial state is loaded from local storage, or an empty object if nothing is stored.
-const initialState: PluginConfigState = JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}');
+// Load from local storage, falling back to empty if missing or invalid.
+function loadInitialState(): PluginConfigState {
+  try {
+    return JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}');
+  } catch (error) {
+    console.error('Failed to parse stored plugin configs, falling back to empty:', error);
+    return {};
+  }
+}
+
+const initialState: PluginConfigState = loadInitialState();
 
 const DEBOUNCE_DELAY = 500; // ms
 

--- a/frontend/src/plugin/pluginConfigSlice.ts
+++ b/frontend/src/plugin/pluginConfigSlice.ts
@@ -34,9 +34,14 @@ function loadInitialState(): PluginConfigState {
     return {};
   }
   try {
-    return JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}');
+    const parsed: unknown = JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}');
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      console.warn('Stored plugin configs are not an object, falling back to empty:', parsed);
+      return {};
+    }
+    return parsed as PluginConfigState;
   } catch (error) {
-    console.error('Failed to parse stored plugin configs, falling back to empty:', error);
+    console.warn('Failed to parse stored plugin configs, falling back to empty:', error);
     return {};
   }
 }

--- a/frontend/src/plugin/pluginStorage.test.ts
+++ b/frontend/src/plugin/pluginStorage.test.ts
@@ -23,7 +23,7 @@ describe('plugin slices module-load state', () => {
   beforeEach(() => {
     vi.resetModules();
     localStorage.clear();
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -37,7 +37,17 @@ describe('plugin slices module-load state', () => {
     const state = reducer(undefined, { type: '@@INIT' });
 
     expect(state.pluginSettings).toEqual([]);
-    expect(console.error).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('pluginsSlice falls back to an empty array when stored settings are not an array', async () => {
+    localStorage.setItem('headlampPluginSettings', '{"not":"an array"}');
+
+    const { default: reducer } = await import('./pluginsSlice');
+    const state = reducer(undefined, { type: '@@INIT' });
+
+    expect(state.pluginSettings).toEqual([]);
+    expect(console.warn).toHaveBeenCalled();
   });
 
   it('pluginConfigSlice falls back to an empty object when stored configs are invalid JSON', async () => {
@@ -47,14 +57,34 @@ describe('plugin slices module-load state', () => {
     const state = reducer(undefined, { type: '@@INIT' });
 
     expect(state).toEqual({});
-    expect(console.error).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('pluginConfigSlice falls back to an empty object when stored configs are not an object', async () => {
+    localStorage.setItem('pluginConfigs', '["not","an object"]');
+
+    const { default: reducer } = await import('./pluginConfigSlice');
+    const state = reducer(undefined, { type: '@@INIT' });
+
+    expect(state).toEqual({});
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('pluginConfigSlice falls back to an empty object when stored configs are null', async () => {
+    localStorage.setItem('pluginConfigs', 'null');
+
+    const { default: reducer } = await import('./pluginConfigSlice');
+    const state = reducer(undefined, { type: '@@INIT' });
+
+    expect(state).toEqual({});
+    expect(console.warn).toHaveBeenCalled();
   });
 
   it('slices fall back to defaults when localStorage is unavailable at import time', async () => {
-    const originalLocalStorage = globalThis.localStorage;
     // Simulate a non-browser / pre-render environment where localStorage is missing.
-    // @ts-expect-error -- intentionally removing localStorage for this test.
-    delete globalThis.localStorage;
+    // Stubbing is more reliable than `delete` since jsdom's localStorage can be
+    // non-configurable.
+    vi.stubGlobal('localStorage', undefined);
 
     try {
       const { default: pluginsReducer } = await import('./pluginsSlice');
@@ -63,7 +93,7 @@ describe('plugin slices module-load state', () => {
       expect(pluginsReducer(undefined, { type: '@@INIT' }).pluginSettings).toEqual([]);
       expect(pluginConfigReducer(undefined, { type: '@@INIT' })).toEqual({});
     } finally {
-      globalThis.localStorage = originalLocalStorage;
+      vi.unstubAllGlobals();
     }
   });
 });

--- a/frontend/src/plugin/pluginStorage.test.ts
+++ b/frontend/src/plugin/pluginStorage.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// These tests exercise the module-load path of the plugin slices: the initial
+// state is computed when the module is first imported, so we seed localStorage
+// (or remove it) and use a fresh module registry for each case.
+describe('plugin slices module-load state', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pluginsSlice falls back to an empty array when stored settings are invalid JSON', async () => {
+    localStorage.setItem('headlampPluginSettings', '{not valid json');
+
+    const { default: reducer } = await import('./pluginsSlice');
+    const state = reducer(undefined, { type: '@@INIT' });
+
+    expect(state.pluginSettings).toEqual([]);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('pluginConfigSlice falls back to an empty object when stored configs are invalid JSON', async () => {
+    localStorage.setItem('pluginConfigs', '{not valid json');
+
+    const { default: reducer } = await import('./pluginConfigSlice');
+    const state = reducer(undefined, { type: '@@INIT' });
+
+    expect(state).toEqual({});
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('slices fall back to defaults when localStorage is unavailable at import time', async () => {
+    const originalLocalStorage = globalThis.localStorage;
+    // Simulate a non-browser / pre-render environment where localStorage is missing.
+    // @ts-expect-error -- intentionally removing localStorage for this test.
+    delete globalThis.localStorage;
+
+    try {
+      const { default: pluginsReducer } = await import('./pluginsSlice');
+      const { default: pluginConfigReducer } = await import('./pluginConfigSlice');
+
+      expect(pluginsReducer(undefined, { type: '@@INIT' }).pluginSettings).toEqual([]);
+      expect(pluginConfigReducer(undefined, { type: '@@INIT' })).toEqual({});
+    } finally {
+      globalThis.localStorage = originalLocalStorage;
+    }
+  });
+});

--- a/frontend/src/plugin/pluginStorage.test.ts
+++ b/frontend/src/plugin/pluginStorage.test.ts
@@ -96,4 +96,26 @@ describe('plugin slices module-load state', () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it('slices fall back to defaults when accessing localStorage throws', async () => {
+    // Restricted/privacy contexts can throw (e.g. SecurityError) on any
+    // localStorage access, including the availability check itself.
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('SecurityError');
+      },
+      clear: () => {},
+    });
+
+    try {
+      const { default: pluginsReducer } = await import('./pluginsSlice');
+      const { default: pluginConfigReducer } = await import('./pluginConfigSlice');
+
+      expect(pluginsReducer(undefined, { type: '@@INIT' }).pluginSettings).toEqual([]);
+      expect(pluginConfigReducer(undefined, { type: '@@INIT' })).toEqual({});
+      expect(console.warn).toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -131,11 +131,21 @@ export interface PluginsState {
   /** Information stored by settings about plugins. */
   pluginSettings: PluginInfo[];
 }
+// Load from local storage, falling back to empty if missing or invalid.
+function loadPluginSettings(): PluginInfo[] {
+  try {
+    return JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]');
+  } catch (error) {
+    console.error('Failed to parse stored plugin settings, falling back to empty:', error);
+    return [];
+  }
+}
+
 const initialState: PluginsState = {
   /** Once the plugins have been fetched and executed. */
   loaded: false,
   /** If plugin settings are saved use those. */
-  pluginSettings: JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]'),
+  pluginSettings: loadPluginSettings(),
 };
 
 export const pluginsSlice = createSlice({

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -137,9 +137,14 @@ function loadPluginSettings(): PluginInfo[] {
     return [];
   }
   try {
-    return JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]');
+    const parsed: unknown = JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]');
+    if (!Array.isArray(parsed)) {
+      console.warn('Stored plugin settings are not an array, falling back to empty:', parsed);
+      return [];
+    }
+    return parsed as PluginInfo[];
   } catch (error) {
-    console.error('Failed to parse stored plugin settings, falling back to empty:', error);
+    console.warn('Failed to parse stored plugin settings, falling back to empty:', error);
     return [];
   }
 }

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -144,7 +144,9 @@ function loadPluginSettings(): PluginInfo[] {
     if (!Array.isArray(parsed)) {
       // Avoid logging the value itself: plugin settings may hold sensitive data.
       console.warn(
-        `Stored plugin settings are not an array (got ${typeof parsed}), falling back to empty.`
+        `Stored plugin settings are not an array (got ${
+          parsed === null ? 'null' : typeof parsed
+        }), falling back to empty.`
       );
       return [];
     }

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -131,8 +131,11 @@ export interface PluginsState {
   /** Information stored by settings about plugins. */
   pluginSettings: PluginInfo[];
 }
-// Load from local storage, falling back to empty if missing or invalid.
+// Load from local storage, falling back to empty if unavailable, missing or invalid.
 function loadPluginSettings(): PluginInfo[] {
+  if (typeof localStorage === 'undefined') {
+    return [];
+  }
   try {
     return JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]');
   } catch (error) {

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -133,10 +133,13 @@ export interface PluginsState {
 }
 // Load from local storage, falling back to empty if unavailable, missing or invalid.
 function loadPluginSettings(): PluginInfo[] {
-  if (typeof localStorage === 'undefined') {
-    return [];
-  }
   try {
+    // Accessing localStorage can itself throw in restricted contexts (e.g. a
+    // SecurityError from a throwing getter), so keep the availability check
+    // inside the try so every failure path falls back to empty.
+    if (typeof localStorage === 'undefined') {
+      return [];
+    }
     const parsed: unknown = JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]');
     if (!Array.isArray(parsed)) {
       console.warn('Stored plugin settings are not an array, falling back to empty:', parsed);
@@ -144,7 +147,7 @@ function loadPluginSettings(): PluginInfo[] {
     }
     return parsed as PluginInfo[];
   } catch (error) {
-    console.warn('Failed to parse stored plugin settings, falling back to empty:', error);
+    console.warn('Failed to read stored plugin settings, falling back to empty:', error);
     return [];
   }
 }

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -142,7 +142,10 @@ function loadPluginSettings(): PluginInfo[] {
     }
     const parsed: unknown = JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]');
     if (!Array.isArray(parsed)) {
-      console.warn('Stored plugin settings are not an array, falling back to empty:', parsed);
+      // Avoid logging the value itself: plugin settings may hold sensitive data.
+      console.warn(
+        `Stored plugin settings are not an array (got ${typeof parsed}), falling back to empty.`
+      );
       return [];
     }
     return parsed as PluginInfo[];


### PR DESCRIPTION
## What

The plugin Redux slices built their initial state by calling `JSON.parse` on localStorage values directly:

- `frontend/src/plugin/pluginConfigSlice.ts` — `JSON.parse(localStorage.getItem(PLUGIN_CONFIG_KEY) || '{}')`
- `frontend/src/plugin/pluginsSlice.ts` — `JSON.parse(localStorage.getItem('headlampPluginSettings') || '[]')`

The `|| '{}'` / `|| '[]'` fallback only covers a *missing* key, not a present-but-invalid value.

## Why

Because this runs at module load to set up `initialState`, a corrupt value makes `JSON.parse` throw *before the store is even created* — the whole app fails to mount and the user gets a blank screen, recoverable only by manually clearing localStorage. Corruption can come from a half-finished write, devtools editing, or the stored shape changing between Headlamp versions. The write side already guards with try/catch; this brings the read side in line.

## How

Wrap both reads in try/catch and fall back to the default (logging a warning) when parsing fails.

Closes #6138