### PR TITLE
frontend: Home story: mock cluster version endpoints

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/index.InaccessibleClusters.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.InaccessibleClusters.stories.storyshot
@@ -1,0 +1,935 @@
+<body>
+  <div>
+    <div
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-1ub3t8b-MuiGrid-root"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-49904w-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-p0cik4"
+        >
+          <div
+            class="MuiBox-root css-j1fy4m"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1ts0dnm-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+              >
+                <div
+                  class="MuiBox-root css-70qvj9"
+                >
+                  <h1
+                    class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
+                  >
+                    Home
+                  </h1>
+                  <div
+                    class="MuiBox-root css-ldp2l3"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-1txv3mw"
+            >
+              <div
+                class="MuiBox-root css-1fkybvm"
+              >
+                <div
+                  class="MuiTabs-root css-1ujnqem-MuiTabs-root"
+                >
+                  <div
+                    class="MuiTabs-scroller MuiTabs-fixed css-jpln7h-MuiTabs-scroller"
+                    style="overflow: hidden; margin-bottom: 0px;"
+                  >
+                    <div
+                      class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+                      role="tablist"
+                    >
+                      <button
+                        aria-selected="true"
+                        class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-mn9ohw-MuiButtonBase-root-MuiTab-root"
+                        role="tab"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+                        >
+                          All Clusters
+                        </p>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-selected="false"
+                        class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-mn9ohw-MuiButtonBase-root-MuiTab-root"
+                        role="tab"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1ezega9-MuiTypography-root"
+                        >
+                          Projects
+                        </p>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                    <span
+                      class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+                      style="left: 0px; width: 0px;"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="MuiBox-root css-ty8jgw"
+                role="status"
+              />
+              <div
+                class="MuiBox-root css-1ipmh7v"
+              >
+                <div
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+                  style="min-height: 0px;"
+                >
+                  <div
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                  >
+                    <div
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-1m87iv1-MuiPaper-root-MuiAlert-root"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                        >
+                          <button
+                            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-1mgnx6i-MuiButtonBase-root-MuiButton-root"
+                            tabindex="0"
+                            type="button"
+                          >
+                            View Clusters
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="Mui-ToolbarDropZone MuiBox-root css-1fwjva3"
+                  style="opacity: 0; visibility: hidden;"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-18b7jph-MuiTypography-root"
+                  >
+                    Drop to group by 
+                  </p>
+                </div>
+                <div
+                  class="MuiBox-root css-zrlv9q"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-1p0wbhh"
+                  >
+                    <div
+                      class="MuiBox-root css-di3982"
+                    >
+                      <button
+                        aria-label="Show/Hide search"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide filters"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="FilterListIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <button
+                        aria-label="Show/Hide columns"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ViewColumnIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M14.67 5v14H9.33V5zm1 14H21V5h-5.33zm-7.34 0V5H3v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <table
+                class="MuiTable-root css-g0cegk-MuiTable-root"
+              >
+                <thead
+                  class="MuiTableHead-root css-1tmrira-MuiTableHead-root"
+                >
+                  <tr
+                    class="css-1lqh5un"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-199xzek-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-4ng264"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-bbxzxe"
+                          >
+                            <span
+                              aria-label="Toggle select all"
+                              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                              data-mui-internal-clone-element="true"
+                            >
+                              <input
+                                aria-label="Toggle select all"
+                                class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                                data-indeterminate="false"
+                                type="checkbox"
+                              />
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                                data-testid="CheckBoxOutlineBlankIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                />
+                              </svg>
+                              <span
+                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                              />
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="ascending"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-pksupb-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      data-sort="asc"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Name
+                          </div>
+                          <span
+                            aria-label="Sorted by Name ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sorted by Name ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-kfi25q-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="ArrowDownwardIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-4ks04s-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Origin
+                          </div>
+                          <span
+                            aria-label="Sort by Origin ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Origin ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-13c0hsi-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Status
+                          </div>
+                          <span
+                            aria-label="Sort by Status ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Status ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-rymsnu-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Warnings
+                          </div>
+                          <span
+                            aria-label="Sort by Warnings descending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Warnings descending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1bc3cd9-MuiTableCell-root"
+                      colspan="1"
+                      data-can-sort="true"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-68rqdf"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Kubernetes Version
+                          </div>
+                          <span
+                            aria-label="Sort by Kubernetes Version ascending"
+                            class="MuiBadge-root css-1c32n2y-MuiBadge-root"
+                            data-mui-internal-clone-element="true"
+                          >
+                            <span
+                              aria-label="Sort by Kubernetes Version ascending"
+                              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-542clt-MuiButtonBase-root-MuiTableSortLabel-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                                data-testid="SyncAltIcon"
+                                focusable="false"
+                                style="transform: rotate(-90deg) scaleX(0.9) translateX(-1px);"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="m18 12 4-4-4-4v3H3v2h15zM6 12l-4 4 4 4v-3h15v-2H6z"
+                                />
+                              </svg>
+                            </span>
+                            <span
+                              class="MuiBadge-badge MuiBadge-standard MuiBadge-invisible MuiBadge-anchorOriginTopRight MuiBadge-anchorOriginTopRightCircular MuiBadge-overlapCircular css-dniquu-MuiBadge-badge"
+                            >
+                              0
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-113nv55-MuiTableCell-root"
+                      colspan="1"
+                      data-index="-1"
+                      scope="col"
+                    >
+                      <div
+                        class="Mui-TableHeadCell-Content MuiBox-root css-1w86f15"
+                      >
+                        <div
+                          class="Mui-TableHeadCell-Content-Labels MuiBox-root css-1byo2ey"
+                        >
+                          <div
+                            class="Mui-TableHeadCell-Content-Wrapper MuiBox-root css-lapokc"
+                          >
+                            Actions
+                          </div>
+                        </div>
+                        <div
+                          class="Mui-TableHeadCell-Content-Actions MuiBox-root css-epvm6"
+                        />
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="css-1obf64m"
+                >
+                  <tr
+                    class="css-1ospngb"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Toggle select row"
+                        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-disabled MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="-1"
+                      >
+                        <input
+                          aria-label="Toggle select row"
+                          class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                          data-indeterminate="false"
+                          disabled=""
+                          type="checkbox"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="CheckBoxOutlineBlankIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+                    >
+                      <span
+                        aria-label="cluster0"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster0/"
+                        >
+                          <div
+                            class="MuiBox-root css-172hjuw"
+                          >
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster0
+                            </span>
+                          </div>
+                        </a>
+                      </span>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                      >
+                        Unknown
+                      </p>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1n4xkg0-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiBox-root css-1rnoxx5"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                          style="margin-left: 8px; color: rgb(198, 40, 40);"
+                        >
+                          Unavailable
+                        </p>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17iljsw-MuiTableCell-root"
+                    >
+                      0
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
+                    >
+                      ⋯
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-133cxkx-MuiTableCell-root"
+                    >
+                      <button
+                        aria-controls="context-menuid"
+                        aria-haspopup="menu"
+                        aria-label="Actions"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <div />
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1ospngb"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Toggle select row"
+                        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-disabled MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="-1"
+                      >
+                        <input
+                          aria-label="Toggle select row"
+                          class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                          data-indeterminate="false"
+                          disabled=""
+                          type="checkbox"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="CheckBoxOutlineBlankIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+                    >
+                      <span
+                        aria-label="cluster1"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster1/"
+                        >
+                          <div
+                            class="MuiBox-root css-172hjuw"
+                          >
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster1
+                            </span>
+                          </div>
+                        </a>
+                      </span>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                      >
+                        Unknown
+                      </p>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1n4xkg0-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiBox-root css-1rnoxx5"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                          style="margin-left: 8px; color: rgb(198, 40, 40);"
+                        >
+                          Unavailable
+                        </p>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17iljsw-MuiTableCell-root"
+                    >
+                      0
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
+                    >
+                      ⋯
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-133cxkx-MuiTableCell-root"
+                    >
+                      <button
+                        aria-controls="context-menuid"
+                        aria-haspopup="menu"
+                        aria-label="Actions"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <div />
+                    </td>
+                  </tr>
+                  <tr
+                    class="css-1ospngb"
+                    data-selected="false"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+                    >
+                      <span
+                        aria-disabled="true"
+                        aria-label="Toggle select row"
+                        class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-disabled MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="-1"
+                      >
+                        <input
+                          aria-label="Toggle select row"
+                          class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                          data-indeterminate="false"
+                          disabled=""
+                          type="checkbox"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                          data-testid="CheckBoxOutlineBlankIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+                    >
+                      <span
+                        aria-label="cluster2"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                      >
+                        <a
+                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                          href="/c/cluster2/"
+                        >
+                          <div
+                            class="MuiBox-root css-172hjuw"
+                          >
+                            <span
+                              class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+                            >
+                              cluster2
+                            </span>
+                          </div>
+                        </a>
+                      </span>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1fu0nlf-MuiTableCell-root"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                      >
+                        Unknown
+                      </p>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1n4xkg0-MuiTableCell-root"
+                    >
+                      <div
+                        class="MuiBox-root css-1rnoxx5"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-ab4e19-MuiTypography-root"
+                          style="margin-left: 8px; color: rgb(198, 40, 40);"
+                        >
+                          Unavailable
+                        </p>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-17iljsw-MuiTableCell-root"
+                    >
+                      0
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
+                    >
+                      ⋯
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-133cxkx-MuiTableCell-root"
+                    >
+                      <button
+                        aria-controls="context-menuid"
+                        aria-haspopup="menu"
+                        aria-label="Actions"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hvz71z-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                      <div />
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <div
+                class="MuiBox-root css-1bxknjp"
+              >
+                <div
+                  class="MuiBox-root css-1llu0od"
+                >
+                  <span />
+                  <div
+                    class="MuiBox-root css-qpxlqp"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Home/index.stories.tsx
+++ b/frontend/src/components/App/Home/index.stories.tsx
@@ -16,6 +16,7 @@
 
 import { configureStore } from '@reduxjs/toolkit';
 import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { initialState } from '../../../redux/configSlice';
