### PR TITLE
backend: auth: Relocate OIDC token refresh middleware and cookie helpers

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1330,6 +1330,25 @@ func hostValidationMiddleware(listenAddr string, port uint) func(http.Handler) h
 	}
 }
 
+// newOIDCMiddlewareConfig maps the server's full HeadlampConfig down to the
+// minimal config the auth package's OIDC token refresh middleware needs. Keeping
+// this mapping in cmd lets the auth package stay decoupled from the global server config.
+func newOIDCMiddlewareConfig(c *headlampconfig.HeadlampConfig) *auth.OIDCMiddlewareConfig {
+	return &auth.OIDCMiddlewareConfig{
+		KubeConfigStore:              c.KubeConfigStore,
+		Cache:                        c.Cache,
+		TelemetryHandler:             c.TelemetryHandler,
+		Metrics:                      c.Metrics,
+		OidcUseAccessToken:           c.OidcUseAccessToken,
+		OidcIdpIssuerURL:             c.OidcIdpIssuerURL,
+		OidcValidatorIdpIssuerURL:    c.OidcValidatorIdpIssuerURL,
+		BaseURL:                      c.BaseURL,
+		SessionTTL:                   c.SessionTTL,
+		UseInCluster:                 c.UseInCluster,
+		UnsafeUseServiceAccountToken: c.UnsafeUseServiceAccountToken,
+	}
+}
+
 func serverHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, error) {
 	handler := createHeadlampHandler(ctx, config)
 
@@ -1337,7 +1356,7 @@ func serverHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, e
 		return nil, err
 	}
 
-	handler = auth.OIDCTokenRefreshMiddleware(config.HeadlampConfig)(handler)
+	handler = auth.OIDCTokenRefreshMiddleware(newOIDCMiddlewareConfig(config.HeadlampConfig))(handler)
 
 	// Only validate the Host header when listening on a loopback address.
 	// When bound to a non-loopback address (e.g. behind a reverse proxy),

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -63,7 +63,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1163,15 +1162,6 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	return r
 }
 
