### PR TITLE
frontend: Table: Add MRT localizations for Arabic, Hebrew and Russian

### DIFF
--- a/frontend/src/components/common/Table/Table.tsx
+++ b/frontend/src/components/common/Table/Table.tsx
@@ -37,14 +37,17 @@ import {
   useMaterialReactTable,
   useMRT_Rows,
 } from 'material-react-table';
+import { MRT_Localization_AR } from 'material-react-table/locales/ar';
 import { MRT_Localization_DE } from 'material-react-table/locales/de';
 import { MRT_Localization_EN } from 'material-react-table/locales/en';
 import { MRT_Localization_ES } from 'material-react-table/locales/es';
 import { MRT_Localization_FR } from 'material-react-table/locales/fr';
+import { MRT_Localization_HE } from 'material-react-table/locales/he';
 import { MRT_Localization_IT } from 'material-react-table/locales/it';
 import { MRT_Localization_JA } from 'material-react-table/locales/ja';
 import { MRT_Localization_KO } from 'material-react-table/locales/ko';
 import { MRT_Localization_PT } from 'material-react-table/locales/pt';
+import { MRT_Localization_RU } from 'material-react-table/locales/ru';
 import { MRT_Localization_ZH_HANS } from 'material-react-table/locales/zh-Hans';
 import { MRT_Localization_ZH_HANT } from 'material-react-table/locales/zh-Hant';
 import { memo, ReactNode, useEffect, useMemo, useState } from 'react';
@@ -154,15 +157,18 @@ function usePageURLState(
   return [zeroIndexPage, setZeroIndexPage];
 }
 
-const tableLocalizationMap: Record<string, MRT_Localization> = {
+const tableLocalizationMap: Partial<Record<string, MRT_Localization>> = {
+  ar: MRT_Localization_AR,
   de: MRT_Localization_DE,
   en: MRT_Localization_EN,
   es: MRT_Localization_ES,
   fr: MRT_Localization_FR,
+  he: MRT_Localization_HE,
   it: MRT_Localization_IT,
   ja: MRT_Localization_JA,
   pt: MRT_Localization_PT,
   ko: MRT_Localization_KO,
+  ru: MRT_Localization_RU,
   zh: MRT_Localization_ZH_HANS,
   'zh-TW': MRT_Localization_ZH_HANT,
 };


### PR DESCRIPTION
## Summary
This PR fixes missing Material React Table localizations for Arabic, Hebrew,
and Russian by adding the corresponding imports and entries to `tableLocalizationMap`
in `Table.tsx`.

## Related Issue
Fixes #6225 

## Changes
- Added `MRT_Localization_AR`, `MRT_Localization_HE`, `MRT_Localization_RU` imports
  from `material-react-table/locales/`
- Added `ar`, `he`, `ru` entries to `tableLocalizationMap` in `Table.tsx`

## Steps to Test
1. Switch app language to Arabic, Hebrew, or Russian in Settings
2. Navigate to any resource list (e.g. Pods, Deployments)
3. Confirm table strings (search placeholder, pagination, filters) are now
   translated instead of staying in English

## Screenshots (if applicable)

## Notes for the Reviewer
- Headlamp already ships i18n locale files for `ar`, `he`, and `ru` under
  `frontend/src/i18n/locales/` — the table just never got updated to match
- `material-react-table` already includes built-in translations for these
  languages, so this is purely additive — 3 imports and 3 map entries only
- No behavior change, no logic change, zero risk of regression
- @illume
