### PR TITLE
backend(auth): move OIDC token refresh middleware to auth package

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -63,7 +63,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1163,15 +1162,6 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	return r
 }
 
-// setTokenFromCookie attempts to get a token from the cookie and set it as Authorization header.
-func setTokenFromCookie(r *http.Request, clusterName string) {
-	tokenFromCookie, err := auth.GetTokenFromCookie(r, clusterName)
-	// Set bearer token from cookie if it exists
-	if err == nil && tokenFromCookie != "" {
-		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenFromCookie))
-	}
-}
-
 func clearRequestAuthorization(r *http.Request) {
 	r.Header.Del("Authorization")
 	r.Header.Del("Cookie")
@@ -1224,7 +1214,7 @@ func (c *HeadlampConfig) requestTokenForContext(
 func applyRequestTokenToContext(r *http.Request, clusterName string, context *kubeconfig.Context) {
 	// Only promote a cookie token when the request does not already provide Authorization.
 	if strings.TrimSpace(r.Header.Get("Authorization")) == "" {
-		setTokenFromCookie(r, clusterName)
+		auth.SetTokenFromCookie(r, clusterName)
 	}
 
 	bearerToken := auth.BearerTokenValue(r.Header.Get("Authorization"))
@@ -1239,141 +1229,26 @@ func applyRequestTokenToContext(r *http.Request, clusterName string, context *ku
 	context.AuthInfo.Token = bearerToken
 }
 
-func (c *HeadlampConfig) incrementRequestCounter(ctx context.Context) {
-	if c.Metrics != nil {
-		c.Metrics.RequestCounter.Add(ctx, 1,
-			metric.WithAttributes(
-				attribute.String("api.route", oidcMiddlewareRoute),
-				attribute.String("status", "start"),
-			))
-	}
-}
-
-// oidcMiddlewareRoute is the api.route attribute value used by the OIDC token
-// refresh middleware for telemetry. It is also the span/operation name.
-const oidcMiddlewareRoute = "OIDCTokenRefreshMiddleware"
-
-// TODO: relocate this middleware (and the setTokenFromCookie helper) to the
-// auth package; RefreshAndSetToken already lives there.
-//
-//nolint:funlen
+// OIDCTokenRefreshMiddleware is a thin wrapper around auth.NewOIDCTokenRefreshMiddleware.
+// The middleware logic was relocated to the auth package to keep authentication
+// concerns together.
 func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		start := time.Now()
-		// status is captured by the deferred RecordDuration below. Each early-return
-		// branch sets it before calling next.ServeHTTP. The happy path leaves it as
-		// "success".
-		status := "success"
+	config := auth.OIDCTokenRefreshConfig{
+		KubeConfigStore:              c.KubeConfigStore,
+		Cache:                        c.Cache,
+		Telemetry:                    c.Telemetry,
+		TelemetryHandler:             c.TelemetryHandler,
+		Metrics:                      c.Metrics,
+		OidcUseAccessToken:           c.OidcUseAccessToken,
+		OidcIdpIssuerURL:             c.OidcIdpIssuerURL,
+		OidcValidatorIdpIssuerURL:    c.OidcValidatorIdpIssuerURL,
+		BaseURL:                      c.BaseURL,
+		SessionTTL:                   c.SessionTTL,
+		UseInCluster:                 c.UseInCluster,
+		UnsafeUseServiceAccountToken: c.UnsafeUseServiceAccountToken,
+	}
 
-		var span trace.Span
-		if c.Telemetry != nil {
-			_, span = telemetry.CreateSpan(ctx, r, "auth", oidcMiddlewareRoute)
-
-			c.TelemetryHandler.RecordEvent(span, "Middleware started")
-
-			defer span.End()
-		}
-
-		defer func() {
-			c.TelemetryHandler.RecordDuration(ctx, start,
-				attribute.String("api.route", oidcMiddlewareRoute),
-				attribute.String("status", status))
-		}()
-
-		c.incrementRequestCounter(ctx)
-
-		// skip if not cluster request
-		if !strings.HasPrefix(r.URL.String(), "/clusters/") {
-			c.TelemetryHandler.RecordEvent(span, "Not a cluster request, skipping OIDC refresh")
-
-			status = "skipped"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// parse cluster and token
-		cluster, token := auth.ParseClusterAndToken(r)
-		if cluster == "" || token == "" {
-			c.TelemetryHandler.RecordEvent(span, "Missing cluster or token, bypassing OIDC refresh")
-
-			status = "missing"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// get oidc config
-		kContext, err := c.KubeConfigStore.GetContext(cluster)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{logFieldCluster: cluster},
-				err, "failed to get context")
-			c.TelemetryHandler.RecordError(span, err, "Failed to get context")
-			c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error", "get_context_failure"))
-
-			status = "get_context_failure"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		if c.shouldUseUnsafeServiceAccountTokenForContext(kContext) {
-			c.TelemetryHandler.RecordEvent(span, "Using service account token, skipping OIDC refresh")
-
-			status = "service_account_token"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// skip if cluster is not using OIDC auth
-		oidcAuthConfig, err := kContext.OidcConfig()
-		if err != nil {
-			c.TelemetryHandler.RecordEvent(span, "OIDC auth not enabled for cluster")
-
-			status = "oidc_auth_not_enabled"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// skip if token is not about to expire
-		if !auth.IsTokenAboutToExpire(token) {
-			c.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
-
-			status = "token_valid"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// refresh and cache new token
-		auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
-			Ctx:                       ctx,
-			OIDCAuthConfig:            oidcAuthConfig,
-			Cache:                     c.Cache,
-			Token:                     token,
-			Cluster:                   cluster,
-			Span:                      span,
-			Writer:                    w,
-			Request:                   r,
-			TelemetryHandler:          c.TelemetryHandler,
-			OIDCUseAccessToken:        c.OidcUseAccessToken,
-			OIDCIdpIssuerURL:          c.OidcIdpIssuerURL,
-			OIDCValidatorIdpIssuerURL: c.OidcValidatorIdpIssuerURL,
-			BaseURL:                   c.BaseURL,
-			SessionTTL:                c.SessionTTL,
-		})
-
-		next.ServeHTTP(w, r)
-	})
+	return auth.NewOIDCTokenRefreshMiddleware(config)(next)
 }
 
 // isLoopbackAddr reports whether the given listen address is a loopback address.
@@ -1793,7 +1668,7 @@ func (c *HeadlampConfig) helmRouteRepositoryHandler(
 		clearRequestAuthorization(r)
 	} else {
 		// fetch token from cookie
-		setTokenFromCookie(r, clusterName)
+		auth.SetTokenFromCookie(r, clusterName)
 	}
 
 	// if no token present in in-cluster mode, return error

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2159,35 +2159,6 @@ func TestOidcStateMapEviction(t *testing.T) {
 	assert.True(t, freshPresent, "fresh OIDC state entry should still be present")
 }
 
-func TestOIDCTokenRefreshMiddleware(t *testing.T) {
-	kubeConfigStore := kubeconfig.NewContextStore()
-	config := &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeConfigStore},
-			Cache:            cache.New[interface{}](),
-			TelemetryHandler: &telemetry.RequestHandler{},
-		},
-	}
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	middleware := config.OIDCTokenRefreshMiddleware(handler)
-
-	// Test case: non-cluster request
-	req := httptest.NewRequestWithContext(context.Background(), "GET", "/non-cluster", nil)
-	rec := httptest.NewRecorder()
-	middleware.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusOK, rec.Code)
-
-	// Test case: cluster request without token
-	req = httptest.NewRequestWithContext(context.Background(), "GET", "/clusters/test-cluster", nil)
-	rec = httptest.NewRecorder()
-	middleware.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusOK, rec.Code)
-}
-
 func TestStartHeadlampServer(t *testing.T) {
 	// Create a temporary directory for plugins
 	tempDir, err := os.MkdirTemp("", "headlamp-test")
@@ -3389,32 +3360,6 @@ func TestHandleClusterServiceProxyUsesServiceAccountToken(t *testing.T) {
 
 // TestOidcUseCookieLogic verifies that the mechanism for promoting an OIDC token
 // from a cookie to the Authorization header works as expected.
-func TestOidcUseCookieLogic(t *testing.T) {
-	clusterName := "test-cluster-oidc"
-	testToken := "fake-token-for-testing"
-	cookieName := "headlamp-auth-" + clusterName + ".0"
-
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "/api/v1/clusters/"+clusterName, nil)
-	assert.NoError(t, err)
-
-	req.AddCookie(&http.Cookie{
-		Name:     cookieName,
-		Value:    testToken,
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteStrictMode,
-	})
-
-	setTokenFromCookie(req, clusterName)
-
-	got := req.Header.Get("Authorization")
-	want := "Bearer " + testToken
-
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}
-
 // TestHelmRouteReleaseHandlerTokenExtraction verifies that helmRouteReleaseHandler
 // sets the Authorization header and propagates the bearer token into the clientConfig
 // in a non-OIDC in-cluster deployment where OidcConf is nil. This is a regression

--- a/backend/pkg/auth/middleware.go
+++ b/backend/pkg/auth/middleware.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// OIDCTokenRefreshConfig holds the configuration needed by the OIDC token
+// refresh middleware. It is a subset of the full HeadlampConfig, containing
+// only the fields relevant to authentication and token lifecycle.
+type OIDCTokenRefreshConfig struct {
+	KubeConfigStore              kubeconfig.ContextStore
+	Cache                        cache.Cache[interface{}]
+	Telemetry                    *telemetry.Telemetry
+	TelemetryHandler             *telemetry.RequestHandler
+	Metrics                      *telemetry.Metrics
+	OidcUseAccessToken           bool
+	OidcIdpIssuerURL             string
+	OidcValidatorIdpIssuerURL    string
+	BaseURL                      string
+	SessionTTL                   int
+	UseInCluster                 bool
+	UnsafeUseServiceAccountToken bool
+}
+
+// oidcMiddlewareRoute is the api.route attribute value used by the OIDC token
+// refresh middleware for telemetry. It is also the span/operation name.
+const oidcMiddlewareRoute = "OIDCTokenRefreshMiddleware"
+
+// SetTokenFromCookie retrieves a token from the request cookie and sets
+// it as the Authorization header.
+func SetTokenFromCookie(r *http.Request, clusterName string) {
+	tokenFromCookie, err := GetTokenFromCookie(r, clusterName)
+	if err == nil && tokenFromCookie != "" {
+		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenFromCookie))
+	}
+}
+
+// NewOIDCTokenRefreshMiddleware creates an HTTP middleware that checks whether
+// the incoming request carries an OIDC token that is about to expire and, if
+// so, refreshes it transparently using the configured OIDC provider.
+//
+//nolint:funlen
+func NewOIDCTokenRefreshMiddleware(config OIDCTokenRefreshConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			start := time.Now()
+			// status is captured by the deferred RecordDuration below. Each early-return
+			// branch sets it before calling next.ServeHTTP. The happy path leaves it as
+			// "success".
+			status := "success"
+
+			var span trace.Span
+			if config.Telemetry != nil {
+				_, span = telemetry.CreateSpan(ctx, r, "auth", oidcMiddlewareRoute)
+
+				config.TelemetryHandler.RecordEvent(span, "Middleware started")
+
+				defer span.End()
+			}
+
+			defer func() {
+				config.TelemetryHandler.RecordDuration(ctx, start,
+					attribute.String("api.route", oidcMiddlewareRoute),
+					attribute.String("status", status))
+			}()
+
+			config.incrementRequestCounter(ctx)
+
+			if config.shouldSkipOIDCRefresh(w, r, span, &status, next) {
+				return
+			}
+
+			cluster, token := ParseClusterAndToken(r)
+			if config.shouldBypassOIDCRefresh(cluster, token, w, r, span, &status, next) {
+				return
+			}
+
+			kContext, err := config.KubeConfigStore.GetContext(cluster)
+			if config.handleGetContextError(err, cluster, w, r, span, ctx, &status, next) {
+				return
+			}
+
+			if config.shouldUseUnsafeServiceAccountTokenForContext(kContext) {
+				config.TelemetryHandler.RecordEvent(span, "Using service account token, skipping OIDC refresh")
+
+				status = "service_account_token"
+
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			oidcAuthConfig, err := kContext.OidcConfig()
+			if config.handleOIDCAuthConfigError(err, w, r, span, &status, next) {
+				return
+			}
+
+			if !IsTokenAboutToExpire(token) {
+				config.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
+
+				status = "token_valid"
+
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			RefreshAndSetToken(RefreshAndSetTokenParams{
+				Ctx:                       ctx,
+				OIDCAuthConfig:            oidcAuthConfig,
+				Cache:                     config.Cache,
+				Token:                     token,
+				Cluster:                   cluster,
+				Span:                      span,
+				Writer:                    w,
+				Request:                   r,
+				TelemetryHandler:          config.TelemetryHandler,
+				OIDCUseAccessToken:        config.OidcUseAccessToken,
+				OIDCIdpIssuerURL:          config.OidcIdpIssuerURL,
+				OIDCValidatorIdpIssuerURL: config.OidcValidatorIdpIssuerURL,
+				BaseURL:                   config.BaseURL,
+				SessionTTL:                config.SessionTTL,
+			})
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// incrementRequestCounter increments the OIDC middleware request counter metric
+// if metrics are configured.
+func (c *OIDCTokenRefreshConfig) incrementRequestCounter(ctx context.Context) {
+	if c.Metrics != nil {
+		c.Metrics.RequestCounter.Add(ctx, 1,
+			metric.WithAttributes(
+				attribute.String("api.route", oidcMiddlewareRoute),
+				attribute.String("status", "start"),
+			))
+	}
+}
+
+// shouldUseUnsafeServiceAccountToken reports whether the config is running
+// in-cluster with unsafe service account token usage enabled.
+func (c *OIDCTokenRefreshConfig) shouldUseUnsafeServiceAccountToken() bool {
+	return c.UseInCluster && c.UnsafeUseServiceAccountToken
+}
+
+// shouldUseUnsafeServiceAccountTokenForContext reports whether the configured
+// cluster context should use its in-cluster service account token instead of
+// going through the OIDC refresh flow.
+func (c *OIDCTokenRefreshConfig) shouldUseUnsafeServiceAccountTokenForContext(
+	kContext *kubeconfig.Context,
+) bool {
+	return c.shouldUseUnsafeServiceAccountToken() && kContext.UsesInClusterServiceAccountToken()
+}
+
+// shouldSkipOIDCRefresh checks whether the request path is not a cluster
+// request and, if so, passes it through to the next handler without
+// attempting an OIDC refresh. It returns true when the request was skipped.
+func (c *OIDCTokenRefreshConfig) shouldSkipOIDCRefresh(
+	w http.ResponseWriter, r *http.Request, span trace.Span,
+	status *string, next http.Handler,
+) bool {
+	if !strings.HasPrefix(r.URL.String(), "/clusters/") {
+		c.TelemetryHandler.RecordEvent(span, "Not a cluster request, skipping OIDC refresh")
+
+		*status = "skipped"
+
+		next.ServeHTTP(w, r)
+
+		return true
+	}
+
+	return false
+}
+
+// shouldBypassOIDCRefresh checks whether the cluster name or token is empty
+// and, if so, passes the request through to the next handler. It returns
+// true when the refresh was bypassed.
+func (c *OIDCTokenRefreshConfig) shouldBypassOIDCRefresh(
+	cluster, token string, w http.ResponseWriter, r *http.Request,
+	span trace.Span, status *string, next http.Handler,
+) bool {
+	if cluster == "" || token == "" {
+		c.TelemetryHandler.RecordEvent(span, "Missing cluster or token, bypassing OIDC refresh")
+
+		*status = "missing"
+
+		next.ServeHTTP(w, r)
+
+		return true
+	}
+
+	return false
+}
+
+// handleGetContextError checks whether a kubeconfig context lookup failed
+// and, on error, logs it, records telemetry, and passes the request through
+// to the next handler. It returns true when an error was handled.
+func (c *OIDCTokenRefreshConfig) handleGetContextError(
+	err error, cluster string, w http.ResponseWriter, r *http.Request,
+	span trace.Span, ctx context.Context, status *string, next http.Handler,
+) bool {
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+			err, "failed to get context")
+
+		c.TelemetryHandler.RecordError(span, err, "Failed to get context")
+		c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error", "get_context_failure"))
+
+		*status = "get_context_failure"
+
+		next.ServeHTTP(w, r)
+
+		return true
+	}
+
+	return false
+}
+
+// handleOIDCAuthConfigError checks whether an OIDC auth config lookup failed
+// and, on error, records a telemetry event and passes the request through to
+// the next handler. It returns true when an error was handled.
+func (c *OIDCTokenRefreshConfig) handleOIDCAuthConfigError(
+	err error, w http.ResponseWriter, r *http.Request, span trace.Span,
+	status *string, next http.Handler,
+) bool {
+	if err != nil {
+		c.TelemetryHandler.RecordEvent(span, "OIDC auth not enabled for cluster")
+
+		*status = "oidc_auth_not_enabled"
+
+		next.ServeHTTP(w, r)
+
+		return true
+	}
+
+	return false
+}

--- a/backend/pkg/auth/middleware_test.go
+++ b/backend/pkg/auth/middleware_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOIDCTokenRefreshMiddleware(t *testing.T) {
+	kubeConfigStore := kubeconfig.NewContextStore()
+	config := auth.OIDCTokenRefreshConfig{
+		KubeConfigStore:  kubeConfigStore,
+		Cache:            cache.New[interface{}](),
+		TelemetryHandler: &telemetry.RequestHandler{},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := auth.NewOIDCTokenRefreshMiddleware(config)(handler)
+
+	// Test case: non-cluster request is skipped
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/non-cluster", nil)
+	rec := httptest.NewRecorder()
+	middleware.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Test case: cluster request without token is bypassed
+	req = httptest.NewRequestWithContext(context.Background(), "GET", "/clusters/test-cluster", nil)
+	rec = httptest.NewRecorder()
+	middleware.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestSetTokenFromCookie(t *testing.T) {
+	clusterName := "test-cluster-oidc"
+	testToken := "fake-token-for-testing"
+	cookieName := "headlamp-auth-" + auth.SanitizeClusterName(clusterName) + ".0"
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/api/v1/clusters/"+clusterName, nil)
+	assert.NoError(t, err)
+
+	req.AddCookie(&http.Cookie{
+		Name:     cookieName,
+		Value:    testToken,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	auth.SetTokenFromCookie(req, clusterName)
+
+	got := req.Header.Get("Authorization")
+	want := "Bearer " + testToken
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
Resolves #6189, #3482

## Summary

This PR extracts the OIDC token refresh middleware from `backend/cmd/headlamp.go` into a dedicated package under `backend/pkg/auth`.

This change implements the existing TODO in `headlamp.go` to move the OIDC middleware into the authentication package.

The behavior is unchanged. This is a refactoring that improves separation of concerns by moving the authentication middleware into the authentication package while keeping `headlamp.go` responsible only for wiring application components together.

## Changes

### New

* Added `backend/pkg/auth/middleware.go` containing:

  * `OIDCTokenRefreshConfig`
  * `SetTokenFromCookie`
  * `NewOIDCTokenRefreshMiddleware`
  * All helper functions previously used by the middleware

### Refactored

* Removed the middleware implementation from `backend/cmd/headlamp.go`.
* Replaced it with a thin wrapper that delegates to `auth.NewOIDCTokenRefreshMiddleware(...)`.
* Updated tests to use `auth.SetTokenFromCookie`.

## Advantages

* Resolves the existing TODO to extract the OIDC middleware.
* Improves separation of concerns by keeping authentication logic inside the auth package.
* Reduces the size and complexity of `backend/cmd/headlamp.go`.
* Makes the middleware easier to locate, understand, test, and reuse.
* Keeps application startup code focused on initialization instead of authentication implementation details.
* Preserves existing runtime behavior.

## Verification

* Related tests passed

> **Note:** There is an existing unrelated test issue involving `DefaultNodeShellNamespace`; this PR does not modify that code.

## Notes for Reviewers

* This PR implements the existing TODO in `backend/cmd/headlamp.go`; it is intended to be a **refactoring only** with no functional changes.
* Most of the diff consists of moving existing code into `backend/pkg/auth`.
* Reviewers may find it easiest to compare the extracted middleware implementation with the previous implementation in `backend/cmd/headlamp.go` to verify the move is behavior-preserving.
* The only changes outside the extraction are updating the wrapper in `headlamp.go` and adjusting the affected test import.
