### PR TITLE
frontend: k8s/node: Extract hooks from static methods to standalone

### DIFF
--- a/frontend/src/lib/k8s/node.ts
+++ b/frontend/src/lib/k8s/node.ts
@@ -64,11 +64,47 @@ export interface KubeNode extends KubeObjectInterface {
   };
 }
 
+export function useNodeMetrics(cluster?: string): [KubeMetrics[] | null, ApiError | null] {
+  const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
+  const [error, setError] = useErrorState(setNodeMetrics);
+
+  function setMetrics(metrics: KubeMetrics[]) {
+    setNodeMetrics(metrics);
+    setError(null);
+  }
+
+  useConnectApi(
+    metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError, cluster)
+  );
+
+  return [nodeMetrics, error];
+}
+
+export function useNodeSummaryStats(
+  nodeName?: string,
+  cluster?: string
+): [KubeNodeSummaryStats | null, ApiError | null] {
+  const [summaryStats, setSummaryStats] = React.useState<KubeNodeSummaryStats | null>(null);
+  const [error, setError] = useErrorState(setSummaryStats);
+
+  function setStats(stats: KubeNodeSummaryStats) {
+    setSummaryStats(stats);
+    setError(null);
+  }
+
+  useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
+
+  return [summaryStats, error];
+}
+
 class Node extends KubeObject<KubeNode> {
   static kind = 'Node';
   static apiName = 'nodes';
   static apiVersion = 'v1';
   static isNamespaced = false;
+
+  static useMetrics = useNodeMetrics;
+  static useNodeSummaryStats = useNodeSummaryStats;
 
   get status(): KubeNode['status'] {
     return this.jsonData.status;
@@ -76,51 +112,6 @@ class Node extends KubeObject<KubeNode> {
 
   get spec(): KubeNode['spec'] {
     return this.jsonData.spec;
-  }
-
-  static useMetrics(cluster?: string): [KubeMetrics[] | null, ApiError | null] {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [nodeMetrics, setNodeMetrics] = React.useState<KubeMetrics[] | null>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [error, setError] = useErrorState(setNodeMetrics);
-
-    function setMetrics(metrics: KubeMetrics[]) {
-      setNodeMetrics(metrics);
-
-      if (metrics !== null) {
-        setError(null);
-      }
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(
-      metrics.bind(null, '/apis/metrics.k8s.io/v1beta1/nodes', setMetrics, setError, cluster)
-    );
-
-    return [nodeMetrics, error];
-  }
-
-  static useNodeSummaryStats(
-    nodeName?: string,
-    cluster?: string
-  ): [KubeNodeSummaryStats | null, ApiError | null] {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [summaryStats, setSummaryStats] = React.useState<KubeNodeSummaryStats | null>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [error, setError] = useErrorState(setSummaryStats);
-
-    function setStats(stats: KubeNodeSummaryStats) {
-      setSummaryStats(stats);
-
-      if (stats !== null) {
-        setError(null);
-      }
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useConnectApi(nodeSummaryStats.bind(null, nodeName || '', setStats, setError, cluster));
-
-    return [summaryStats, error];
   }
 
   getExternalIP(): string {

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -488,6 +488,8 @@
         "cluster.x-k8s.io/deployment-name",
       ],
       "default": [Function],
+      "useNodeMetrics": [Function],
+      "useNodeSummaryStats": [Function],
     },
     "persistentVolume": {
       "PV_SOURCE_TYPES": [


### PR DESCRIPTION
## Summary

Extracts `useNodeMetrics` and `useNodeSummaryStats` from static class methods on the `Node` class into standalone exported hook functions. This fixes `react-hooks/rules-of-hooks` violations since React hooks cannot be called inside class methods (even static ones).

## Related Issue

Fixes #5246

## Changes

- Added `useNodeMetrics()` standalone exported hook function at module scope in `frontend/src/lib/k8s/node.ts`
- Added `useNodeSummaryStats()` standalone exported hook function at module scope
- Assigned both as static properties on the `Node` class for backward compatibility: `static useMetrics = useNodeMetrics; static useNodeSummaryStats = useNodeSummaryStats;`
- Removed all 6 `// eslint-disable-next-line react-hooks/rules-of-hooks` suppression comments
- Updated pluginLib snapshot to reflect the two new named exports

## Steps to Test

1. Run `npm run frontend:lint` — should have 0 `react-hooks/rules-of-hooks` errors
2. Run `npm run frontend:tsc` — type-check should pass
3. Run `npm run frontend:test` — tests should pass (pluginLib snapshot updated with new exports)

## Notes for the Reviewer

- No changes needed in consumer components (`Details.tsx`, `List.tsx`, `Overview.tsx`) — they keep calling `Node.useMetrics()` and `Node.useNodeSummaryStats()` via the static aliases.
- Follows the same backward-compatible pattern used in `event.ts` for `useEventListForClusters` / `useWarningList`.
