### PR TITLE
frontend: base64: Fix btoa crash on non-Latin1 kubeconfig text

### DIFF
--- a/frontend/src/components/App/Notifications/notificationsSlice.ts
+++ b/frontend/src/components/App/Notifications/notificationsSlice.ts
@@ -16,6 +16,7 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import _ from 'lodash';
+import { encodeBase64 } from '../../../helpers/base64';
 import { getCluster } from '../../../lib/cluster';
 
 /**
@@ -114,7 +115,7 @@ export class Notification implements NotificationIface {
       }
     }
     // generate the id based on the message and the date attached to a notification
-    this.id = btoa(unescape(encodeURIComponent(`${this.date},${this.message},${this.cluster}`)));
+    this.id = encodeBase64(`${this.date},${this.message},${this.cluster}`);
   }
 
   prepareMessage(message: string) {

--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -30,6 +30,7 @@ import { useDropzone } from 'react-dropzone';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { encodeBase64 } from '../../helpers/base64';
 import { useClustersConf } from '../../lib/k8s';
 import { setCluster } from '../../lib/k8s/api/v1/clusterApi';
 import { setStatelessConfig } from '../../redux/configSlice';
@@ -373,7 +374,7 @@ function KubeConfigLoader() {
     if (state === Step.ConfigureClusters) {
       function loadClusters() {
         const selectedClusterConfig = configWithSelectedClusters(fileContent, selectedClusters);
-        setCluster({ kubeconfig: btoa(yaml.dump(selectedClusterConfig)) })
+        setCluster({ kubeconfig: encodeBase64(yaml.dump(selectedClusterConfig)) })
           .then(parsedConfig => {
             if (parsedConfig?.clusters?.length > 0) {
               const currentStatelessClusters = store.getState().config.statelessClusters;

--- a/frontend/src/helpers/backstageMessageReceiver.ts
+++ b/frontend/src/helpers/backstageMessageReceiver.ts
@@ -17,6 +17,7 @@
 import jsyaml from 'js-yaml';
 import { KubeconfigObject } from '../lib/k8s/kubeconfig';
 import * as statelessFunctions from '../stateless';
+import { decodeBase64, encodeBase64 } from './base64';
 import { isBackstage } from './isBackstage';
 
 // BACKSTAGE_TOKEN_STORAGE_KEY is the key used to store the backstage token in the local storage
@@ -53,7 +54,7 @@ export function getBackstageToken(): string | null {
 async function storeKubeconfigFromBackstage(kubeconfig: string) {
   try {
     // Decode base64 kubeconfig
-    const decodedKubeconfig = atob(kubeconfig);
+    const decodedKubeconfig = decodeBase64(kubeconfig);
     const parsedKubeconfig = jsyaml.load(decodedKubeconfig) as KubeconfigObject;
 
     // For each context, create a new kubeconfig
@@ -85,7 +86,7 @@ async function storeKubeconfigFromBackstage(kubeconfig: string) {
 
         // Convert back to YAML and base64 encode
         const newKubeconfigYaml = jsyaml.dump(newKubeconfig, { lineWidth: -1 });
-        const newKubeconfigBase64 = btoa(newKubeconfigYaml);
+        const newKubeconfigBase64 = encodeBase64(newKubeconfigYaml);
         await statelessFunctions.findAndReplaceKubeconfig(context.name, newKubeconfigBase64, true);
       }
     );

--- a/frontend/src/helpers/base64.test.ts
+++ b/frontend/src/helpers/base64.test.ts
@@ -45,4 +45,11 @@ describe('base64 helpers', () => {
     const input = 'plain-ascii-kubeconfig';
     expect(encodeBase64(input)).toBe(btoa(input));
   });
+
+  it('decodes legacy Latin1 base64 produced by btoa', () => {
+    // Values stored before the UTF-8 helpers existed were produced via
+    // btoa(latin1String) and must still decode to the original text.
+    const input = 'café';
+    expect(decodeBase64(btoa(input))).toBe(input);
+  });
 });

--- a/frontend/src/helpers/base64.test.ts
+++ b/frontend/src/helpers/base64.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { decodeBase64, encodeBase64 } from './base64';
+
+describe('base64 helpers', () => {
+  it('round-trips ASCII text', () => {
+    const input = 'apiVersion: v1\nkind: Config';
+    expect(decodeBase64(encodeBase64(input))).toBe(input);
+  });
+
+  it('round-trips non-Latin1 text (CJK)', () => {
+    const input = 'cluster-name: 集群-生产';
+    expect(decodeBase64(encodeBase64(input))).toBe(input);
+  });
+
+  it('round-trips emoji', () => {
+    const input = 'context: prod 🚀✅';
+    expect(decodeBase64(encodeBase64(input))).toBe(input);
+  });
+
+  it('round-trips an empty string', () => {
+    expect(decodeBase64(encodeBase64(''))).toBe('');
+  });
+
+  it('does not throw on characters outside the Latin1 range', () => {
+    // The platform btoa() throws InvalidCharacterError here.
+    expect(() => encodeBase64('集群')).not.toThrow();
+  });
+
+  it('is backward compatible with btoa for ASCII input', () => {
+    const input = 'plain-ascii-kubeconfig';
+    expect(encodeBase64(input)).toBe(btoa(input));
+  });
+});

--- a/frontend/src/helpers/base64.ts
+++ b/frontend/src/helpers/base64.ts
@@ -39,20 +39,29 @@
 export function encodeBase64(str: string): string {
   const bytes = new TextEncoder().encode(str);
   let binary = '';
-  bytes.forEach(byte => {
-    binary += String.fromCharCode(byte);
-  });
+  // Build in chunks to avoid O(n^2) string concatenation and argument limits.
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
   return btoa(binary);
 }
 
 /**
  * Decodes a base64 string that was produced from UTF-8 bytes.
  *
+ * Falls back to the raw Latin1 string for legacy values that were produced by a
+ * plain `btoa()` on a Latin1 JS string (e.g. names containing "é"), so existing
+ * stored kubeconfigs/IDs keep decoding correctly.
+ *
  * @param base64 - The base64 string to decode.
- * @returns The decoded UTF-8 string.
+ * @returns The decoded string.
  */
 export function decodeBase64(base64: string): string {
   const binary = atob(base64);
   const bytes = Uint8Array.from(binary, char => char.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return binary;
+  }
 }

