### PR TITLE
frontend: workload: Fix Jobs, CronJobs, JobSets overview charts stuck at 100%

### DIFF
--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -124,6 +124,14 @@ export default function Overview() {
     return <Link routeName={workload.pluralName}>{workloadLabel[workload.className]}</Link>;
   }
 
+  // Jobs/CronJobs/JobSets have no replica fields either (like Pods), so they
+  // classify health per item instead of by replica match.
+  const jobHealth: { [className: string]: (item: Workload) => ReturnType<Job['getHealth']> } = {
+    [Job.className]: item => (item as Job).getHealth(),
+    [CronJob.className]: item => (item as CronJob).getHealth(),
+    [JobSet.className]: item => (item as JobSet).getHealth(),
+  };
+
   return (
     <PageGrid>
       <SectionBox py={2} mt={1}>
@@ -134,8 +142,16 @@ export default function Overview() {
                 workloadData={workloadsData[workload.className] || null}
                 title={<ChartLink workload={workload} />}
                 partialLabel={t('translation|Failed')}
-                totalLabel={workload === Pod ? t('translation|Healthy') : t('translation|Running')}
-                categorize={workload === Pod ? item => (item as Pod).getHealth() : undefined}
+                totalLabel={
+                  workload === Pod || jobHealth[workload.className]
+                    ? t('translation|Healthy')
+                    : t('translation|Running')
+                }
+                categorize={
+                  workload === Pod
+                    ? item => (item as Pod).getHealth()
+                    : jobHealth[workload.className]
+                }
               />
             </Grid>
           ))}

