### PR TITLE
backend: k8cache: Invalidate named GET cache keys on informer events

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -370,5 +370,7 @@ func invalidateCacheKeysForResourceEvent(
 	}
 
 	namedKey := buildCacheKey(gvr.Group, name, namespace, contextKey)
-	_ = k8scache.Delete(context.Background(), namedKey)
+	if err := k8scache.Delete(context.Background(), namedKey); err != nil {
+		logger.Log(logger.LevelError, nil, err, "error while deleting key")
+	}
 }

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -340,13 +340,35 @@ func handleKeyGenerationAndDeletion(obj interface{}, gvr schema.GroupVersionReso
 		return
 	}
 
-	namespace := unstructuredObj.GetNamespace()
-	key := buildCacheKey(gvr.Group, gvr.Resource, namespace, contextKey)
+	invalidateCacheKeysForResourceEvent(
+		gvr,
+		unstructuredObj.GetNamespace(),
+		unstructuredObj.GetName(),
+		contextKey,
+		k8scache,
+	)
+}
 
-	logger.Log(logger.LevelInfo, nil, nil, redactCacheKey(key)+" will be deleted from the cache")
+// invalidateCacheKeysForResourceEvent evicts cached list responses (including the
+// all-namespace list variant via DeleteKeys) and a cached named GET response.
+// GenerateKey stores list paths with gvr.Resource as the kind segment, but named
+// GET paths use the object name as the kind segment.
+func invalidateCacheKeysForResourceEvent(
+	gvr schema.GroupVersionResource,
+	namespace, name, contextKey string,
+	k8scache cache.Cache[string],
+) {
+	listKey := buildCacheKey(gvr.Group, gvr.Resource, namespace, contextKey)
 
-	if err := k8scache.Delete(context.Background(), key); err != nil {
-		logger.Log(logger.LevelError, nil, err, "error while deleting key")
+	logger.Log(logger.LevelInfo, nil, nil,
+		redactCacheKey(listKey)+" and related cache keys will be deleted from the cache")
+
+	DeleteKeys(listKey, k8scache)
+
+	if name == "" {
 		return
 	}
+
+	namedKey := buildCacheKey(gvr.Group, name, namespace, contextKey)
+	_ = k8scache.Delete(context.Background(), namedKey)
 }

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -439,7 +439,98 @@ func TestRunInformerToWatch_OldResource(t *testing.T) {
 	close(stopCh)
 }
 
-// GetKindAndVerb — missing / empty mux "api" var  (0% branch today)
+func TestInvalidateCacheKeysForResourceEvent(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	contextKey := "test-context"
+	listKey := "+pods+default+" + contextKey
+	allNamespacesKey := "+pods++" + contextKey
+	namedKey := "+test-pod+default+" + contextKey
+	unrelatedKey := "+services+default+" + contextKey
+
+	mockCache := &MockCache{
+		store: map[string]string{
+			listKey:          "list-data",
+			allNamespacesKey: "all-namespaces-list-data",
+			namedKey:         "named-get-data",
+			unrelatedKey:     "unrelated-data",
+		},
+	}
+
+	k8cache.ExportedInvalidateCacheKeysForResourceEvent(
+		gvr, "default", "test-pod", contextKey, mockCache,
+	)
+
+	for _, key := range []string{listKey, allNamespacesKey, namedKey} {
+		_, err := mockCache.Get(context.Background(), key)
+		assert.Error(t, err, "key %q should be evicted", key)
+	}
+
+	val, err := mockCache.Get(context.Background(), unrelatedKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "unrelated-data", val)
+}
+
+// TestRunInformerToWatch_InvalidatesListNamedAndAllNamespaceCacheKeys verifies
+// informer events evict namespaced list, all-namespace list, and named GET keys.
+func TestRunInformerToWatch_InvalidatesListNamedAndAllNamespaceCacheKeys(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	contextKey := "test-context"
+	listKey := "+pods+default+" + contextKey
+	allNamespacesKey := "+pods++" + contextKey
+	namedKey := "+test-pod+default+" + contextKey
+	unrelatedKey := "+services+default+" + contextKey
+
+	mockPod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":              "test-pod",
+				"namespace":         "default",
+				"creationTimestamp": time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	clientMap := map[schema.GroupVersionResource]string{gvr: "PodList"}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, clientMap)
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, 0, "", nil)
+
+	mockCache := &MockCache{
+		store: map[string]string{
+			listKey:          "list-data",
+			allNamespacesKey: "all-namespaces-list-data",
+			namedKey:         "named-get-data",
+			unrelatedKey:     "unrelated-data",
+		},
+	}
+
+	k8cache.RunInformerToWatch([]schema.GroupVersionResource{gvr}, factory, contextKey, mockCache)
+
+	stopCh := make(chan struct{})
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
+
+	err := client.Tracker().Add(mockPod)
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		for _, key := range []string{listKey, allNamespacesKey, namedKey} {
+			if _, err := mockCache.Get(context.Background(), key); err == nil {
+				return false
+			}
+		}
+
+		if _, err := mockCache.Get(context.Background(), unrelatedKey); err != nil {
+			return false
+		}
+
+		return true
+	}, 2*time.Second, 50*time.Millisecond, "informer should evict list, all-namespace, and named GET keys")
+
+	close(stopCh)
+}
 
 // TestGetKindAndVerb_NoMuxVars exercises the early-return path where the
 // "api" mux variable is absent from the request context.

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -152,3 +152,12 @@ func ExportedFilterImportantResources(gvrList []schema.GroupVersionResource) []s
 func ExportedReturnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
 	return returnGVRList(apiResourceLists)
 }
