### PR TITLE
plugins: Add rollback support for failed plugin updates

### DIFF
--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -435,6 +435,43 @@ describe('PluginManager', () => {
       fs.rmSync(pluginDestDir, { recursive: true });
     }
   });
+
+  it('should recover an orphaned backup directory when the sibling plugin folder is missing', () => {
+    // Simulate an interrupted update: only <name>.backup exists, <name> does not
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'list-orphan-backup-plugins');
+    const backupDir = `${path.join(pluginDestDir, 'headlamp_minikube')}.backup`;
+    const originalDir = path.join(pluginDestDir, 'headlamp_minikube');
+
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(path.join(backupDir, 'main.js'), 'console.log("orphan");');
+    fs.writeFileSync(
+      path.join(backupDir, 'package.json'),
+      JSON.stringify({
+        name: 'headlamp_minikube',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: {
+          title: 'Minikube',
+        },
+      })
+    );
+
+    const plugins = PluginManager.list(pluginDestDir);
+    expect(plugins).toBeDefined();
+
+    // The restored plugin should appear in the list
+    const recovered = plugins!.find(p => p.pluginName === 'headlamp_minikube');
+    expect(recovered).toBeDefined();
+
+    // The .backup folder should be gone; the restored folder should exist
+    expect(fs.existsSync(backupDir)).toBe(false);
+    expect(fs.existsSync(originalDir)).toBe(true);
+
+    // Clean up
+    if (fs.existsSync(pluginDestDir)) {
+      fs.rmSync(pluginDestDir, { recursive: true });
+    }
+  });
 });
 
 /**

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -406,6 +406,35 @@ describe('PluginManager', () => {
       fs.rmSync(testDataDir, { recursive: true });
     }
   }, 30000);
+
+  it('should ignore backup directories during listing', () => {
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'list-backup-plugins');
+
+    // Create a backup directory with valid plugin files
+    const backupDir = `${path.join(pluginDestDir, 'headlamp_minikube')}.backup`;
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(path.join(backupDir, 'main.js'), 'console.log("ghost");');
+    fs.writeFileSync(
+      path.join(backupDir, 'package.json'),
+      JSON.stringify({
+        name: 'headlamp_minikube',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: {
+          title: 'Minikube',
+        },
+      })
+    );
+
+    const plugins = PluginManager.list(pluginDestDir);
+    expect(plugins).toBeDefined();
+    expect(plugins!.length).toBe(0);
+
+    // Clean up
+    if (fs.existsSync(pluginDestDir)) {
+      fs.rmSync(pluginDestDir, { recursive: true });
+    }
+  });
 });
 
 /**

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -410,25 +410,31 @@ describe('PluginManager', () => {
   it('should ignore backup directories during listing', () => {
     const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'list-backup-plugins');
 
-    // Create a backup directory with valid plugin files
-    const backupDir = `${path.join(pluginDestDir, 'headlamp_minikube')}.backup`;
+    const pluginDir = path.join(pluginDestDir, 'headlamp_minikube');
+    const backupDir = `${pluginDir}.backup`;
+    const pluginPackageJson = JSON.stringify({
+      name: 'headlamp_minikube',
+      version: '1.0.0',
+      isManagedByHeadlampPlugin: true,
+      artifacthub: { title: 'Minikube' },
+    });
+
+    // Create the original plugin folder (sibling present → backup is NOT orphaned)
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'main.js'), 'console.log("plugin");');
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), pluginPackageJson);
+
+    // Create the backup directory alongside the original
     fs.mkdirSync(backupDir, { recursive: true });
     fs.writeFileSync(path.join(backupDir, 'main.js'), 'console.log("ghost");');
-    fs.writeFileSync(
-      path.join(backupDir, 'package.json'),
-      JSON.stringify({
-        name: 'headlamp_minikube',
-        version: '1.0.0',
-        isManagedByHeadlampPlugin: true,
-        artifacthub: {
-          title: 'Minikube',
-        },
-      })
-    );
+    fs.writeFileSync(path.join(backupDir, 'package.json'), pluginPackageJson);
 
     const plugins = PluginManager.list(pluginDestDir);
     expect(plugins).toBeDefined();
-    expect(plugins!.length).toBe(0);
+    // Only the original is listed; the .backup sibling must not appear as a plugin entry
+    expect(plugins!.length).toBe(1);
+    expect(plugins!.some(p => p.folderName === 'headlamp_minikube.backup')).toBe(false);
+    expect(plugins![0].folderName).toBe('headlamp_minikube');
 
     // Clean up
     if (fs.existsSync(pluginDestDir)) {

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -26,7 +26,7 @@ import nock from 'nock';
 import os from 'os';
 import path from 'path';
 import * as tar from 'tar';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { PluginManager } from './plugin-management';
 import { getExtraFiles } from './plugin-management';
 
@@ -317,10 +317,9 @@ describe('PluginManager', () => {
     mockArtifactHubAPIWithoutPlatformSpecific(testDataDir);
 
     // 4. Force cpSync to fail during move
-    const originalCpSync = fs.cpSync;
-    fs.cpSync = () => {
+    const cpSyncSpy = vi.spyOn(fs, 'cpSync').mockImplementation(() => {
       throw new Error('Simulated filesystem error during moveDirs');
-    };
+    });
 
     try {
       // 5. Run update and expect it to fail (passing null progressCallback so error throws)
@@ -336,8 +335,7 @@ describe('PluginManager', () => {
       expect(packageJson.artifacthub.version).toBe('0.0.1');
     } finally {
       // Restore fs.cpSync
-      fs.cpSync = originalCpSync;
-
+      cpSyncSpy.mockRestore();
       // Clean up
       if (fs.existsSync(pluginDestDir)) {
         fs.rmSync(pluginDestDir, { recursive: true });

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -210,6 +210,204 @@ describe('PluginManager', () => {
       fs.rmSync(testDataDir, { recursive: true });
     }
   }, 30000);
+
+  it('should successfully update a plugin and remove the backup directory', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'update-success-data');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'update-success-plugins');
+
+    // 1. Create a minimal plugin tarball representing the new version (0.1.0)
+    await createMinimalPluginTarball(testDataDir);
+
+    // 2. Install the "old" plugin (0.0.1) manually
+    const pluginDir = path.join(pluginDestDir, 'headlamp_minikube');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'main.js'), 'console.log("old version");');
+    fs.writeFileSync(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'headlamp_minikube',
+          version: '0.0.1',
+          description: 'A UI for managing Minikube',
+          main: 'main.js',
+          isManagedByHeadlampPlugin: true,
+          artifacthub: {
+            name: 'headlamp_minikube',
+            title: 'Minikube',
+            url: 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube',
+            version: '0.0.1',
+            repoName: 'test-repo',
+            author: 'tester',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    // 3. Mock the ArtifactHub API for the new version
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir);
+
+    const progress: any[] = [];
+    const progressCallback = (update: any) => {
+      progress.push(update);
+    };
+
+    // 4. Run update
+    await PluginManager.update(
+      'headlamp_minikube',
+      pluginDestDir,
+      HEADLAMP_VERSION,
+      progressCallback,
+      null
+    );
+
+    // 5. Verify the update succeeded
+    expect(fs.existsSync(pluginDir)).toBe(true);
+    expect(fs.existsSync(`${pluginDir}.backup`)).toBe(false);
+
+    // Verify main.js exists and version in package.json is updated to 0.1.0
+    const packageJson = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8'));
+    expect(packageJson.artifacthub.version).toBe('0.1.0');
+
+    // Clean up
+    if (fs.existsSync(pluginDestDir)) {
+      fs.rmSync(pluginDestDir, { recursive: true });
+    }
+    if (fs.existsSync(testDataDir)) {
+      fs.rmSync(testDataDir, { recursive: true });
+    }
+  }, 30000);
+
+  it('should restore the original plugin if a failure occurs during move', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'update-move-fail-data');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'update-move-fail-plugins');
+
+    // 1. Create a minimal plugin tarball representing the new version
+    await createMinimalPluginTarball(testDataDir);
+
+    // 2. Install the "old" plugin (0.0.1) manually
+    const pluginDir = path.join(pluginDestDir, 'headlamp_minikube');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'main.js'), 'console.log("old version");');
+    fs.writeFileSync(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'headlamp_minikube',
+          version: '0.0.1',
+          description: 'A UI for managing Minikube',
+          main: 'main.js',
+          isManagedByHeadlampPlugin: true,
+          artifacthub: {
+            name: 'headlamp_minikube',
+            title: 'Minikube',
+            url: 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube',
+            version: '0.0.1',
+            repoName: 'test-repo',
+            author: 'tester',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    // 3. Mock the ArtifactHub API for the new version
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir);
+
+    // 4. Force cpSync to fail during move
+    const originalCpSync = fs.cpSync;
+    fs.cpSync = () => {
+      throw new Error('Simulated filesystem error during moveDirs');
+    };
+
+    try {
+      // 5. Run update and expect it to fail (passing null progressCallback so error throws)
+      await expect(
+        PluginManager.update('headlamp_minikube', pluginDestDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toThrow('Simulated filesystem error during moveDirs');
+
+      // 6. Verify that the original plugin is restored
+      expect(fs.existsSync(pluginDir)).toBe(true);
+      expect(fs.existsSync(`${pluginDir}.backup`)).toBe(false);
+
+      const packageJson = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8'));
+      expect(packageJson.artifacthub.version).toBe('0.0.1');
+    } finally {
+      // Restore fs.cpSync
+      fs.cpSync = originalCpSync;
+
+      // Clean up
+      if (fs.existsSync(pluginDestDir)) {
+        fs.rmSync(pluginDestDir, { recursive: true });
+      }
+      if (fs.existsSync(testDataDir)) {
+        fs.rmSync(testDataDir, { recursive: true });
+      }
+    }
+  }, 30000);
+
+  it('should leave the existing plugin untouched if a failure occurs before backup creation', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'update-pre-backup-fail-data');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'update-pre-backup-fail-plugins');
+
+    // 1. Create a minimal plugin tarball representing the new version
+    await createMinimalPluginTarball(testDataDir);
+
+    // 2. Install the "old" plugin (0.0.1) manually
+    const pluginDir = path.join(pluginDestDir, 'headlamp_minikube');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, 'main.js'), 'console.log("old version");');
+    fs.writeFileSync(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'headlamp_minikube',
+          version: '0.0.1',
+          description: 'A UI for managing Minikube',
+          main: 'main.js',
+          isManagedByHeadlampPlugin: true,
+          artifacthub: {
+            name: 'headlamp_minikube',
+            title: 'Minikube',
+            url: 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube',
+            version: '0.0.1',
+            repoName: 'test-repo',
+            author: 'tester',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    // 3. Mock the ArtifactHub API with invalid data or network failure to cause failure before backup creation
+    nock.cleanAll();
+    nock('https://artifacthub.io')
+      .get('/api/v1/packages/headlamp/test-repo/headlamp_minikube')
+      .reply(500, 'Internal Server Error');
+
+    // 4. Run update and expect it to fail (passing null progressCallback so error throws)
+    await expect(
+      PluginManager.update('headlamp_minikube', pluginDestDir, HEADLAMP_VERSION, null, null)
+    ).rejects.toThrow();
+
+    // 5. Verify the existing plugin is completely untouched
+    expect(fs.existsSync(pluginDir)).toBe(true);
+    expect(fs.existsSync(`${pluginDir}.backup`)).toBe(false);
+
+    const packageJson = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf8'));
+    expect(packageJson.artifacthub.version).toBe('0.0.1');
+
+    // Clean up
+    if (fs.existsSync(pluginDestDir)) {
+      fs.rmSync(pluginDestDir, { recursive: true });
+    }
+    if (fs.existsSync(testDataDir)) {
+      fs.rmSync(testDataDir, { recursive: true });
+    }
+  }, 30000);
 });
 
 /**

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -327,7 +327,14 @@ export class PluginManager {
 
         if (fs.existsSync(pluginDir)) {
           if (fs.existsSync(backupDir)) {
-            fs.rmSync(backupDir, { recursive: true, force: true });
+            // Only discard a leftover backup if the current plugin dir looks valid.
+            // Otherwise, restore first to avoid losing the last known-good copy.
+            if (!checkValidPluginFolder(pluginDir)) {
+              fs.rmSync(pluginDir, { recursive: true, force: true });
+              fs.renameSync(backupDir, pluginDir);
+            } else {
+               fs.rmSync(backupDir, { recursive: true, force: true });
+            }
           }
           fs.renameSync(pluginDir, backupDir);
           backupCreated = true;

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -316,15 +316,15 @@ export class PluginManager {
 
       // sleep(2000);  // comment out for testing
 
-      // create the destination folder if it doesn't exist
-      if (!fs.existsSync(destinationFolder)) {
-        fs.mkdirSync(destinationFolder, { recursive: true });
-      }
-
       const backupDir = `${pluginDir}.backup`;
       let backupCreated = false;
 
       try {
+        // create the destination folder if it doesn't exist
+        if (!fs.existsSync(destinationFolder)) {
+          fs.mkdirSync(destinationFolder, { recursive: true });
+        }
+
         if (fs.existsSync(pluginDir)) {
           if (fs.existsSync(backupDir)) {
             fs.rmSync(backupDir, { recursive: true, force: true });
@@ -603,10 +603,9 @@ async function downloadExtractArchive(
   }
 
   // Create temporary folder for extraction
-  const tempDir = await fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
-  // Defaulting to '' should never happen if recursive is true. So this is for the type
-  // checker only.
-  const tempFolder = fs.mkdirSync(path.join(tempDir, pluginName), { recursive: true }) ?? '';
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
+  const tempFolder = path.join(tempDir, pluginName);
+  fs.mkdirSync(tempFolder, { recursive: true });
 
   try {
     // First, download and extract the main archive

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -352,7 +352,11 @@ export class PluginManager {
         }
 
         if (progressCallback) {
-          progressCallback({ type: 'success', message: 'Plugin Updated' });
+          try {
+            progressCallback({ type: 'success', message: 'Plugin Updated' });
+          } catch (callbackErr) {
+            console.error('Progress callback failed:', callbackErr);
+          }
         }
       } catch (err) {
         let finalErr = err as Error;

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -1086,10 +1086,6 @@ async function fetchPluginInfo(
 
     return pkg;
   } catch (e) {
-    if (progressCallback) {
-      progressCallback({ type: 'error', message: e instanceof Error ? e.message : String(e) });
-    }
-
     throw e;
   }
 }

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -299,7 +299,11 @@ export class PluginManager {
         moveDirs(tempFolder, pluginDir);
 
         if (backupCreated && fs.existsSync(backupDir)) {
-          fs.rmSync(backupDir, { recursive: true, force: true });
+          try {
+            fs.rmSync(backupDir, { recursive: true, force: true });
+          } catch (cleanupErr) {
+            console.error('Failed to remove backup directory after successful update:', cleanupErr);
+          }
         }
 
         if (progressCallback) {

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -1104,6 +1104,9 @@ async function fetchPluginInfo(
  * @returns True if the folder is a valid Headlamp plugin folder, false otherwise.
  */
 function checkValidPluginFolder(folder: string): boolean {
+  if (folder.endsWith('.backup')) {
+    return false;
+  }
   if (!fs.existsSync(folder)) {
     return false;
   }

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -129,11 +129,17 @@ export interface ArtifactHubHeadlampPkg {
 function moveDirs(currentPath: string, newPath: string) {
   try {
     fs.cpSync(currentPath, newPath, { recursive: true, force: true });
-    fs.rmSync(currentPath, { recursive: true });
-    console.log(`Moved directory from ${currentPath} to ${newPath}`);
   } catch (err) {
-    console.error(`Error moving directory from ${currentPath} to ${newPath}:`, err);
+    console.error(`Error copying directory from ${currentPath} to ${newPath}:`, err);
     throw err;
+  }
+  console.log(`Copied directory from ${currentPath} to ${newPath}`);
+  try {
+    fs.rmSync(currentPath, { recursive: true });
+  } catch (err) {
+    // Source cleanup is non-fatal: the copy succeeded, so the destination is complete.
+    // Log and continue so rollback is not triggered unnecessarily (e.g. temp dir locked on Windows).
+    console.warn(`Warning: could not remove source directory ${currentPath}:`, err);
   }
 }
 

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -333,7 +333,7 @@ export class PluginManager {
               fs.rmSync(pluginDir, { recursive: true, force: true });
               fs.renameSync(backupDir, pluginDir);
             } else {
-               fs.rmSync(backupDir, { recursive: true, force: true });
+              fs.rmSync(backupDir, { recursive: true, force: true });
             }
           }
           fs.renameSync(pluginDir, backupDir);

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -191,13 +191,15 @@ export class PluginManager {
     progressCallback: null | ProgressCallback = null,
     signal: AbortSignal | null = null
   ) {
+    let tempFolder = '';
     try {
-      const [name, tempFolder] = await downloadExtractArchive(
+      const [name, downloadedTempFolder] = await downloadExtractArchive(
         pluginData,
         headlampVersion,
         progressCallback,
         signal
       );
+      tempFolder = downloadedTempFolder;
 
       // sleep(2000);  // comment out for testing
 
@@ -207,6 +209,20 @@ export class PluginManager {
       }
       // move the plugin to the destination folder
       moveDirs(tempFolder, path.join(destinationFolder, path.basename(name)));
+
+      // Clean up the parent temp directory created by mkdtempSync (moveDirs only removes tempFolder)
+      try {
+        const tempParent = path.dirname(tempFolder);
+        if (
+          fs.existsSync(tempParent) &&
+          path.basename(tempParent).startsWith('headlamp-plugin-temp-')
+        ) {
+          fs.rmSync(tempParent, { recursive: true, force: true });
+        }
+      } catch (cleanupErr) {
+        console.error('Failed to clean up temporary parent directory:', cleanupErr);
+      }
+
       if (progressCallback) {
         progressCallback({ type: 'success', message: 'Plugin Installed' });
       }
@@ -217,6 +233,22 @@ export class PluginManager {
         addToPath([binPath], 'installed plugin');
       }
     } catch (e) {
+      if (tempFolder) {
+        try {
+          if (fs.existsSync(tempFolder)) {
+            fs.rmSync(tempFolder, { recursive: true, force: true });
+          }
+          const tempParent = path.dirname(tempFolder);
+          if (
+            fs.existsSync(tempParent) &&
+            path.basename(tempParent).startsWith('headlamp-plugin-temp-')
+          ) {
+            fs.rmSync(tempParent, { recursive: true, force: true });
+          }
+        } catch (cleanupErr) {
+          console.error('Failed to clean up temporary directory:', cleanupErr);
+        }
+      }
       if (progressCallback) {
         progressCallback({ type: 'error', message: e instanceof Error ? e.message : String(e) });
       } else {
@@ -298,6 +330,19 @@ export class PluginManager {
         // move the plugin to the destination folder
         moveDirs(tempFolder, pluginDir);
 
+        // Clean up the parent temp directory created by mkdtempSync (moveDirs only removes tempFolder)
+        try {
+          const tempParent = path.dirname(tempFolder);
+          if (
+            fs.existsSync(tempParent) &&
+            path.basename(tempParent).startsWith('headlamp-plugin-temp-')
+          ) {
+            fs.rmSync(tempParent, { recursive: true, force: true });
+          }
+        } catch (cleanupErr) {
+          console.error('Failed to clean up temporary parent directory:', cleanupErr);
+        }
+
         if (backupCreated && fs.existsSync(backupDir)) {
           try {
             fs.rmSync(backupDir, { recursive: true, force: true });
@@ -310,6 +355,7 @@ export class PluginManager {
           progressCallback({ type: 'success', message: 'Plugin Updated' });
         }
       } catch (err) {
+        let finalErr = err as Error;
         if (backupCreated && fs.existsSync(backupDir)) {
           try {
             if (fs.existsSync(pluginDir)) {
@@ -318,6 +364,10 @@ export class PluginManager {
             fs.renameSync(backupDir, pluginDir);
           } catch (rollbackErr) {
             console.error('Failed to restore backup directory during rollback:', rollbackErr);
+            finalErr = new AggregateError(
+              [err as Error, rollbackErr as Error],
+              'Plugin update failed and rollback failed'
+            );
           }
         }
         try {
@@ -334,7 +384,7 @@ export class PluginManager {
         } catch (cleanupErr) {
           console.error('Failed to clean up temporary directory:', cleanupErr);
         }
-        throw err;
+        throw finalErr;
       }
     } catch (e) {
       if (progressCallback) {
@@ -548,35 +598,46 @@ async function downloadExtractArchive(
   // checker only.
   const tempFolder = fs.mkdirSync(path.join(tempDir, pluginName), { recursive: true }) ?? '';
 
-  // First, download and extract the main archive
-  if (progressCallback) {
-    progressCallback({ type: 'info', message: 'Downloading main plugin archive' });
+  try {
+    // First, download and extract the main archive
+    if (progressCallback) {
+      progressCallback({ type: 'info', message: 'Downloading main plugin archive' });
+    }
+
+    await downloadAndExtractSingleArchive(
+      pluginInfo.archiveURL,
+      pluginInfo.archiveChecksum,
+      tempFolder,
+      progressCallback,
+      signal
+    );
+
+    await downloadExtraFiles(pluginInfo.extraFiles, tempFolder, progressCallback, signal);
+
+    // Add artifacthub metadata to the plugin
+    const packageJSON = JSON.parse(fs.readFileSync(`${tempFolder}/package.json`, 'utf8'));
+    packageJSON.artifacthub = {
+      name: pluginName,
+      title: pluginInfo.display_name,
+      url: `https://artifacthub.io/packages/headlamp/${pluginInfo.repository.name}/${pluginName}`,
+      version: pluginInfo.version,
+      repoName: pluginInfo.repository.name,
+      author: pluginInfo.repository.user_alias,
+    };
+    packageJSON.isManagedByHeadlampPlugin = true;
+    fs.writeFileSync(`${tempFolder}/package.json`, JSON.stringify(packageJSON, null, 2));
+
+    return [pluginName, tempFolder];
+  } catch (err) {
+    try {
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    } catch (cleanupErr) {
+      console.error('Failed to clean up temporary directory on failure:', cleanupErr);
+    }
+    throw err;
   }
-
-  await downloadAndExtractSingleArchive(
-    pluginInfo.archiveURL,
-    pluginInfo.archiveChecksum,
-    tempFolder,
-    progressCallback,
-    signal
-  );
-
-  await downloadExtraFiles(pluginInfo.extraFiles, tempFolder, progressCallback, signal);
-
-  // Add artifacthub metadata to the plugin
-  const packageJSON = JSON.parse(fs.readFileSync(`${tempFolder}/package.json`, 'utf8'));
-  packageJSON.artifacthub = {
-    name: pluginName,
-    title: pluginInfo.display_name,
-    url: `https://artifacthub.io/packages/headlamp/${pluginInfo.repository.name}/${pluginName}`,
-    version: pluginInfo.version,
-    repoName: pluginInfo.repository.name,
-    author: pluginInfo.repository.user_alias,
-  };
-  packageJSON.isManagedByHeadlampPlugin = true;
-  fs.writeFileSync(`${tempFolder}/package.json`, JSON.stringify(packageJSON, null, 2));
-
-  return [pluginName, tempFolder];
 }
 
 /**

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -283,16 +283,54 @@ export class PluginManager {
         fs.mkdirSync(destinationFolder, { recursive: true });
       }
 
-      // remove the existing plugin folder
-      fs.rmSync(pluginDir, { recursive: true, force: true });
+      const backupDir = `${pluginDir}.backup`;
+      let backupCreated = false;
 
-      // create the plugin folder
-      fs.mkdirSync(pluginDir, { recursive: true });
+      try {
+        if (fs.existsSync(pluginDir)) {
+          if (fs.existsSync(backupDir)) {
+            fs.rmSync(backupDir, { recursive: true, force: true });
+          }
+          fs.renameSync(pluginDir, backupDir);
+          backupCreated = true;
+        }
 
-      // move the plugin to the destination folder
-      moveDirs(tempFolder, pluginDir);
-      if (progressCallback) {
-        progressCallback({ type: 'success', message: 'Plugin Updated' });
+        // move the plugin to the destination folder
+        moveDirs(tempFolder, pluginDir);
+
+        if (backupCreated && fs.existsSync(backupDir)) {
+          fs.rmSync(backupDir, { recursive: true, force: true });
+        }
+
+        if (progressCallback) {
+          progressCallback({ type: 'success', message: 'Plugin Updated' });
+        }
+      } catch (err) {
+        if (backupCreated && fs.existsSync(backupDir)) {
+          try {
+            if (fs.existsSync(pluginDir)) {
+              fs.rmSync(pluginDir, { recursive: true, force: true });
+            }
+            fs.renameSync(backupDir, pluginDir);
+          } catch (rollbackErr) {
+            console.error('Failed to restore backup directory during rollback:', rollbackErr);
+          }
+        }
+        try {
+          if (fs.existsSync(tempFolder)) {
+            fs.rmSync(tempFolder, { recursive: true, force: true });
+          }
+          const tempParent = path.dirname(tempFolder);
+          if (
+            fs.existsSync(tempParent) &&
+            path.basename(tempParent).startsWith('headlamp-plugin-temp-')
+          ) {
+            fs.rmSync(tempParent, { recursive: true, force: true });
+          }
+        } catch (cleanupErr) {
+          console.error('Failed to clean up temporary directory:', cleanupErr);
+        }
+        throw err;
       }
     } catch (e) {
       if (progressCallback) {

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -473,8 +473,36 @@ export class PluginManager {
       // Filter out directories (plugins)
       const pluginFolders = entries.filter(entry => entry.isDirectory());
 
-      // Iterate through each plugin folder
+      // Recover orphaned .backup directories: if a <name>.backup exists but <name> does not,
+      // an interrupted update left only the backup. Restore it so the plugin is discoverable.
       for (const pluginFolder of pluginFolders) {
+        if (!pluginFolder.name.endsWith('.backup')) {
+          continue;
+        }
+        const backupDir = path.join(folder, pluginFolder.name);
+        const originalDir = backupDir.slice(0, -'.backup'.length);
+        if (!fs.existsSync(originalDir)) {
+          console.warn(
+            `Detected orphaned backup directory "${backupDir}" with no corresponding plugin folder. ` +
+              `Restoring it to "${originalDir}" to recover from an interrupted update.`
+          );
+          try {
+            fs.renameSync(backupDir, originalDir);
+          } catch (restoreErr) {
+            console.error(
+              `Failed to restore orphaned backup "${backupDir}" to "${originalDir}":`,
+              restoreErr
+            );
+          }
+        }
+      }
+
+      // Re-read entries after potential recovery so restored plugins are included
+      const entriesAfterRecovery = fs.readdirSync(folder, { withFileTypes: true });
+      const pluginFoldersAfterRecovery = entriesAfterRecovery.filter(entry => entry.isDirectory());
+
+      // Iterate through each plugin folder
+      for (const pluginFolder of pluginFoldersAfterRecovery) {
         const pluginDir = path.join(folder, pluginFolder.name);
 
         if (checkValidPluginFolder(pluginDir)) {

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -174,7 +174,7 @@ class PluginManager {
         moveDirs(tempFolder, pluginDir);
 
         if (backupCreated && fs.existsSync(backupDir)) {
-            try {
+          try {
             fs.rmSync(backupDir, { recursive: true, force: true });
           } catch (cleanupErr) {
             console.error('Failed to remove backup directory after successful update:', cleanupErr);

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -50,11 +50,17 @@ const envPaths = require('env-paths');
 function moveDirs(currentPath, newPath) {
   try {
     fs.cpSync(currentPath, newPath, { recursive: true, force: true });
-    fs.rmSync(currentPath, { recursive: true });
-    console.log(`Moved directory from ${currentPath} to ${newPath}`);
   } catch (err) {
-    console.error(`Error moving directory from ${currentPath} to ${newPath}:`, err);
+    console.error(`Error copying directory from ${currentPath} to ${newPath}:`, err);
     throw err;
+  }
+  console.log(`Copied directory from ${currentPath} to ${newPath}`);
+  try {
+    fs.rmSync(currentPath, { recursive: true });
+  } catch (err) {
+    // Source cleanup is non-fatal: the copy succeeded, so the destination is complete.
+    // Log and continue so rollback is not triggered unnecessarily (e.g. temp dir locked on Windows).
+    console.warn(`Warning: could not remove source directory ${currentPath}:`, err);
   }
 }
 

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -632,9 +632,8 @@ async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
   } catch (e) {
     if (progressCallback) {
       progressCallback({ type: 'error', message: e.message });
-    } else {
-      throw e;
     }
+    throw e;
   }
 }
 
@@ -647,6 +646,9 @@ async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
  * @returns {boolean} True if the folder is a valid Headlamp plugin folder, false otherwise.
  */
 function checkValidPluginFolder(folder) {
+  if (folder.endsWith('.backup')) {
+    return false;
+  }
   if (!fs.existsSync(folder)) {
     return false;
   }

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -631,9 +631,6 @@ async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
     }
     return pluginInfo;
   } catch (e) {
-    if (progressCallback) {
-      progressCallback({ type: 'error', message: e.message });
-    }
     throw e;
   }
 }

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -188,15 +188,15 @@ class PluginManager {
 
       // sleep(2000);  // comment out for testing
 
-      // create the destination folder if it doesn't exist
-      if (!fs.existsSync(destinationFolder)) {
-        fs.mkdirSync(destinationFolder, { recursive: true });
-      }
-
       const backupDir = `${pluginDir}.backup`;
       let backupCreated = false;
 
       try {
+        // create the destination folder if it doesn't exist
+        if (!fs.existsSync(destinationFolder)) {
+          fs.mkdirSync(destinationFolder, { recursive: true });
+        }
+
         if (fs.existsSync(pluginDir)) {
           if (fs.existsSync(backupDir)) {
             fs.rmSync(backupDir, { recursive: true, force: true });
@@ -485,8 +485,9 @@ async function downloadExtractPlugin(
     throw new Error('Download cancelled');
   }
 
-  const tempDir = await fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
-  const tempFolder = fs.mkdirSync(path.join(tempDir, pluginName), { recursive: true });
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
+  const tempFolder = path.join(tempDir, pluginName);
+  fs.mkdirSync(tempFolder, { recursive: true });
 
   try {
     if (progressCallback) {

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -486,8 +486,7 @@ async function downloadExtractPlugin(
       throw new Error('Download cancelled');
     }
 
-    // await sleep(4000); // comment out for testing
-    const archResponse = await fetch(archiveURL, { redirect: 'follow', follow: 10 }, { signal });
+    const archResponse = await fetch(archiveURL, { redirect: 'follow', signal });
     if (!archResponse.ok) {
       throw new Error(`Failed to download tarball. Status code: ${archResponse.status}`);
     }
@@ -597,7 +596,7 @@ async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
     if (progressCallback) {
       progressCallback({ type: 'info', message: 'Fetching Plugin Metadata' });
     }
-    let response = await fetch(apiURL, { redirect: 'follow', follow: 10 }, { signal });
+    let response = await fetch(apiURL, { redirect: 'follow', signal });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -612,8 +611,7 @@ async function fetchPluginInfo(URL, progressCallback, signal, pluginVersion) {
       const baseURL = apiURL.endsWith('/') ? apiURL.slice(0, -1) : apiURL;
       response = await fetch(
         `${baseURL}/${pluginVersion}`,
-        { redirect: 'follow', follow: 10 },
-        { signal }
+        { redirect: 'follow', signal }
       );
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -199,7 +199,14 @@ class PluginManager {
 
         if (fs.existsSync(pluginDir)) {
           if (fs.existsSync(backupDir)) {
-            fs.rmSync(backupDir, { recursive: true, force: true });
+            // Only discard a leftover backup if the current plugin dir looks valid.
+            // Otherwise, restore first to avoid losing the last known-good copy.
+            if (!checkValidPluginFolder(pluginDir)) {
+              fs.rmSync(pluginDir, { recursive: true, force: true });
+              fs.renameSync(backupDir, pluginDir);
+            } else {
+              fs.rmSync(backupDir, { recursive: true, force: true });
+            }
           }
           fs.renameSync(pluginDir, backupDir);
           backupCreated = true;

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -174,7 +174,11 @@ class PluginManager {
         moveDirs(tempFolder, pluginDir);
 
         if (backupCreated && fs.existsSync(backupDir)) {
-          fs.rmSync(backupDir, { recursive: true, force: true });
+            try {
+            fs.rmSync(backupDir, { recursive: true, force: true });
+          } catch (cleanupErr) {
+            console.error('Failed to remove backup directory after successful update:', cleanupErr);
+          }
         }
 
         if (progressCallback) {

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -77,14 +77,16 @@ class PluginManager {
     signal = null,
     pluginVersion = ''
   ) {
+    let tempFolder = '';
     try {
-      const [name, tempFolder] = await downloadExtractPlugin(
+      const [name, downloadedTempFolder] = await downloadExtractPlugin(
         URL,
         headlampVersion,
         progressCallback,
         signal,
         pluginVersion
       );
+      tempFolder = downloadedTempFolder;
 
       // sleep(2000);  // comment out for testing
 
@@ -94,10 +96,37 @@ class PluginManager {
       }
       // move the plugin to the destination folder
       moveDirs(tempFolder, path.join(destinationFolder, path.basename(name)));
+
+      // Clean up the parent temp directory created by mkdtempSync (moveDirs only removes tempFolder)
+      try {
+        const tempParent = path.dirname(tempFolder);
+        if (
+          fs.existsSync(tempParent) &&
+          path.basename(tempParent).startsWith('headlamp-plugin-temp-')
+        ) {
+          fs.rmSync(tempParent, { recursive: true, force: true });
+        }
+      } catch (cleanupErr) {
+        console.error('Failed to clean up temporary parent directory:', cleanupErr);
+      }
+
       if (progressCallback) {
         progressCallback({ type: 'success', message: 'Plugin Installed' });
       }
     } catch (e) {
+      if (tempFolder) {
+        try {
+          if (fs.existsSync(tempFolder)) {
+            fs.rmSync(tempFolder, { recursive: true, force: true });
+          }
+          const tempParent = path.dirname(tempFolder);
+          if (fs.existsSync(tempParent) && path.basename(tempParent).startsWith('headlamp-plugin-temp-')) {
+            fs.rmSync(tempParent, { recursive: true, force: true });
+          }
+        } catch (cleanupErr) {
+          console.error('Failed to clean up temporary directory:', cleanupErr);
+        }
+      }
       if (progressCallback) {
         progressCallback({ type: 'error', message: e.message });
       } else {
@@ -173,6 +202,19 @@ class PluginManager {
         // move the plugin to the destination folder
         moveDirs(tempFolder, pluginDir);
 
+        // Clean up the parent temp directory created by mkdtempSync (moveDirs only removes tempFolder)
+        try {
+          const tempParent = path.dirname(tempFolder);
+          if (
+            fs.existsSync(tempParent) &&
+            path.basename(tempParent).startsWith('headlamp-plugin-temp-')
+          ) {
+            fs.rmSync(tempParent, { recursive: true, force: true });
+          }
+        } catch (cleanupErr) {
+          console.error('Failed to clean up temporary parent directory:', cleanupErr);
+        }
+
         if (backupCreated && fs.existsSync(backupDir)) {
           try {
             fs.rmSync(backupDir, { recursive: true, force: true });
@@ -185,6 +227,7 @@ class PluginManager {
           progressCallback({ type: 'success', message: 'Plugin Updated' });
         }
       } catch (err) {
+        let finalErr = err;
         if (backupCreated && fs.existsSync(backupDir)) {
           try {
             if (fs.existsSync(pluginDir)) {
@@ -193,6 +236,10 @@ class PluginManager {
             fs.renameSync(backupDir, pluginDir);
           } catch (rollbackErr) {
             console.error('Failed to restore backup directory during rollback:', rollbackErr);
+            finalErr = new AggregateError(
+              [err, rollbackErr],
+              'Plugin update failed and rollback failed'
+            );
           }
         }
         try {
@@ -206,7 +253,7 @@ class PluginManager {
         } catch (cleanupErr) {
           console.error('Failed to clean up temporary directory:', cleanupErr);
         }
-        throw err;
+        throw finalErr;
       }
     } catch (e) {
       if (progressCallback) {
@@ -431,90 +478,101 @@ async function downloadExtractPlugin(
   const tempDir = await fs.mkdtempSync(path.join(os.tmpdir(), 'headlamp-plugin-temp-'));
   const tempFolder = fs.mkdirSync(path.join(tempDir, pluginName), { recursive: true });
 
-  if (progressCallback) {
-    progressCallback({ type: 'info', message: 'Downloading Plugin' });
-  }
-  if (signal && signal.aborted) {
-    throw new Error('Download cancelled');
-  }
+  try {
+    if (progressCallback) {
+      progressCallback({ type: 'info', message: 'Downloading Plugin' });
+    }
+    if (signal && signal.aborted) {
+      throw new Error('Download cancelled');
+    }
 
-  // await sleep(4000); // comment out for testing
-  const archResponse = await fetch(archiveURL, { redirect: 'follow', follow: 10 }, { signal });
-  if (!archResponse.ok) {
-    throw new Error(`Failed to download tarball. Status code: ${archResponse.status}`);
-  }
+    // await sleep(4000); // comment out for testing
+    const archResponse = await fetch(archiveURL, { redirect: 'follow', follow: 10 }, { signal });
+    if (!archResponse.ok) {
+      throw new Error(`Failed to download tarball. Status code: ${archResponse.status}`);
+    }
 
-  if (signal && signal.aborted) {
-    throw new Error('Download cancelled');
-  }
+    if (signal && signal.aborted) {
+      throw new Error('Download cancelled');
+    }
 
-  if (progressCallback) {
-    progressCallback({ type: 'info', message: 'Plugin Downloaded' });
-  }
+    if (progressCallback) {
+      progressCallback({ type: 'info', message: 'Plugin Downloaded' });
+    }
 
-  const archChunks = [];
-  let archBufferLengeth = 0;
+    const archChunks = [];
+    let archBufferLengeth = 0;
 
-  for await (const chunk of archResponse.body) {
-    archChunks.push(chunk);
-    archBufferLengeth += chunk.length;
-  }
+    for await (const chunk of archResponse.body) {
+      archChunks.push(chunk);
+      archBufferLengeth += chunk.length;
+    }
 
-  const archBuffer = Buffer.concat(archChunks, archBufferLengeth);
+    const archBuffer = Buffer.concat(archChunks, archBufferLengeth);
 
-  const archiveChecksum = crypto.createHash('sha256').update(archBuffer).digest('hex');
+    const archiveChecksum = crypto.createHash('sha256').update(archBuffer).digest('hex');
 
-  if (archiveChecksum !== checksum) {
-    throw new Error('Checksum mismatch.');
-  }
+    if (archiveChecksum !== checksum) {
+      throw new Error('Checksum mismatch.');
+    }
 
-  if (signal && signal.aborted) {
-    throw new Error('Download cancelled');
-  }
+    if (signal && signal.aborted) {
+      throw new Error('Download cancelled');
+    }
 
-  if (progressCallback) {
-    progressCallback({ type: 'info', message: 'Extracting Plugin' });
-  }
-  const archStream = new stream.PassThrough();
-  archStream.end(archBuffer);
+    if (progressCallback) {
+      progressCallback({ type: 'info', message: 'Extracting Plugin' });
+    }
+    const archStream = new stream.PassThrough();
+    archStream.end(archBuffer);
 
-  const extractStream = archStream.pipe(zlib.createGunzip()).pipe(
-    tar.extract({
-      cwd: tempFolder,
-      strip: 1,
-      sync: true,
-    })
-  );
+    const extractStream = archStream.pipe(zlib.createGunzip()).pipe(
+      tar.extract({
+        cwd: tempFolder,
+        strip: 1,
+        sync: true,
+      })
+    );
 
-  await new Promise((resolve, reject) => {
-    extractStream.on('finish', () => {
-      resolve();
+    await new Promise((resolve, reject) => {
+      extractStream.on('finish', () => {
+        resolve();
+      });
+      extractStream.on('error', err => {
+        reject(err);
+      });
     });
-    extractStream.on('error', err => {
-      reject(err);
-    });
-  });
 
-  if (signal && signal.aborted) {
-    throw new Error('Download cancelled');
-  }
+    if (signal && signal.aborted) {
+      throw new Error('Download cancelled');
+    }
 
-  if (progressCallback) {
-    progressCallback({ type: 'info', message: 'Plugin Extracted' });
+    if (progressCallback) {
+      progressCallback({ type: 'info', message: 'Plugin Extracted' });
+    }
+    // add artifacthub metadata to the plugin
+    const packageJSON = JSON.parse(fs.readFileSync(`${tempFolder}/package.json`, 'utf8'));
+    packageJSON.artifacthub = {
+      name: pluginName,
+      title: pluginInfo.display_name,
+      url: `https://artifacthub.io/packages/headlamp/${pluginInfo.repository.name}/${pluginName}`,
+      version: pluginInfo.version,
+      repoName: pluginInfo.repository.name,
+      author: pluginInfo.repository.user_alias,
+    };
+    packageJSON.isManagedByHeadlampPlugin = true;
+    fs.writeFileSync(`${tempFolder}/package.json`, JSON.stringify(packageJSON, null, 2));
+    return [pluginName, tempFolder];
+  } catch (err) {
+    try {
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    } catch (cleanupErr) {
+      console.error('Failed to clean up temporary directory on failure:', cleanupErr);
+    }
+    throw err;
   }
-  // add artifacthub metadata to the plugin
-  const packageJSON = JSON.parse(fs.readFileSync(`${tempFolder}/package.json`, 'utf8'));
-  packageJSON.artifacthub = {
-    name: pluginName,
-    title: pluginInfo.display_name,
-    url: `https://artifacthub.io/packages/headlamp/${pluginInfo.repository.name}/${pluginName}`,
-    version: pluginInfo.version,
-    repoName: pluginInfo.repository.name,
-    author: pluginInfo.repository.user_alias,
-  };
-  packageJSON.isManagedByHeadlampPlugin = true;
-  fs.writeFileSync(`${tempFolder}/package.json`, JSON.stringify(packageJSON, null, 2));
-  return [pluginName, tempFolder];
 }
 
 /**

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -224,7 +224,11 @@ class PluginManager {
         }
 
         if (progressCallback) {
-          progressCallback({ type: 'success', message: 'Plugin Updated' });
+            try {
+              progressCallback({ type: 'success', message: 'Plugin Updated' });
+            }  catch (callbackErr) {
+              console.error('Progress callback failed:', callbackErr);
+            }
         }
       } catch (err) {
         let finalErr = err;

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -343,8 +343,36 @@ class PluginManager {
       // Filter out directories (plugins)
       const pluginFolders = entries.filter(entry => entry.isDirectory());
 
-      // Iterate through each plugin folder
+      // Recover orphaned .backup directories: if a <name>.backup exists but <name> does not,
+      // an interrupted update left only the backup. Restore it so the plugin is discoverable.
       for (const pluginFolder of pluginFolders) {
+        if (!pluginFolder.name.endsWith('.backup')) {
+          continue;
+        }
+        const backupDir = path.join(folder, pluginFolder.name);
+        const originalDir = backupDir.slice(0, -'.backup'.length);
+        if (!fs.existsSync(originalDir)) {
+          console.warn(
+            `Detected orphaned backup directory "${backupDir}" with no corresponding plugin folder. ` +
+              `Restoring it to "${originalDir}" to recover from an interrupted update.`
+          );
+          try {
+            fs.renameSync(backupDir, originalDir);
+          } catch (restoreErr) {
+            console.error(
+              `Failed to restore orphaned backup "${backupDir}" to "${originalDir}":`,
+              restoreErr
+            );
+          }
+        }
+      }
+
+      // Re-read entries after potential recovery so restored plugins are included
+      const entriesAfterRecovery = fs.readdirSync(folder, { withFileTypes: true });
+      const pluginFoldersAfterRecovery = entriesAfterRecovery.filter(entry => entry.isDirectory());
+
+      // Iterate through each plugin folder
+      for (const pluginFolder of pluginFoldersAfterRecovery) {
         const pluginDir = path.join(folder, pluginFolder.name);
 
         if (checkValidPluginFolder(pluginDir)) {

--- a/plugins/pluginctl/src/plugin-management.js
+++ b/plugins/pluginctl/src/plugin-management.js
@@ -158,16 +158,51 @@ class PluginManager {
         fs.mkdirSync(destinationFolder, { recursive: true });
       }
 
-      // remove the existing plugin folder
-      fs.rmSync(pluginDir, { recursive: true, force: true });
+      const backupDir = `${pluginDir}.backup`;
+      let backupCreated = false;
 
-      // create the plugin folder
-      fs.mkdirSync(pluginDir, { recursive: true });
+      try {
+        if (fs.existsSync(pluginDir)) {
+          if (fs.existsSync(backupDir)) {
+            fs.rmSync(backupDir, { recursive: true, force: true });
+          }
+          fs.renameSync(pluginDir, backupDir);
+          backupCreated = true;
+        }
 
-      // move the plugin to the destination folder
-      moveDirs(tempFolder, pluginDir);
-      if (progressCallback) {
-        progressCallback({ type: 'success', message: 'Plugin Updated' });
+        // move the plugin to the destination folder
+        moveDirs(tempFolder, pluginDir);
+
+        if (backupCreated && fs.existsSync(backupDir)) {
+          fs.rmSync(backupDir, { recursive: true, force: true });
+        }
+
+        if (progressCallback) {
+          progressCallback({ type: 'success', message: 'Plugin Updated' });
+        }
+      } catch (err) {
+        if (backupCreated && fs.existsSync(backupDir)) {
+          try {
+            if (fs.existsSync(pluginDir)) {
+              fs.rmSync(pluginDir, { recursive: true, force: true });
+            }
+            fs.renameSync(backupDir, pluginDir);
+          } catch (rollbackErr) {
+            console.error('Failed to restore backup directory during rollback:', rollbackErr);
+          }
+        }
+        try {
+          if (fs.existsSync(tempFolder)) {
+            fs.rmSync(tempFolder, { recursive: true, force: true });
+          }
+          const tempParent = path.dirname(tempFolder);
+          if (fs.existsSync(tempParent) && path.basename(tempParent).startsWith('headlamp-plugin-temp-')) {
+            fs.rmSync(tempParent, { recursive: true, force: true });
+          }
+        } catch (cleanupErr) {
+          console.error('Failed to clean up temporary directory:', cleanupErr);
+        }
+        throw err;
       }
     } catch (e) {
       if (progressCallback) {

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -22,7 +22,6 @@ const path = require('path');
 const PluginManager = pluginManagement.PluginManager;
 const validateArchiveURL = pluginManagement.validateArchiveURL;
 
-
 // Mocking progressCallback function for testing
 // eslint-disable-next-line
 const mockProgressCallback = jest.fn(args => {
@@ -95,9 +94,19 @@ describe('PluginManager Test Cases', () => {
   });
 
   test('Update Plugin Rollback on Move Failure', async () => {
-    // Set a lower version first in the installed plugin
     const pluginDir = path.join(tempDir, 'headlamp_flux');
     const backupDir = `${pluginDir}.backup`;
+    // Ensure the plugin exists for this test so it can run in isolation.
+    if (!fs.existsSync(pluginDir)) {
+      await PluginManager.install(
+        'https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_flux',
+        tempDir,
+        '',
+        mockProgressCallback
+      );
+      jest.clearAllMocks();
+    }
+    // Set a lower version first in the installed plugin
     const packageJSONPath = path.join(pluginDir, 'package.json');
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
     packageJSON.artifacthub.version = '0.0.1'; // Lower version to trigger update
@@ -154,7 +163,7 @@ describe('PluginManager Test Cases', () => {
 
   test('Error propagation when progressCallback is provided', async () => {
     const errorCallback = jest.fn();
-    
+
     // install should resolve to undefined when progressCallback is provided, as it catches the error and reports it via callback
     await expect(
       PluginManager.install(
@@ -194,9 +203,7 @@ describe('PluginManager Test Cases', () => {
     PluginManager.list(tempDir, listCallback);
 
     // The list should not contain the ghost-plugin
-    const listedPlugins = listCallback.mock.calls.find(
-      call => call[0].type === 'success'
-    )[0].data;
+    const listedPlugins = listCallback.mock.calls.find(call => call[0].type === 'success')[0].data;
 
     const ghostFound = listedPlugins.some(p => p.folderName === 'ghost-plugin.backup');
     expect(ghostFound).toBe(false);
@@ -208,15 +215,23 @@ describe('PluginManager Test Cases', () => {
 
 describe('validateArchiveURL', () => {
   test('valid GitHub release URL', () => {
-    expect(validateArchiveURL('https://github.com/kubernetes-sigs/headlamp/releases/download/v0.24.1/Headlamp-0.24.1-win-x64.exe')).toBe(true);
+    expect(
+      validateArchiveURL(
+        'https://github.com/kubernetes-sigs/headlamp/releases/download/v0.24.1/Headlamp-0.24.1-win-x64.exe'
+      )
+    ).toBe(true);
   });
 
   test('valid GitHub archive URL', () => {
-    expect(validateArchiveURL('https://github.com/owner/repo/archive/refs/tags/v1.0.0.zip')).toBe(true);
+    expect(validateArchiveURL('https://github.com/owner/repo/archive/refs/tags/v1.0.0.zip')).toBe(
+      true
+    );
   });
 
   test('valid Bitbucket download URL', () => {
-    expect(validateArchiveURL('https://bitbucket.org/owner/repo/downloads/package-1.0.0.zip')).toBe(true);
+    expect(validateArchiveURL('https://bitbucket.org/owner/repo/downloads/package-1.0.0.zip')).toBe(
+      true
+    );
   });
 
   test('valid Bitbucket get archive URL', () => {
@@ -224,7 +239,11 @@ describe('validateArchiveURL', () => {
   });
 
   test('valid GitLab release URL', () => {
-    expect(validateArchiveURL('https://gitlab.com/gitlab-org/gitlab/-/archive/v17.2.0-ee/gitlab-v17.2.0-ee.tar.gz')).toBe(true);
+    expect(
+      validateArchiveURL(
+        'https://gitlab.com/gitlab-org/gitlab/-/archive/v17.2.0-ee/gitlab-v17.2.0-ee.tar.gz'
+      )
+    ).toBe(true);
   });
 
   test('invalid URL', () => {

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -103,7 +103,6 @@ describe('PluginManager Test Cases', () => {
     fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));
 
     // Mock fs.cpSync to throw an error during moveDirs
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const cpSyncSpy = jest.spyOn(fs, 'cpSync').mockImplementation(() => {
       throw new Error('Mocked copy failure');
     });

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -93,6 +93,39 @@ describe('PluginManager Test Cases', () => {
     });
   });
 
+  test('Update Plugin Rollback on Move Failure', async () => {
+    // Set a lower version first in the installed plugin
+    const pluginDir = `${tempDir}/headlamp_flux`;
+    const backupDir = `${pluginDir}.backup`;
+    const packageJSONPath = `${pluginDir}/package.json`;
+    const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
+    packageJSON.artifacthub.version = '0.0.1'; // Lower version to trigger update
+    fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));
+
+    // Mock fs.cpSync to throw an error during moveDirs
+    const cpSyncSpy = jest.spyOn(fs, 'cpSync').mockImplementation(() => {
+      throw new Error('Mocked copy failure');
+    });
+
+    await PluginManager.update('@headlamp-k8s/flux', tempDir, '', mockProgressCallback);
+
+    expect(mockProgressCallback).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'Mocked copy failure',
+    });
+
+    // Verify the original plugin folder exists and is restored
+    expect(fs.existsSync(pluginDir)).toBe(true);
+    const restoredPackageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
+    expect(restoredPackageJSON.artifacthub.version).toBe('0.0.1');
+
+    // Verify that the backup folder was cleaned up
+    expect(fs.existsSync(backupDir)).toBe(false);
+
+    // Restore the spy
+    cpSyncSpy.mockRestore();
+  });
+
   test('Uninstall Plugin', async () => {
     const tempDir = tmp.dirSync({ unsafeCleanup: true }).name;
 

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -17,6 +17,7 @@
 const pluginManagement = require('./plugin-management.js');
 const tmp = require('tmp');
 const fs = require('fs');
+const path = require('path');
 
 const PluginManager = pluginManagement.PluginManager;
 const validateArchiveURL = pluginManagement.validateArchiveURL;
@@ -149,6 +150,59 @@ describe('PluginManager Test Cases', () => {
     });
 
     fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('Error propagation when progressCallback is provided', async () => {
+    const errorCallback = jest.fn();
+    
+    // install should resolve to undefined when progressCallback is provided, as it catches the error and reports it via callback
+    await expect(
+      PluginManager.install(
+        'https://artifacthub.io/packages/headlamp/headlamp-plugins/non-existent-plugin',
+        tempDir,
+        '',
+        errorCallback
+      )
+    ).resolves.toBeUndefined();
+
+    expect(errorCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringContaining('HTTP error! status: 404'),
+      })
+    );
+  });
+
+  test('List ignores backup directories', () => {
+    // Create a backup directory with valid plugin files
+    const backupDir = path.join(tempDir, 'ghost-plugin.backup');
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(path.join(backupDir, 'main.js'), 'console.log("ghost");');
+    fs.writeFileSync(
+      path.join(backupDir, 'package.json'),
+      JSON.stringify({
+        name: 'ghost-plugin',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: {
+          title: 'Ghost Plugin',
+        },
+      })
+    );
+
+    const listCallback = jest.fn();
+    PluginManager.list(tempDir, listCallback);
+
+    // The list should not contain the ghost-plugin
+    const listedPlugins = listCallback.mock.calls.find(
+      call => call[0].type === 'success'
+    )[0].data;
+
+    const ghostFound = listedPlugins.some(p => p.folderName === 'ghost-plugin.backup');
+    expect(ghostFound).toBe(false);
+
+    // Clean up
+    fs.rmSync(backupDir, { recursive: true, force: true });
   });
 });
 

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -211,6 +211,39 @@ describe('PluginManager Test Cases', () => {
     // Clean up
     fs.rmSync(backupDir, { recursive: true, force: true });
   });
+
+  test('List recovers orphaned backup directory when sibling is missing', () => {
+    // Simulate an interrupted update: only <name>.backup exists, <name> does not
+    const orphanBackupDir = path.join(tempDir, 'orphan-plugin.backup');
+    fs.mkdirSync(orphanBackupDir, { recursive: true });
+    fs.writeFileSync(path.join(orphanBackupDir, 'main.js'), 'console.log("orphan");');
+    fs.writeFileSync(
+      path.join(orphanBackupDir, 'package.json'),
+      JSON.stringify({
+        name: 'orphan-plugin',
+        version: '1.0.0',
+        isManagedByHeadlampPlugin: true,
+        artifacthub: {
+          title: 'Orphan Plugin',
+        },
+      })
+    );
+
+    const listCallback = jest.fn();
+    PluginManager.list(tempDir, listCallback);
+
+    const listedPlugins = listCallback.mock.calls.find(call => call[0].type === 'success')[0].data;
+
+    // The restored plugin should appear in the list (recovered from .backup)
+    const recovered = listedPlugins.find(p => p.pluginName === 'orphan-plugin');
+    expect(recovered).toBeDefined();
+    // The .backup folder should no longer exist; the restored folder should
+    expect(fs.existsSync(orphanBackupDir)).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, 'orphan-plugin'))).toBe(true);
+
+    // Clean up
+    fs.rmSync(path.join(tempDir, 'orphan-plugin'), { recursive: true, force: true });
+  });
 });
 
 describe('validateArchiveURL', () => {

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -96,9 +96,9 @@ describe('PluginManager Test Cases', () => {
 
   test('Update Plugin Rollback on Move Failure', async () => {
     // Set a lower version first in the installed plugin
-    const pluginDir = `${tempDir}/headlamp_flux`;
+    const pluginDir = path.join(tempDir, 'headlamp_flux');
     const backupDir = `${pluginDir}.backup`;
-    const packageJSONPath = `${pluginDir}/package.json`;
+    const packageJSONPath = path.join(pluginDir, 'package.json');
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
     packageJSON.artifacthub.version = '0.0.1'; // Lower version to trigger update
     fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));

--- a/plugins/pluginctl/src/plugin-management.test.js
+++ b/plugins/pluginctl/src/plugin-management.test.js
@@ -103,27 +103,30 @@ describe('PluginManager Test Cases', () => {
     fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));
 
     // Mock fs.cpSync to throw an error during moveDirs
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const cpSyncSpy = jest.spyOn(fs, 'cpSync').mockImplementation(() => {
       throw new Error('Mocked copy failure');
     });
 
-    await PluginManager.update('@headlamp-k8s/flux', tempDir, '', mockProgressCallback);
+    try {
+      await PluginManager.update('@headlamp-k8s/flux', tempDir, '', mockProgressCallback);
 
-    expect(mockProgressCallback).toHaveBeenCalledWith({
-      type: 'error',
-      message: 'Mocked copy failure',
-    });
+      expect(mockProgressCallback).toHaveBeenCalledWith({
+        type: 'error',
+        message: 'Mocked copy failure',
+      });
 
-    // Verify the original plugin folder exists and is restored
-    expect(fs.existsSync(pluginDir)).toBe(true);
-    const restoredPackageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
-    expect(restoredPackageJSON.artifacthub.version).toBe('0.0.1');
+      // Verify the original plugin folder exists and is restored
+      expect(fs.existsSync(pluginDir)).toBe(true);
+      const restoredPackageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
+      expect(restoredPackageJSON.artifacthub.version).toBe('0.0.1');
 
-    // Verify that the backup folder was cleaned up
-    expect(fs.existsSync(backupDir)).toBe(false);
-
-    // Restore the spy
-    cpSyncSpy.mockRestore();
+      // Verify that the backup folder was cleaned up
+      expect(fs.existsSync(backupDir)).toBe(false);
+    } finally {
+      // Restore the spy
+      cpSyncSpy.mockRestore();
+    }
   });
 
   test('Uninstall Plugin', async () => {


### PR DESCRIPTION
## Summary

This PR makes plugin updates transactional by introducing a backup-and-rollback mechanism in the plugin update flow.

Previously, `PluginManager.update() `removed the existing plugin before moving the newly downloaded version into place. If the move operation failed due to filesystem errors, insufficient permissions, or disk space issues, the original plugin was permanently lost. This change ensures that the existing plugin is preserved and automatically restored if the update process fails.

## Related Issue

Fixes #6174

## Changes

- Added backup-and-rollback logic to the plugin update workflow.
- Created a temporary backup of the existing plugin before applying updates.
- Restored the original plugin automatically when update operations fail.
- Added unit tests covering successful updates, rollback behavior, and failure scenarios.
- Improved update reliability by preventing plugin loss during failed updates.