--- a/frontend/src/components/workload/Overview.tsx
+++ b/frontend/src/components/workload/Overview.tsx
@@ -126,11 +126,12 @@ export default function Overview() {
 
   // Jobs/CronJobs/JobSets have no replica fields either (like Pods), so they
   // classify health per item instead of by replica match.
-  const jobHealth: { [className: string]: (item: Workload) => ReturnType<Job['getHealth']> } = {
-    [Job.className]: item => (item as Job).getHealth(),
-    [CronJob.className]: item => (item as CronJob).getHealth(),
-    [JobSet.className]: item => (item as JobSet).getHealth(),
-  };
+  const jobHealth: Record<string, ((item: Workload) => ReturnType<Job['getHealth']>) | undefined> =
+    {
+      [Job.className]: item => (item as Job).getHealth(),
+      [CronJob.className]: item => (item as CronJob).getHealth(),
+      [JobSet.className]: item => (item as JobSet).getHealth(),
+    };
 
   return (
     <PageGrid>

--- a/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/Overview.Workloads.stories.storyshot
@@ -708,7 +708,12 @@
                           <p
                             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
                           >
-                            1 Running
+                            0 Healthy
+                            <span
+                              class="MuiBox-root css-172fsqw"
+                            >
+                              1 Other
+                            </span>
                           </p>
                         </div>
                         <div
@@ -757,9 +762,13 @@
                                   <g
                                     class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
                                   >
                                     <path
-                                      aria-label="100 %"
+                                      aria-label="0 %"
                                       class="recharts-sector"
                                       cx="61"
                                       cy="61"
@@ -771,13 +780,21 @@
             A 33.800000000000004,33.800000000000004,0,
             1,0,
             61,27.199999999999996 Z"
-                                      fill="#000"
-                                      name="total"
+                                      fill="#9e9e9e"
+                                      name="transitional"
                                       role="img"
                                       stroke="#e0e0e0"
                                       tabindex="-1"
                                     />
                                   </g>
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
                                   <text
                                     class="recharts-text recharts-label"
                                     fill="#808080"
@@ -791,7 +808,7 @@
                                       dy="0.355em"
                                       x="61"
                                     >
-                                      100 %
+                                      0 %
                                     </tspan>
                                   </text>
                                 </g>
@@ -832,7 +849,7 @@
                           <p
                             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
                           >
-                            1 Running
+                            1 Healthy
                           </p>
                         </div>
                         <div
@@ -877,10 +894,6 @@
                                   <g
                                     class="recharts-layer recharts-pie-sector"
                                     tabindex="-1"
-                                  />
-                                  <g
-                                    class="recharts-layer recharts-pie-sector"
-                                    tabindex="-1"
                                   >
                                     <path
                                       aria-label="100 %"
@@ -895,13 +908,29 @@
             A 33.800000000000004,33.800000000000004,0,
             1,0,
             61,27.199999999999996 Z"
-                                      fill="#000"
-                                      name="total"
+                                      fill="#2e7d32"
+                                      name="healthy"
                                       role="img"
                                       stroke="#e0e0e0"
                                       tabindex="-1"
                                     />
                                   </g>
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
+                                  <g
+                                    class="recharts-layer recharts-pie-sector"
+                                    tabindex="-1"
+                                  />
                                   <text
                                     class="recharts-text recharts-label"
                                     fill="#808080"
@@ -956,7 +985,7 @@
                           <p
                             class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom css-7142su-MuiTypography-root"
                           >
-                            0 Running
+                            0 Healthy
                           </p>
                         </div>
                         <div

--- a/frontend/src/lib/k8s/cronJob.test.ts
+++ b/frontend/src/lib/k8s/cronJob.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import CronJob from './cronJob';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('CronJob class', () => {
+  describe('getHealth', () => {
+    const makeCronJob = (spec: any = {}, status: any = {}) =>
+      new CronJob({
+        apiVersion: 'batch/v1',
+        kind: 'CronJob',
+        metadata: { name: 'test-cronjob', namespace: 'default' },
+        spec: { schedule: '* * * * *', ...spec },
+        status,
+      } as any);
+
+    it('classifies a suspended cron job as degraded', () => {
+      expect(makeCronJob({ suspend: true }).getHealth()).toBe('degraded');
+    });
+
+    it('classifies a cron job with active jobs as transitional', () => {
+      expect(makeCronJob({}, { active: [{ name: 'job-1' }] }).getHealth()).toBe('transitional');
+    });
+
+    it('classifies a never-run cron job as healthy', () => {
+      expect(makeCronJob().getHealth()).toBe('healthy');
+    });
+
+    it('classifies a cron job whose last run succeeded as healthy', () => {
+      expect(
+        makeCronJob(
+          {},
+          { lastScheduleTime: '2026-01-01T00:00:00Z', lastSuccessfulTime: '2026-01-01T00:01:00Z' }
+        ).getHealth()
+      ).toBe('healthy');
+    });
+
+    it('classifies a cron job scheduled but never succeeded as failed', () => {
+      expect(makeCronJob({}, { lastScheduleTime: '2026-01-01T00:00:00Z' }).getHealth()).toBe(
+        'failed'
+      );
+    });
+
+    it('classifies a cron job whose last schedule is newer than last success as failed', () => {
+      expect(
+        makeCronJob(
+          {},
+          { lastScheduleTime: '2026-01-01T00:05:00Z', lastSuccessfulTime: '2026-01-01T00:00:00Z' }
+        ).getHealth()
+      ).toBe('failed');
+    });
+
+    it('treats suspend as taking priority over a failing schedule', () => {
+      expect(
+        makeCronJob({ suspend: true }, { lastScheduleTime: '2026-01-01T00:00:00Z' }).getHealth()
+      ).toBe('degraded');
+    });
+  });
+});

--- a/frontend/src/lib/k8s/cronJob.ts
+++ b/frontend/src/lib/k8s/cronJob.ts
@@ -17,6 +17,7 @@
 import type { KubeContainer } from './cluster';
 import type { KubeMetadata } from './KubeMetadata';
 import { KubeObject, type KubeObjectInterface } from './KubeObject';
+import type { WorkloadHealthCategory } from './Workload';
 
 /**
  * CronJob structure returned by the k8s API.
@@ -102,6 +103,28 @@ class CronJob extends KubeObject<KubeCronJob> {
 
   getContainers(): KubeContainer[] {
     return this.spec.jobTemplate?.spec?.template?.spec?.containers || [];
+  }
+
+  /**
+   * Classifies the cron job into a coarse health category for the Workloads
+   * overview chart. Cron jobs have no replica fields, so the replica-mismatch
+   * logic used for other workloads can't apply. A suspended cron job is
+   * degraded, one with running jobs is transitional, and one whose last run was
+   * scheduled but never recorded a success is treated as failed.
+   */
+  getHealth(): WorkloadHealthCategory {
+    if (this.spec?.suspend) {
+      return 'degraded';
+    }
+    if ((this.status?.active?.length ?? 0) > 0) {
+      return 'transitional';
+    }
+    const lastSchedule = this.status?.lastScheduleTime;
+    const lastSuccess = this.status?.lastSuccessfulTime;
+    if (lastSchedule && (!lastSuccess || new Date(lastSchedule) > new Date(lastSuccess))) {
+      return 'failed';
+    }
+    return 'healthy';
   }
 }
 

--- a/frontend/src/lib/k8s/job.test.ts
+++ b/frontend/src/lib/k8s/job.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import Job from './job';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('Job class', () => {
+  describe('getHealth', () => {
+    const makeJob = (status: any) =>
+      new Job({
+        apiVersion: 'batch/v1',
+        kind: 'Job',
+        metadata: { name: 'test-job', namespace: 'default' },
+        spec: {},
+        status,
+      } as any);
+
+    it('classifies a Complete job as healthy', () => {
+      expect(makeJob({ conditions: [{ type: 'Complete', status: 'True' }] }).getHealth()).toBe(
+        'healthy'
+      );
+    });
+
+    it('classifies a Failed job as failed', () => {
+      expect(makeJob({ conditions: [{ type: 'Failed', status: 'True' }] }).getHealth()).toBe(
+        'failed'
+      );
+    });
+
+    it('classifies a Suspended job as degraded', () => {
+      expect(makeJob({ conditions: [{ type: 'Suspended', status: 'True' }] }).getHealth()).toBe(
+        'degraded'
+      );
+    });
+
+    it('classifies a running job with no terminal condition as transitional', () => {
+      expect(makeJob({ active: 1 }).getHealth()).toBe('transitional');
+      expect(makeJob({}).getHealth()).toBe('transitional');
+    });
+
+    it('ignores conditions whose status is not True', () => {
+      expect(makeJob({ conditions: [{ type: 'Failed', status: 'False' }] }).getHealth()).toBe(
+        'transitional'
+      );
+    });
+
+    it('prioritizes Failed over Complete', () => {
+      expect(
+        makeJob({
+          conditions: [
+            { type: 'Complete', status: 'True' },
+            { type: 'Failed', status: 'True' },
+          ],
+        }).getHealth()
+      ).toBe('failed');
+    });
+  });
+});

--- a/frontend/src/lib/k8s/job.ts
+++ b/frontend/src/lib/k8s/job.ts
@@ -19,6 +19,7 @@ import { KubeMetadata } from './KubeMetadata';
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
 import { KubePodSpec } from './pod';
+import type { WorkloadHealthCategory } from './Workload';
 
 export interface KubeJob extends KubeObjectInterface {
   spec: {
@@ -64,6 +65,32 @@ class Job extends KubeObject<KubeJob> {
 
   getContainers(): KubeContainer[] {
     return this.spec?.template?.spec?.containers || [];
+  }
+
+  /**
+   * Classifies the job into a coarse health category for the Workloads overview
+   * chart. Jobs have no replica fields, so the replica-mismatch logic used for
+   * other workloads can't apply. This relies on the same conditions the Jobs
+   * list shows (Complete / Failed / Suspended); a job with no terminal
+   * condition yet is still running and treated as transitional.
+   */
+  getHealth(): WorkloadHealthCategory {
+    const conditions = this.status?.conditions || [];
+    const isTrue = (type: string) =>
+      conditions.some(
+        (c: { type: string; status: string }) => c.type === type && c.status === 'True'
+      );
+
+    if (isTrue('Failed')) {
+      return 'failed';
+    }
+    if (isTrue('Complete')) {
+      return 'healthy';
+    }
+    if (isTrue('Suspended')) {
+      return 'degraded';
+    }
+    return 'transitional';
   }
 
   /** Returns the duration of the job in milliseconds. */

--- a/frontend/src/lib/k8s/jobSet.test.ts
+++ b/frontend/src/lib/k8s/jobSet.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import JobSet from './jobSet';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('JobSet class', () => {
+  describe('getHealth', () => {
+    const makeJobSet = (status: any) =>
+      new JobSet({
+        apiVersion: 'jobset.x-k8s.io/v1alpha2',
+        kind: 'JobSet',
+        metadata: { name: 'test-jobset', namespace: 'default' },
+        spec: {},
+        status,
+      } as any);
+
+    it('classifies a Completed job set as healthy', () => {
+      expect(makeJobSet({ conditions: [{ type: 'Completed', status: 'True' }] }).getHealth()).toBe(
+        'healthy'
+      );
+    });
+
+    it('classifies a Failed job set as failed', () => {
+      expect(makeJobSet({ conditions: [{ type: 'Failed', status: 'True' }] }).getHealth()).toBe(
+        'failed'
+      );
+    });
+
+    it('classifies a Suspended job set as degraded', () => {
+      expect(makeJobSet({ conditions: [{ type: 'Suspended', status: 'True' }] }).getHealth()).toBe(
+        'degraded'
+      );
+    });
+
+    it('classifies a job set with no terminal condition as transitional', () => {
+      expect(makeJobSet({}).getHealth()).toBe('transitional');
+      expect(
+        makeJobSet({ conditions: [{ type: 'StartupPolicyCompleted', status: 'True' }] }).getHealth()
+      ).toBe('transitional');
+    });
+
+    it('prioritizes Failed over Completed', () => {
+      expect(
+        makeJobSet({
+          conditions: [
+            { type: 'Completed', status: 'True' },
+            { type: 'Failed', status: 'True' },
+          ],
+        }).getHealth()
+      ).toBe('failed');
+    });
+  });
+});

--- a/frontend/src/lib/k8s/jobSet.ts
+++ b/frontend/src/lib/k8s/jobSet.ts
@@ -16,6 +16,7 @@
 
 import type { KubeObjectInterface } from './KubeObject';
 import { KubeObject } from './KubeObject';
+import type { WorkloadHealthCategory } from './Workload';
 
 export interface KubeJobSet extends KubeObjectInterface {
   spec: {
@@ -43,6 +44,30 @@ class JobSet extends KubeObject<KubeJobSet> {
 
   get status() {
     return this.jsonData.status;
+  }
+
+  /**
+   * Classifies the job set into a coarse health category for the Workloads
+   * overview chart. Job sets have no replica fields, so the replica-mismatch
+   * logic used for other workloads can't apply. This relies on the same
+   * conditions the Job Sets list shows (Failed / Completed / Suspended); a job
+   * set with no terminal condition yet is still running and treated as
+   * transitional.
+   */
+  getHealth(): WorkloadHealthCategory {
+    const conditions = this.status?.conditions || [];
+    const isTrue = (type: string) => conditions.some(c => c.type === type && c.status === 'True');
+
+    if (isTrue('Failed')) {
+      return 'failed';
+    }
+    if (isTrue('Completed')) {
+      return 'healthy';
+    }
+    if (isTrue('Suspended')) {
+      return 'degraded';
+    }
+    return 'transitional';
   }
 
   static getBaseObject(): KubeJobSet {


### PR DESCRIPTION
## What this does

The Workloads overview reuses `WorkloadCircleChart` for every tile. Its default
health logic counts an item as failed only when `getReadyReplicas() !=
getTotalReplicas()`. Jobs, CronJobs, and JobSets have none of those replica
fields, so the check is always false and those three tiles are permanently stuck
at 100% regardless of the real state of the objects.

This is the same root cause as the Pods tile fixed in #6114. This PR extends that
PR's optional `categorize()` classifier to the three remaining replica-less
kinds, so every non-replica tile renders a real multi-segment health ring and the
overview row stays visually consistent.

Fixes #6173.

## How

Each kind gets a `getHealth()` in the k8s model layer, mirroring the status logic
its own list page already shows:

- **Job** — `Failed` → failed, `Complete` → healthy, `Suspended` → degraded,
  otherwise (still running) → transitional.
- **CronJob** — suspended (`spec.suspend`) → degraded, has `status.active` jobs →
  transitional, scheduled but last run never succeeded
  (`lastScheduleTime` newer than `lastSuccessfulTime`) → failed, otherwise healthy.
- **JobSet** — `Failed` → failed, `Completed` → healthy, `Suspended` → degraded,
  otherwise → transitional.

`Overview.tsx` wires these in via a per-kind `categorizers` map. Unit tests cover
each category and the priority ordering; the `Overview.Workloads` storyshot is
updated.

## Dependency

> #6114 (the Pods tile fix) — which introduced the `categorize()` prop and
> `WorkloadHealthCategory` type this builds on — has now merged. This branch is
> rebased onto `main`, so the diff is just the Jobs/CronJobs/JobSets delta:
> the model `getHealth()` helpers, their tests, and the `Overview.tsx` wiring.

## Testing

- New unit tests for `Job`/`CronJob`/`JobSet` `getHealth()` (18 cases) pass.
- Storyshots pass; `Overview.Workloads` regenerated to reflect real health.
- `tsc`, ESLint, Prettier clean.

