### PR TITLE
frontend: Add AI_ASSISTANT_OPEN HeadlampEvent for plugin-to-AI-Assistant communication

### DIFF
--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -345,6 +345,7 @@
     "METADATA": "METADATA",
   },
   "DefaultHeadlampEvents": {
+    "AI_ASSISTANT_OPEN": "headlamp.ai-assistant-open",
     "CREATE_RESOURCE": "headlamp.create-resource",
     "DELETE_RESOURCE": "headlamp.delete-resource",
     "DELETE_RESOURCES": "headlamp.delete-resources",

--- a/frontend/src/plugin/registry.tsx
+++ b/frontend/src/plugin/registry.tsx
@@ -73,6 +73,7 @@ import {
 } from '../redux/clusterProviderSlice';
 import {
   addEventCallback,
+  AIAssistantOpenEvent,
   CreateResourceEvent,
   DeleteResourceEvent,
   EditResourceEvent,
@@ -145,6 +146,7 @@ export type {
   ResourceDetailsViewLoadedEvent,
   ResourceListViewLoadedEvent,
   EventListEvent,
+  AIAssistantOpenEvent,
   PluginSettingsDetailsProps,
   PluginSettingsComponentType,
   GraphSource,

--- a/frontend/src/redux/headlampEventSlice.test.tsx
+++ b/frontend/src/redux/headlampEventSlice.test.tsx
@@ -15,8 +15,13 @@
  */
 
 import { configureStore } from '@reduxjs/toolkit';
-import eventCallbackReducer, { addEventCallback, eventAction } from './headlampEventSlice';
-import { listenerMiddleware } from './headlampEventSlice';
+import eventCallbackReducer, {
+  addEventCallback,
+  AIAssistantOpenEvent,
+  eventAction,
+  HeadlampEventType,
+  listenerMiddleware,
+} from './headlampEventSlice';
 
 function getStore() {
   return configureStore({
@@ -80,6 +85,80 @@ describe('eventsSlice', () => {
       );
 
       expect(callbackResponses).toEqual([0, 1]);
+    });
+  });
+
+  describe('AI_ASSISTANT_OPEN event', () => {
+    it('should dispatch AI_ASSISTANT_OPEN with prompt only', () => {
+      const received: AIAssistantOpenEvent[] = [];
+      store.dispatch(
+        addEventCallback(event => {
+          if (event.type === HeadlampEventType.AI_ASSISTANT_OPEN) {
+            received.push(event as AIAssistantOpenEvent);
+          }
+        })
+      );
+
+      store.dispatch(
+        eventAction({
+          type: HeadlampEventType.AI_ASSISTANT_OPEN,
+          data: { prompt: 'Why is this pod crashlooping?' },
+        })
+      );
+
+      expect(received).toHaveLength(1);
+      expect(received[0].data.prompt).toBe('Why is this pod crashlooping?');
+      expect(received[0].data.context).toBeUndefined();
+    });
+
+    it('should dispatch AI_ASSISTANT_OPEN with prompt and full context', () => {
+      const received: AIAssistantOpenEvent[] = [];
+      store.dispatch(
+        addEventCallback(event => {
+          if (event.type === HeadlampEventType.AI_ASSISTANT_OPEN) {
+            received.push(event as AIAssistantOpenEvent);
+          }
+        })
+      );
+
+      store.dispatch(
+        eventAction({
+          type: HeadlampEventType.AI_ASSISTANT_OPEN,
+          data: {
+            prompt: 'Explain this finding.',
+            context: {
+              sourcePlugin: 'kubebuddy',
+              cluster: 'prod-cluster',
+              resource: {
+                kind: 'Service',
+                name: 'network-observability',
+                namespace: 'kube-system',
+                apiVersion: 'v1',
+              },
+            },
+          },
+        })
+      );
+
+      expect(received).toHaveLength(1);
+      expect(received[0].data.context?.sourcePlugin).toBe('kubebuddy');
+      expect(received[0].data.context?.resource?.kind).toBe('Service');
+      expect(received[0].data.context?.resource?.namespace).toBe('kube-system');
+    });
+
+    it('should not trigger other event handlers for unrelated event types', () => {
+      const aiReceived: AIAssistantOpenEvent[] = [];
+      store.dispatch(
+        addEventCallback(event => {
+          if (event.type === HeadlampEventType.AI_ASSISTANT_OPEN) {
+            aiReceived.push(event as AIAssistantOpenEvent);
+          }
+        })
+      );
+
+      store.dispatch(eventAction({ type: 'some.other-event', data: {} }));
+
+      expect(aiReceived).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/redux/headlampEventSlice.ts
+++ b/frontend/src/redux/headlampEventSlice.ts
@@ -63,6 +63,8 @@ export enum HeadlampEventType {
   LIST_VIEW = 'headlamp.list-view',
   /** Events related to loading events for a resource. */
   OBJECT_EVENTS = 'headlamp.object-events',
+  /** Event to request the AI Assistant panel to open with an optional prompt and context. */
+  AI_ASSISTANT_OPEN = 'headlamp.ai-assistant-open',
 }
 
 /**
@@ -352,6 +354,28 @@ export interface EventListEvent {
   };
 }
 
+/**
+ * Event fired when a plugin requests the AI Assistant panel to open with a prefilled prompt.
+ */
+export interface AIAssistantOpenEvent extends HeadlampEvent<HeadlampEventType.AI_ASSISTANT_OPEN> {
+  data: {
+    /** The prompt to prefill in the AI Assistant input. */
+    prompt: string;
+    /** Optional context passed to the AI Assistant alongside the prompt. */
+    context?: {
+      sourcePlugin?: string;
+      cluster?: string;
+      resource?: {
+        kind: string;
+        name: string;
+        namespace?: string;
+        apiVersion?: string;
+      };
+      [key: string]: unknown;
+    };
+  };
+}
+
 export type HeadlampEventCallback = (data: HeadlampEvent) => void;
 
 const initialState: {
@@ -451,6 +475,9 @@ export function useEventCallback(
 export function useEventCallback(
   eventInfo: HeadlampEventType.OBJECT_EVENTS
 ): (events: Event[], resource?: KubeObject) => void;
+export function useEventCallback(
+  eventType: HeadlampEventType.AI_ASSISTANT_OPEN
+): (data: EventDataType<AIAssistantOpenEvent>) => void;
 export function useEventCallback(eventType?: HeadlampEventType | string) {
   const dispatch = useDispatch();
 
@@ -521,6 +548,8 @@ export function useEventCallback(eventType?: HeadlampEventType | string) {
       return dispatchDataEventFunc<ResourceDetailsViewLoadedEvent>(HeadlampEventType.DETAILS_VIEW);
     case HeadlampEventType.LIST_VIEW:
       return dispatchDataEventFunc<ResourceListViewLoadedEvent>(HeadlampEventType.LIST_VIEW);
+    case HeadlampEventType.AI_ASSISTANT_OPEN:
+      return dispatchDataEventFunc<AIAssistantOpenEvent>(HeadlampEventType.AI_ASSISTANT_OPEN);
     case HeadlampEventType.OBJECT_EVENTS:
       return (events: Event[], resource?: KubeObject) => {
         dispatch(


### PR DESCRIPTION
## Summary

This PR adds a new `HeadlampEventType.AI_ASSISTANT_OPEN` event that allows any plugin to open the AI Assistant panel with a prefilled prompt and optional resource context.

## Related Issue

Fixes #6143

## Changes

- Added `AI_ASSISTANT_OPEN = 'headlamp.ai-assistant-open'` to `HeadlampEventType` enum
- Added `AIAssistantOpenEvent` interface with typed `prompt` and optional `context` (sourcePlugin, cluster, resource)
- Added `useEventCallback` overload for the new event type
- Exported `AIAssistantOpenEvent` from the plugin public API (`registry.tsx`)

## Steps to Test

1. In a plugin, import `DefaultHeadlampEvents` and `useEventCallback` from `@kinvolk/headlamp-plugin/lib`
2. Call `useEventCallback(DefaultHeadlampEvents.AI_ASSISTANT_OPEN)` and dispatch it with a `prompt` and optional `context`
3. The AI Assistant plugin (once updated to listen for this event) will open its panel with the prefilled prompt

## Notes for the Reviewer

- This is the core/infrastructure side of #6143. The AI Assistant plugin (`@headlamp-k8s/ai-assistant`) needs a follow-up to add a `registerHeadlampEventCallback` listener for this event type and open its panel.
- The event is a safe no-op if AI Assistant is not installed.
- `joaquimrocha` suggested the HeadlampEvent approach in the issue comments — this implements exactly that.