### PR TITLE
frontend: Fix RangeError crash for invalid timezone in localeDate

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -20,6 +20,7 @@ import {
   flattenClusterListItems,
   formatDuration,
   getPercentStr,
+  isValidTimezone,
   normalizeUnit,
   timeAgo,
 } from './util';
@@ -343,6 +344,37 @@ describe('normalizeUnit', () => {
     it('shows plural cores', () => {
       expect(normalizeUnit('cpu', '2')).toBe('2 cores');
     });
+  });
+});
+
+describe('isValidTimezone', () => {
+  it('returns true for valid IANA timezone identifiers', () => {
+    expect(isValidTimezone('UTC')).toBe(true);
+    expect(isValidTimezone('America/New_York')).toBe(true);
+    expect(isValidTimezone('Europe/Bucharest')).toBe(true);
+    expect(isValidTimezone('Asia/Tokyo')).toBe(true);
+  });
+
+  it('returns false for Etc/Unknown (the Chrome crash case)', () => {
+    const originalDateTimeFormat = Intl.DateTimeFormat;
+    const spy = vi.spyOn(Intl, 'DateTimeFormat').mockImplementation((locale, options) => {
+      if (options && options.timeZone === 'Etc/Unknown') {
+        throw new RangeError('Invalid time zone');
+      }
+      return new originalDateTimeFormat(locale, options);
+    });
+
+    try {
+      expect(isValidTimezone('Etc/Unknown')).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('returns false for other unrecognised timezone strings', () => {
+    expect(isValidTimezone('Invalid/Timezone')).toBe(false);
+    expect(isValidTimezone('foobar')).toBe(false);
+    expect(isValidTimezone(':/etc/localtime')).toBe(false);
   });
 });
 

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -203,6 +203,35 @@ export function formatDuration(duration: number, options: TimeAgoOptions = {}) {
   return humanDuration(duration);
 }
 
+const tzCache = new Map<string, boolean>();
+
+/**
+ * Returns true when tz is a valid IANA timezone string accepted by the
+ * Intl API. Some Linux systems expose TZ=:/etc/localtime which Chrome
+ * resolves to "Etc/Unknown" — an identifier that Node accepts but browsers
+ * reject with a RangeError.
+ */
+export function isValidTimezone(tz: string): boolean {
+  if (!import.meta.env.UNDER_TEST) {
+    const cached = tzCache.get(tz);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+    if (!import.meta.env.UNDER_TEST) {
+      tzCache.set(tz, true);
+    }
+    return true;
+  } catch {
+    if (!import.meta.env.UNDER_TEST) {
+      tzCache.set(tz, false);
+    }
+    return false;
+  }
+}
+
 export function localeDate(date: DateParam) {
   const options: Intl.DateTimeFormatOptions = { timeZoneName: 'short' };
   let locale: string | undefined = undefined;
@@ -214,7 +243,10 @@ export function localeDate(date: DateParam) {
     locale = 'en-US';
     return new Date(date).toISOString();
   } else {
-    options.timeZone = store.getState().config.settings.timezone;
+    const tz = store.getState().config.settings.timezone;
+    if (tz && isValidTimezone(tz)) {
+      options.timeZone = tz;
+    }
   }
 
   return new Date(date).toLocaleString(locale, options);

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -614,6 +614,7 @@
     "getResourceMetrics": [Function],
     "getResourceStr": [Function],
     "getTotalReplicas": [Function],
+    "isValidTimezone": [Function],
     "localeDate": [Function],
     "normalizeUnit": [Function],
     "timeAgo": [Function],


### PR DESCRIPTION
## Summary

Fixes a crash in Chrome when the system timezone resolves to an identifier that browsers reject (e.g. `Etc/Unknown`), but that Node.js and Firefox accept.

On some Linux systems setting `TZ=:/etc/localtime`, Chrome exposes the timezone as `Etc/Unknown`. Passing this value directly to `toLocaleString()` throws a `RangeError` because Chrome's Intl implementation strictly validates timezone identifiers.

## Related Issue

Fixes #5741

## Changes

- Extracted a new `isValidTimezone(tz: string): boolean` helper in `frontend/src/lib/util.ts` that probes `Intl.DateTimeFormat` inside a try-catch to determine whether a timezone identifier is accepted by the browser.
- Updated `localeDate()` to call `isValidTimezone()` before applying the timezone from the Redux store, falling back to the browser's local timezone when the stored value is invalid.
- Added unit tests for `isValidTimezone()` covering valid IANA identifiers, `Etc/Unknown` (the reported crash case), and other unrecognised strings.

## Steps to Test

1. Run `npm run frontend:test` — all tests pass including the new `isValidTimezone` suite.
2. To reproduce the original crash: on a Linux system with `TZ=:/etc/localtime`, open Headlamp in Chrome and navigate to any view that renders timestamps — the page should no longer crash.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

The probe uses `Intl.DateTimeFormat(undefined, { timeZone: tz })` rather than `new Date().toLocaleString(undefined, { timeZone: tz })` so that it validates the timezone without actually formatting a date, keeping the check cheap. The helper is exported to keep it directly testable without needing to bypass the `UNDER_TEST` guard in `localeDate`.