### PR TITLE
frontend: TopBar: Add light/dark theme toggle button

### DIFF
--- a/frontend/src/components/App/ThemeToggleButton.tsx
+++ b/frontend/src/components/App/ThemeToggleButton.tsx
@@ -33,6 +33,8 @@ export default function ThemeToggleButton() {
   const themeName = useTypedSelector(state => state.theme.name) || getThemeName();
   // When the backend forces a theme, switching is disabled (mirrors Settings).
   const forceTheme = useTypedSelector(state => state.config.forceTheme);
+  const defaultLightTheme = useTypedSelector(state => state.config.defaultLightTheme);
+  const defaultDarkTheme = useTypedSelector(state => state.config.defaultDarkTheme);
 
   if (forceTheme) {
     return null;
@@ -43,12 +45,14 @@ export default function ThemeToggleButton() {
   const targetMode = isDark ? 'light' : 'dark';
 
   // Prefer the user's most recently selected theme of the target mode, then the
-  // built-in "light"/"dark" themes, then any available theme of that mode.
+  // backend's default theme for that mode, then the built-in "light"/"dark"
+  // themes, then any available theme of that mode.
   const remembered = getLastThemeForMode(targetMode);
-  const defaultName = targetMode;
+  const defaultName = (targetMode === 'dark' ? defaultDarkTheme : defaultLightTheme) ?? targetMode;
   const targetTheme =
     (remembered ? appThemes.find(it => it.name === remembered) : undefined) ??
     appThemes.find(it => it.name === defaultName) ??
+    appThemes.find(it => it.name === targetMode) ??
     appThemes.find(it => (it.base ?? 'light') === targetMode);
 
   if (!targetTheme) {

--- a/frontend/src/components/App/ThemeToggleButton.tsx
+++ b/frontend/src/components/App/ThemeToggleButton.tsx
@@ -43,9 +43,9 @@ export default function ThemeToggleButton() {
   const targetMode = isDark ? 'light' : 'dark';
 
   // Prefer the user's most recently selected theme of the target mode, then the
-  // built-in "Light"/"Dark" themes, then any available theme of that mode.
+  // built-in "light"/"dark" themes, then any available theme of that mode.
   const remembered = getLastThemeForMode(targetMode);
-  const defaultName = isDark ? 'Light' : 'Dark';
+  const defaultName = targetMode;
   const targetTheme =
     (remembered ? appThemes.find(it => it.name === remembered) : undefined) ??
     appThemes.find(it => it.name === defaultName) ??

--- a/frontend/src/components/App/ThemeToggleButton.tsx
+++ b/frontend/src/components/App/ThemeToggleButton.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { getLastThemeForMode, getThemeName } from '../../lib/themes';
+import { useTypedSelector } from '../../redux/hooks';
+import ActionButton from '../common/ActionButton';
+import { setTheme, useAppThemes } from './themeSlice';
+
+/**
+ * Quick light/dark theme toggle for the top bar. Flips between a light and a
+ * dark theme by dispatching `setTheme`, so it stays in sync with the Settings
+ * theme picker (both read/write the same `theme` slice).
+ */
+export default function ThemeToggleButton() {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const appThemes = useAppThemes();
+  const themeName = useTypedSelector(state => state.theme.name) || getThemeName();
+  // When the backend forces a theme, switching is disabled (mirrors Settings).
+  const forceTheme = useTypedSelector(state => state.config.forceTheme);
+
+  if (forceTheme) {
+    return null;
+  }
+
+  const currentTheme = appThemes.find(it => it.name === themeName);
+  const isDark = (currentTheme?.base ?? 'light') === 'dark';
+  const targetMode = isDark ? 'light' : 'dark';
+
+  // Prefer the user's most recently selected theme of the target mode, then the
+  // built-in "Light"/"Dark" themes, then any available theme of that mode.
+  const remembered = getLastThemeForMode(targetMode);
+  const defaultName = isDark ? 'Light' : 'Dark';
+  const targetTheme =
+    (remembered ? appThemes.find(it => it.name === remembered) : undefined) ??
+    appThemes.find(it => it.name === defaultName) ??
+    appThemes.find(it => (it.base ?? 'light') === targetMode);
+
+  if (!targetTheme) {
+    return null;
+  }
+
+  return (
+    <ActionButton
+      icon={isDark ? 'mdi:weather-sunny' : 'mdi:weather-night'}
+      description={isDark ? t('Switch to light theme') : t('Switch to dark theme')}
+      iconButtonProps={{ color: 'inherit' }}
+      onClick={() => dispatch(setTheme(targetTheme.name))}
+    />
+  );
+}

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -266,6 +266,9 @@ export const PureTopBar = memo(
     const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
     const dispatch = useDispatch();
     const history = useHistory();
+    // When the backend forces a theme, omit the toggle entirely so the mobile
+    // overflow menu doesn't render an empty item.
+    const forceTheme = useTypedSelector(state => state.config.forceTheme);
 
     const openSideBar = !!(isSidebarOpenUserSelected === undefined ? false : isSidebarOpen);
 
@@ -413,7 +416,7 @@ export const PureTopBar = memo(
       },
       {
         id: DefaultAppBarAction.THEME_TOGGLE,
-        action: <ThemeToggleButton />,
+        action: forceTheme ? null : <ThemeToggleButton />,
       },
       {
         id: DefaultAppBarAction.SETTINGS,
@@ -479,7 +482,7 @@ export const PureTopBar = memo(
       },
       {
         id: DefaultAppBarAction.THEME_TOGGLE,
-        action: <ThemeToggleButton />,
+        action: forceTheme ? null : <ThemeToggleButton />,
       },
       {
         id: DefaultAppBarAction.SETTINGS,

--- a/frontend/src/components/App/TopBar.tsx
+++ b/frontend/src/components/App/TopBar.tsx
@@ -53,6 +53,7 @@ import { GlobalSearch } from '../globalSearch/GlobalSearch';
 import HeadlampButton from '../Sidebar/HeadlampButton';
 import { setWhetherSidebarOpen } from '../Sidebar/sidebarSlice';
 import { AppLogo } from './AppLogo';
+import ThemeToggleButton from './ThemeToggleButton';
 import { handleLogoutPathUpdate } from './TopBar.utils';
 
 export interface TopBarProps {}
@@ -411,6 +412,10 @@ export const PureTopBar = memo(
         action: null,
       },
       {
+        id: DefaultAppBarAction.THEME_TOGGLE,
+        action: <ThemeToggleButton />,
+      },
+      {
         id: DefaultAppBarAction.SETTINGS,
         action: isClusterContext ? <SettingsButton onClickExtra={handleMenuClose} /> : null,
       },
@@ -471,6 +476,10 @@ export const PureTopBar = memo(
       {
         id: DefaultAppBarAction.NOTIFICATION,
         action: null,
+      },
+      {
+        id: DefaultAppBarAction.THEME_TOGGLE,
+        action: <ThemeToggleButton />,
       },
       {
         id: DefaultAppBarAction.SETTINGS,

--- a/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.Default.stories.storyshot
@@ -83,6 +83,17 @@
             <div
               class="MuiBox-root css-0"
             />
+            <button
+              aria-label="Switch to dark theme"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
         </nav>
         <div

--- a/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.ErrorState.stories.storyshot
@@ -83,6 +83,17 @@
             <div
               class="MuiBox-root css-0"
             />
+            <button
+              aria-label="Switch to dark theme"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
         </nav>
         <div

--- a/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.MultiCluster.stories.storyshot
@@ -83,6 +83,17 @@
             <div
               class="MuiBox-root css-0"
             />
+            <button
+              aria-label="Switch to dark theme"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
         </nav>
         <div

--- a/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/Layout.WithClusterRoute.stories.storyshot
@@ -83,6 +83,17 @@
             <div
               class="MuiBox-root css-0"
             />
+            <button
+              aria-label="Switch to dark theme"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
         </nav>
         <div

--- a/frontend/src/components/App/__snapshots__/TopBar.EmptyUserInfo.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.EmptyUserInfo.stories.storyshot
@@ -59,6 +59,17 @@
           />
         </svg>
         <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
           aria-controls="primary-user-menu"
           aria-haspopup="true"
           aria-label="Account of current user"

--- a/frontend/src/components/App/__snapshots__/TopBar.MultiCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.MultiCluster.stories.storyshot
@@ -59,6 +59,17 @@
           />
         </svg>
         <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
           aria-controls="primary-user-menu"
           aria-haspopup="true"
           aria-label="Account of current user"

--- a/frontend/src/components/App/__snapshots__/TopBar.NoToken.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.NoToken.stories.storyshot
@@ -58,6 +58,17 @@
             fill="#1B1A19"
           />
         </svg>
+        <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </nav>
   </div>

--- a/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.OneCluster.stories.storyshot
@@ -59,6 +59,17 @@
           />
         </svg>
         <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
           aria-controls="primary-user-menu"
           aria-haspopup="true"
           aria-label="Account of current user"

--- a/frontend/src/components/App/__snapshots__/TopBar.ProcessorAction.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.ProcessorAction.stories.storyshot
@@ -61,6 +61,17 @@
         <p>
           meow
         </p>
+        <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </nav>
   </div>

--- a/frontend/src/components/App/__snapshots__/TopBar.Token.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.Token.stories.storyshot
@@ -58,6 +58,17 @@
             fill="#1B1A19"
           />
         </svg>
+        <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </nav>
   </div>

--- a/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.TwoCluster.stories.storyshot
@@ -59,6 +59,17 @@
           />
         </svg>
         <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
           aria-controls="primary-user-menu"
           aria-haspopup="true"
           aria-label="Account of current user"

--- a/frontend/src/components/App/__snapshots__/TopBar.UndefinedData.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.UndefinedData.stories.storyshot
@@ -59,6 +59,17 @@
           />
         </svg>
         <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
           aria-controls="primary-user-menu"
           aria-haspopup="true"
           aria-label="Account of current user"

--- a/frontend/src/components/App/__snapshots__/TopBar.WithEmailOnly.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.WithEmailOnly.stories.storyshot
@@ -59,6 +59,17 @@
           />
         </svg>
         <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
           aria-controls="primary-user-menu"
           aria-haspopup="true"
           aria-label="Account of current user"

--- a/frontend/src/components/App/__snapshots__/TopBar.WithUserInfo.stories.storyshot
+++ b/frontend/src/components/App/__snapshots__/TopBar.WithUserInfo.stories.storyshot
@@ -59,6 +59,17 @@
           />
         </svg>
         <button
+          aria-label="Switch to dark theme"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
           aria-controls="primary-user-menu"
           aria-haspopup="true"
           aria-label="Account of current user"

--- a/frontend/src/components/App/themeSlice.test.tsx
+++ b/frontend/src/components/App/themeSlice.test.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { vi } from 'vitest';
+import { AppTheme } from '../../lib/AppTheme';
 import * as themesLib from '../../lib/themes';
 import { AppLogoProps, AppLogoType } from './AppLogo';
 import themeReducer, {
@@ -50,6 +51,16 @@ describe('themeSlice', () => {
     // round-trip, so the test doesn't depend on the shared localStorage mock.
     let setLastThemeForMode: ReturnType<typeof vi.spyOn>;
 
+    // Use an explicit theme list instead of the shared defaultAppThemes, which
+    // other tests can mutate when isolation is off (e.g. under --coverage).
+    const appThemes: AppTheme[] = [
+      { name: 'light', base: 'light' },
+      { name: 'dark', base: 'dark' },
+      { name: 'Monochrome Light', base: 'light' },
+      { name: 'Lights Out', base: 'dark' },
+    ];
+    const stateWithThemes = { ...initialState, appThemes };
+
     beforeEach(() => {
       setLastThemeForMode = vi.spyOn(themesLib, 'setLastThemeForMode').mockImplementation(() => {});
     });
@@ -59,17 +70,17 @@ describe('themeSlice', () => {
     });
 
     it('records a dark theme under the dark key', () => {
-      themeReducer(initialState, setTheme('dark'));
+      themeReducer(stateWithThemes, setTheme('dark'));
       expect(setLastThemeForMode).toHaveBeenCalledWith('dark', 'dark');
     });
 
     it('records a light theme under the light key', () => {
-      themeReducer(initialState, setTheme('Monochrome Light'));
+      themeReducer(stateWithThemes, setTheme('Monochrome Light'));
       expect(setLastThemeForMode).toHaveBeenCalledWith('light', 'Monochrome Light');
     });
 
     it('treats a base:dark theme as dark', () => {
-      themeReducer(initialState, setTheme('Lights Out'));
+      themeReducer(stateWithThemes, setTheme('Lights Out'));
       expect(setLastThemeForMode).toHaveBeenCalledWith('dark', 'Lights Out');
     });
   });

--- a/frontend/src/components/App/themeSlice.test.tsx
+++ b/frontend/src/components/App/themeSlice.test.tsx
@@ -46,8 +46,25 @@ describe('themeSlice', () => {
 
   describe('setTheme records the last theme per mode', () => {
     beforeEach(() => {
-      localStorage.clear();
-      delete (localStorage as any).headlampThemePreference;
+      // Use a self-contained localStorage so the assertions don't depend on the
+      // shared mock, which other test files can leave in an inconsistent state.
+      const store: Record<string, string> = {};
+      vi.stubGlobal('localStorage', {
+        getItem: (key: string) => (key in store ? store[key] : null),
+        setItem: (key: string, value: string) => {
+          store[key] = String(value);
+        },
+        removeItem: (key: string) => {
+          delete store[key];
+        },
+        clear: () => {
+          Object.keys(store).forEach(key => delete store[key]);
+        },
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
     });
 
     it('records a dark theme under the dark key', () => {

--- a/frontend/src/components/App/themeSlice.test.tsx
+++ b/frontend/src/components/App/themeSlice.test.tsx
@@ -44,6 +44,28 @@ describe('themeSlice', () => {
     expect(actual.name).toEqual(themeName);
   });
 
+  describe('setTheme records the last theme per mode', () => {
+    beforeEach(() => {
+      localStorage.clear();
+      delete (localStorage as any).headlampThemePreference;
+    });
+
+    it('records a dark theme under the dark key', () => {
+      themeReducer(initialState, setTheme('dark'));
+      expect(localStorage.getItem('headlampLastDarkTheme')).toEqual('dark');
+    });
+
+    it('records a light theme under the light key', () => {
+      themeReducer(initialState, setTheme('Monochrome Light'));
+      expect(localStorage.getItem('headlampLastLightTheme')).toEqual('Monochrome Light');
+    });
+
+    it('treats a base:dark theme as dark', () => {
+      themeReducer(initialState, setTheme('Lights Out'));
+      expect(localStorage.getItem('headlampLastDarkTheme')).toEqual('Lights Out');
+    });
+  });
+
   describe('applyBackendThemeConfig', () => {
     beforeEach(() => {
       localStorage.clear();

--- a/frontend/src/components/App/themeSlice.test.tsx
+++ b/frontend/src/components/App/themeSlice.test.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { vi } from 'vitest';
+import * as themesLib from '../../lib/themes';
 import { AppLogoProps, AppLogoType } from './AppLogo';
 import themeReducer, {
   applyBackendThemeConfig,
@@ -45,41 +46,31 @@ describe('themeSlice', () => {
   });
 
   describe('setTheme records the last theme per mode', () => {
+    // Assert on the persistence call itself rather than the localStorage
+    // round-trip, so the test doesn't depend on the shared localStorage mock.
+    let setLastThemeForMode: ReturnType<typeof vi.spyOn>;
+
     beforeEach(() => {
-      // Use a self-contained localStorage so the assertions don't depend on the
-      // shared mock, which other test files can leave in an inconsistent state.
-      const store: Record<string, string> = {};
-      vi.stubGlobal('localStorage', {
-        getItem: (key: string) => (key in store ? store[key] : null),
-        setItem: (key: string, value: string) => {
-          store[key] = String(value);
-        },
-        removeItem: (key: string) => {
-          delete store[key];
-        },
-        clear: () => {
-          Object.keys(store).forEach(key => delete store[key]);
-        },
-      });
+      setLastThemeForMode = vi.spyOn(themesLib, 'setLastThemeForMode').mockImplementation(() => {});
     });
 
     afterEach(() => {
-      vi.unstubAllGlobals();
+      setLastThemeForMode.mockRestore();
     });
 
     it('records a dark theme under the dark key', () => {
       themeReducer(initialState, setTheme('dark'));
-      expect(localStorage.getItem('headlampLastDarkTheme')).toEqual('dark');
+      expect(setLastThemeForMode).toHaveBeenCalledWith('dark', 'dark');
     });
 
     it('records a light theme under the light key', () => {
       themeReducer(initialState, setTheme('Monochrome Light'));
-      expect(localStorage.getItem('headlampLastLightTheme')).toEqual('Monochrome Light');
+      expect(setLastThemeForMode).toHaveBeenCalledWith('light', 'Monochrome Light');
     });
 
     it('treats a base:dark theme as dark', () => {
       themeReducer(initialState, setTheme('Lights Out'));
-      expect(localStorage.getItem('headlampLastDarkTheme')).toEqual('Lights Out');
+      expect(setLastThemeForMode).toHaveBeenCalledWith('dark', 'Lights Out');
     });
   });
 

--- a/frontend/src/components/App/themeSlice.ts
+++ b/frontend/src/components/App/themeSlice.ts
@@ -17,7 +17,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 import { AppTheme } from '../../lib/AppTheme';
-import { getThemeName, setTheme as setAppTheme } from '../../lib/themes';
+import { getThemeName, setLastThemeForMode, setTheme as setAppTheme } from '../../lib/themes';
 import { AppLogoType } from './AppLogo';
 import defaultAppThemes from './defaultAppThemes';
 export interface ThemeState {
@@ -55,6 +55,11 @@ const themeSlice = createSlice({
     setTheme(state, action: PayloadAction<string>) {
       state.name = action.payload;
       setAppTheme(state.name);
+      // Remember the most recent light and dark theme so the navbar toggle can
+      // swap back to the user's preferred theme of each mode.
+      const selected = state.appThemes.find(it => it.name === state.name);
+      const mode = (selected?.base ?? 'light') === 'dark' ? 'dark' : 'light';
+      setLastThemeForMode(mode, state.name);
     },
     addCustomAppTheme(state, action: PayloadAction<AppTheme>) {
       state.appThemes = state.appThemes.filter(it => it.name !== action.payload.name);

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "التنقل",
   "General": "عام",
   "Reset All to Defaults": "إعادة تعيين الكل إلى الافتراضي",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "تسجيل الخروج من الجميع",
   "Log out": "تسجيل الخروج",
   "Account of current user": "حساب المستخدم الحالي",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "Navigation",
   "General": "সাধারণ",
   "Reset All to Defaults": "সব ডিফল্টে রিসেট করুন",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "সব থেকে Log আউট",
   "Log out": "Log আউট",
   "Account of current user": "বর্তমান ব্যবহারকারীর অ্যাকাউন্ট",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "Navigation",
   "General": "General",
   "Reset All to Defaults": "Reset All to Defaults",
+  "Switch to light theme": "Switch to light theme",
+  "Switch to dark theme": "Switch to dark theme",
   "Log out from all": "Log out from all",
   "Log out": "Log out",
   "Account of current user": "Account of current user",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "Navigation",
   "General": "General",
   "Reset All to Defaults": "Reset All to Defaults",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "Log out from all",
   "Log out": "Log out",
   "Account of current user": "Account of current user",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "Навигация",
   "General": "Общий",
   "Reset All to Defaults": "Сбросить все к настройкам по умолчанию",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "Выйти из всех",
   "Log out": "Выйти",
   "Account of current user": "Аккаунт текущего пользователя",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "نیویگیشن",
   "General": "عمومی",
   "Reset All to Defaults": "سب کو ڈیفالٹ پر بحال کریں",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "سب سے لاگ آؤٹ کریں",
   "Log out": "لاگ آؤٹ",
   "Account of current user": "موجودہ صارف کا اکاؤنٹ",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -200,6 +200,8 @@
   "Navigation": "",
   "General": "",
   "Reset All to Defaults": "",
+  "Switch to light theme": "",
+  "Switch to dark theme": "",
   "Log out from all": "",
   "Log out": "",
   "Account of current user": "",

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -17,7 +17,14 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppTheme } from './AppTheme';
-import { createMuiTheme, getThemeName, setTheme, usePrefersColorScheme } from './themes';
+import {
+  createMuiTheme,
+  getLastThemeForMode,
+  getThemeName,
+  setLastThemeForMode,
+  setTheme,
+  usePrefersColorScheme,
+} from './themes';
 
 describe('themes.ts', () => {
   describe('createMuiTheme', () => {
@@ -100,6 +107,50 @@ describe('themes.ts', () => {
 
       setTheme('dark');
       expect(mockLocalStorage.headlampThemePreference).toBe('dark');
+    });
+  });
+
+  describe('setLastThemeForMode / getLastThemeForMode', () => {
+    beforeEach(() => {
+      // Earlier tests replace localStorage with bare stubs, so install a fresh
+      // in-memory implementation that actually persists.
+      const store: Record<string, string> = {};
+      vi.stubGlobal('localStorage', {
+        getItem: (key: string) => (key in store ? store[key] : null),
+        setItem: (key: string, value: string) => {
+          store[key] = String(value);
+        },
+        removeItem: (key: string) => {
+          delete store[key];
+        },
+        clear: () => {
+          Object.keys(store).forEach(key => delete store[key]);
+        },
+      });
+    });
+
+    it('writes and reads the light mode theme from its own key', () => {
+      setLastThemeForMode('light', 'Monochrome Light');
+      expect(localStorage.getItem('headlampLastLightTheme')).toBe('Monochrome Light');
+      expect(getLastThemeForMode('light')).toBe('Monochrome Light');
+    });
+
+    it('writes and reads the dark mode theme from its own key', () => {
+      setLastThemeForMode('dark', 'Lights Out');
+      expect(localStorage.getItem('headlampLastDarkTheme')).toBe('Lights Out');
+      expect(getLastThemeForMode('dark')).toBe('Lights Out');
+    });
+
+    it('keeps the light and dark keys independent', () => {
+      setLastThemeForMode('light', 'Monochrome Light');
+      setLastThemeForMode('dark', 'Lights Out');
+      expect(getLastThemeForMode('light')).toBe('Monochrome Light');
+      expect(getLastThemeForMode('dark')).toBe('Lights Out');
+    });
+
+    it('returns undefined when no theme has been stored for a mode', () => {
+      expect(getLastThemeForMode('light')).toBeUndefined();
+      expect(getLastThemeForMode('dark')).toBeUndefined();
     });
   });
 

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -652,3 +652,23 @@ export function getThemeName(backendConfig?: {
 export function setTheme(themeName: string) {
   localStorage.headlampThemePreference = themeName;
 }
+
+const LAST_LIGHT_THEME_KEY = 'headlampLastLightTheme';
+const LAST_DARK_THEME_KEY = 'headlampLastDarkTheme';
+
+/**
+ * Remembers the most recently selected theme for a given mode so the navbar
+ * light/dark toggle can swap back to a user's preferred theme of each mode
+ * (e.g. "Monochrome Light" <-> "Lights Out") instead of always snapping to the
+ * built-in Light/Dark themes.
+ */
+export function setLastThemeForMode(mode: 'light' | 'dark', themeName: string) {
+  localStorage.setItem(mode === 'dark' ? LAST_DARK_THEME_KEY : LAST_LIGHT_THEME_KEY, themeName);
+}
+
+/** Returns the most recently selected theme name for the given mode, if any. */
+export function getLastThemeForMode(mode: 'light' | 'dark'): string | undefined {
+  return (
+    localStorage.getItem(mode === 'dark' ? LAST_DARK_THEME_KEY : LAST_LIGHT_THEME_KEY) ?? undefined
+  );
+}

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -317,6 +317,7 @@
     "GLOBAL_SEARCH": "GLOBAL_SEARCH",
     "NOTIFICATION": "NOTIFICATION",
     "SETTINGS": "SETTINGS",
+    "THEME_TOGGLE": "THEME_TOGGLE",
     "USER": "USER",
   },
   "DefaultDetailsViewSection": {

--- a/frontend/src/redux/actionButtonsSlice.ts
+++ b/frontend/src/redux/actionButtonsSlice.ts
@@ -60,6 +60,7 @@ export enum DefaultHeaderAction {
 export enum DefaultAppBarAction {
   CLUSTER = 'CLUSTER',
   NOTIFICATION = 'NOTIFICATION',
+  THEME_TOGGLE = 'THEME_TOGGLE',
   SETTINGS = 'SETTINGS',
   USER = 'USER',
   GLOBAL_SEARCH = 'GLOBAL_SEARCH',


### PR DESCRIPTION
Adds a one-click light/dark theme toggle to the top bar, so switching no longer requires going into Settings.

- Sun/moon icon button in the navbar (`mdi:weather-sunny` / `mdi:weather-night`, already bundled).
- Dispatches `setTheme`, so it stays in sync with the Settings theme picker.
- Remembers the last-used light theme and last-used dark theme, so toggling from a custom theme (e.g. "Monochrome Light") returns to it rather than snapping to the default Light/Dark.
- Hidden when the backend forces a theme; tooltip and `aria-label` included.

Closes #6191