### PR TITLE
Fix accessibility: decorative status icons exposed to screen readers

### DIFF
--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -98,7 +98,7 @@ export function makePodStatusLabel(pod: Pod, showContainerStatus: boolean, t: TF
         <Box display="inline">
           <StatusLabel status={status}>
             {(status === 'warning' || status === 'error') && (
-              <Icon aria-label="hidden" icon="mdi:alert-outline" width="1.2rem" height="1.2rem" />
+              <Icon aria-hidden="true" icon="mdi:alert-outline" width="1.2rem" height="1.2rem" />
             )}
             {reason}
           </StatusLabel>


### PR DESCRIPTION
## Summary
This PR fixes an accessibility issue where decorative status and warning icons were incorrectly using `aria-label="hidden"`, which exposes "hidden" as an accessible name instead of hiding the icon from screen readers.

Since the visual status is already displayed via the text, these icons should be treated as decorative.

## Changes
- Replaced `aria-label="hidden"` with `aria-hidden="true"` where appropriate
- Ensures icons are ignored by assistive technologies when redundant

## Testing
- Ran `npm run lint`
- Ran `npm test`
- Verified UI behavior manually in browser

## Notes
This improves accessibility compliance without affecting visual layout or functionality.