### PR TITLE
frontend: LogsButton: Fix translation key case mismatch

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -229,7 +229,7 @@ function LogsButtonContent({ item }: LogsButtonProps) {
         console.error('Error fetching pods:', error);
         enqueueSnackbar(
           t('translation|Failed to fetch pods: {{error}}', {
-            error: error instanceof Error ? error.message : t('translation|Unknown error'),
+            error: error instanceof Error ? error.message : t('translation|unknown error'),
           }),
           {
             variant: 'error',


### PR DESCRIPTION
## Summary

Fixes a translation key case mismatch in `LogsButton` that prevented the localized string from being resolved correctly.

## Changes

- Updated the translation key passed to `t(...)` to match the defined i18n key casing.

## Note for Reviewers

This is a small i18n fix only. No behavior or UI logic was changed; the update ensures the correct translation key is used and existing localized strings are displayed as intended.