### PR TITLE
frontend(Storybook): A8RInfo: Add Storybook story

### DIFF
--- a/frontend/src/components/common/Resource/A8RInfo.stories.tsx
+++ b/frontend/src/components/common/Resource/A8RInfo.stories.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import A8RInfo from './A8RInfo';
+
+export default {
+  title: 'Resource/A8RInfo',
+  component: A8RInfo,
+  argTypes: {},
+} as Meta;
+
+const Template: StoryFn<typeof A8RInfo> = args => <A8RInfo {...args} />;
+
+export const WithAllMetadata = Template.bind({});
+WithAllMetadata.args = {
+  annotations: {
+    'a8r.io/owner': 'team-awesome',
+    'a8r.io/description': 'A service that does awesome things',
+    'a8r.io/chat': 'https://chat.example.com/awesome',
+    'a8r.io/bugs': 'https://bugs.example.com/awesome',
+  },
+};
+
+export const WithDescriptionOnly = Template.bind({});
+WithDescriptionOnly.args = {
+  annotations: {
+    'a8r.io/description': 'A minimal service',
+  },
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  annotations: {},
+};
+
+export const WithLinks = Template.bind({});
+WithLinks.args = {
+  annotations: {
+    'a8r.io/owner': 'sre-team',
+    'a8r.io/repository': 'https://github.com/example/my-service',
+    'a8r.io/documentation': 'https://docs.example.com/my-service',
+    'a8r.io/support': 'https://support.example.com',
+  },
+};

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.Empty.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.Empty.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.WithAllMetadata.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.WithAllMetadata.stories.storyshot
@@ -1,0 +1,78 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1hdbc19"
+    >
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Description
+            :
+          </strong>
+           
+          A service that does awesome things
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Owner
+            :
+          </strong>
+           
+          team-awesome
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Chat
+            :
+          </strong>
+           
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+            href="https://chat.example.com/awesome"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://chat.example.com/awesome
+          </a>
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Bugs
+            :
+          </strong>
+           
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+            href="https://bugs.example.com/awesome"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://bugs.example.com/awesome
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.WithDescriptionOnly.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.WithDescriptionOnly.stories.storyshot
@@ -1,0 +1,22 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1hdbc19"
+    >
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Description
+            :
+          </strong>
+           
+          A minimal service
+        </p>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/Resource/__snapshots__/A8RInfo.WithLinks.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/A8RInfo.WithLinks.stories.storyshot
@@ -1,0 +1,85 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1hdbc19"
+    >
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Owner
+            :
+          </strong>
+           
+          sre-team
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Documentation
+            :
+          </strong>
+           
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+            href="https://docs.example.com/my-service"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://docs.example.com/my-service
+          </a>
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Repository
+            :
+          </strong>
+           
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+            href="https://github.com/example/my-service"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://github.com/example/my-service
+          </a>
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-70qvj9"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+        >
+          <strong>
+            Support
+            :
+          </strong>
+           
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+            href="https://support.example.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://support.example.com
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
@@ -690,7 +690,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/job/__snapshots__/Details.Running.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/Details.Running.stories.storyshot
@@ -595,7 +595,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/storage/__snapshots__/VolumeAttributesClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeAttributesClassDetails.Base.stories.storyshot
@@ -220,7 +220,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Adds `A8RInfo.stories.tsx` to provide Storybook coverage for the `A8RInfo` component.

## Changes

Added 4 stories covering the primary display states:

- `WithAllMetadata`
- `WithDescriptionOnly`
- `Empty` (verifies null render behavior)
- `WithLinks`

## Note for Reviewers

This is a Storybook-only change. `A8RInfo` is a pure display component, so no API mocking or test setup is required. The stories document existing behavior and cover the main rendering states of the component.