@@ -55,8 +56,6 @@ const ourState = {
   shortcuts: { ...shortcutsReducer(undefined, { type: '' }) },
 };
 
-// @todo: Add a way for the results from useClustersVersion to be mocked, so not
-// all clusters appear as not accessible.
 export default {
   title: 'Home/Home',
   component: Home,
@@ -81,6 +80,23 @@ Base.decorators = [
     );
   },
 ];
+Base.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get('http://localhost:4466/clusters/cluster0/version', () =>
+          HttpResponse.json({ major: '1', minor: '28', gitVersion: 'v1.28.0' })
+        ),
+        http.get('http://localhost:4466/clusters/cluster1/version', () =>
+          HttpResponse.json({ major: '1', minor: '28', gitVersion: 'v1.28.0' })
+        ),
+        http.get('http://localhost:4466/clusters/cluster2/version', () =>
+          HttpResponse.json({ major: '1', minor: '28', gitVersion: 'v1.28.0' })
+        ),
+      ],
+    },
+  },
+};
 
 const loadingState = {
   ...ourState,
@@ -107,3 +123,17 @@ LoadingClusters.decorators = [
     );
   },
 ];
+
+export const InaccessibleClusters = Template.bind({});
+InaccessibleClusters.decorators = Base.decorators;
+InaccessibleClusters.parameters = {
+  msw: {
+    handlers: {
+      story: [
+        http.get('http://localhost:4466/clusters/cluster0/version', () => HttpResponse.error()),
+        http.get('http://localhost:4466/clusters/cluster1/version', () => HttpResponse.error()),
+        http.get('http://localhost:4466/clusters/cluster2/version', () => HttpResponse.error()),
+      ],
+    },
+  },
+};