--- a/frontend/src/helpers/base64.ts
+++ b/frontend/src/helpers/base64.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * UTF-8 safe base64 helpers.
+ *
+ * The platform `btoa`/`atob` only operate on the Latin1 range (code points
+ * 0-255) and throw `InvalidCharacterError` for any other character. These
+ * helpers encode/decode through UTF-8 first, so text containing non-Latin1
+ * characters (CJK, emoji, etc.) is handled correctly.
+ *
+ * The output is standard base64 of the UTF-8 bytes, which is identical to
+ * plain `btoa` for ASCII input and matches what the backend expects.
+ *
+ * NOTE: Use these only for *text*. Raw binary data (e.g. Kubernetes secret
+ * values) must keep using `atob`/`btoa` directly, since running bytes through
+ * `TextDecoder`/`TextEncoder` would corrupt them.
+ */
+
+/**
+ * Encodes a string to base64, handling characters outside the Latin1 range.
+ *
+ * @param str - The string to encode.
+ * @returns The base64 encoded representation of the UTF-8 bytes of `str`.
+ */
+export function encodeBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let binary = '';
+  bytes.forEach(byte => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+/**
+ * Decodes a base64 string that was produced from UTF-8 bytes.
+ *
+ * @param base64 - The base64 string to decode.
+ * @returns The decoded UTF-8 string.
+ */
+export function decodeBase64(base64: string): string {
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, char => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}

--- a/frontend/src/stateless/deleteClusterKubeconfig.ts
+++ b/frontend/src/stateless/deleteClusterKubeconfig.ts
@@ -15,6 +15,7 @@
  */
 
 import * as jsyaml from 'js-yaml';
+import { decodeBase64, encodeBase64 } from '../helpers/base64';
 import { KubeconfigObject } from '../lib/k8s/kubeconfig';
 import {
   CursorSuccessEvent,
@@ -66,7 +67,7 @@ export async function deleteClusterKubeconfig(
 
           const row = cursor.value;
           const kubeconfig64 = row.kubeconfig;
-          const parsed = jsyaml.load(atob(kubeconfig64)) as KubeconfigObject;
+          const parsed = jsyaml.load(decodeBase64(kubeconfig64)) as KubeconfigObject;
 
           const { matchingKubeconfig, matchingContext } = findMatchingContexts(
             clusterName,
@@ -129,7 +130,7 @@ export async function deleteClusterKubeconfig(
           }
 
           // save the updated kubeconfig back to indexedDB
-          const updatedKubeconfig64 = btoa(jsyaml.dump(parsed));
+          const updatedKubeconfig64 = encodeBase64(jsyaml.dump(parsed));
           const updatedRow = { ...row, kubeconfig: updatedKubeconfig64 };
 
           const putRequest = store.put(updatedRow);

--- a/frontend/src/stateless/findKubeconfigByClusterName.ts
+++ b/frontend/src/stateless/findKubeconfigByClusterName.ts
@@ -15,6 +15,7 @@
  */
 
 import * as jsyaml from 'js-yaml';
+import { decodeBase64 } from '../helpers/base64';
 import { KubeconfigObject } from '../lib/k8s/kubeconfig';
 import {
   CursorSuccessEvent,
@@ -65,7 +66,7 @@ export function findKubeconfigByClusterName(
             const kubeconfigObject = cursor.value;
             const kubeconfig = kubeconfigObject.kubeconfig;
 
-            const parsedKubeconfig = jsyaml.load(atob(kubeconfig)) as KubeconfigObject;
+            const parsedKubeconfig = jsyaml.load(decodeBase64(kubeconfig)) as KubeconfigObject;
             // Check for "headlamp_info" in extensions
             const { matchingKubeconfig, matchingContext } = findMatchingContexts(
               clusterName,

--- a/frontend/src/stateless/updateStatelessClusterKubeconfig.ts
+++ b/frontend/src/stateless/updateStatelessClusterKubeconfig.ts
@@ -15,6 +15,7 @@
  */
 
 import * as jsyaml from 'js-yaml';
+import { decodeBase64, encodeBase64 } from '../helpers/base64';
 import { KubeconfigObject } from '../lib/k8s/kubeconfig';
 import {
   CursorSuccessEvent,
@@ -73,7 +74,7 @@ export function updateStatelessClusterKubeconfig(
 
           const row = cursor.value;
           const rowKubeconfig64 = row.kubeconfig;
-          const parsed = jsyaml.load(atob(rowKubeconfig64)) as KubeconfigObject;
+          const parsed = jsyaml.load(decodeBase64(rowKubeconfig64)) as KubeconfigObject;
 
           const { matchingKubeconfig, matchingContext } = findMatchingContexts(clusterName, parsed);
 
@@ -100,7 +101,7 @@ export function updateStatelessClusterKubeconfig(
           target.context.extensions = extensions;
 
           // now we need to modify the yaml back into this row only
-          const updatedKubeconfig = btoa(jsyaml.dump(parsed));
+          const updatedKubeconfig = encodeBase64(jsyaml.dump(parsed));
           const updatedRow = { ...row, kubeconfig: updatedKubeconfig };
 
           const putRequest = store.put(updatedRow);


### PR DESCRIPTION
# Summary
This PR fixes a crash caused by `btoa()` throwing `InvalidCharacterError` when a kubeconfig contains non-Latin1 characters (e.g. Chinese cluster/context names from a `zh-CN` locale). The fix introduces UTF-8-safe base64 helpers and routes all text-based encoding through them.

# Related Issue
Fixes  #6151 

# Changes
- Added `frontend/src/helpers/base64.ts` with `encodeBase64` / `decodeBase64` helpers that round-trip text through `TextEncoder` / `TextDecoder` before base64 encoding — output is identical to `btoa` for ASCII input, so no migration is needed
- Updated `KubeConfigLoader.tsx` to use the new helpers when loading a kubeconfig
- Updated `backstageMessageReceiver.ts` to use the new helpers when receiving a kubeconfig over the Backstage MessagePort channel
- Updated `updateStatelessClusterKubeconfig.ts`, `deleteStatelessClusterKubeconfig.ts`, and `findKubeconfigByClusterName.ts` for stored stateless cluster operations
- Updated `notificationsSlice.ts` to drop the deprecated `unescape/encodeURIComponent` pattern in favour of the same UTF-8-safe encoding
- Left `atob`/`btoa` in `Resource.tsx` intentionally untouched — those handle raw binary bytes where UTF-8 decoding would corrupt data

# Steps to Test
1. Create or load a kubeconfig that contains non-Latin1 text (e.g. Chinese cluster or context names)
2. Load the kubeconfig via the UI and via the Backstage MessagePort channel
3. Perform update and delete operations on a stateless cluster using that kubeconfig
4. Confirm no `InvalidCharacterError` is thrown and the kubeconfig round-trips correctly
5. Verify existing ASCII kubeconfigs are unaffected — encoded output should be byte-for-byte identical to before

# Notes for the Reviewer
- The helper output is standard base64 of the UTF-8 bytes, identical to `btoa` for ASCII, so stored kubeconfigs and the backend `/parseKubeConfig` wire format are fully backward compatible — no data migration required
- The `atob`/`btoa` calls in `Resource.tsx` are deliberately excluded; they carry binary bytes and UTF-8 decoding would corrupt them
- Test coverage added in `frontend/src/helpers/base64.test.ts` — covers ASCII, CJK, emoji, empty string, non-Latin1 no-throw assertion, and backward compatibility with `btoa` for ASCII; 30 tests passed with `vitest run`, ESLint and `tsc --noEmit` clean

