### PR TITLE
cleanup: frontend: NodeShellAction: Fix namepsace typo and remove dead code

### DIFF
--- a/frontend/src/components/node/NodeShellAction.tsx
+++ b/frontend/src/components/node/NodeShellAction.tsx
@@ -58,7 +58,7 @@ export function NodeShellAction(props: NodeShellTerminalProps) {
   function isLinux(item: Node | null): boolean {
     return item?.status?.nodeInfo?.operatingSystem === 'linux';
   }
-  const namepsace = nodeTerminalNamespace(cluster);
+  const namespace = nodeTerminalNamespace(cluster);
   const activityId = 'node-shell-' + item.metadata.uid;
 
   if (!isNodeTerminalEnabled(cluster)) {
@@ -66,8 +66,8 @@ export function NodeShellAction(props: NodeShellTerminalProps) {
   }
   return (
     <>
-      <AuthVisible authVerb="create" item={Pod} namespace={namepsace}>
-        <AuthVisible item={Pod} namespace={namepsace} authVerb="get" subresource="exec">
+      <AuthVisible authVerb="create" item={Pod} namespace={namespace}>
+        <AuthVisible item={Pod} namespace={namespace} authVerb="get" subresource="exec">
           <ActionButton
             description={
               isLinux(item)
@@ -98,15 +98,6 @@ export function NodeShellAction(props: NodeShellTerminalProps) {
           />
         </AuthVisible>
       </AuthVisible>
-      {/* <NodeShellTerminal
-        key="terminal"
-        open={showShell}
-        title={t('Shell: {{ itemName }}', { itemName: item.metadata.name })}
-        item={item}
-        onClose={() => {
-          setShowShell(false);
-        }}
-      /> */}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes a variable name typo and removes dead commented-out code from
`NodeShellAction.tsx`.

## Changes

- Renamed `namepsace` → `namespace` (line 61, usages at lines 69-70)
- Removed dead commented-out `<NodeShellTerminal>` block referencing
  undeclared variables `showShell` and `setShowShell`

### Note for Reviewers

This is a cleanup-only change with no functional impact.

* Corrects a variable name typo (`namepsace` → `namespace`) for consistency and readability.
* Removes an unused commented-out `<NodeShellTerminal>` block that referenced undeclared variables (`showShell`, `setShowShell`) and was not part of the active code path.

No behavior changes are expected.