--- a/frontend/src/components/App/Home/index.stories.tsx
+++ b/frontend/src/components/App/Home/index.stories.tsx
@@ -21,6 +21,7 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { initialState } from '../../../redux/configSlice';
 import shortcutsReducer from '../../../redux/shortcutsSlice';
+import { API_BASE } from '../../../test';
 import Home from '.';
 
 const ourState = {
@@ -84,13 +85,13 @@ Base.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/clusters/cluster0/version', () =>
+        http.get(`${API_BASE}/clusters/cluster0/version`, () =>
           HttpResponse.json({ major: '1', minor: '28', gitVersion: 'v1.28.0' })
         ),
-        http.get('http://localhost:4466/clusters/cluster1/version', () =>
+        http.get(`${API_BASE}/clusters/cluster1/version`, () =>
           HttpResponse.json({ major: '1', minor: '28', gitVersion: 'v1.28.0' })
         ),
-        http.get('http://localhost:4466/clusters/cluster2/version', () =>
+        http.get(`${API_BASE}/clusters/cluster2/version`, () =>
           HttpResponse.json({ major: '1', minor: '28', gitVersion: 'v1.28.0' })
         ),
       ],
@@ -130,9 +131,9 @@ InaccessibleClusters.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get('http://localhost:4466/clusters/cluster0/version', () => HttpResponse.error()),
-        http.get('http://localhost:4466/clusters/cluster1/version', () => HttpResponse.error()),
-        http.get('http://localhost:4466/clusters/cluster2/version', () => HttpResponse.error()),
+        http.get(`${API_BASE}/clusters/cluster0/version`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/clusters/cluster1/version`, () => HttpResponse.error()),
+        http.get(`${API_BASE}/clusters/cluster2/version`, () => HttpResponse.error()),
       ],
     },
   },


### PR DESCRIPTION
closes #6196

## Summary
This PR fixes the Home Storybook story by adding MSW mock handlers for `useClustersVersion`. Without these mocks, the default story always showed the clusters as inaccessible. Now the `Base` story renders them as accessible, while the error case is covered separately.

## Related Issue
Fixes #6196

## Changes
- Added `import { http, HttpResponse } from 'msw'` to `index.stories.tsx`
- Added `Base.parameters` with story-level MSW handlers that return a valid Kubernetes version response for the three cluster version endpoints (`cluster0`, `cluster1`, and `cluster2`)
- Added a new `InaccessibleClusters` story that mocks all version endpoints with `HttpResponse.error()` so the unreachable state is easy to test and document
- Removed the `@todo` comment since the missing mock is no longer an issue
- Updated the storyshots to match the new stories

## Steps to Test
1. Run `cd frontend && npm run storybook`
2. Go to **Home → Home** in the Storybook sidebar.
3. Open the `Base` story. All three clusters should show as **Active/Accessible** without any warning messages.
4. Open the `LoadingClusters` story. It should still show the loading state as before.
5. Open the `InaccessibleClusters` story. All three clusters should show as **Unavailable**.

## Notes for the Reviewer
- The only files changed are `frontend/src/components/App/Home/index.stories.tsx` and the corresponding storyshot snapshot. No component logic, API, or backend code was touched.
- The MSW handlers use `parameters.msw.handlers.story` to override the global mocks from `baseMocks.ts` only for this story, which is already the pattern used elsewhere in the codebase.
- Storyshots were regenerated using `npm run storybook:update-snapshots`.