### PR TITLE
frontend: EditorDialog: Preserve scroll position across validation errors

### DIFF
--- a/frontend/src/components/common/Resource/EditorDialog.test.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.test.tsx
@@ -20,24 +20,30 @@ import React from 'react';
 import { TestContext } from '../../../test';
 import EditorDialog from './EditorDialog';
 
-const { mockSetModelMarkers, mockGetModel, mockTextarea, mockEditorInstance } = vi.hoisted(() => {
-  const textarea = document.createElement('textarea');
-  return {
-    mockSetModelMarkers: vi.fn(),
-    mockGetModel: vi.fn(() => ({})),
-    mockTextarea: textarea,
-    mockEditorInstance: {
-      getDomNode: () => ({
-        querySelector: (selector: string) => {
-          if (selector === 'textarea') {
-            return textarea;
-          }
-          return null;
-        },
-      }),
-    },
-  };
-});
+const { mockSetModelMarkers, mockGetModel, mockTextarea, mockEditorInstance, mockOnChangeRef } =
+  vi.hoisted(() => {
+    const textarea = document.createElement('textarea');
+    return {
+      mockSetModelMarkers: vi.fn(),
+      mockGetModel: vi.fn(() => ({})),
+      mockTextarea: textarea,
+      mockEditorInstance: {
+        getDomNode: () => ({
+          querySelector: (selector: string) => {
+            if (selector === 'textarea') {
+              return textarea;
+            }
+            return null;
+          },
+        }),
+        getScrollTop: vi.fn(() => 123),
+        getPosition: vi.fn(() => ({ lineNumber: 5, column: 10 })),
+        setScrollTop: vi.fn(),
+        setPosition: vi.fn(),
+      },
+      mockOnChangeRef: { current: undefined as ((value: string | undefined) => void) | undefined },
+    };
+  });
 
 vi.mock('js-yaml', () => {
   class YAMLException extends Error {
@@ -67,6 +73,8 @@ vi.mock('@monaco-editor/react', () => {
   return {
     Monaco: {} as any,
     Editor: ({ onChange, onMount }: any) => {
+      mockOnChangeRef.current = onChange;
+
       React.useEffect(() => {
         onMount?.(
           { ...mockEditorInstance, getModel: mockGetModel },
@@ -122,11 +130,18 @@ describe('EditorDialog', () => {
     vi.useFakeTimers();
     localStorage.setItem('useSimpleEditor', 'true');
     mockTextarea.id = '';
+    // jsdom doesn't implement requestAnimationFrame; run callbacks
+    // synchronously so the scroll/cursor restore is deterministic in tests.
+    vi.stubGlobal('requestAnimationFrame', (cb: (time: number) => void) => {
+      cb(0);
+      return 0;
+    });
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   function renderEditorDialog() {
@@ -262,5 +277,43 @@ describe('EditorDialog', () => {
       'aria-controls',
       textareaId
     );
+  });
+
+  it('restores Monaco scroll position and cursor after validation produces an error', () => {
+    localStorage.setItem('useSimpleEditor', 'false');
+
+    renderEditorDialog();
+
+    act(() => {
+      mockOnChangeRef.current?.('invalid');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockEditorInstance.setScrollTop).toHaveBeenCalledWith(123);
+    expect(mockEditorInstance.setPosition).toHaveBeenCalledWith({ lineNumber: 5, column: 10 });
+  });
+
+  it('does not touch scroll/cursor when validation finds nothing to update', () => {
+    localStorage.setItem('useSimpleEditor', 'false');
+
+    renderEditorDialog();
+
+    // The dialog's mount effect re-detects the mocked (JSON-shaped) initial
+    // content as format 'json'. Valid JSON without "invalid" in it keeps
+    // both format ('json') and error ('') unchanged, so there's nothing for
+    // the validation tick to restore.
+    act(() => {
+      mockOnChangeRef.current?.('{"apiVersion":"v1","kind":"Node"}');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockEditorInstance.setScrollTop).not.toHaveBeenCalled();
+    expect(mockEditorInstance.setPosition).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/common/Resource/EditorDialog.tsx
+++ b/frontend/src/components/common/Resource/EditorDialog.tsx
@@ -262,11 +262,27 @@ export default function EditorDialog(props: EditorDialogProps) {
         code: value || '',
         format: originalCodeRef.current.format,
       });
-      if (code.format !== format) {
+
+      const willUpdateCode = code.format !== format;
+      const willUpdateError = error !== (err?.message || '');
+
+      // Nothing will change, so there's no re-render and nothing to restore.
+      if (!willUpdateCode && !willUpdateError) {
+        return;
+      }
+
+      // The state updates below re-render the editor and reset its scroll
+      // position. Save it here and restore it once the re-render settles, so
+      // the user doesn't lose their place.
+      const editor = editorRef.current;
+      const scrollTop = editor?.getScrollTop();
+      const position = editor?.getPosition();
+
+      if (willUpdateCode) {
         setCode(currentCode => ({ code: currentCode.code || '', format }));
       }
 
-      if (error !== (err?.message || '')) {
+      if (willUpdateError) {
         setError(err?.message || '');
       }
 
@@ -306,6 +322,20 @@ export default function EditorDialog(props: EditorDialogProps) {
             monacoRef.current.editor.setModelMarkers(model, 'headlamp-yaml-parse', []);
           }
         }
+      }
+
+      if (editor && scrollTop !== undefined) {
+        requestAnimationFrame(() => {
+          // The editor may have been unmounted (e.g. switched to the simple
+          // editor) or replaced between capture and this frame.
+          if (editorRef.current !== editor) {
+            return;
+          }
+          editor.setScrollTop(scrollTop);
+          if (position) {
+            editor.setPosition(position);
+          }
+        });
       }
     }, 500); // ms
 


### PR DESCRIPTION
## Summary

Fixes the YAML/JSON editor jumping back to the top whenever a validation error fires while editing large manifests. EditorDialog re-validates content 500ms after the user stops typing, and when validation finds an error, the resulting state updates re-render the editor and reset its scroll position — so anyone editing near the bottom of a large manifest gets yanked back to line 1 mid-edit.

## Related Issue

Fixes #5703

## Changes

- Added a ref to the live Monaco editor instance via `onMount`.
- In the validation timeout, capture scrollTop and cursor position right before the error/code state updates that trigger a re-render.
- Restore both on the next animation frame once the re-render settles.

## Steps to Test

1. Open the YAML editor for any resource, paste a long manifest (50+ lines).
2. Scroll down so you're viewing content near the bottom.
3. Type something that breaks YAML syntax.
4. Wait ~1 second for the error to appear.
5. Confirm the editor stays at your scroll position instead of jumping back to the top.

## Screenshots (if applicable)

N/A — scroll/cursor behavior fix, not a visual change.

## Notes for the Reviewer

Verified with a scripted Playwright check against Monaco's own API (getScrollTop/getVisibleRanges) showing identical scroll position before and after a validation error, plus manual testing in Storybook.