### PR TITLE
app: Retry frontend load in dev mode

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1546,7 +1546,22 @@ function startElectron() {
       },
     });
 
-    // Load the frontend
+    // Load the frontend. For a dev/external server (http URL) the dev server may not be
+    // listening yet, especially on Windows where it can take seconds to start. Retry on
+    // connection errors (< -100) instead of leaving a blank screen; ignore ERR_ABORTED (-3)
+    // so in-app navigation isn't disrupted.
+    if (startUrl.startsWith('http')) {
+      let retryTimer: ReturnType<typeof setTimeout> | null = null;
+      mainWindow.webContents.on('did-fail-load', (_event, errorCode, _desc, _url, isMainFrame) => {
+        if (isMainFrame && errorCode <= -100 && !retryTimer) {
+          retryTimer = setTimeout(() => {
+            retryTimer = null;
+            mainWindow && !mainWindow.isDestroyed() && mainWindow.loadURL(startUrl);
+          }, 1000);
+        }
+      });
+    }
+
     mainWindow.loadURL(startUrl);
 
     setMenu(mainWindow, currentMenu);


### PR DESCRIPTION
This change makes the Electron window retry loading the frontend in dev mode when the dev server isn't ready yet, instead of loading once and giving up. Previously on Windows, the dev server often wasn't listening when the window loaded `http://localhost:3000`, so the load failed with `ERR_CONNECTION_REFUSED` and stayed blank until the frontend was started manually first.

Related: 
- #2258 

### Testing
- [x] `make app-test` passes
- [x] Blank screen no longer occurs when starting the app before the dev server is ready