### PR TITLE
frontend(ci): Update story snapshots for Job and VolumeAttributesClass details

### DIFF
--- a/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/Details.Default.stories.storyshot
@@ -690,7 +690,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/job/__snapshots__/Details.Running.stories.storyshot
+++ b/frontend/src/components/job/__snapshots__/Details.Running.stories.storyshot
@@ -595,7 +595,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/storage/__snapshots__/VolumeAttributesClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeAttributesClassDetails.Base.stories.storyshot
@@ -220,7 +220,19 @@
                   </h2>
                   <div
                     class="MuiBox-root css-ldp2l3"
-                  />
+                  >
+                    <button
+                      aria-label="Events lifetime information"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Updates three existing Storybook snapshots that began failing after a dependency/MUI change introduced a new **"Events lifetime information"** icon button in the Events section.

## Root Cause

A recent dependency update added an informational icon button to the Events panel when no events are present. Existing snapshots were generated before this UI element existed and therefore expected an empty container, resulting in snapshot mismatches.

## Changes

Updated the affected snapshots to match the current rendered output:

* `Job/JobDetailsView` — Default
* `Job/JobDetailsView` — Running
* `VolumeAttributesClass/DetailsView` — Base

## Notes

This is a maintenance-only change with no functional behavior modifications. Merging this PR on `main` prevents unrelated branches from carrying snapshot updates and keeps Storybook tests aligned with the current UI.
