### PR TITLE
.github: Build Windows x64 and arm64 separately

### DIFF
--- a/.github/workflows/app-artifacts-win.yml
+++ b/.github/workflows/app-artifacts-win.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       actions: write # needed to upload artifacts
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: x64


### PR DESCRIPTION
The `build-windows` job builds the x64 and arm64 release artifacts as two matrix legs, but with the default fail-fast behavior, a failure in either architecture immediately cancels the other while it's still running - the canceled leg imports a confusing `"The operation was canceled"`, its artifact is lost, and the whole workflow has to be re-run instead of just the arch that actually failed. 

This sets `fail-fast: false` so the two architectures build independently and only the failing leg needs a re-run.

Fixes: #6180 