### PR TITLE
frontend: CreateNamespaceButton: Fix react-hooks/set-state-in-effect by deriving validation state during render

### DIFF
--- a/frontend/src/components/namespace/CreateNamespaceButton.stories.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.stories.tsx
@@ -16,6 +16,7 @@
 
 import { Meta, StoryObj } from '@storybook/react';
 import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { expect, userEvent, waitFor } from 'storybook/test';
 import { TestContext } from '../../test';
@@ -110,5 +111,41 @@ export const NotValidNameLong: StoryObj = {
 
     expect(errorMessage).toBeVisible();
     expect(button).not.toBeEnabled();
+  },
+};
+export const NamespaceAlreadyExists: StoryObj = {
+  parameters: {
+    msw: {
+      handlers: {
+        story: [
+          http.post('*/api/v1/namespaces', () =>
+            HttpResponse.json({ message: 'namespace already exists' }, { status: 409 })
+          ),
+        ],
+      },
+    },
+  },
+  play: async () => {
+    await userEvent.click(screen.getByLabelText('Create'));
+
+    await waitFor(() => expect(screen.getByLabelText('Dialog')).toBeVisible());
+
+    await waitFor(() => userEvent.type(screen.getByRole('textbox'), 'existing-namespace'), {
+      timeout: 5000,
+    });
+
+    const createButton = await screen.findByRole('button', { name: 'Create' });
+    await userEvent.click(createButton);
+
+    const errorMessage = await screen.findByText('A namespace with this name already exists.');
+    expect(errorMessage).toBeVisible();
+
+    await waitFor(() => userEvent.type(screen.getByRole('textbox'), '-edited'), {
+      timeout: 5000,
+    });
+
+    expect(
+      screen.queryByText('A namespace with this name already exists.')
+    ).not.toBeInTheDocument();
   },
 };

--- a/frontend/src/components/namespace/CreateNamespaceButton.tsx
+++ b/frontend/src/components/namespace/CreateNamespaceButton.tsx
@@ -21,7 +21,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { getCluster } from '../../lib/cluster';
@@ -35,9 +35,8 @@ import { AuthVisible } from '../common/Resource';
 export default function CreateNamespaceButton() {
   const { t } = useTranslation(['glossary', 'translation']);
   const [namespaceName, setNamespaceName] = useState('');
-  const [isValidNamespaceName, setIsValidNamespaceName] = useState(false);
-  const [nameHelperMessage, setNameHelperMessage] = useState('');
   const [namespaceDialogOpen, setNamespaceDialogOpen] = useState(false);
+  const [namespaceExistsError, setNamespaceExistsError] = useState(false);
   const dispatchCreateEvent = useEventCallback(HeadlampEventType.CREATE_RESOURCE);
   const dispatch: AppDispatch = useDispatch();
 
@@ -63,8 +62,7 @@ export default function CreateNamespaceButton() {
         console.error('Error creating namespace:', error);
         if (statusCode === 409) {
           setNamespaceDialogOpen(true);
-          setIsValidNamespaceName(false);
-          setNameHelperMessage(t('translation|A namespace with this name already exists.'));
+          setNamespaceExistsError(true);
         }
         throw error;
       }
@@ -94,23 +92,24 @@ export default function CreateNamespaceButton() {
     );
   }
 
-  useEffect(() => {
-    const isValidNamespaceFormat = Namespace.isValidNamespaceFormat(namespaceName);
-    setIsValidNamespaceName(isValidNamespaceFormat);
+  function handleClose() {
+    setNamespaceDialogOpen(false);
+    setNamespaceExistsError(false);
+  }
 
-    if (!isValidNamespaceFormat) {
-      if (namespaceName.length > 63) {
-        setNameHelperMessage(t('translation|Namespaces must be under 64 characters.'));
-      } else {
-        setNameHelperMessage(
-          t(
-            "translation|Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character."
-          )
-        );
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespaceName]);
+  const isValidNamespaceFormat = Namespace.isValidNamespaceFormat(namespaceName);
+  const formatHelperMessage = !isValidNamespaceFormat
+    ? namespaceName.length > 63
+      ? t('translation|Namespaces must be under 64 characters.')
+      : t(
+          "translation|Namespaces must contain only lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character."
+        )
+    : '';
+
+  const isValidNamespaceName = isValidNamespaceFormat && !namespaceExistsError;
+  const nameHelperMessage = namespaceExistsError
+    ? t('translation|A namespace with this name already exists.')
+    : formatHelperMessage;
 
   return (
     <AuthVisible item={Namespace} authVerb="create">
@@ -124,11 +123,7 @@ export default function CreateNamespaceButton() {
         }}
       />
 
-      <Dialog
-        aria-label="Dialog"
-        open={namespaceDialogOpen}
-        onClose={() => setNamespaceDialogOpen(false)}
-      >
+      <Dialog aria-label="Dialog" open={namespaceDialogOpen} onClose={handleClose}>
         <DialogTitle>{t('translation|Create Namespace')}</DialogTitle>
         <DialogContent>
           <Box component="form" style={{ width: '20vw', maxWidth: '20vw' }}>
@@ -144,7 +139,10 @@ export default function CreateNamespaceButton() {
               }
               fullWidth
               value={namespaceName}
-              onChange={event => setNamespaceName(event.target.value.toLowerCase())}
+              onChange={event => {
+                setNamespaceName(event.target.value.toLowerCase());
+                setNamespaceExistsError(false);
+              }}
               onKeyDown={e => {
                 if (e.key === 'Enter') {
                   e.preventDefault();
@@ -160,12 +158,7 @@ export default function CreateNamespaceButton() {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button
-            data-testid="create-namespace-dialog-cancel-button"
-            onClick={() => {
-              setNamespaceDialogOpen(false);
-            }}
-          >
+          <Button data-testid="create-namespace-dialog-cancel-button" onClick={handleClose}>
             {t('translation|Cancel')}
           </Button>
           <Button


### PR DESCRIPTION
## Summary
This PR fixes a react-hooks/set-state-in-effect violation in
CreateNamespaceButton by deriving validation state during render instead of
via useEffect + setState.

## Related Issue
Replaces #6122 (superseded — that branch had picked up ~234 unrelated files
from a stale rebase; this is the same fix, rebased cleanly on current main)

## Changes
- Removed useEffect-derived validation state (isValidNamespaceName,
  nameHelperMessage); validation is now derived during render instead
- Added namespaceExistsError state to handle the existing-namespace case
- Added a NamespaceAlreadyExists Storybook story

## Steps to Test
1. Run `npm run storybook` in the frontend directory
2. Navigate to Namespace → CreateNamespaceButton in the sidebar
3. Open the create-namespace dialog and check validation messages render
   correctly without a hooks warning in the console
4. Check the new NamespaceAlreadyExists story renders the expected error state

## Screenshots (if applicable)
N/A — no visual changes, this is a hooks/logic fix

## Notes for the Reviewer
- This PR only touches CreateNamespaceButton.tsx and its story — intentionally
  kept minimal after #6122's branch picked up unrelated files (Docker,
  Helm chart schema, Electron preload, plugin-management, i18n strings)
  due to a stale rebase. Closing #6122 in favor of this one.