-// setTokenFromCookie attempts to get a token from the cookie and set it as Authorization header.
-func setTokenFromCookie(r *http.Request, clusterName string) {
-	tokenFromCookie, err := auth.GetTokenFromCookie(r, clusterName)
-	// Set bearer token from cookie if it exists
-	if err == nil && tokenFromCookie != "" {
-		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenFromCookie))
-	}
-}
-
 func clearRequestAuthorization(r *http.Request) {
 	r.Header.Del("Authorization")
 	r.Header.Del("Cookie")
@@ -1224,7 +1214,7 @@ func (c *HeadlampConfig) requestTokenForContext(
 func applyRequestTokenToContext(r *http.Request, clusterName string, context *kubeconfig.Context) {
 	// Only promote a cookie token when the request does not already provide Authorization.
 	if strings.TrimSpace(r.Header.Get("Authorization")) == "" {
-		setTokenFromCookie(r, clusterName)
+		auth.SetTokenFromCookie(r, clusterName)
 	}
 
 	bearerToken := auth.BearerTokenValue(r.Header.Get("Authorization"))
@@ -1237,143 +1227,6 @@ func applyRequestTokenToContext(r *http.Request, clusterName string, context *ku
 	}
 
 	context.AuthInfo.Token = bearerToken
-}
-
-func (c *HeadlampConfig) incrementRequestCounter(ctx context.Context) {
-	if c.Metrics != nil {
-		c.Metrics.RequestCounter.Add(ctx, 1,
-			metric.WithAttributes(
-				attribute.String("api.route", oidcMiddlewareRoute),
-				attribute.String("status", "start"),
-			))
-	}
-}
-
-// oidcMiddlewareRoute is the api.route attribute value used by the OIDC token
-// refresh middleware for telemetry. It is also the span/operation name.
-const oidcMiddlewareRoute = "OIDCTokenRefreshMiddleware"
-
-// TODO: relocate this middleware (and the setTokenFromCookie helper) to the
-// auth package; RefreshAndSetToken already lives there.
-//
-//nolint:funlen
-func (c *HeadlampConfig) OIDCTokenRefreshMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		start := time.Now()
-		// status is captured by the deferred RecordDuration below. Each early-return
-		// branch sets it before calling next.ServeHTTP. The happy path leaves it as
-		// "success".
-		status := "success"
-
-		var span trace.Span
-		if c.Telemetry != nil {
-			_, span = telemetry.CreateSpan(ctx, r, "auth", oidcMiddlewareRoute)
-
-			c.TelemetryHandler.RecordEvent(span, "Middleware started")
-
-			defer span.End()
-		}
-
-		defer func() {
-			c.TelemetryHandler.RecordDuration(ctx, start,
-				attribute.String("api.route", oidcMiddlewareRoute),
-				attribute.String("status", status))
-		}()
-
-		c.incrementRequestCounter(ctx)
-
-		// skip if not cluster request
-		if !strings.HasPrefix(r.URL.String(), "/clusters/") {
-			c.TelemetryHandler.RecordEvent(span, "Not a cluster request, skipping OIDC refresh")
-
-			status = "skipped"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// parse cluster and token
-		cluster, token := auth.ParseClusterAndToken(r)
-		if cluster == "" || token == "" {
-			c.TelemetryHandler.RecordEvent(span, "Missing cluster or token, bypassing OIDC refresh")
-
-			status = "missing"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// get oidc config
-		kContext, err := c.KubeConfigStore.GetContext(cluster)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{logFieldCluster: cluster},
-				err, "failed to get context")
-			c.TelemetryHandler.RecordError(span, err, "Failed to get context")
-			c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error", "get_context_failure"))
-
-			status = "get_context_failure"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		if c.shouldUseUnsafeServiceAccountTokenForContext(kContext) {
-			c.TelemetryHandler.RecordEvent(span, "Using service account token, skipping OIDC refresh")
-
-			status = "service_account_token"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// skip if cluster is not using OIDC auth
-		oidcAuthConfig, err := kContext.OidcConfig()
-		if err != nil {
-			c.TelemetryHandler.RecordEvent(span, "OIDC auth not enabled for cluster")
-
-			status = "oidc_auth_not_enabled"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// skip if token is not about to expire
-		if !auth.IsTokenAboutToExpire(token) {
-			c.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
-
-			status = "token_valid"
-
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// refresh and cache new token
-		auth.RefreshAndSetToken(auth.RefreshAndSetTokenParams{
-			Ctx:                       ctx,
-			OIDCAuthConfig:            oidcAuthConfig,
-			Cache:                     c.Cache,
-			Token:                     token,
-			Cluster:                   cluster,
-			Span:                      span,
-			Writer:                    w,
-			Request:                   r,
-			TelemetryHandler:          c.TelemetryHandler,
-			OIDCUseAccessToken:        c.OidcUseAccessToken,
-			OIDCIdpIssuerURL:          c.OidcIdpIssuerURL,
-			OIDCValidatorIdpIssuerURL: c.OidcValidatorIdpIssuerURL,
-			BaseURL:                   c.BaseURL,
-			SessionTTL:                c.SessionTTL,
-		})
-
-		next.ServeHTTP(w, r)
-	})
 }
 
 // isLoopbackAddr reports whether the given listen address is a loopback address.
@@ -1484,7 +1337,7 @@ func serverHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, e
 		return nil, err
 	}
 
-	handler = config.OIDCTokenRefreshMiddleware(handler)
+	handler = auth.OIDCTokenRefreshMiddleware(config.HeadlampConfig)(handler)
 
 	// Only validate the Host header when listening on a loopback address.
 	// When bound to a non-loopback address (e.g. behind a reverse proxy),
@@ -1793,7 +1646,7 @@ func (c *HeadlampConfig) helmRouteRepositoryHandler(
 		clearRequestAuthorization(r)
 	} else {
 		// fetch token from cookie
-		setTokenFromCookie(r, clusterName)
+		auth.SetTokenFromCookie(r, clusterName)
 	}
 
 	// if no token present in in-cluster mode, return error

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	auth "github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	inventorymetadata "github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
@@ -2173,7 +2174,7 @@ func TestOIDCTokenRefreshMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	middleware := config.OIDCTokenRefreshMiddleware(handler)
+	middleware := auth.OIDCTokenRefreshMiddleware(config.HeadlampConfig)(handler)
 
 	// Test case: non-cluster request
 	req := httptest.NewRequestWithContext(context.Background(), "GET", "/non-cluster", nil)
@@ -3405,7 +3406,7 @@ func TestOidcUseCookieLogic(t *testing.T) {
 		SameSite: http.SameSiteStrictMode,
 	})
 
-	setTokenFromCookie(req, clusterName)
+	auth.SetTokenFromCookie(req, clusterName)
 
 	got := req.Header.Get("Authorization")
 	want := "Bearer " + testToken

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2162,19 +2162,17 @@ func TestOidcStateMapEviction(t *testing.T) {
 
 func TestOIDCTokenRefreshMiddleware(t *testing.T) {
 	kubeConfigStore := kubeconfig.NewContextStore()
-	config := &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG:      &headlampconfig.HeadlampCFG{KubeConfigStore: kubeConfigStore},
-			Cache:            cache.New[interface{}](),
-			TelemetryHandler: &telemetry.RequestHandler{},
-		},
+	config := &auth.OIDCMiddlewareConfig{
+		KubeConfigStore:  kubeConfigStore,
+		Cache:            cache.New[interface{}](),
+		TelemetryHandler: &telemetry.RequestHandler{},
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	middleware := auth.OIDCTokenRefreshMiddleware(config.HeadlampConfig)(handler)
+	middleware := auth.OIDCTokenRefreshMiddleware(config)(handler)
 
 	// Test case: non-cluster request
 	req := httptest.NewRequestWithContext(context.Background(), "GET", "/non-cluster", nil)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -2185,6 +2185,14 @@ func TestOIDCTokenRefreshMiddleware(t *testing.T) {
 	rec = httptest.NewRecorder()
 	middleware.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Test case: nil config acts as a pass-through instead of panicking
+	nilMiddleware := auth.OIDCTokenRefreshMiddleware(nil)(handler)
+	req = httptest.NewRequestWithContext(context.Background(), "GET", "/clusters/test-cluster", nil)
+	rec = httptest.NewRecorder()
+
+	assert.NotPanics(t, func() { nilMiddleware.ServeHTTP(rec, req) })
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestStartHeadlampServer(t *testing.T) {

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -778,6 +778,12 @@ func getOidcConfig(
 //
 //nolint:funlen
 func OIDCTokenRefreshMiddleware(c *OIDCMiddlewareConfig) func(http.Handler) http.Handler {
+	if c == nil {
+		return func(next http.Handler) http.Handler {
+			return next
+		}
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -34,10 +34,12 @@ import (
 	"github.com/jmespath/go-jmespath"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
 )
@@ -648,5 +650,193 @@ func RefreshAndSetToken(params RefreshAndSetTokenParams) {
 		SetTokenCookie(params.Writer, params.Request, params.Cluster, newTokenString, params.BaseURL, params.SessionTTL)
 
 		params.TelemetryHandler.RecordEvent(params.Span, "Token refreshed successfully")
+	}
+}
+
+// SetTokenFromCookie attempts to get a token from the cookie and set it as Authorization header.
+func SetTokenFromCookie(r *http.Request, clusterName string) {
+	tokenFromCookie, err := GetTokenFromCookie(r, clusterName)
+	// Set bearer token from cookie if it exists
+	if err == nil && tokenFromCookie != "" {
+		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenFromCookie))
+	}
+}
+
+// ShouldUseUnsafeServiceAccountTokenForContext reports whether Headlamp is configured
+// to use the in-cluster service account token.
+func ShouldUseUnsafeServiceAccountTokenForContext(c *headlampconfig.HeadlampConfig, kContext *kubeconfig.Context) bool {
+	if c == nil || kContext == nil {
+		return false
+	}
+
+	useSA := c.UseInCluster && c.UnsafeUseServiceAccountToken
+
+	return useSA && kContext.UsesInClusterServiceAccountToken()
+}
+
+// oidcMiddlewareRoute is the api.route attribute value used by the OIDC token
+// refresh middleware for telemetry. It is also the span/operation name.
+const oidcMiddlewareRoute = "OIDCTokenRefreshMiddleware"
+
+func incrementRequestCounter(c *headlampconfig.HeadlampConfig, ctx context.Context) {
+	if c.Metrics != nil {
+		c.Metrics.RequestCounter.Add(ctx, 1,
+			metric.WithAttributes(
+				attribute.String("api.route", oidcMiddlewareRoute),
+				attribute.String("status", "start"),
+			))
+	}
+}
+
+func verifyAndGetToken(
+	c *headlampconfig.HeadlampConfig,
+	r *http.Request,
+	span trace.Span,
+) (string, string, bool, string) {
+	// skip if not cluster request
+	if !strings.HasPrefix(r.URL.String(), "/clusters/") {
+		if c.TelemetryHandler != nil {
+			c.TelemetryHandler.RecordEvent(span, "Not a cluster request, skipping OIDC refresh")
+		}
+
+		return "", "", true, "skipped"
+	}
+
+	// parse cluster and token
+	cluster, token := ParseClusterAndToken(r)
+	if cluster == "" || token == "" {
+		if c.TelemetryHandler != nil {
+			c.TelemetryHandler.RecordEvent(span, "Missing cluster or token, bypassing OIDC refresh")
+		}
+
+		return "", "", true, "missing"
+	}
+
+	return cluster, token, false, ""
+}
+
+func getOidcConfig(
+	c *headlampconfig.HeadlampConfig,
+	cluster string,
+	ctx context.Context,
+	span trace.Span,
+) (*kubeconfig.OidcConfig, bool, string) {
+	kContext, err := c.KubeConfigStore.GetContext(cluster)
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"cluster": cluster},
+			err, "failed to get context")
+
+		if c.TelemetryHandler != nil {
+			c.TelemetryHandler.RecordError(span, err, "Failed to get context")
+			c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error", "get_context_failure"))
+		}
+
+		return nil, true, "get_context_failure"
+	}
+
+	if ShouldUseUnsafeServiceAccountTokenForContext(c, kContext) {
+		if c.TelemetryHandler != nil {
+			c.TelemetryHandler.RecordEvent(span, "Using service account token, skipping OIDC refresh")
+		}
+
+		return nil, true, "service_account_token"
+	}
+
+	// skip if cluster is not using OIDC auth
+	oidcAuthConfig, err := kContext.OidcConfig()
+	if err != nil {
+		if c.TelemetryHandler != nil {
+			c.TelemetryHandler.RecordEvent(span, "OIDC auth not enabled for cluster")
+		}
+
+		return nil, true, "oidc_auth_not_enabled"
+	}
+
+	return oidcAuthConfig, false, ""
+}
+
+// OIDCTokenRefreshMiddleware refreshes the OIDC token if it's about to expire.
+//
+//nolint:funlen
+func OIDCTokenRefreshMiddleware(c *headlampconfig.HeadlampConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			start := time.Now()
+			// status is captured by the deferred RecordDuration below. Each early-return
+			// branch sets it before calling next.ServeHTTP. The happy path leaves it as
+			// "success".
+			status := "success"
+
+			var span trace.Span
+			if c.TelemetryHandler != nil {
+				_, span = telemetry.CreateSpan(ctx, r, "auth", oidcMiddlewareRoute)
+
+				c.TelemetryHandler.RecordEvent(span, "Middleware started")
+
+				defer span.End()
+			}
+
+			defer func() {
+				if c.TelemetryHandler != nil {
+					c.TelemetryHandler.RecordDuration(ctx, start,
+						attribute.String("api.route", oidcMiddlewareRoute),
+						attribute.String("status", status))
+				}
+			}()
+
+			incrementRequestCounter(c, ctx)
+
+			cluster, token, skip, newStatus := verifyAndGetToken(c, r, span)
+			if skip {
+				status = newStatus
+
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			oidcAuthConfig, skipOIDC, newOIDCStatus := getOidcConfig(c, cluster, ctx, span)
+			if skipOIDC {
+				status = newOIDCStatus
+
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			// skip if token is not about to expire
+			if !IsTokenAboutToExpire(token) {
+				if c.TelemetryHandler != nil {
+					c.TelemetryHandler.RecordEvent(span, "Token not about to expire, skipping refresh")
+				}
+
+				status = "token_valid"
+
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			// refresh and cache new token
+			RefreshAndSetToken(RefreshAndSetTokenParams{
+				Ctx:                       ctx,
+				OIDCAuthConfig:            oidcAuthConfig,
+				Cache:                     c.Cache,
+				Token:                     token,
+				Cluster:                   cluster,
+				Span:                      span,
+				Writer:                    w,
+				Request:                   r,
+				TelemetryHandler:          c.TelemetryHandler,
+				OIDCUseAccessToken:        c.OidcUseAccessToken,
+				OIDCIdpIssuerURL:          c.OidcIdpIssuerURL,
+				OIDCValidatorIdpIssuerURL: c.OidcValidatorIdpIssuerURL,
+				BaseURL:                   c.BaseURL,
+				SessionTTL:                c.SessionTTL,
+			})
+
+			next.ServeHTTP(w, r)
+		})
 	}
 }

--- a/backend/pkg/auth/auth.go
+++ b/backend/pkg/auth/auth.go
@@ -34,7 +34,6 @@ import (
 	"github.com/jmespath/go-jmespath"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
-	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/telemetry"
@@ -662,9 +661,29 @@ func SetTokenFromCookie(r *http.Request, clusterName string) {
 	}
 }
 
+// OIDCMiddlewareConfig carries only the configuration that the OIDC token refresh
+// middleware and its helpers need. It decouples the auth package from the server's
+// full HeadlampConfig, improving testability and keeping auth's dependency surface small.
+type OIDCMiddlewareConfig struct {
+	KubeConfigStore  kubeconfig.ContextStore
+	Cache            cache.Cache[interface{}]
+	TelemetryHandler *telemetry.RequestHandler
+	Metrics          *telemetry.Metrics
+
+	OidcUseAccessToken        bool
+	OidcIdpIssuerURL          string
+	OidcValidatorIdpIssuerURL string
+
+	BaseURL    string
+	SessionTTL int
+
+	UseInCluster                 bool
+	UnsafeUseServiceAccountToken bool
+}
+
 // ShouldUseUnsafeServiceAccountTokenForContext reports whether Headlamp is configured
 // to use the in-cluster service account token.
-func ShouldUseUnsafeServiceAccountTokenForContext(c *headlampconfig.HeadlampConfig, kContext *kubeconfig.Context) bool {
+func ShouldUseUnsafeServiceAccountTokenForContext(c *OIDCMiddlewareConfig, kContext *kubeconfig.Context) bool {
 	if c == nil || kContext == nil {
 		return false
 	}
@@ -678,7 +697,7 @@ func ShouldUseUnsafeServiceAccountTokenForContext(c *headlampconfig.HeadlampConf
 // refresh middleware for telemetry. It is also the span/operation name.
 const oidcMiddlewareRoute = "OIDCTokenRefreshMiddleware"
 
-func incrementRequestCounter(c *headlampconfig.HeadlampConfig, ctx context.Context) {
+func incrementRequestCounter(c *OIDCMiddlewareConfig, ctx context.Context) {
 	if c.Metrics != nil {
 		c.Metrics.RequestCounter.Add(ctx, 1,
 			metric.WithAttributes(
@@ -689,7 +708,7 @@ func incrementRequestCounter(c *headlampconfig.HeadlampConfig, ctx context.Conte
 }
 
 func verifyAndGetToken(
-	c *headlampconfig.HeadlampConfig,
+	c *OIDCMiddlewareConfig,
 	r *http.Request,
 	span trace.Span,
 ) (string, string, bool, string) {
@@ -716,7 +735,7 @@ func verifyAndGetToken(
 }
 
 func getOidcConfig(
-	c *headlampconfig.HeadlampConfig,
+	c *OIDCMiddlewareConfig,
 	cluster string,
 	ctx context.Context,
 	span trace.Span,
@@ -758,7 +777,7 @@ func getOidcConfig(
 // OIDCTokenRefreshMiddleware refreshes the OIDC token if it's about to expire.
 //
 //nolint:funlen
-func OIDCTokenRefreshMiddleware(c *headlampconfig.HeadlampConfig) func(http.Handler) http.Handler {
+func OIDCTokenRefreshMiddleware(c *OIDCMiddlewareConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()


### PR DESCRIPTION
## Summary
This PR refactors the backend codebase by relocating the OIDC token refresh middleware (`OIDCTokenRefreshMiddleware`) and the cookie token promotion helper (`setTokenFromCookie`) from the main server startup package (`backend/cmd`) to the core authentication package (`backend/pkg/auth`). 

This resolves an existing TODO comment in the codebase, decoupling the auth request-handling middleware from the command execution layer to improve package modularity and testability.

## Related Issue
Fixes #6214

## Changes
- **Relocated Core Auth Logic**: Moved `OIDCTokenRefreshMiddleware` and `setTokenFromCookie` (exported as `SetTokenFromCookie`) to `auth.go`.
- **Decoupled Dependencies**: Introduced `auth.OIDCMiddlewareConfig` holding only what the middleware needs (`KubeConfigStore`, `Cache`, OIDC settings, `BaseURL`/`SessionTTL`, telemetry/metrics handlers, and in-cluster SA token flags). The middleware and helpers (`ShouldUseUnsafeServiceAccountTokenForContext`, `incrementRequestCounter`, `verifyAndGetToken`, `getOidcConfig`) now take this struct, removing `auth`'s import of `headlampconfig`.
- **Nil-Config Safety**: `OIDCTokenRefreshMiddleware` now treats a nil config as a pass-through (no-op) middleware instead of dereferencing it and panicking, matching the existing nil-handling in `ShouldUseUnsafeServiceAccountTokenForContext`.
- **Refactored for Linter Conformity**: Extracted check steps in `OIDCTokenRefreshMiddleware` into decoupled helper routines (`verifyAndGetToken` and `getOidcConfig`) to satisfy `gocognit` cognitive complexity rules.
- **Updated Server Wiring**: Added `newOIDCMiddlewareConfig` in `headlamp.go` to map `HeadlampConfig` down to `OIDCMiddlewareConfig`, keeping the server-config coupling on the `cmd` side. Updated middleware registration and token helper calls.
- **Updated Unit Tests**: Updated `TestOIDCTokenRefreshMiddleware` to construct `OIDCMiddlewareConfig` directly (demonstrating the testability win) and to cover the nil-config pass-through case; updated `TestOidcUseCookieLogic` to point to the new package-level implementations.
- **Cleaned Imports**: Removed unused OTel metrics import from `headlamp.go`.

## Steps to Test

1.  Verify that the backend builds successfully:
```
   npm run backend:build
```
2. Verify that there are no style, complexity, or formatting issues: 
```
npm run backend:lint
```
3. Run the backend test suite to verify middleware correctness:
```
npm run backend:test
```
