### PR TITLE
Fix/releaser bump helm chart

### DIFF
--- a/docs/development/release-guide.md
+++ b/docs/development/release-guide.md
@@ -21,10 +21,25 @@ Create a new branch called "rc-X.Y.Z" where X.Y.Z is the new release version.
 
 ### 2. Bump the app “version”
 
-On the main branch, bump the “version” field in app/package.json, run "npm i" inside app/ and commit with:
+If using the automated **Headlamp Releaser** tool (recommended), run the `start` command to automate version bumping, dependency installations, Helm template regeneration, and committing:
 
 ```shell
-git commit app/package* -m "app: Bump version to X.Y.Z"
+# Navigate to the releaser directory, install deps, build/link it, and start the release
+cd tools/releaser
+npm install
+npm run build && npm link
+releaser start X.Y.Z
+```
+
+This will automatically commit the changes with the message:
+`releaser: bump version to X.Y.Z`
+
+If performing the version bump manually instead:
+On the release branch, bump the “version” field in `app/package.json`, run `npm install` inside `app/` (and update Helm Chart version/templates if applicable), then stage and commit the changes with:
+
+```shell
+git add app/package.json app/package-lock.json charts/headlamp/Chart.yaml charts/headlamp/tests/expected_templates
+git commit --signoff -m "releaser: bump version to X.Y.Z"
 ```
 
 Bug fix: make a branch off the tag, and cherry pick everything in. Or make a branch off main and remove merge commits compared to previous tag (On the branch to remove merge commits, do: "`git rebase main`").

--- a/tools/releaser/README.md
+++ b/tools/releaser/README.md
@@ -35,7 +35,8 @@ releaser <command>
 export GITHUB_TOKEN=your-token-here
 
 # 1. Start the release (creates branch hl-rc-0.42.0, bumps version
-#    in app/package.json, runs npm install, and commits)
+#    in app/package.json and charts/headlamp/Chart.yaml, runs npm install,
+#    regenerates Helm templates, and commits)
 releaser start 0.42.0
 
 # 2. Create the GitHub draft release
@@ -79,7 +80,7 @@ For published releases, this also checks extended assets such as container image
 
 ### `start` — Start a new release
 
