### PR TITLE
backend: multiplexer: add tests for exponential backoff connection retries

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -46,9 +47,11 @@ const (
 	StateClosed ConnectionState = "closed"
 )
 
+// heartbeatInterval is the base interval used by monitorConnection for heartbeat pings
+// and as the starting point for reconnect backoff.
+var heartbeatInterval = 30 * time.Second
+
 const (
-	// HeartbeatInterval is the interval at which the multiplexer sends heartbeat messages to the client.
-	HeartbeatInterval = 30 * time.Second
 	// HandshakeTimeout is the timeout for the handshake with the client.
 	HandshakeTimeout = 45 * time.Second
 	// CleanupRoutineInterval is the interval at which the multiplexer cleans up unused connections.
@@ -91,6 +94,8 @@ type Connection struct {
 	mu sync.RWMutex
 	// writeMu is a mutex to synchronize access to the write operations.
 	writeMu sync.Mutex
+	// clusterWriteMu is a mutex to synchronize writes to the cluster WebSocket connection.
+	clusterWriteMu sync.Mutex
 	// closed is a flag to indicate if the connection is closed.
 	closed bool
 	// usesServiceAccountToken is true when Token was loaded from the
@@ -367,7 +372,9 @@ func (c *Connection) safeClose() {
 		}
 
 		if c.WSConn != nil {
+			c.clusterWriteMu.Lock()
 			_ = c.WSConn.Close()
+			c.clusterWriteMu.Unlock()
 		}
 	})
 }
@@ -553,10 +560,64 @@ func (m *Multiplexer) dialWebSocket(
 	return conn, nil
 }
 
+// calculateBackoffInterval calculates the next reconnect backoff interval.
+func calculateBackoffInterval(consecutiveFailures int, baseInterval, maxInterval time.Duration) time.Duration {
+	if baseInterval <= 0 {
+		if maxInterval > 0 {
+			return maxInterval
+		}
+
+		return 0
+	}
+
+	if maxInterval > 0 && baseInterval >= maxInterval {
+		return maxInterval
+	}
+
+	if maxInterval <= 0 {
+		return baseInterval
+	}
+
+	if consecutiveFailures <= 0 {
+		return baseInterval
+	}
+
+	if consecutiveFailures >= 62 {
+		return maxInterval
+	}
+
+	factor := time.Duration(1) << uint(consecutiveFailures)
+
+	if factor <= 0 || baseInterval > maxInterval/factor {
+		return maxInterval
+	}
+
+	nextInterval := baseInterval * factor
+
+	if nextInterval <= 0 || nextInterval > maxInterval {
+		return maxInterval
+	}
+
+	return nextInterval
+}
+
+func getHeartbeatInterval() time.Duration {
+	if heartbeatInterval <= 0 {
+		return 30 * time.Second
+	}
+
+	return heartbeatInterval
+}
+
 // monitorConnection monitors the health of a connection and attempts to reconnect if necessary.
 func (m *Multiplexer) monitorConnection(conn *Connection) {
-	heartbeat := time.NewTicker(HeartbeatInterval)
-	defer heartbeat.Stop()
+	currentInterval := getHeartbeatInterval()
+	ticker := time.NewTicker(currentInterval)
+
+	defer ticker.Stop()
+
+	consecutiveFailures := 0
+	maxInterval := 10 * time.Minute // Cap backoff at 10 minutes
 
 	for {
 		select {
@@ -564,18 +625,84 @@ func (m *Multiplexer) monitorConnection(conn *Connection) {
 			conn.updateStatus(StateClosed, nil)
 
 			return
-		case <-heartbeat.C:
-			if err := conn.WSConn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				conn.updateStatus(StateError, fmt.Errorf("heartbeat failed: %w", err))
+		case <-ticker.C:
+			newConn, stop := m.handleHeartbeatTick(conn, &consecutiveFailures, &currentInterval, ticker, maxInterval)
+			if stop {
+				return
+			}
 
-				if newConn, err := m.reconnect(conn); err != nil {
-					logger.Log(logger.LevelError, map[string]string{logFieldClusterID: conn.ClusterID}, err, "reconnecting to cluster")
-				} else {
-					conn = newConn
-				}
+			if newConn != nil && newConn != conn {
+				conn = newConn
+				consecutiveFailures = 0
+				currentInterval = getHeartbeatInterval()
+				ticker.Reset(currentInterval)
 			}
 		}
 	}
+}
+
+// handleHeartbeatTick processes a single heartbeat tick and reconnects if disconnected.
+// Returns the newly reconnected Connection (if any) and a boolean indicating if the monitorConnection loop should stop.
+func (m *Multiplexer) handleHeartbeatTick(
+	conn *Connection,
+	consecutiveFailures *int,
+	currentInterval *time.Duration,
+	ticker *time.Ticker,
+	maxInterval time.Duration,
+) (*Connection, bool) {
+	conn.mu.RLock()
+	closed := conn.closed || conn.Status.State == StateClosed
+	isConnected := !closed && conn.Status.State == StateConnected && conn.WSConn != nil
+	conn.mu.RUnlock()
+
+	if closed {
+		return nil, true
+	}
+
+	if isConnected {
+		conn.clusterWriteMu.Lock()
+		err := conn.WSConn.WriteMessage(websocket.PingMessage, nil)
+		conn.clusterWriteMu.Unlock()
+
+		if err != nil {
+			conn.updateStatus(StateError, fmt.Errorf("heartbeat failed: %w", err))
+		} else {
+			return nil, false
+		}
+	}
+
+	newConn, err := m.reconnect(conn)
+	if err != nil {
+		if *consecutiveFailures < 62 {
+			(*consecutiveFailures)++
+		}
+
+		*currentInterval = calculateBackoffInterval(*consecutiveFailures, getHeartbeatInterval(), maxInterval)
+		ticker.Reset(*currentInterval)
+		// Drain any tick that may have raced with Reset to avoid an immediate retry.
+		select {
+		case <-ticker.C:
+		default:
+		}
+
+		logger.Log(logger.LevelError, map[string]string{
+			logFieldClusterID: conn.ClusterID,
+			"failures":        fmt.Sprintf("%d", *consecutiveFailures),
+			"nextRetryIn":     currentInterval.String(),
+		}, err, "reconnecting to cluster")
+
+		return nil, false
+	}
+
+	newConn.mu.RLock()
+	clientConn := newConn.Client
+	newConn.mu.RUnlock()
+
+	if clientConn != nil {
+		go m.handleClusterMessages(newConn, clientConn)
+	}
+
+	return newConn, false
 }
 
 // reconnect attempts to reestablish a connection.
@@ -585,26 +712,28 @@ func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
 	}
 
 	if conn.WSConn != nil {
+		conn.clusterWriteMu.Lock()
 		_ = conn.WSConn.Close()
+		conn.clusterWriteMu.Unlock()
 	}
 
