### PR TITLE
backend: replace fmt.Println with structured logger in startup

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -645,8 +645,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 		r = baseRoute.PathPrefix(config.BaseURL).Subrouter()
 	}
 
-	fmt.Println("*** Headlamp Server ***")
-	fmt.Println("  API Routers:")
+	logger.Log(logger.LevelInfo, nil, nil, "*** Headlamp Server ***")
+	logger.Log(logger.LevelInfo, nil, nil, "  API Routers:")
 
 	// load kubeConfig clusters
 	err := kubeconfig.LoadAndStoreKubeConfigs(config.KubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig, skipFunc)


### PR DESCRIPTION
## Summary

This PR replaces `fmt.Println` calls with the structured `logger.Log` utility in the backend startup sequence.

## Related Issue

Fixes #6223

## Changes

- Replaced standard output prints with structured logging calls (`logger.Log(logger.LevelInfo, ...)`) in `backend/cmd/headlamp.go` lines 648-649.

## Steps to Test

1. Navigate to the `backend/` directory.
2. Run backend cmd unit tests to ensure everything builds and passes:
   ```bash
   go test -v ./cmd