### PR TITLE
backend: refactor StartHeadlampServer by extracting runServer

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1496,7 +1496,6 @@ func serverHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, e
 	return handler, nil
 }
 
-//nolint:funlen
 func StartHeadlampServer(config *HeadlampConfig) {
 	tel, err := initTelemetry(config)
 	if err != nil {
@@ -1535,6 +1534,12 @@ func StartHeadlampServer(config *HeadlampConfig) {
 		return
 	}
 
+	runServer(config, cancel, handler)
+}
+
+// runServer creates the HTTP server, sets up graceful shutdown, starts
+// listening (TLS or plain), and handles the server completion and errors.
+func runServer(config *HeadlampConfig, cancel context.CancelFunc, handler http.Handler) {
 	listenHost := strings.TrimPrefix(strings.TrimSuffix(config.ListenAddr, "]"), "[")
 	addr := net.JoinHostPort(listenHost, fmt.Sprintf("%d", config.Port))
 
@@ -1547,6 +1552,8 @@ func StartHeadlampServer(config *HeadlampConfig) {
 
 	serverDone := make(chan struct{})
 	setupGracefulShutdown(server, cancel, serverDone)
+
+	var err error
 
 	if config.TLSCertPath != "" && config.TLSKeyPath != "" {
 		err = server.ListenAndServeTLS(config.TLSCertPath, config.TLSKeyPath)


### PR DESCRIPTION


## Summary

This PR refactors `StartHeadlampServer` by extracting the server startup and shutdown logic into a dedicated `runServer` helper.

The extraction removes the existing `//nolint:funlen` suppression while preserving the original behavior. `StartHeadlampServer` now focuses on orchestration, with the server lifecycle encapsulated in a smaller helper.

## Changes

* Extracted `runServer(config, cancel, handler)` from `StartHeadlampServer`.
* Moved:

  * HTTP server creation
  * TLS/plain HTTP startup
  * Graceful shutdown handling
  * Server error handling
* Removed the `//nolint:funlen` suppression from `StartHeadlampServer`.
* No functional changes or API changes.

## Advantages

* Removes the need for the `//nolint:funlen` suppression.
* Improves separation of responsibilities between orchestration and server lifecycle management.
* Makes `StartHeadlampServer` easier to read and maintain.
* Keeps the server startup logic localized in a dedicated helper.
* Preserves existing runtime behavior.

## Verification

* Relevant tests passed

## Notes for Reviewers

* This is intended to be a **refactoring only** with no behavioral changes.
* The extracted helper is unexported and does not modify the public API.
* The diff is intentionally small and primarily consists of moving existing logic into `runServer`.
* The primary goal is to improve readability and eliminate the `//nolint:funlen` suppression.
