### PR TITLE
frontend: LogsButton: Activity tab title for workload logs is not localized

### DIFF
--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -142,10 +142,14 @@ vi.mock('i18next', async importOriginal => {
       ? resolvedKey.replace('{{ itemName }}', options.itemName)
       : resolvedKey;
   };
+  const defaultExport: any = actual.default;
+  if (defaultExport) {
+    defaultExport.t = fakeT;
+  }
   return {
     ...actual,
     t: fakeT,
-    default: { ...actual.default, t: fakeT },
+    default: defaultExport,
   };
 });
 vi.mock('../../../lib/k8s', () => ({ labelSelectorToQuery: vi.fn(() => 'app=test') }));

--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -125,6 +125,25 @@ vi.mock('../../../lib/k8s/job', () => {
   return { default: Job, __esModule: true };
 });
 
+// launchWorkloadLogs calls i18next's t() directly (outside any React tree), so
+// without this mock it resolves against an uninitialized i18next instance and
+// returns undefined instead of the interpolated string. Keep everything else
+// from the real module intact (other code, e.g. the redux store, calls
+// i18next.t() too) and only patch t() to do simple key interpolation.
+vi.mock('i18next', async importOriginal => {
+  const actual = await importOriginal<typeof import('i18next')>();
+  const fakeT = (key: string, options?: { itemName?: string }) => {
+    const resolvedKey = key.split('|').pop() ?? key;
+    return options?.itemName
+      ? resolvedKey.replace('{{ itemName }}', options.itemName)
+      : resolvedKey;
+  };
+  return {
+    ...actual,
+    t: fakeT,
+    default: { ...actual.default, t: fakeT },
+  };
+});
 vi.mock('../../../lib/k8s', () => ({ labelSelectorToQuery: vi.fn(() => 'app=test') }));
 vi.mock('../../../lib/k8s/api/v2/fetch', () => ({
   clusterFetch: (...args: any[]) => mockClusterFetch(...args),

--- a/frontend/src/components/common/Resource/LogsButton.test.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.test.tsx
@@ -133,7 +133,11 @@ vi.mock('../../../lib/k8s/job', () => {
 vi.mock('i18next', async importOriginal => {
   const actual = await importOriginal<typeof import('i18next')>();
   const fakeT = (key: string, options?: { itemName?: string }) => {
-    const resolvedKey = key.split('|').pop() ?? key;
+    // Keep existing tests stable by defaulting to returning the key unchanged.
+    if (key !== 'glossary|Logs: {{ itemName }}') {
+      return key;
+    }
+    const resolvedKey = 'Logs: {{ itemName }}';
     return options?.itemName
       ? resolvedKey.replace('{{ itemName }}', options.itemName)
       : resolvedKey;

--- a/frontend/src/components/common/Resource/LogsButton.tsx
+++ b/frontend/src/components/common/Resource/LogsButton.tsx
@@ -26,6 +26,7 @@ import Select from '@mui/material/Select';
 import { styled } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
 import { Terminal as XTerminal } from '@xterm/xterm';
+import { t } from 'i18next';
 import { useSnackbar } from 'notistack';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -686,7 +687,7 @@ export function launchWorkloadLogs(
   }
   Activity.launch({
     id: 'logs-' + item.metadata.uid,
-    title: 'Logs: ' + item.metadata.name,
+    title: t('glossary|Logs: {{ itemName }}', { itemName: item.metadata.name }),
     icon: <Icon icon="mdi:file-document-box-outline" width="100%" height="100%" />,
     cluster: item.cluster,
     location: 'full',


### PR DESCRIPTION
## Summary

Fixes the Activity tab title shown when viewing workload logs for Deployments, ReplicaSets, DaemonSets, StatefulSets, and Jobs via the `LogsButton` action.

The title was previously constructed using a hardcoded English string:

```ts
title: 'Logs: ' + item.metadata.name
```

As a result, the Activity tab title remained in English even when Headlamp was running in another language.

This change reuses the existing `"Logs: {{ itemName }}"` translation key that is already used by other log views, making the workload logs Activity title localizable and consistent with the rest of the UI.

Fixes #6170

## Changes

- Replace the hardcoded Activity title in `launchWorkloadLogs()`
- Reuse the existing translation key already present in locale files
- Update related tests to cover the translated code path

## Additional Context

Other log-related entry points already use the translated `"Logs: {{ itemName }}"` title. This change aligns workload logs with the existing behavior and completes the recent localization work in this area without requiring any new translation keys or locale updates.