-Update `app/package.json` with the new version, run `npm install` in the app directory, and commit the changes. By default, a release branch named `hl-rc-<version>` is created.
+Update `app/package.json` and `charts/headlamp/Chart.yaml` with the new version, run `npm install` in the app directory, regenerate Helm expected templates via `make helm-update-template-version` (requires `make`, `bash`, and `helm` on PATH), and commit the changes. By default, a release branch named `hl-rc-<version>` is created.
 
 ```bash
 releaser start <release-version> [options]

--- a/tools/releaser/src/commands/check.ts
+++ b/tools/releaser/src/commands/check.ts
@@ -1,9 +1,13 @@
 import chalk from 'chalk';
 import { getRelease, checkArtifactsForRelease, checkExtendedAssets } from '../utils/github.js';
-import { sanitizeVersion } from '../utils/version.js';
+import { sanitizeVersion, isValidVersion } from '../utils/version.js';
 
 export async function checkRelease(releaseVersion: string): Promise<void> {
   const version = sanitizeVersion(releaseVersion);
+  if (!isValidVersion(version)) {
+    console.error(chalk.red(`Error: Invalid semantic version format "${version}".`));
+    process.exit(1);
+  }
   console.log(chalk.blue(`Checking release for version ${version}...`));
 
   try {

--- a/tools/releaser/src/commands/publish.ts
+++ b/tools/releaser/src/commands/publish.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { getRelease, publishDraftRelease, associateTagWithRelease } from '../utils/github.js';
 import { pushTag } from '../utils/git.js';
-import { sanitizeVersion } from '../utils/version.js';
+import { sanitizeVersion, isValidVersion } from '../utils/version.js';
 
 interface PublishOptions {
   force?: boolean;
@@ -10,6 +10,10 @@ interface PublishOptions {
 
 export async function publishRelease(releaseVersion: string, options: PublishOptions): Promise<void> {
   const version = sanitizeVersion(releaseVersion);
+  if (!isValidVersion(version)) {
+    console.error(chalk.red(`Error: Invalid semantic version format "${version}".`));
+    process.exit(1);
+  }
   console.log(chalk.blue(`Publishing release v${version}...`));
 
   try {

--- a/tools/releaser/src/commands/start.ts
+++ b/tools/releaser/src/commands/start.ts
@@ -2,15 +2,31 @@ import chalk from 'chalk';
 import path from 'path';
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { getRepoRoot, commitVersionChange, branchExists, createAndCheckoutBranch, getCurrentBranch } from '../utils/git.js';
-import { sanitizeVersion } from '../utils/version.js';
+import {
+  getRepoRoot,
+  commitVersionChange,
+  branchExists,
+  createAndCheckoutBranch,
+  getCurrentBranch,
+} from '../utils/git.js';
+import { sanitizeVersion, isValidVersion } from '../utils/version.js';
 
 interface StartOptions {
   noBranch?: boolean;
 }
 
-export function startRelease(releaseVersion: string, options: StartOptions): void {
+export function startRelease(
+  releaseVersion: string,
+  options: StartOptions,
+): void {
   const version = sanitizeVersion(releaseVersion);
+  if (!isValidVersion(version)) {
+    console.error(
+      chalk.red(`Error: Invalid semantic version format "${version}".`),
+    );
+    process.exit(1);
+  }
+
   const branchName = `hl-rc-${version}`;
   let branchCreated = false;
 
@@ -23,14 +39,22 @@ export function startRelease(releaseVersion: string, options: StartOptions): voi
     // Create branch unless --no-branch is specified
     if (!options.noBranch) {
       if (branchExists(branchName)) {
-        console.log(chalk.yellow(`⚠️  Branch ${branchName} already exists, staying on current branch`));
+        console.log(
+          chalk.yellow(
+            `⚠️  Branch ${branchName} already exists, staying on current branch`,
+          ),
+        );
         const currentBranch = getCurrentBranch();
         console.log(chalk.blue(`Current branch: ${currentBranch}`));
       } else {
-        console.log(chalk.blue(`Creating and checking out branch ${branchName}...`));
+        console.log(
+          chalk.blue(`Creating and checking out branch ${branchName}...`),
+        );
         createAndCheckoutBranch(branchName);
         branchCreated = true;
-        console.log(chalk.green(`✅ Created and checked out branch ${branchName}`));
+        console.log(
+          chalk.green(`✅ Created and checked out branch ${branchName}`),
+        );
       }
     }
 
@@ -38,24 +62,89 @@ export function startRelease(releaseVersion: string, options: StartOptions): voi
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
     packageJson.version = version;
 
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-    console.log(chalk.green(`✅ Updated app/package.json with version ${version}`));
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify(packageJson, null, 2) + '\n',
+    );
+    console.log(
+      chalk.green(`✅ Updated app/package.json with version ${version}`),
+    );
+
+    // Update charts/headlamp/Chart.yaml with new version
+    const chartYamlPath = path.join(
+      repoRoot,
+      'charts',
+      'headlamp',
+      'Chart.yaml',
+    );
+    if (!fs.existsSync(chartYamlPath)) {
+      throw new Error(`Chart.yaml not found: ${chartYamlPath}`);
+    }
+    const originalChartYaml = fs.readFileSync(chartYamlPath, 'utf-8');
+    const hasVersion = /^version:\s*.+$/m.test(originalChartYaml);
+    const hasAppVersion = /^appVersion:\s*.+$/m.test(originalChartYaml);
+    if (!hasVersion || !hasAppVersion) {
+      throw new Error(
+        `Expected 'version' and 'appVersion' keys in ${chartYamlPath}`,
+      );
+    }
+    const chartYaml = originalChartYaml
+      .replace(/^version:\s*.+$/m, `version: ${version}`)
+      .replace(/^appVersion:\s*.+$/m, `appVersion: ${version}`);
+    fs.writeFileSync(chartYamlPath, chartYaml, 'utf-8');
+    console.log(
+      chalk.green(
+        `✅ Updated charts/headlamp/Chart.yaml with version ${version}`,
+      ),
+    );
 
     // Run npm install in app directory
     console.log(chalk.blue('Running npm install in app directory...'));
-    execSync('npm install', { stdio: 'inherit', cwd: path.join(repoRoot, 'app') });
+    execSync('npm install', {
+      stdio: 'inherit',
+      cwd: path.join(repoRoot, 'app'),
+    });
     console.log(chalk.green('✅ npm install completed'));
+
+    // Regenerate expected templates
+    console.log(
+      chalk.blue(
+        'Running make helm-update-template-version to update expected templates...',
+      ),
+    );
+    try {
+      execSync('make helm-update-template-version', {
+        stdio: 'inherit',
+        cwd: repoRoot,
+      });
+    } catch (err) {
+      const e = new Error(
+        'Failed to update Helm expected templates. Ensure ' +
+          "'make', 'bash', and 'helm' are installed and available on PATH.",
+      ) as Error & { cause?: unknown };
+      e.cause = err;
+      throw e;
+    }
+    console.log(chalk.green('✅ Expected templates updated'));
 
     // Commit the changes
     console.log(chalk.blue('Committing changes...'));
     commitVersionChange(version);
-    console.log(chalk.green(`✅ Changes committed with message "app: Bump version to ${version}"`));
+    console.log(
+      chalk.green(
+        `✅ Changes committed with message "releaser: bump version to ${version}"`,
+      ),
+    );
 
-    console.log(chalk.green(`\nRelease ${version} has been started successfully!`));
+    console.log(
+      chalk.green(`\nRelease ${version} has been started successfully!`),
+    );
     if (branchCreated) {
       console.log(chalk.blue(`Branch: ${branchName}`));
     }
-    console.log(`You can now create a tag with 'releaser tag' and publish with 'releaser publish ${version}'`);
+    console.log(
+      `You can now create a tag with 'releaser tag' and publish with 'releaser publish ${version}'`,
+    );
   } catch (error) {
     console.error(chalk.red('Error starting release:'));
     console.error(error);

--- a/tools/releaser/src/utils/git.ts
+++ b/tools/releaser/src/utils/git.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { isValidVersion } from './version.js';
 
 export function getRepoRoot(): string {
   try {
@@ -26,13 +27,20 @@ export function getCurrentVersion(): string {
 }
 
 export function commitVersionChange(version: string): void {
+  if (!isValidVersion(version)) {
+    console.error(`Error: Invalid semantic version format "${version}".`);
+    process.exit(1);
+  }
+
   const repoRoot = getRepoRoot();
   const packageJsonPath = path.join(repoRoot, 'app', 'package.json');
   const packageLockJsonPath = path.join(repoRoot, 'app', 'package-lock.json');
+  const chartYamlPath = path.join(repoRoot, 'charts', 'headlamp', 'Chart.yaml');
+  const expectedTemplatesPath = path.join(repoRoot, 'charts', 'headlamp', 'tests', 'expected_templates');
 
   try {
-    execSync(`git add "${packageJsonPath}" "${packageLockJsonPath}"`);
-    execSync(`git commit --signoff -m "app: Bump version to ${version}"`);
+    execSync(`git add "${packageJsonPath}" "${packageLockJsonPath}" "${chartYamlPath}" "${expectedTemplatesPath}"`);
+    execSync(`git commit --signoff -m "releaser: bump version to ${version}"`);
   } catch (error) {
     console.error('Error: Failed to commit version change');
     console.error(error);
@@ -41,6 +49,11 @@ export function commitVersionChange(version: string): void {
 }
 
 export function createReleaseTag(version: string): void {
+  if (!isValidVersion(version)) {
+    console.error(`Error: Invalid semantic version format "${version}".`);
+    process.exit(1);
+  }
+
   try {
     execSync(`git tag -a v${version} -m "Release ${version}"`);
   } catch (error) {
@@ -51,6 +64,11 @@ export function createReleaseTag(version: string): void {
 }
 
 export function pushTag(version: string): void {
+  if (!isValidVersion(version)) {
+    console.error(`Error: Invalid semantic version format "${version}".`);
+    process.exit(1);
+  }
+
   try {
     execSync(`git push origin v${version}`);
   } catch (error) {

--- a/tools/releaser/src/utils/version.ts
+++ b/tools/releaser/src/utils/version.ts
@@ -1,18 +1,37 @@
 import chalk from 'chalk';
+import * as semver from 'semver';
 
 /**
- * Sanitizes a version string by removing any leading 'v' if present.
+ * Sanitizes a version string by trimming whitespace and removing any leading 'v' if present.
  * Warns the user if the input contained a leading 'v'.
  *
  * @param version The version string to sanitize
  * @returns The sanitized version string
  */
 export function sanitizeVersion(version: string): string {
-  if (version.startsWith('v')) {
-    const sanitized = version.substring(1);
-    console.log(chalk.yellow(`Warning: Version "${version}" contains a leading 'v'. The 'v' prefix has been removed.`));
+  const trimmed = version.trim();
+  if (/^[vV]/.test(trimmed)) {
+    const sanitized = trimmed.substring(1);
+    console.log(chalk.yellow(`Warning: Version "${version}" contains a leading 'v' prefix. The prefix has been removed.`));
     console.log(chalk.yellow(`Using version "${sanitized}" instead.`));
     return sanitized;
   }
-  return version;
+  return trimmed;
+}
+
+/**
+ * Validates if a version string is a strict semantic version (no leading/trailing whitespace, no leading 'v' or '=', and no build metadata).
+ * Allows standard semver (e.g. 0.24.0) and prerelease versions (e.g. 0.24.0-rc1).
+ *
+ * @param version The version string to validate
+ * @returns True if valid, false otherwise
+ */
+export function isValidVersion(version: string): boolean {
+  if (version !== version.trim()) {
+    return false;
+  }
+  if (/^[vV=]/.test(version) || version.includes('+')) {
+    return false;
+  }
+  return semver.valid(version) === version;
 }


### PR DESCRIPTION
## Summary

Automate bumping of the Helm chart (`Chart.yaml`) version and `appVersion`, and the regeneration of expected templates during the release startup process (`releaser start`). This ensures that the git tag cut for a release already has the correct Helm chart configuration.

## Related Issue

Fixes #6065

## Changes

- `tools/releaser/src/commands/start.ts`: Updated the `startRelease` function to bump the `version` and `appVersion` in `charts/headlamp/Chart.yaml` to the target release version, and execute `make helm-update-template-version` to update the Helm expected test templates.
- `tools/releaser/src/utils/git.ts`: Updated `commitVersionChange` to stage the modified `charts/headlamp` files in addition to the app package configuration files and updated the commit message structure.

## Steps to Test

1. [Step 1: e.g., Navigate to ...]
2. [Step 2: Click on ...]
3. [Step 3: Observe behavior or check logs/output]

## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated release workflow guidance, including setup and version-start commands.
  - Release preparation now updates Helm chart versions and regenerates expected templates automatically.
  - Release commits include updated chart and template files.

- **Bug Fixes**
  - Added semantic-version validation before checking, preparing, publishing, tagging, or pushing releases.
  - Improved handling of version input, including whitespace and leading `v` prefixes.
  - Added clearer errors when versions are invalid or required release tools are unavailable.

- **Documentation**
  - Updated release instructions for both automated and manual workflows, including dependencies and signoff steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->