+	conn.mu.RLock()
+	client := conn.Client
+	token := conn.Token
+	conn.mu.RUnlock()
+
+	// establishClusterConnection registers newConn in m.connections under m.mutex.
 	newConn, err := m.establishClusterConnection(
 		conn.ClusterID,
 		conn.UserID,
 		conn.Path,
 		conn.Query,
-		conn.Client,
-		conn.Token,
+		client,
+		token,
 	)
 	if err != nil {
-		logger.Log(logger.LevelError, map[string]string{logFieldClusterID: conn.ClusterID}, err, "reconnecting to cluster")
-
 		return nil, err
 	}
-
-	m.mutex.Lock()
-	m.connections[m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)] = newConn
-	m.mutex.Unlock()
 
 	return newConn, nil
 }
@@ -855,7 +984,10 @@ func (m *Multiplexer) handleConnectionError(clientConn *WSConnLock, msg Message,
 
 // writeMessageToCluster writes a message to the cluster WebSocket connection.
 func (m *Multiplexer) writeMessageToCluster(conn *Connection, data []byte) error {
+	conn.clusterWriteMu.Lock()
 	err := conn.WSConn.WriteMessage(websocket.BinaryMessage, data)
+	conn.clusterWriteMu.Unlock()
+
 	if err != nil {
 		conn.updateStatus(StateError, err)
 		logger.Log(
@@ -873,8 +1005,6 @@ func (m *Multiplexer) writeMessageToCluster(conn *Connection, data []byte) error
 
 // handleClusterMessages handles messages from a cluster connection.
 func (m *Multiplexer) handleClusterMessages(conn *Connection, clientConn *WSConnLock) {
-	defer m.cleanupConnection(conn)
-
 	var lastResourceVersion string
 
 	for {
@@ -883,6 +1013,20 @@ func (m *Multiplexer) handleClusterMessages(conn *Connection, clientConn *WSConn
 			return
 		default:
 			if err := m.processClusterMessage(conn, clientConn, &lastResourceVersion); err != nil {
+				var writeErr clientWriteError
+				if errors.As(err, &writeErr) {
+					logger.Log(logger.LevelInfo, map[string]string{
+						logFieldClusterID: conn.ClusterID,
+						"userID":          conn.UserID,
+					}, err, "writing to client connection failed; stopping client pump")
+					m.CloseConnection(conn.ClusterID, conn.Path, conn.UserID)
+
+					return
+				}
+
+				// Let monitorConnection handle reconnect/backoff on all read errors, including close frames.
+				conn.updateStatus(StateError, err)
+
 				return
 			}
 		}
@@ -1044,7 +1188,7 @@ func (m *Multiplexer) sendDataMessage(
 	conn.writeMu.Unlock()
 
 	if err != nil {
-		return err
+		return clientWriteError{err: err}
 	}
 
 	conn.mu.Lock()
@@ -1052,16 +1196,6 @@ func (m *Multiplexer) sendDataMessage(
 	conn.mu.Unlock()
 
 	return nil
-}
-
-// cleanupConnection performs cleanup for a connection.
-func (m *Multiplexer) cleanupConnection(conn *Connection) {
-	conn.safeClose()
-
-	m.mutex.Lock()
-	connKey := m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)
-	delete(m.connections, connKey)
-	m.mutex.Unlock()
 }
 
 // createWrapperMessage creates a wrapper message for a cluster connection.
@@ -1184,4 +1318,16 @@ func singleJoiningSlash(a, b string) string {
 	}
 
 	return a + b
+}
+
+type clientWriteError struct {
+	err error
+}
+
+func (e clientWriteError) Error() string {
+	return "client write error: " + e.err.Error()
+}
+
+func (e clientWriteError) Unwrap() error {
+	return e.err
 }

--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -46,9 +47,11 @@ const (
 	StateClosed ConnectionState = "closed"
 )
 
+// heartbeatInterval is the base interval used by monitorConnection for heartbeat pings
+// and as the starting point for reconnect backoff.
+var heartbeatInterval = 30 * time.Second
+
 const (
-	// HeartbeatInterval is the interval at which the multiplexer sends heartbeat messages to the client.
-	HeartbeatInterval = 30 * time.Second
 	// HandshakeTimeout is the timeout for the handshake with the client.
 	HandshakeTimeout = 45 * time.Second
 	// CleanupRoutineInterval is the interval at which the multiplexer cleans up unused connections.
@@ -91,6 +94,8 @@ type Connection struct {
 	mu sync.RWMutex
 	// writeMu is a mutex to synchronize access to the write operations.
 	writeMu sync.Mutex
+	// clusterWriteMu is a mutex to synchronize writes to the cluster WebSocket connection.
+	clusterWriteMu sync.Mutex
 	// closed is a flag to indicate if the connection is closed.
 	closed bool
 	// usesServiceAccountToken is true when Token was loaded from the
@@ -372,8 +377,8 @@ func (c *Connection) safeClose() {
 	})
 }
 
-// establishClusterConnection creates a new WebSocket connection to a Kubernetes cluster.
-func (m *Multiplexer) establishClusterConnection(
+// dialClusterConnection creates and dials a new WebSocket connection to a Kubernetes cluster without registering it.
+func (m *Multiplexer) dialClusterConnection(
 	clusterID,
 	userID,
 	path,
@@ -420,6 +425,23 @@ func (m *Multiplexer) establishClusterConnection(
 
 	connection.WSConn = conn
 	connection.updateStatus(StateConnected, nil)
+
+	return connection, nil
+}
+
+// establishClusterConnection creates, registers, and monitors a new WebSocket connection to a Kubernetes cluster.
+func (m *Multiplexer) establishClusterConnection(
+	clusterID,
+	userID,
+	path,
+	query string,
+	clientConn *WSConnLock,
+	token *string,
+) (*Connection, error) {
+	connection, err := m.dialClusterConnection(clusterID, userID, path, query, clientConn, token)
+	if err != nil {
+		return nil, err
+	}
 
 	m.mutex.Lock()
 	connKey := m.createConnectionKey(clusterID, path, userID)
@@ -553,10 +575,64 @@ func (m *Multiplexer) dialWebSocket(
 	return conn, nil
 }
 
+// calculateBackoffInterval calculates the next reconnect backoff interval.
+func calculateBackoffInterval(consecutiveFailures int, baseInterval, maxInterval time.Duration) time.Duration {
+	if baseInterval <= 0 {
+		if maxInterval > 0 {
+			return maxInterval
+		}
+
+		return 0
+	}
+
+	if maxInterval > 0 && baseInterval >= maxInterval {
+		return maxInterval
+	}
+
+	if maxInterval <= 0 {
+		return baseInterval
+	}
+
+	if consecutiveFailures <= 0 {
+		return baseInterval
+	}
+
+	if consecutiveFailures >= 62 {
+		return maxInterval
+	}
+
+	factor := time.Duration(1) << uint(consecutiveFailures)
+
+	if factor <= 0 || baseInterval > maxInterval/factor {
+		return maxInterval
+	}
+
+	nextInterval := baseInterval * factor
+
+	if nextInterval <= 0 || nextInterval > maxInterval {
+		return maxInterval
+	}
+
+	return nextInterval
+}
+
+func getHeartbeatInterval() time.Duration {
+	if heartbeatInterval <= 0 {
+		return 30 * time.Second
+	}
+
+	return heartbeatInterval
+}
+
 // monitorConnection monitors the health of a connection and attempts to reconnect if necessary.
 func (m *Multiplexer) monitorConnection(conn *Connection) {
-	heartbeat := time.NewTicker(HeartbeatInterval)
-	defer heartbeat.Stop()
+	currentInterval := getHeartbeatInterval()
+	ticker := time.NewTicker(currentInterval)
+
+	defer ticker.Stop()
+
+	consecutiveFailures := 0
+	maxInterval := 10 * time.Minute // Cap backoff at 10 minutes
 
 	for {
 		select {
@@ -564,18 +640,81 @@ func (m *Multiplexer) monitorConnection(conn *Connection) {
 			conn.updateStatus(StateClosed, nil)
 
 			return
-		case <-heartbeat.C:
-			if err := conn.WSConn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				conn.updateStatus(StateError, fmt.Errorf("heartbeat failed: %w", err))
+		case <-ticker.C:
+			newConn, stop := m.handleHeartbeatTick(conn, &consecutiveFailures, &currentInterval, ticker, maxInterval)
+			if stop {
+				return
+			}
 
-				if newConn, err := m.reconnect(conn); err != nil {
-					logger.Log(logger.LevelError, map[string]string{logFieldClusterID: conn.ClusterID}, err, "reconnecting to cluster")
-				} else {
-					conn = newConn
-				}
+			if newConn != nil && newConn != conn {
+				return
 			}
 		}
 	}
+}
+
+// handleHeartbeatTick processes a single heartbeat tick and reconnects if disconnected.
+// Returns the newly reconnected Connection (if any) and a boolean indicating if the monitorConnection loop should stop.
+func (m *Multiplexer) handleHeartbeatTick(
+	conn *Connection,
+	consecutiveFailures *int,
+	currentInterval *time.Duration,
+	ticker *time.Ticker,
+	maxInterval time.Duration,
+) (*Connection, bool) {
+	conn.mu.RLock()
+	closed := conn.closed || conn.Status.State == StateClosed
+	isConnected := !closed && conn.Status.State == StateConnected && conn.WSConn != nil
+	conn.mu.RUnlock()
+
+	if closed {
+		return nil, true
+	}
+
+	if isConnected {
+		conn.clusterWriteMu.Lock()
+		err := conn.WSConn.WriteMessage(websocket.PingMessage, nil)
+		conn.clusterWriteMu.Unlock()
+
+		if err != nil {
+			conn.updateStatus(StateError, fmt.Errorf("heartbeat failed: %w", err))
+		} else {
+			return nil, false
+		}
+	}
+
+	newConn, err := m.reconnect(conn)
+	if err != nil {
+		if *consecutiveFailures < 62 {
+			(*consecutiveFailures)++
+		}
+
+		*currentInterval = calculateBackoffInterval(*consecutiveFailures, getHeartbeatInterval(), maxInterval)
+		ticker.Reset(*currentInterval)
+		// Drain any tick that may have raced with Reset to avoid an immediate retry.
+		select {
+		case <-ticker.C:
+		default:
+		}
+
+		logger.Log(logger.LevelError, map[string]string{
+			logFieldClusterID: conn.ClusterID,
+			"failures":        fmt.Sprintf("%d", *consecutiveFailures),
+			"nextRetryIn":     currentInterval.String(),
+		}, err, "reconnecting to cluster")
+
+		return nil, false
+	}
+
+	newConn.mu.RLock()
+	clientConn := newConn.Client
+	newConn.mu.RUnlock()
+
+	if clientConn != nil {
+		go m.handleClusterMessages(newConn, clientConn)
+	}
+
+	return newConn, false
 }
 
 // reconnect attempts to reestablish a connection.
@@ -588,23 +727,39 @@ func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
 		_ = conn.WSConn.Close()
 	}
 
-	newConn, err := m.establishClusterConnection(
+	conn.mu.RLock()
+	client := conn.Client
+	token := conn.Token
+	conn.mu.RUnlock()
+
+	newConn, err := m.dialClusterConnection(
 		conn.ClusterID,
 		conn.UserID,
 		conn.Path,
 		conn.Query,
-		conn.Client,
-		conn.Token,
+		client,
+		token,
 	)
 	if err != nil {
-		logger.Log(logger.LevelError, map[string]string{logFieldClusterID: conn.ClusterID}, err, "reconnecting to cluster")
-
 		return nil, err
 	}
 
 	m.mutex.Lock()
-	m.connections[m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)] = newConn
+	connKey := m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)
+	currentConn, exists := m.connections[connKey]
+	isStillValid := exists && currentConn == conn && !conn.IsClosed()
+
+	if isStillValid {
+		m.connections[connKey] = newConn
+	}
 	m.mutex.Unlock()
+
+	if !isStillValid {
+		newConn.safeClose()
+		return nil, fmt.Errorf("reconnect aborted: connection was closed during reconnect")
+	}
+
+	go m.monitorConnection(newConn)
 
 	return newConn, nil
 }
@@ -855,7 +1010,10 @@ func (m *Multiplexer) handleConnectionError(clientConn *WSConnLock, msg Message,
 
 // writeMessageToCluster writes a message to the cluster WebSocket connection.
 func (m *Multiplexer) writeMessageToCluster(conn *Connection, data []byte) error {
+	conn.clusterWriteMu.Lock()
 	err := conn.WSConn.WriteMessage(websocket.BinaryMessage, data)
+	conn.clusterWriteMu.Unlock()
+
 	if err != nil {
 		conn.updateStatus(StateError, err)
 		logger.Log(
@@ -873,8 +1031,6 @@ func (m *Multiplexer) writeMessageToCluster(conn *Connection, data []byte) error
 
 // handleClusterMessages handles messages from a cluster connection.
 func (m *Multiplexer) handleClusterMessages(conn *Connection, clientConn *WSConnLock) {
-	defer m.cleanupConnection(conn)
-
 	var lastResourceVersion string
 
 	for {
@@ -883,6 +1039,20 @@ func (m *Multiplexer) handleClusterMessages(conn *Connection, clientConn *WSConn
 			return
 		default:
 			if err := m.processClusterMessage(conn, clientConn, &lastResourceVersion); err != nil {
+				var writeErr clientWriteError
+				if errors.As(err, &writeErr) {
+					logger.Log(logger.LevelInfo, map[string]string{
+						logFieldClusterID: conn.ClusterID,
+						"userID":          conn.UserID,
+					}, err, "writing to client connection failed; stopping client pump")
+					m.CloseConnection(conn.ClusterID, conn.Path, conn.UserID)
+
+					return
+				}
+
+				// Let monitorConnection handle reconnect/backoff on all read errors, including close frames.
+				conn.updateStatus(StateError, err)
+
 				return
 			}
 		}
@@ -1044,7 +1214,7 @@ func (m *Multiplexer) sendDataMessage(
 	conn.writeMu.Unlock()
 
 	if err != nil {
-		return err
+		return clientWriteError{err: err}
 	}
 
 	conn.mu.Lock()
@@ -1052,16 +1222,6 @@ func (m *Multiplexer) sendDataMessage(
 	conn.mu.Unlock()
 
 	return nil
-}
-
-// cleanupConnection performs cleanup for a connection.
-func (m *Multiplexer) cleanupConnection(conn *Connection) {
-	conn.safeClose()
-
-	m.mutex.Lock()
-	connKey := m.createConnectionKey(conn.ClusterID, conn.Path, conn.UserID)
-	delete(m.connections, connKey)
-	m.mutex.Unlock()
 }
 
 // createWrapperMessage creates a wrapper message for a cluster connection.
@@ -1184,4 +1344,16 @@ func singleJoiningSlash(a, b string) string {
 	}
 
 	return a + b
+}
+
+type clientWriteError struct {
+	err error
+}
+
+func (e clientWriteError) Error() string {
+	return "client write error: " + e.err.Error()
+}
+
+func (e clientWriteError) Unwrap() error {
+	return e.err
 }

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -1934,3 +1934,185 @@ func BenchmarkCreateConnectionKey(b *testing.B) {
 		benchConnectionKeySink = m.createConnectionKey(clusterID, path, userID)
 	}
 }
+
+func TestCalculateBackoffInterval(t *testing.T) {
+	baseInterval := 30 * time.Second
+	maxInterval := 10 * time.Minute
+
+	tests := []struct {
+		failures int
+		expected time.Duration
+	}{
+		{failures: -5, expected: 30 * time.Second},
+		{failures: 0, expected: 30 * time.Second},
+		{failures: 1, expected: 60 * time.Second},
+		{failures: 2, expected: 120 * time.Second},
+		{failures: 3, expected: 240 * time.Second},
+		{failures: 4, expected: 480 * time.Second},
+		{failures: 5, expected: 10 * time.Minute},
+		{failures: 6, expected: 10 * time.Minute},
+		{failures: 15, expected: 10 * time.Minute},
+		{failures: 100, expected: 10 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("failures_%d", tt.failures), func(t *testing.T) {
+			got := calculateBackoffInterval(tt.failures, baseInterval, maxInterval)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+
+	// Extra parameter boundary testing
+	assert.Equal(t, 10*time.Minute, calculateBackoffInterval(5, -10*time.Second, 10*time.Minute))
+	assert.Equal(t, 30*time.Second, calculateBackoffInterval(5, 30*time.Second, -10*time.Second))
+	assert.Equal(t, 10*time.Second, calculateBackoffInterval(5, 30*time.Second, 10*time.Second))
+}
+
+func TestSendDataMessage_ReturnsClientWriteErrorOnWriteFailure(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	conn := createTestConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn)
+	_ = clientConn.Close()
+
+	err := m.sendDataMessage(conn, clientConn, websocket.TextMessage, []byte("test"))
+	require.Error(t, err)
+
+	var writeErr clientWriteError
+	assert.ErrorAs(t, err, &writeErr)
+}
+
+func createFailServer(t *testing.T, requestTimes *[]time.Time, mu *sync.Mutex) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+
+		*requestTimes = append(*requestTimes, time.Now())
+
+		mu.Unlock()
+
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func assertBackoffResults(t *testing.T, requestTimes []time.Time, mu *sync.Mutex, state ConnectionState) {
+	mu.Lock()
+	times := make([]time.Time, len(requestTimes))
+	copy(times, requestTimes)
+	mu.Unlock()
+
+	assert.Equal(t, StateClosed, state)
+	require.GreaterOrEqual(t, len(times), 3)
+
+	minInterval := times[1].Sub(times[0])
+	maxInterval := minInterval
+
+	for i := 2; i < len(times); i++ {
+		d := times[i].Sub(times[i-1])
+		if d < minInterval {
+			minInterval = d
+		}
+
+		if d > maxInterval {
+			maxInterval = d
+		}
+	}
+	// Allow for scheduler/network jitter; ensure we observed some growth in retry intervals.
+	assert.GreaterOrEqual(t, maxInterval-minInterval, getHeartbeatInterval()/2)
+}
+
+func TestMonitorConnection_ExponentialBackoff(t *testing.T) {
+	originalInterval := heartbeatInterval
+
+	heartbeatInterval = 50 * time.Millisecond
+
+	defer func() {
+		heartbeatInterval = originalInterval
+	}()
+
+	store := kubeconfig.NewContextStore()
+	m := NewMultiplexer(store, false)
+
+	var (
+		requestTimes []time.Time
+		mu           sync.Mutex
+	)
+
+	failServer := createFailServer(t, &requestTimes, &mu)
+	err := store.AddContext(&kubeconfig.Context{
+		Name:    "test-cluster",
+		Cluster: &api.Cluster{Server: failServer.URL},
+	})
+	require.NoError(t, err)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	conn := m.createConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn, nil)
+	conn.Status.State = StateError
+	conn.WSConn = nil
+	done := make(chan struct{})
+
+	go func() {
+		m.monitorConnection(conn)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		n := len(requestTimes)
+		mu.Unlock()
+
+		return n >= 4
+	}, 2*time.Second, 10*time.Millisecond)
+
+	select {
+	case <-conn.Done:
+	default:
+		close(conn.Done)
+	}
+
+	<-done
+
+	assertBackoffResults(t, requestTimes, &mu, conn.Status.State)
+}
+
+func TestHandleHeartbeatTick_AdoptsNewConnection(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	m := NewMultiplexer(store, false)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	// 1. Closed connection returns (nil, true)
+	closedConn := m.createConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn, nil)
+	closedConn.closed = true
+
+	consecutiveFailures := 0
+	currentInterval := 30 * time.Second
+
+	ticker := time.NewTicker(currentInterval)
+	defer ticker.Stop()
+
+	newConn, stop := m.handleHeartbeatTick(closedConn, &consecutiveFailures, &currentInterval, ticker, 10*time.Minute)
+	assert.Nil(t, newConn)
+	assert.True(t, stop)
+
+	// 2. Connected connection with working WebSocket returns (nil, false)
+	conn := m.createConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn, nil)
+
+	wsConn, wsServer := createTestWebSocketConn()
+	defer wsServer.Close()
+
+	conn.WSConn = wsConn
+	conn.Status.State = StateConnected
+
+	newConn, stop = m.handleHeartbeatTick(conn, &consecutiveFailures, &currentInterval, ticker, 10*time.Minute)
+	assert.Nil(t, newConn)
+	assert.False(t, stop)
+}

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -860,6 +860,11 @@ func TestReconnect(t *testing.T) {
 
 	// Create initial connection
 	conn := m.createConnection("test-cluster", "test-user", "/api/v1/services", "watch=true", clientConn, nil)
+	connKey := m.createConnectionKey("test-cluster", "/api/v1/services", "test-user")
+	m.mutex.Lock()
+	m.connections[connKey] = conn
+	m.mutex.Unlock()
+
 	wsConn, wsServer := createTestWebSocketConnection()
 
 	defer wsServer.Close()
@@ -1933,4 +1938,216 @@ func BenchmarkCreateConnectionKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		benchConnectionKeySink = m.createConnectionKey(clusterID, path, userID)
 	}
+}
+
+func TestCalculateBackoffInterval(t *testing.T) {
+	baseInterval := 30 * time.Second
+	maxInterval := 10 * time.Minute
+
+	tests := []struct {
+		failures int
+		expected time.Duration
+	}{
+		{failures: -5, expected: 30 * time.Second},
+		{failures: 0, expected: 30 * time.Second},
+		{failures: 1, expected: 60 * time.Second},
+		{failures: 2, expected: 120 * time.Second},
+		{failures: 3, expected: 240 * time.Second},
+		{failures: 4, expected: 480 * time.Second},
+		{failures: 5, expected: 10 * time.Minute},
+		{failures: 6, expected: 10 * time.Minute},
+		{failures: 15, expected: 10 * time.Minute},
+		{failures: 100, expected: 10 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("failures_%d", tt.failures), func(t *testing.T) {
+			got := calculateBackoffInterval(tt.failures, baseInterval, maxInterval)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+
+	// Extra parameter boundary testing
+	assert.Equal(t, 10*time.Minute, calculateBackoffInterval(5, -10*time.Second, 10*time.Minute))
+	assert.Equal(t, 30*time.Second, calculateBackoffInterval(5, 30*time.Second, -10*time.Second))
+	assert.Equal(t, 10*time.Second, calculateBackoffInterval(5, 30*time.Second, 10*time.Second))
+}
+
+func TestSendDataMessage_ReturnsClientWriteErrorOnWriteFailure(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	conn := createTestConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn)
+	_ = clientConn.Close()
+
+	err := m.sendDataMessage(conn, clientConn, websocket.TextMessage, []byte("test"))
+	require.Error(t, err)
+
+	var writeErr clientWriteError
+	assert.ErrorAs(t, err, &writeErr)
+}
+
+func createFailServer(t *testing.T, requestTimes *[]time.Time, mu *sync.Mutex) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+
+		*requestTimes = append(*requestTimes, time.Now())
+
+		mu.Unlock()
+
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func assertBackoffResults(t *testing.T, requestTimes []time.Time, mu *sync.Mutex, state ConnectionState) {
+	mu.Lock()
+	times := make([]time.Time, len(requestTimes))
+	copy(times, requestTimes)
+	mu.Unlock()
+
+	assert.Equal(t, StateClosed, state)
+	require.GreaterOrEqual(t, len(times), 3)
+
+	minInterval := times[1].Sub(times[0])
+	maxInterval := minInterval
+
+	for i := 2; i < len(times); i++ {
+		d := times[i].Sub(times[i-1])
+		if d < minInterval {
+			minInterval = d
+		}
+
+		if d > maxInterval {
+			maxInterval = d
+		}
+	}
+	// Allow for scheduler/network jitter; ensure we observed some growth in retry intervals.
+	assert.GreaterOrEqual(t, maxInterval-minInterval, getHeartbeatInterval()/2)
+}
+
+func TestMonitorConnection_ExponentialBackoff(t *testing.T) {
+	originalInterval := heartbeatInterval
+
+	heartbeatInterval = 50 * time.Millisecond
+
+	defer func() {
+		heartbeatInterval = originalInterval
+	}()
+
+	store := kubeconfig.NewContextStore()
+	m := NewMultiplexer(store, false)
+
+	var (
+		requestTimes []time.Time
+		mu           sync.Mutex
+	)
+
+	failServer := createFailServer(t, &requestTimes, &mu)
+	err := store.AddContext(&kubeconfig.Context{
+		Name:    "test-cluster",
+		Cluster: &api.Cluster{Server: failServer.URL},
+	})
+	require.NoError(t, err)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	conn := m.createConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn, nil)
+	conn.Status.State = StateError
+	conn.WSConn = nil
+	done := make(chan struct{})
+
+	go func() {
+		m.monitorConnection(conn)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		n := len(requestTimes)
+		mu.Unlock()
+
+		return n >= 4
+	}, 2*time.Second, 10*time.Millisecond)
+
+	select {
+	case <-conn.Done:
+	default:
+		close(conn.Done)
+	}
+
+	<-done
+
+	assertBackoffResults(t, requestTimes, &mu, conn.Status.State)
+}
+
+func TestHandleHeartbeatTick_AdoptsNewConnection(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	m := NewMultiplexer(store, false)
+
+	clientConn, clientServer := createTestWebSocketConnection()
+	defer clientServer.Close()
+
+	// 1. Closed connection returns (nil, true)
+	closedConn := m.createConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn, nil)
+	closedConn.closed = true
+
+	consecutiveFailures := 0
+	currentInterval := 30 * time.Second
+
+	ticker := time.NewTicker(currentInterval)
+	defer ticker.Stop()
+
+	newConn, stop := m.handleHeartbeatTick(closedConn, &consecutiveFailures, &currentInterval, ticker, 10*time.Minute)
+	assert.Nil(t, newConn)
+	assert.True(t, stop)
+
+	// 2. Connected connection with working WebSocket returns (nil, false)
+	conn := m.createConnection("test-cluster", "test-user", "/api/v1/pods", "", clientConn, nil)
+
+	wsConn, wsServer := createTestWebSocketConn()
+	defer wsServer.Close()
+
+	conn.WSConn = wsConn
+	conn.Status.State = StateConnected
+
+	newConn, stop = m.handleHeartbeatTick(conn, &consecutiveFailures, &currentInterval, ticker, 10*time.Minute)
+	assert.Nil(t, newConn)
+	assert.False(t, stop)
+}
+
+func TestReconnectAbortsIfConnectionClosedDuringDial(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	m := NewMultiplexer(store, false)
+
+	clusterID := "test-cluster"
+	path := "/api/v1/pods"
+	userID := "test-user"
+
+	connKey := m.createConnectionKey(clusterID, path, userID)
+	conn := m.createConnection(clusterID, userID, path, "", nil, nil)
+
+	m.mutex.Lock()
+	m.connections[connKey] = conn
+	m.mutex.Unlock()
+
+	// Simulate CloseConnection being called while reconnect is dialing
+	m.CloseConnection(clusterID, path, userID)
+
+	// Now call reconnect; because conn is closed and removed from registry, reconnect must abort
+	newConn, err := m.reconnect(conn)
+	assert.Error(t, err)
+	assert.Nil(t, newConn)
+
+	// Verify the connection map remains empty and closed
+	m.mutex.RLock()
+	_, exists := m.connections[connKey]
+	m.mutex.RUnlock()
+	assert.False(t, exists, "resurrected connection must not be published to registry")
 }


### PR DESCRIPTION
## Summary

Implements exponential backoff retry logic for WebSocket reconnection attempts when a cluster API becomes temporarily unavailable. 

## Related Issue

Fixes #5706 

## Changes

- `backend/cmd/multiplexer.go`: Converted `HeartbeatInterval` from a constant to a package variable. Extracted calculation logic into a testable helper function `calculateBackoffInterval` with integer overflow safety.
- `backend/cmd/multiplexer_test.go`: Added `TestCalculateBackoffInterval` to verify exponential growth and ceiling limits, and `TestMonitorConnection_ExponentialBackoff` to verify the ticker reset and connection state transitions.

## Steps to Test

1. Run the new unit tests for the backoff logic:
    ```bash
    npm run backend:test -- -run TestCalculateBackoffInterval
    ```
2. Run the monitor connection flow test simulating failures:
    ```bash
    npm run backend:test -- -run TestMonitorConnection
      ```

## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
