### PR TITLE
portforward: handler: Fix cluster name exposing userID suffix in response

### DIFF
--- a/backend/pkg/portforward/export_test.go
+++ b/backend/pkg/portforward/export_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import "github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+
+// StorePortForwardForTest inserts a portForward entry into the cache as
+// StartPortForward would for a dynamic cluster, allowing unit tests to
+// exercise GetPortForwards without a real Kubernetes cluster.
+func StorePortForwardForTest(c cache.Cache[interface{}], clusterName, userID string) error {
+	pf := portForward{
+		ID:         "test-id-001",
+		Pod:        "test-pod",
+		Namespace:  "default",
+		Cluster:    clusterName,
+		cacheKey:   clusterName + userID,
+		Port:       "8080",
+		TargetPort: "80",
+		Status:     RUNNING,
+	}
+	portforwardstore(c, pf)
+
+	return nil
+}

--- a/backend/pkg/portforward/handler.go
+++ b/backend/pkg/portforward/handler.go
@@ -92,6 +92,7 @@ type portForward struct {
 	ServiceNamespace string `json:"serviceNamespace"`
 	Namespace        string `json:"namespace"`
 	Cluster          string `json:"cluster"`
+	cacheKey         string `json:"-"`
 	Port             string `json:"port"`
 	TargetPort       string `json:"targetPort"`
 	Status           string `json:"status"`
@@ -192,7 +193,7 @@ func StartPortForward(kubeConfigStore kubeconfig.ContextStore, cache cache.Cache
 		token, _ = auth.GetTokenFromCookie(r, requestClusterName)
 	}
 
-	err = startPortForward(kContext, cache, p, token, clusterName)
+	err = startPortForward(kContext, cache, p, token, clusterName, requestClusterName)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "starting portforward")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -592,7 +593,7 @@ func runAndMonitorPortForward(
 // startPortForward starts a port forward. This is the internal function that was refactored.
 // It sets up Kubernetes clients, initializes the port forwarder, and manages its lifecycle.
 func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{}],
