### PR TITLE
ci: codeql: Add SAST workflow for Go and TypeScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "21 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
This PR adds CodeQL static analysis SAST scanning for both Go (backend) and TypeScript/JavaScript (frontend) by introducing a new codeql.yml workflow that runs on every push to main, every pull request, and a weekly schedule.

## Related Issue
This is a follow-up to #6076, which fixed a 52-file circular import (KubeObject.ts <-> index.ts) that previously caused CodeQL's TypeScript analysis to hang indefinitely. That hang is what blocked the earlier attempts in #2463 and #4294.

## Changes
- Added .github/workflows/codeql.yml with CodeQL analysis configured as two independent matrix jobs: go (build-mode: autobuild) and javascript-typescript (build-mode: none)
- Used the security-and-quality query suite to keep first-run results focused and avoid noise
- All actions pinned to SHA hashes (actions/checkout, github/codeql-action/init, github/codeql-action/analyze) for supply chain security
- Scoped permissions to least privilege: security-events: write only inside the job, contents: read at the workflow level

## Steps to Test
1. Once merged, the workflow runs automatically on the next push or pull request against main
2. Verified independently before opening this PR: pushed this exact workflow to a fork branch built on top of #6076's fix and triggered it via a throwaway PR
3. Both jobs completed successfully with no hang: Analyze (go) succeeded in 5m 55s, Analyze (javascript-typescript) succeeded in 2m 16s
4. Checked Security > Code scanning filtered by tool:CodeQL afterward: 0 open findings from CodeQL on either language

## Screenshots (if applicable)
Attached: successful Analyze (go) run, successful Analyze (javascript-typescript) run, and the Code scanning alerts page filtered to the CodeQL tool showing 0 findings.
<img width="1865" height="1010" alt="Screenshot from 2026-06-19 15-37-23" src="https://github.com/user-attachments/assets/c705e57b-02e9-4dbf-8d43-1a8be3625f3f" />
<img width="1865" height="1010" alt="Screenshot from 2026-06-19 15-37-27" src="https://github.com/user-attachments/assets/f57a3304-ebdc-4046-944e-3fd328b7acef" />
<img width="1865" height="1010" alt="Screenshot from 2026-06-19 15-37-15" src="https://github.com/user-attachments/assets/f1202588-4690-4c43-b9b4-3222149c8c1b" />

## Notes for the Reviewer
- This directly targets the OpenSSF Scorecard SAST check, which currently scores 1/10 because no SAST tool runs on commits
- Started with security-and-quality rather than security-extended to keep the first integration clean; happy to expand the query suite later once this has been running for a while
- The Go job uses build-mode: autobuild since the backend module builds cleanly without custom steps; no manual build script was needed