### PR TITLE
github: app.yml: Cache deps and cancel stale app builds

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-linux:
     runs-on: ubuntu-22.04
@@ -35,9 +39,15 @@ jobs:
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+        cache-dependency-path: |
+          app/package-lock.json
+          frontend/package-lock.json
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: '1.26.*'
+        cache-dependency-path: |
+          backend/go.sum
     - name: Run tests
       run: make app-test
     - name: Run tsc type checker
@@ -66,9 +76,15 @@ jobs:
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+        cache-dependency-path: |
+          app/package-lock.json
+          frontend/package-lock.json
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: '1.26.*'
+        cache-dependency-path: |
+          backend/go.sum
     - name: Dependencies
       uses: crazy-max/ghaction-chocolatey@e80bd39bb49cae70b67ea53d52d00833a7255c21 # v1.7.0
       with:
@@ -93,9 +109,15 @@ jobs:
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+        cache-dependency-path: |
+          app/package-lock.json
+          frontend/package-lock.json
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: '1.26.*'
+        cache-dependency-path: |
+          backend/go.sum
     - name: Dependencies
       run: brew install make
     - name: Run tests


### PR DESCRIPTION
The `Build App` workflow had no dependency caching (unlike `app-artifacts-*` and `frontend`) and no concurrency control, making it one of the slowest PR checks. This caches npm and Go deps and cancels superseded runs on new pushes.

### Changes

- Add `cache: 'npm'` to `setup-node` (app + frontend lockfiles) and a Go module cache path to `setup-go`, matching the existing artifact workflows
- Add a `concurrency` group that cancels in-progress runs when a PR is updated

### Testing

- [x] `make app-test`, `make app-tsc`, and the OS builds pass
- [x] Cached runs skip the cold dependency overloads