+
+// ExportedInvalidateCacheKeysForResourceEvent exposes invalidateCacheKeysForResourceEvent for testing.
+func ExportedInvalidateCacheKeysForResourceEvent(
+	gvr schema.GroupVersionResource,
+	namespace, name, contextKey string,
+	k8scache cache.Cache[string],
+) {
+	invalidateCacheKeysForResourceEvent(gvr, namespace, name, contextKey, k8scache)
+}


### PR DESCRIPTION
### Summary
Informer-driven cache invalidation in k8cache only deleted list-shaped keys built from gvr.Resource (e.g. +pods+default+<context>). That left two stale-cache gaps:

Named GET / detail views — single-object GETs are cached with the object name in the key segment (e.g. +my-pod+default+<context>), which informer invalidation never cleared.
All-namespace lists — same gap as [#5776](https://github.com/kubernetes-sigs/headlamp/issues/5776): list invalidation did not use DeleteKeys, so +pods++<context> could stay stale.
This PR routes informer invalidation through a new helper that evicts list keys (via DeleteKeys) and named GET keys.

### Motivation
When backend cache is enabled, a user can open a pod detail page, then the pod changes elsewhere (controller, kubectl, another tab). The informer fires, but the cached named GET response can still be served — detail views show stale data.

HandleNonGETCacheInvalidation already uses DeleteKeys for mutations; informer invalidation did not match that behavior.

### Changes
Add invalidateCacheKeysForResourceEvent() in cacheInvalidation.go
On informer add/update/delete, evict:
namespaced list key — e.g. +pods+default+<context>
all-namespace list key — e.g. +pods++<context> (via DeleteKeys)
named GET key — e.g. +<objectName>+default+<context>
Add TestInvalidateCacheKeysForResourceEvent and informer integration coverage
Export helper in export_test.go for unit testing


###Test plan

 cd backend && go test ./pkg/k8cache/ -run TestInvalidateCacheKeysForResourceEvent -v

 Manual: enable --cache-enabled, open pod detail, change pod via kubectl label, refresh detail — data should update (no stale X-HEADLAMP-CACHE body)