### PR TITLE
app: fix zombie backend process on Windows

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -879,9 +879,15 @@ function quitServerProcess() {
   }
 
   serverProcess.stdin.destroy();
-  // @todo: should we try and end the process a bit more gracefully?
-  //       What happens if the kill signal doesn't kill it?
-  serverProcess.kill();
+  if (serverProcess.pid) {
+    try {
+      killProcess(serverProcess.pid);
+    } catch (e) {
+      console.info('Backend process already stopped or not found.');
+    }
+  } else {
+    serverProcess.kill();
+  }
 
   serverProcess = null;
 }


### PR DESCRIPTION
Previously, when closing the Headlamp app on Windows, the `serverProcess.kill()` call did not forcefully terminate the entire process tree, leaving zombie `headlamp-server` instances running in the background and hoarding ports.

This commit updates `quitServerProcess()` to use the `killProcess()` utility, which relies on `taskkill /pid <pid> /T /F` on Windows to fully terminate the backend. It also adds a try-catch block to prevent exceptions from bubbling up and crashing the main process during shutdown if the backend has already exited.

## Summary
This PR fixes a critical bug on Windows where the Headlamp backend (`headlamp-server.exe`) becomes an orphaned zombie process when the desktop app is closed.

## Related Issue
Fixes #6156

## Changes
- Updated `quitServerProcess()` in `app/electron/main.ts` to use the cross-platform `killProcess(pid)` utility instead of `serverProcess.kill()`.
- Added a `try/catch` block around the kill command to gracefully handle cases where the backend process has already terminated independently, preventing unhandled exception dialogs from crashing the Electron main process during shutdown.

## Steps to Test
1. Launch the Headlamp Desktop App on a Windows machine.
2. Verify that it connects to your cluster successfully.
3. Close the Headlamp Desktop App.
4. Open Windows Task Manager and check the "Details" tab.
5. Observe that there are no orphaned `headlamp-server.exe` processes running in the background.

## Notes for the Reviewer
- The fix utilizes the existing `killProcess` function which correctly uses `taskkill /pid <pid> /T /F` to forcefully terminate the entire process tree on Windows. For non-Windows platforms, it preserves the existing `SIGHUP` behavior.
