### PR TITLE
charts: headlamp: Fix error if OIDC ClientId is a number

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -312,7 +312,7 @@ spec:
             {{- end }}
             {{- if not $oidc.externalSecret.enabled}}
             # Check if externalSecret is disabled
-            {{- if or (ne $oidc.clientID "") (ne $clientID "") }}
+            {{- if or (ne ($oidc.clientID | quote ) "") (ne $clientID "") }}
             # Check if clientID is non empty either from env or oidc.config
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             {{- end }}

--- a/charts/headlamp/templates/secret.yaml
+++ b/charts/headlamp/templates/secret.yaml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 data:
 {{- with .clientID }}
-  clientID: {{ . | b64enc | quote }}
+  clientID: {{ . | quote | b64enc | quote }}
 {{- end }}
 {{- with .clientSecret }}
   clientSecret: {{ . | b64enc | quote }}

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -219,7 +219,7 @@
               }
             },
             "clientID": {
-              "type": "string",
+              "type": ["string", "integer"],
               "description": "Issuer of the OIDC provider"
             },
             "clientSecret": {


### PR DESCRIPTION
## Summary

This PR fixes a Helm bug that occurs when the OIDC Client ID consists only of numbers.
If the number is enclosed in quotes (or single quotes), the Client ID is generated incorrectly in the URL.

## Related Issue

## Changes

- Updated charts/headlamp/values.schema.json to accept integer values for OIDC-ClientId

## Steps to Test

1. Navigate to `charts/headlamp/values.yaml` and set a number value in `config.oidc.clientID`
2. Generate Helm files with `helm template`
3. View the generated secret in console (or output file) and verify

## Screenshots (if applicable)


## Notes for the Reviewer