-	p portForwardRequest, token string, clusterName string,
+	p portForwardRequest, token string, clusterName string, requestClusterName string,
 ) error {
 	clientset, rConf, err := getKubeClientAndConfig(kContext, token)
 	if err != nil {
@@ -628,7 +629,8 @@ func startPortForward(kContext *kubeconfig.Context, cache cache.Cache[interface{
 		ID:               p.ID,
 		closeChan:        stopChan,
 		Pod:              p.Pod,
-		Cluster:          clusterName,
+		Cluster:          requestClusterName,
+		cacheKey:         clusterName,
 		Namespace:        p.Namespace,
 		Service:          p.Service,
 		ServiceNamespace: p.ServiceNamespace,

--- a/backend/pkg/portforward/handler_test.go
+++ b/backend/pkg/portforward/handler_test.go
@@ -325,7 +325,60 @@ func TestStartPortForward(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(deleteRespBody), "stopped")
 
-	chState, err = ch.Get(context.Background(), cacheKey)
-	require.Error(t, err, "port-forward with key %s should be deleted from cache, but Get returned no error", cacheKey)
-	require.Nil(t, chState)
+	require.Eventually(t, func() bool {
+		_, err := ch.Get(context.Background(), cacheKey)
+		return err != nil
+	}, 3*time.Second, 50*time.Millisecond,
+		"port-forward with key %s should be deleted from cache", cacheKey)
+}
+
+// TestGetPortForwardsClusterNameNotExposingUserID verifies that when a dynamic
+// cluster request carries an X-HEADLAMP-USER-ID header, the port forwards
+// returned by GetPortForwards contain the original cluster name and not the
+// internal cache key (clusterName + userID).
+func TestGetPortForwardsClusterNameNotExposingUserID(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "k8s-prod"
+
+	const userID = "f04bd0db261b76f3"
+
+	ch := cache.New[interface{}]()
+
+	// Simulate what startPortForward does internally: store a portForward
+	// with Cluster set to the original name and cacheKey set to the
+	// userID-suffixed internal key.
+	err := portforward.StorePortForwardForTest(ch, clusterName, userID)
+	require.NoError(t, err)
+
+	listReq := &http.Request{
+		Header: make(http.Header),
+	}
+	listResp := httptest.NewRecorder()
+	listReq.URL = &url.URL{}
+	listReq.Header.Set("X-HEADLAMP-USER-ID", userID)
+	listReq = mux.SetURLVars(listReq, map[string]string{"clusterName": clusterName})
+
+	portforward.GetPortForwards(ch, listResp, listReq)
+
+	listRes := listResp.Result()
+	defer func() { _ = listRes.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, listRes.StatusCode)
+
+	listData, err := io.ReadAll(listRes.Body)
+	require.NoError(t, err)
+
+	var pfList []map[string]interface{}
+
+	err = json.Unmarshal(listData, &pfList)
+	require.NoError(t, err)
+	require.Len(t, pfList, 1, "expected exactly one port forward in list")
+
+	clusterVal, ok := pfList[0]["cluster"]
+	require.True(t, ok, "'cluster' field missing from port forward response")
+	assert.Equal(t, clusterName, clusterVal,
+		"cluster field must be the original cluster name, not the internal cache key")
+	assert.NotContains(t, clusterVal, userID,
+		"cluster field must not contain the X-HEADLAMP-USER-ID suffix")
 }

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -30,11 +30,18 @@ const storeKeyPrefix = "PORT_FORWARD_"
 // portforwardKeyGenerator generates a unique key
 // based on the cluster name, id,service name, and pod name.
 func portforwardKeyGenerator(p portForward) string {
-	if p.ID != "" {
-		return storeKeyPrefix + p.Cluster + p.ID
+	clusterKey := p.cacheKey
+	if clusterKey == "" {
+		// Fallback for entries that predate the cacheKey field (e.g. static
+		// clusters where userID is empty and cacheKey == Cluster).
+		clusterKey = p.Cluster
 	}
 
-	key := storeKeyPrefix + p.Cluster
+	if p.ID != "" {
+		return storeKeyPrefix + clusterKey + p.ID
+	}
+
+	key := storeKeyPrefix + clusterKey
 
 	if p.Service != "" {
 		key += p.Service

--- a/backend/pkg/portforward/store.go
+++ b/backend/pkg/portforward/store.go
@@ -32,8 +32,8 @@ const storeKeyPrefix = "PORT_FORWARD_"
 func portforwardKeyGenerator(p portForward) string {
 	clusterKey := p.cacheKey
 	if clusterKey == "" {
-		// Fallback for entries that predate the cacheKey field (e.g. static
-		// clusters where userID is empty and cacheKey == Cluster).
+		// Fallback for entries created before the cacheKey field existed
+		// (cacheKey unset), where the cache key was derived from Cluster.
 		clusterKey = p.Cluster
 	}
 


### PR DESCRIPTION
## Summary
This PR fixes the port forwarding list being empty for dynamically added clusters by ensuring the backend returns the original cluster name in API responses instead of the internal cache key (which has `X-HEADLAMP-USER-ID` appended to it).

## Related Issue
Fixes #6187

## Changes
- Added unexported `cacheKey` field (tagged `json:"-"`) to the `portForward` struct in `handler.go` to separate the internal cache key from the API-facing cluster name
- Updated `startPortForward` to accept `requestClusterName` and populate `Cluster` with the original name and `cacheKey` with the userID-suffixed internal key
- Updated `portforwardKeyGenerator` in `store.go` to use `cacheKey` for cache lookups, with a fallback to `Cluster` for static clusters where userID is empty

## Steps to Test
1. Start Headlamp Desktop (macOS or Linux)
2. Add a cluster dynamically
3. Create a port forward for any pod in that cluster
4. Navigate to the Port Forwarding page
5. Observe that the port forward is now listed (previously the list was empty)
6. Verify that stop/delete actions on the port forward still work correctly
7. Repeat with a statically configured cluster to confirm no regression

## Screenshots (if applicable)

## Notes for the Reviewer
- The fix is backend-only; no frontend changes are required
- `cacheKey` is never serialized to JSON (`json:"-"`), so the API contract is unchanged for all other fields
- Static clusters are unaffected because when `X-HEADLAMP-USER-ID` is absent, `clusterName == requestClusterName` and the fallback in `portforwardKeyGenerator` ensures correct behavior