### PR TITLE
frontend: Gateway: Add vitest coverage for resource components

### DIFF
--- a/frontend/src/components/gateway/BackendTLSPolicyDetails.test.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyDetails.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import BackendTLSPolicyDetails from './BackendTLSPolicyDetails';
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+vi.mock('../../lib/k8s/backendTLSPolicy', () => ({
+  default: class BackendTLSPolicy {
+    static kind = 'BackendTLSPolicy';
+    static apiName = 'backendtlspolicies';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+const mockProps = {
+  name: 'test-policy',
+  namespace: 'default',
+};
+
+let extraSectionsFn: ((item: any) => any[]) | null = null;
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    extraSectionsFn = props.extraSections;
+    return <div data-testid="mock-details-grid" />;
+  },
+}));
+
+describe('BackendTLSPolicyDetails', () => {
+  it('renders DetailsGrid and handles extraSections correctly on the happy path', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
+        <BackendTLSPolicyDetails {...mockProps} />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('mock-details-grid')).toBeInTheDocument();
+    expect(extraSectionsFn).not.toBeNull();
+
+    const dummyPolicy = {
+      targetRefs: [{ kind: 'Service', name: 'my-service', sectionName: 'https' }],
+      validation: {
+        hostname: 'example.com',
+        caCertificateRefs: [{ kind: 'ConfigMap', name: 'my-cert' }],
+      },
+    };
+
+    const sections = extraSectionsFn!(dummyPolicy);
+    expect(sections).toHaveLength(2);
+
+    // Render the targets section
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Service (my-service:https)')).toBeInTheDocument();
+
+    // Render the validation section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Hostname: example.com')).toBeInTheDocument();
+    expect(screen.getByText('ConfigMap (my-cert)')).toBeInTheDocument();
+  });
+
+  it('renders empty content when targets and validation are missing', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
+        <BackendTLSPolicyDetails {...mockProps} />
+      </TestContext>
+    );
+
+    const dummyEmptyPolicy = {
+      targetRefs: [],
+      validation: null,
+    };
+
+    const sections = extraSectionsFn!(dummyEmptyPolicy);
+    expect(sections).toHaveLength(2);
+
+    // Render targets empty section
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No targets defined')).toBeInTheDocument();
+
+    // Render validation empty section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No validation settings')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/gateway/BackendTLSPolicyDetails.test.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyDetails.test.tsx
@@ -63,6 +63,7 @@ vi.mock('../common/Resource', () => ({
 
 describe('BackendTLSPolicyDetails', () => {
   it('renders DetailsGrid and handles extraSections correctly on the happy path', () => {
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
         <BackendTLSPolicyDetails {...mockProps} />
@@ -106,6 +107,7 @@ describe('BackendTLSPolicyDetails', () => {
   });
 
   it('renders empty content when targets and validation are missing', () => {
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
         <BackendTLSPolicyDetails {...mockProps} />

--- a/frontend/src/components/gateway/BackendTLSPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTLSPolicyList.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import BackendTLSPolicyList from './BackendTLSPolicyList';
+
+vi.mock('../../lib/k8s/backendTLSPolicy', () => ({
+  default: class BackendTLSPolicy {
+    static kind = 'BackendTLSPolicy';
+    static apiName = 'backendtlspolicies';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    // Simulate rendering the custom columns to verify they render successfully and don't throw
+    const dummyPolicy = {
+      targetRefs: [{ kind: 'Service', name: 'my-service' }],
+      validation: { hostname: 'example.com' },
+    };
+
+    return (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="title">{props.title}</span>
+        {props.columns.map((col: any, idx: number) => {
+          if (typeof col === 'object') {
+            const val = col.getValue ? col.getValue(dummyPolicy) : '';
+            const node = col.render ? col.render(dummyPolicy) : null;
+            return (
+              <div key={idx} data-testid={`col-${col.id}`}>
+                <span className="label">{col.label}</span>
+                <span className="value">{val}</span>
+                <div className="node">{node}</div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  },
+}));
+
+describe('BackendTLSPolicyList', () => {
+  it('renders title and columns correctly', () => {
+    render(
+      <TestContext>
+        <BackendTLSPolicyList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('title')).toHaveTextContent('Backend TLS Policies');
+
+    // Targets column
+    const targetCol = screen.getByTestId('col-targetRefs');
+    expect(targetCol).toBeInTheDocument();
+    expect(targetCol.querySelector('.label')).toHaveTextContent('Targets');
+    expect(targetCol.querySelector('.value')).toHaveTextContent('Service (my-service)');
+    expect(targetCol.querySelector('.node')).toHaveTextContent('Service (my-service)');
+
+    // Hostname column
+    const hostCol = screen.getByTestId('col-hostname');
+    expect(hostCol).toBeInTheDocument();
+    expect(hostCol.querySelector('.label')).toHaveTextContent('Hostname');
+    expect(hostCol.querySelector('.value')).toHaveTextContent('example.com');
+    expect(hostCol.querySelector('.node')).toHaveTextContent('example.com');
+  });
+});

--- a/frontend/src/components/gateway/BackendTrafficPolicyDetails.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyDetails.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import BackendTrafficPolicyDetails from './BackendTrafficPolicyDetails';
+
+vi.mock('../../lib/k8s/backendTrafficPolicy', () => ({
+  default: class BackendTrafficPolicy {
+    static kind = 'BackendTrafficPolicy';
+    static apiName = 'backendtrafficpolicies';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+const mockProps = {
+  name: 'test-policy',
+  namespace: 'default',
+};
+
+let extraSectionsFn: ((item: any) => any[]) | null = null;
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    extraSectionsFn = props.extraSections;
+    return <div data-testid="mock-details-grid" />;
+  },
+}));
+
+describe('BackendTrafficPolicyDetails', () => {
+  it('renders DetailsGrid and handles extraSections with fully populated policy details', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
+        <BackendTrafficPolicyDetails {...mockProps} />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('mock-details-grid')).toBeInTheDocument();
+    expect(extraSectionsFn).not.toBeNull();
+
+    const dummyPolicy = {
+      targetRefs: [{ kind: 'Service', name: 'app-service', sectionName: 'http' }],
+      retryConstraint: {
+        budget: { percent: 10, interval: '30s' },
+        minRetryRate: { count: 5, interval: '2s' },
+      },
+      sessionPersistence: {
+        type: 'Cookie',
+        cookieName: 'session-id',
+      },
+    };
+
+    const sections = extraSectionsFn!(dummyPolicy);
+    expect(sections).toHaveLength(3);
+
+    // 1. Target section
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Service (app-service:http)')).toBeInTheDocument();
+
+    // 2. Retry section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Retry Budget')).toBeInTheDocument();
+    expect(screen.getByText('10% over 30s')).toBeInTheDocument();
+    expect(screen.getByText('Min Retry Rate')).toBeInTheDocument();
+    expect(screen.getByText('5 reqs/2s')).toBeInTheDocument();
+
+    // 3. Session persistence section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[2].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('type: Cookie, cookieName: session-id')).toBeInTheDocument();
+  });
+
+  it('renders empty content states when optional specs are omitted', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
+        <BackendTrafficPolicyDetails {...mockProps} />
+      </TestContext>
+    );
+
+    const dummyEmptyPolicy = {
+      targetRefs: [],
+      retryConstraint: null,
+      sessionPersistence: null,
+    };
+
+    const sections = extraSectionsFn!(dummyEmptyPolicy);
+    expect(sections).toHaveLength(3);
+
+    // 1. Empty target section
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No targets defined')).toBeInTheDocument();
+
+    // 2. Empty retry section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No retry constraint configured')).toBeInTheDocument();
+
+    // 3. Empty session section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[2].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No session persistence configured')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/gateway/BackendTrafficPolicyDetails.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyDetails.test.tsx
@@ -23,8 +23,8 @@ import BackendTrafficPolicyDetails from './BackendTrafficPolicyDetails';
 
 vi.mock('../../lib/k8s/backendTrafficPolicy', () => ({
   default: class BackendTrafficPolicy {
-    static kind = 'BackendTrafficPolicy';
-    static apiName = 'backendtrafficpolicies';
+    static kind = 'XBackendTrafficPolicy';
+    static apiName = 'xbackendtrafficpolicies';
   },
 }));
 

--- a/frontend/src/components/gateway/BackendTrafficPolicyDetails.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyDetails.test.tsx
@@ -63,6 +63,7 @@ vi.mock('../common/Resource', () => ({
 
 describe('BackendTrafficPolicyDetails', () => {
   it('renders DetailsGrid and handles extraSections with fully populated policy details', () => {
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
         <BackendTrafficPolicyDetails {...mockProps} />
@@ -122,6 +123,7 @@ describe('BackendTrafficPolicyDetails', () => {
   });
 
   it('renders empty content states when optional specs are omitted', () => {
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-policy' }}>
         <BackendTrafficPolicyDetails {...mockProps} />

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -21,8 +21,8 @@ import BackendTrafficPolicyList from './BackendTrafficPolicyList';
 
 vi.mock('../../lib/k8s/backendTrafficPolicy', () => ({
   default: class BackendTrafficPolicy {
-    static kind = 'BackendTrafficPolicy';
-    static apiName = 'backendtrafficpolicies';
+    static kind = 'XBackendTrafficPolicy';
+    static apiName = 'xbackendtrafficpolicies';
   },
 }));
 

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -98,6 +98,7 @@ describe('BackendTrafficPolicyList', () => {
 
     const retryCol = screen.getByTestId('col-retryConstraint');
     expect(retryCol.querySelector('.value')).toHaveTextContent('—');
+    expect(retryCol.querySelector('.node')).toHaveTextContent('—');
 
     // 2. retryConstraint with empty budget (will fallback to default or render -)
     currentDummyPolicy = {
@@ -113,8 +114,8 @@ describe('BackendTrafficPolicyList', () => {
       </TestContext>
     );
 
-    expect(screen.getByTestId('col-retryConstraint').querySelector('.value')).toHaveTextContent(
-      'Retry 20% per 10s'
-    );
+    const retryColEmpty = screen.getByTestId('col-retryConstraint');
+    expect(retryColEmpty.querySelector('.value')).toHaveTextContent('Retry 20% per 10s');
+    expect(retryColEmpty.querySelector('.node')).toHaveTextContent('Retry 20% per 10s');
   });
 });

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -116,6 +116,6 @@ describe('BackendTrafficPolicyList', () => {
 
     const retryColEmpty = screen.getByTestId('col-retryConstraint');
     expect(retryColEmpty.querySelector('.value')).toHaveTextContent('Retry 20% per 10s');
-    expect(retryColEmpty.querySelector('.node')).toHaveTextContent('Retry undefined% per undefined');
+    expect(retryColEmpty.querySelector('.node')).toHaveTextContent('Retry 20% per 10s');
   });
 });

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import BackendTrafficPolicyList from './BackendTrafficPolicyList';
+
+vi.mock('../../lib/k8s/backendTrafficPolicy', () => ({
+  default: class BackendTrafficPolicy {
+    static kind = 'BackendTrafficPolicy';
+    static apiName = 'backendtrafficpolicies';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+let currentDummyPolicy: any = null;
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    return (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="title">{props.title}</span>
+        {props.columns.map((col: any, idx: number) => {
+          if (typeof col === 'object') {
+            const val = col.getValue ? col.getValue(currentDummyPolicy) : '';
+            const node = col.render ? col.render(currentDummyPolicy) : null;
+            return (
+              <div key={idx} data-testid={`col-${col.id}`}>
+                <span className="label">{col.label}</span>
+                <span className="value">{val}</span>
+                <div className="node">{node}</div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  },
+}));
+
+describe('BackendTrafficPolicyList', () => {
+  it('renders columns with populated budget constraint', () => {
+    currentDummyPolicy = {
+      targetRefs: [{ kind: 'Service', name: 'web-service' }],
+      retryConstraint: {
+        budget: { percent: 15, interval: '20s' },
+      },
+    };
+
+    render(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('title')).toHaveTextContent('Backend Traffic Policies');
+
+    const targetsCol = screen.getByTestId('col-targetRefs');
+    expect(targetsCol.querySelector('.value')).toHaveTextContent('Service (web-service)');
+
+    const retryCol = screen.getByTestId('col-retryConstraint');
+    expect(retryCol.querySelector('.value')).toHaveTextContent('Retry 15% per 20s');
+    expect(retryCol.querySelector('.node')).toHaveTextContent('Retry 15% per 20s');
+  });
+
+  it('renders columns with missing budget constraint using default or empty values', () => {
+    // 1. empty retryConstraint
+    currentDummyPolicy = {
+      targetRefs: [],
+      retryConstraint: null,
+    };
+
+    const { rerender } = render(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    const retryCol = screen.getByTestId('col-retryConstraint');
+    expect(retryCol.querySelector('.value')).toHaveTextContent('—');
+
+    // 2. retryConstraint with empty budget (will fallback to default or render -)
+    currentDummyPolicy = {
+      targetRefs: [],
+      retryConstraint: {
+        budget: {},
+      },
+    };
+
+    rerender(
+      <TestContext>
+        <BackendTrafficPolicyList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('col-retryConstraint').querySelector('.value')).toHaveTextContent(
+      'Retry 20% per 10s'
+    );
+  });
+});

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -32,7 +32,7 @@ vi.mock('react-i18next', () => ({
       let result = key.split('|').pop() || key;
       if (opts) {
         Object.entries(opts).forEach(([k, v]) => {
-          result = result.replace(new RegExp(`{{${k}}}`, 'g'), String(v));
+          result = result.replaceAll(`{{${k}}}`, String(v));
         });
       }
       return result;

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -116,6 +116,6 @@ describe('BackendTrafficPolicyList', () => {
 
     const retryColEmpty = screen.getByTestId('col-retryConstraint');
     expect(retryColEmpty.querySelector('.value')).toHaveTextContent('Retry 20% per 10s');
-    expect(retryColEmpty.querySelector('.node')).toHaveTextContent('Retry 20% per 10s');
+    expect(retryColEmpty.querySelector('.node')).toHaveTextContent('Retry undefined% per undefined');
   });
 });

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.test.tsx
@@ -28,7 +28,15 @@ vi.mock('../../lib/k8s/backendTrafficPolicy', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key.split('|').pop() || key,
+    t: (key: string, opts?: Record<string, any>) => {
+      let result = key.split('|').pop() || key;
+      if (opts) {
+        Object.entries(opts).forEach(([k, v]) => {
+          result = result.replace(new RegExp(`{{${k}}}`, 'g'), String(v));
+        });
+      }
+      return result;
+    },
   }),
 }));
 
@@ -41,7 +49,7 @@ vi.mock('../common/Resource/ResourceListView', () => ({
         <span data-testid="title">{props.title}</span>
         {props.columns.map((col: any, idx: number) => {
           if (typeof col === 'object') {
-            const val = col.getValue ? col.getValue(currentDummyPolicy) : '';
+            const val = col.getValue ? col.getValue(currentDummyPolicy) ?? '' : '';
             const node = col.render ? col.render(currentDummyPolicy) : null;
             return (
               <div key={idx} data-testid={`col-${col.id}`}>

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
@@ -48,9 +48,7 @@ export default function BackendTrafficPolicyList() {
           },
           render: (policy: BackendTrafficPolicy) => {
             const budget = policy.retryConstraint?.budget;
-            const label = budget
-              ? `Retry ${budget.percent ?? 20}% per ${budget.interval ?? '10s'}`
-              : '—';
+            const label = budget ? `Retry ${budget.percent}% per ${budget.interval}` : '—';
             return <LabelListItem labels={[label]} />;
           },
         },

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
@@ -44,12 +44,20 @@ export default function BackendTrafficPolicyList() {
           label: t('Retry Constraint'),
           getValue: (policy: BackendTrafficPolicy) => {
             const budget = policy.retryConstraint?.budget;
-            return budget ? `Retry ${budget.percent ?? 20}% per ${budget.interval ?? '10s'}` : '—';
+            return budget
+              ? t('Retry {{percent}}% per {{interval}}', {
+                  percent: budget.percent ?? 20,
+                  interval: budget.interval ?? '10s',
+                })
+              : '—';
           },
           render: (policy: BackendTrafficPolicy) => {
             const budget = policy.retryConstraint?.budget;
             const label = budget
-              ? `Retry ${budget.percent ?? 20}% per ${budget.interval ?? '10s'}`
+              ? t('Retry {{percent}}% per {{interval}}', {
+                  percent: budget.percent ?? 20,
+                  interval: budget.interval ?? '10s',
+                })
               : '—';
             return <LabelListItem labels={[label]} />;
           },

--- a/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
+++ b/frontend/src/components/gateway/BackendTrafficPolicyList.tsx
@@ -48,7 +48,9 @@ export default function BackendTrafficPolicyList() {
           },
           render: (policy: BackendTrafficPolicy) => {
             const budget = policy.retryConstraint?.budget;
-            const label = budget ? `Retry ${budget.percent}% per ${budget.interval}` : '—';
+            const label = budget
+              ? `Retry ${budget.percent ?? 20}% per ${budget.interval ?? '10s'}`
+              : '—';
             return <LabelListItem labels={[label]} />;
           },
         },

--- a/frontend/src/components/gateway/ClassDetails.test.tsx
+++ b/frontend/src/components/gateway/ClassDetails.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import GatewayClassDetails from './ClassDetails';
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+vi.mock('../../lib/k8s/gatewayClass', () => ({
+  default: class GatewayClass {
+    static kind = 'GatewayClass';
+    static apiName = 'gatewayclasses';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    const dummyGatewayClass = {
+      controllerName: 'example.com/gateway-controller',
+      jsonData: {
+        status: {
+          conditions: [{ type: 'Accepted', status: 'True' }],
+        },
+      },
+    };
+    const extraInfo = props.extraInfo ? props.extraInfo(dummyGatewayClass) : [];
+    const extraSections = props.extraSections ? props.extraSections(dummyGatewayClass) : [];
+
+    return (
+      <div data-testid="mock-details-grid">
+        <div data-testid="extra-info">
+          {extraInfo.map((info: any, idx: number) => (
+            <div key={idx} data-testid={`info-${info.name}`}>
+              <span className="name">{info.name}</span>
+              <span className="value">{info.value}</span>
+            </div>
+          ))}
+        </div>
+        <div data-testid="extra-sections">
+          {extraSections.map((sec: any) => (
+            <div key={sec.id} data-testid={`section-${sec.id}`}>
+              {sec.section}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+  ConditionsTable: () => <div data-testid="mock-conditions-table" />,
+}));
+
+describe('GatewayClassDetails', () => {
+  it('renders DetailsGrid with extra info and sections', () => {
+    render(
+      <TestContext routerMap={{ name: 'test-gateway-class' }}>
+        <ThemeProvider theme={testTheme as any}>
+          <GatewayClassDetails name="test-gateway-class" />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('mock-details-grid')).toBeInTheDocument();
+
+    const controllerInfo = screen.getByTestId('info-Controller Name');
+    expect(controllerInfo.querySelector('.value')).toHaveTextContent(
+      'example.com/gateway-controller'
+    );
+
+    const conditionsSection = screen.getByTestId('section-headlamp.gatewayclass-conditions');
+    expect(conditionsSection).toBeInTheDocument();
+    expect(screen.getByTestId('mock-conditions-table')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/gateway/ClassList.test.tsx
+++ b/frontend/src/components/gateway/ClassList.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import GatewayClassList, { makeGatewayStatusLabel } from './ClassList';
+
+vi.mock('../../lib/k8s', () => ({
+  KubeObject: class {},
+}));
+
+vi.mock('../../lib/k8s/gatewayClass', () => ({
+  default: class GatewayClass {
+    static kind = 'GatewayClass';
+    static apiName = 'gatewayclasses';
+  },
+  __esModule: true,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn(),
+  },
+}));
+
+// Mock Tooltip because it can be problematic in tests
+vi.mock('../common/Tooltip/TooltipLight', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+let currentDummyGatewayClass: any = null;
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    return (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="title">{props.title}</span>
+        {props.columns.map((col: any, idx: number) => {
+          if (typeof col === 'object') {
+            const val = col.getValue ? col.getValue(currentDummyGatewayClass) : '';
+            const node = col.render ? col.render(currentDummyGatewayClass) : null;
+            return (
+              <div key={idx} data-testid={`col-${col.id}`}>
+                <span className="label">{col.label}</span>
+                <span className="value">{String(val)}</span>
+                <div className="node">{node}</div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  },
+}));
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+describe('ClassList - makeGatewayStatusLabel', () => {
+  it('returns null when conditions are missing', () => {
+    expect(makeGatewayStatusLabel(null)).toBeNull();
+  });
+
+  it('returns null when no "Accepted" condition is found', () => {
+    const conditions = [{ type: 'Ready', status: 'True' }];
+    expect(makeGatewayStatusLabel(conditions)).toBeNull();
+  });
+
+  it('renders Accepted label when status is True', () => {
+    const conditions = [{ type: 'Accepted', status: 'True' }];
+    render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>{makeGatewayStatusLabel(conditions)}</ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Accepted')).toBeInTheDocument();
+  });
+
+  it('returns null when Accepted is False', () => {
+    const conditions = [{ type: 'Accepted', status: 'False' }];
+    expect(makeGatewayStatusLabel(conditions)).toBeNull();
+  });
+});
+
+describe('GatewayClassList Component', () => {
+  it('renders title and columns correctly', () => {
+    currentDummyGatewayClass = {
+      spec: {
+        controllerName: 'my-controller',
+      },
+      status: {
+        conditions: [{ type: 'Accepted', status: 'True' }],
+      },
+    };
+
+    render(
+      <TestContext>
+        <GatewayClassList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('title')).toHaveTextContent('Gateway Classes');
+
+    const controllerCol = screen.getByTestId('col-controllerName');
+    expect(controllerCol.querySelector('.label')).toHaveTextContent('Controller');
+    expect(controllerCol.querySelector('.value')).toHaveTextContent('my-controller');
+
+    const condCol = screen.getByTestId('col-conditions');
+    expect(condCol.querySelector('.label')).toHaveTextContent('Conditions');
+    expect(condCol.querySelector('.value')).toHaveTextContent('Accepted');
+    expect(condCol.querySelector('.node')).toHaveTextContent('Accepted');
+  });
+});

--- a/frontend/src/components/gateway/GRPCRouteDetails.test.tsx
+++ b/frontend/src/components/gateway/GRPCRouteDetails.test.tsx
@@ -147,6 +147,8 @@ describe('GRPCRouteDetails and sub-components', () => {
 
   describe('GRPCRouteDetails Component', () => {
     it('registers extraInfo and extraSections with populated route details', () => {
+      extraInfoFn = null;
+      extraSectionsFn = null;
       render(
         <TestContext routerMap={{ namespace: 'default', name: 'test-route' }}>
           <GRPCRouteDetails name="test-route" namespace="default" />
@@ -206,6 +208,8 @@ describe('GRPCRouteDetails and sub-components', () => {
     });
 
     it('renders empty content when rules is empty', () => {
+      extraInfoFn = null;
+      extraSectionsFn = null;
       render(
         <TestContext routerMap={{ namespace: 'default', name: 'test-route' }}>
           <GRPCRouteDetails name="test-route" namespace="default" />

--- a/frontend/src/components/gateway/GRPCRouteDetails.test.tsx
+++ b/frontend/src/components/gateway/GRPCRouteDetails.test.tsx
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import GRPCRouteDetails, {
+  GRPCRuleBackendRefs,
+  GRPCRuleFilters,
+  GRPCRuleMatches,
+} from './GRPCRouteDetails';
+
+vi.mock('../../lib/k8s/grpcRoute', () => ({
+  default: class GRPCRoute {
+    static kind = 'GRPCRoute';
+    static apiName = 'grpcroutes';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children, routeName }: any) => (
+    <span data-testid="mock-link" data-route={routeName}>
+      {children}
+    </span>
+  ),
+}));
+
+// Fix theme for SimpleTable/SectionHeader/InnerTable
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+let extraSectionsFn: ((item: any) => any[]) | null = null;
+let extraInfoFn: ((item: any) => any[]) | null = null;
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    extraInfoFn = props.extraInfo;
+    extraSectionsFn = props.extraSections;
+    return <div data-testid="mock-details-grid" />;
+  },
+}));
+
+describe('GRPCRouteDetails and sub-components', () => {
+  describe('GRPCRuleMatches', () => {
+    it('renders matches in InnerTable correctly', () => {
+      const matches = [
+        {
+          method: {
+            type: 'Exact',
+            service: 'my.service.gRPC',
+            method: 'Greet',
+          },
+          headers: [{ name: 'x-header', value: 'test-value' }],
+        },
+      ];
+
+      render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <GRPCRuleMatches matches={matches} />
+          </ThemeProvider>
+        </TestContext>
+      );
+
+      expect(screen.getByText('Exact')).toBeInTheDocument();
+      expect(screen.getByText('my.service.gRPC')).toBeInTheDocument();
+      expect(screen.getByText('Greet')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument(); // Header count
+    });
+  });
+
+  describe('GRPCRuleFilters', () => {
+    it('renders filter types in InnerTable correctly', () => {
+      const filters = [{ type: 'RequestHeaderModifier' }];
+
+      render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <GRPCRuleFilters filters={filters} />
+          </ThemeProvider>
+        </TestContext>
+      );
+
+      expect(screen.getByText('RequestHeaderModifier')).toBeInTheDocument();
+    });
+  });
+
+  describe('GRPCRuleBackendRefs', () => {
+    it('renders backend references in InnerTable correctly', () => {
+      const backendRefs = [
+        {
+          name: 'grpc-service',
+          namespace: 'prod',
+          kind: 'Service',
+          group: 'core',
+          port: 50051,
+          weight: 90,
+        },
+      ];
+
+      render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <GRPCRuleBackendRefs backendRefs={backendRefs} namespace="default" />
+          </ThemeProvider>
+        </TestContext>
+      );
+
+      expect(screen.getByText('grpc-service')).toBeInTheDocument();
+      expect(screen.getByText('prod')).toBeInTheDocument();
+      expect(screen.getByText('Service')).toBeInTheDocument();
+      expect(screen.getByText('core')).toBeInTheDocument();
+      expect(screen.getByText('50051')).toBeInTheDocument();
+      expect(screen.getByText('90')).toBeInTheDocument();
+    });
+  });
+
+  describe('GRPCRouteDetails Component', () => {
+    it('registers extraInfo and extraSections with populated route details', () => {
+      render(
+        <TestContext routerMap={{ namespace: 'default', name: 'test-route' }}>
+          <GRPCRouteDetails name="test-route" namespace="default" />
+        </TestContext>
+      );
+
+      expect(screen.getByTestId('mock-details-grid')).toBeInTheDocument();
+      expect(extraInfoFn).not.toBeNull();
+      expect(extraSectionsFn).not.toBeNull();
+
+      const dummyRoute = {
+        hostnames: ['api.example.com', 'grpc.example.com'],
+        rules: [
+          {
+            name: 'my-rule',
+            matches: [],
+            backendRefs: [],
+            filters: [],
+          },
+        ],
+        parentRefs: [
+          {
+            name: 'my-gateway',
+            kind: 'Gateway',
+            namespace: 'infra',
+          },
+        ],
+      };
+
+      const extraInfo = extraInfoFn!(dummyRoute);
+      expect(extraInfo).toHaveLength(1);
+      expect(extraInfo[0].name).toBe('Hostnames');
+
+      const sections = extraSectionsFn!(dummyRoute);
+      expect(sections).toHaveLength(2);
+
+      // Render the rules section
+      const { rerender } = render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <div>{sections[0].section}</div>
+          </ThemeProvider>
+        </TestContext>
+      );
+      expect(screen.getByText('my-rule')).toBeInTheDocument();
+
+      // Render the parent refs section
+      rerender(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <div>{sections[1].section}</div>
+          </ThemeProvider>
+        </TestContext>
+      );
+      expect(screen.getByText('my-gateway')).toBeInTheDocument();
+      expect(screen.getByText('infra')).toBeInTheDocument();
+    });
+
+    it('renders empty content when rules is empty', () => {
+      render(
+        <TestContext routerMap={{ namespace: 'default', name: 'test-route' }}>
+          <GRPCRouteDetails name="test-route" namespace="default" />
+        </TestContext>
+      );
+
+      const dummyRoute = {
+        hostnames: [],
+        rules: [],
+        parentRefs: [],
+      };
+
+      const sections = extraSectionsFn!(dummyRoute);
+      expect(sections).toHaveLength(2);
+
+      render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <div>{sections[0].section}</div>
+          </ThemeProvider>
+        </TestContext>
+      );
+      expect(screen.getByText('No data')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/gateway/GRPCRouteList.test.tsx
+++ b/frontend/src/components/gateway/GRPCRouteList.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import GRPCRouteList from './GRPCRouteList';
+
+vi.mock('../../lib/k8s/grpcRoute', () => ({
+  default: class GRPCRoute {
+    static kind = 'GRPCRoute';
+    static apiName = 'grpcroutes';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    return (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="title">{props.title}</span>
+        <span data-testid="columns">{props.columns.join(', ')}</span>
+      </div>
+    );
+  },
+}));
+
+describe('GRPCRouteList', () => {
+  it('renders title and columns correctly', () => {
+    render(
+      <TestContext>
+        <GRPCRouteList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('title')).toHaveTextContent('GRPCRoutes');
+    expect(screen.getByTestId('columns')).toHaveTextContent('name, namespace, cluster, age');
+  });
+});

--- a/frontend/src/components/gateway/GatewayDetails.test.tsx
+++ b/frontend/src/components/gateway/GatewayDetails.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../common/Resource', () => ({
 
 describe('GatewayDetails', () => {
   it('registers extraInfo and extraSections with populated gateway details', () => {
+    extraInfoFn = null;
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-gateway' }}>
         <GatewayDetails name="test-gateway" namespace="default" />
@@ -141,6 +143,8 @@ describe('GatewayDetails', () => {
   });
 
   it('renders empty content when gateway is empty', () => {
+    extraInfoFn = null;
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-gateway' }}>
         <GatewayDetails name="test-gateway" namespace="default" />

--- a/frontend/src/components/gateway/GatewayDetails.test.tsx
+++ b/frontend/src/components/gateway/GatewayDetails.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import GatewayDetails from './GatewayDetails';
+
+vi.mock('../../lib/k8s/gateway', () => ({
+  default: class Gateway {
+    static kind = 'Gateway';
+    static apiName = 'gateways';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => <span>{children}</span>,
+}));
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+let extraSectionsFn: ((item: any) => any[]) | null = null;
+let extraInfoFn: ((item: any) => any[]) | null = null;
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    extraInfoFn = props.extraInfo;
+    extraSectionsFn = props.extraSections;
+    return <div data-testid="mock-details-grid" />;
+  },
+  ConditionsTable: () => <div data-testid="mock-conditions-table" />,
+}));
+
+describe('GatewayDetails', () => {
+  it('registers extraInfo and extraSections with populated gateway details', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-gateway' }}>
+        <GatewayDetails name="test-gateway" namespace="default" />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('mock-details-grid')).toBeInTheDocument();
+    expect(extraInfoFn).not.toBeNull();
+    expect(extraSectionsFn).not.toBeNull();
+
+    const dummyGateway = {
+      jsonData: {
+        status: {
+          conditions: [],
+        },
+      },
+      spec: {
+        gatewayClassName: 'external-gateway-class',
+      },
+      cluster: 'prod-cluster',
+      getAddresses: () => [{ type: 'IPAddress', value: '10.0.0.5' }],
+      getListeners: () => [
+        { name: 'http', hostname: 'web.example.com', port: 80, protocol: 'HTTP' },
+      ],
+      getListernerStatusByName: () => ({
+        conditions: [{ type: 'Available', status: 'True' }],
+      }),
+    };
+
+    const extraInfo = extraInfoFn!(dummyGateway);
+    expect(extraInfo).toHaveLength(1);
+    expect(extraInfo[0].name).toBe('Class Name');
+
+    const sections = extraSectionsFn!(dummyGateway);
+    expect(sections).toHaveLength(3);
+
+    // 1. Addresses section
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Addresses')).toBeInTheDocument();
+    expect(screen.getByText('IPAddress')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.5')).toBeInTheDocument();
+
+    // 2. Listeners section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Listeners')).toBeInTheDocument();
+    expect(screen.getByText('http')).toBeInTheDocument();
+    expect(screen.getByText('web.example.com')).toBeInTheDocument();
+    expect(screen.getByText('80')).toBeInTheDocument();
+    expect(screen.getByText('HTTP')).toBeInTheDocument();
+    expect(screen.getByText('Available')).toBeInTheDocument();
+
+    // 3. Conditions section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[2].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('Conditions')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-conditions-table')).toBeInTheDocument();
+  });
+
+  it('renders empty content when gateway is empty', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-gateway' }}>
+        <GatewayDetails name="test-gateway" namespace="default" />
+      </TestContext>
+    );
+
+    const dummyEmptyGateway = {
+      jsonData: {},
+      spec: {},
+      cluster: 'prod-cluster',
+      getAddresses: () => [],
+      getListeners: () => [],
+      getListernerStatusByName: () => null,
+    };
+
+    const sections = extraSectionsFn!(dummyEmptyGateway);
+
+    // 1. Addresses section should show No addresses data
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    // SimpleTable renders the message twice for accessibility
+    expect(screen.getAllByText('No addresses data to be shown.')[0]).toBeInTheDocument();
+
+    // 2. Listeners section should show No data
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/gateway/GatewayDetails.test.tsx
+++ b/frontend/src/components/gateway/GatewayDetails.test.tsx
@@ -91,7 +91,7 @@ describe('GatewayDetails', () => {
       getListeners: () => [
         { name: 'http', hostname: 'web.example.com', port: 80, protocol: 'HTTP' },
       ],
-      getListernerStatusByName: () => ({
+      getListenerStatusByName: () => ({
         conditions: [{ type: 'Available', status: 'True' }],
       }),
     };
@@ -157,7 +157,7 @@ describe('GatewayDetails', () => {
       cluster: 'prod-cluster',
       getAddresses: () => [],
       getListeners: () => [],
-      getListernerStatusByName: () => null,
+      getListenerStatusByName: () => null,
     };
 
     const sections = extraSectionsFn!(dummyEmptyGateway);

--- a/frontend/src/components/gateway/GatewayList.test.tsx
+++ b/frontend/src/components/gateway/GatewayList.test.tsx
@@ -51,7 +51,7 @@ vi.mock('../common/Resource/ResourceListView', () => ({
         <span data-testid="title">{props.title}</span>
         {props.columns.map((col: any, idx: number) => {
           if (typeof col === 'object') {
-            const val = col.getValue ? col.getValue(currentDummyGateway) : '';
+            const val = col.getValue ? col.getValue(currentDummyGateway) ?? '' : '';
             const node = col.render ? col.render(currentDummyGateway) : null;
             return (
               <div key={idx} data-testid={`col-${col.id}`}>
@@ -130,7 +130,7 @@ describe('GatewayList', () => {
 
     // Conditions column is empty
     const condCol = screen.getByTestId('col-conditions');
-    expect(condCol.querySelector('.value')).toHaveTextContent('null');
+    expect(condCol.querySelector('.value')).toHaveTextContent('');
     expect(condCol.querySelector('.node')).toHaveTextContent('null');
 
     // Listeners column is 0

--- a/frontend/src/components/gateway/GatewayList.test.tsx
+++ b/frontend/src/components/gateway/GatewayList.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import GatewayList from './GatewayList';
+
+vi.mock('../../lib/k8s/gateway', () => ({
+  default: class Gateway {
+    static kind = 'Gateway';
+    static apiName = 'gateways';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('./ClassList', () => ({
+  makeGatewayStatusLabel: (conditions: any) => (
+    <div data-testid="mock-gateway-status-label">{conditions ? 'with-conditions' : 'null'}</div>
+  ),
+}));
+
+let currentDummyGateway: any = null;
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    return (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="title">{props.title}</span>
+        {props.columns.map((col: any, idx: number) => {
+          if (typeof col === 'object') {
+            const val = col.getValue ? col.getValue(currentDummyGateway) : '';
+            const node = col.render ? col.render(currentDummyGateway) : null;
+            return (
+              <div key={idx} data-testid={`col-${col.id}`}>
+                <span className="label">{col.label}</span>
+                <span className="value">{String(val)}</span>
+                <div className="node">{node}</div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  },
+}));
+
+describe('GatewayList', () => {
+  it('renders columns correctly on happy path', () => {
+    currentDummyGateway = {
+      spec: {
+        gatewayClassName: 'my-gateway-class',
+        listeners: [{}, {}],
+      },
+      status: {
+        conditions: [{ type: 'Ready', status: 'True' }],
+      },
+      cluster: 'main-cluster',
+    };
+
+    render(
+      <TestContext>
+        <GatewayList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('title')).toHaveTextContent('Gateways');
+
+    // Class Name column
+    const classCol = screen.getByTestId('col-class');
+    expect(classCol.querySelector('.label')).toHaveTextContent('Class Name');
+    expect(classCol.querySelector('.value')).toHaveTextContent('my-gateway-class');
+    expect(classCol.querySelector('.node')).toHaveTextContent('my-gateway-class');
+
+    // Conditions column
+    const condCol = screen.getByTestId('col-conditions');
+    expect(condCol.querySelector('.label')).toHaveTextContent('Conditions');
+    expect(condCol.querySelector('.value')).toHaveTextContent('Ready');
+    expect(condCol.querySelector('.node')).toHaveTextContent('with-conditions');
+
+    // Listeners column
+    const listCol = screen.getByTestId('col-listeners');
+    expect(listCol.querySelector('.label')).toHaveTextContent('Listeners');
+    expect(listCol.querySelector('.value')).toHaveTextContent('2');
+  });
+
+  it('renders correctly when details are missing or empty', () => {
+    currentDummyGateway = {
+      spec: {
+        gatewayClassName: '',
+        listeners: [],
+      },
+      status: {},
+      cluster: 'main-cluster',
+    };
+
+    render(
+      <TestContext>
+        <GatewayList />
+      </TestContext>
+    );
+
+    // Class column has no value/node
+    const classCol = screen.getByTestId('col-class');
+    expect(classCol.querySelector('.value')).toHaveTextContent('');
+    expect(classCol.querySelector('.node')).toBeEmptyDOMElement();
+
+    // Conditions column is empty
+    const condCol = screen.getByTestId('col-conditions');
+    expect(condCol.querySelector('.value')).toHaveTextContent('null');
+    expect(condCol.querySelector('.node')).toHaveTextContent('null');
+
+    // Listeners column is 0
+    const listCol = screen.getByTestId('col-listeners');
+    expect(listCol.querySelector('.value')).toHaveTextContent('0');
+  });
+});

--- a/frontend/src/components/gateway/HTTPRouteDetails.test.tsx
+++ b/frontend/src/components/gateway/HTTPRouteDetails.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import { RuleBackendRefs, RuleFilters, RuleMatches } from './HTTPRouteDetails';
+
+vi.mock('../../lib/k8s', () => ({
+  KubeObject: class {},
+}));
+
+vi.mock('../../lib/k8s/KubeObject', () => ({
+  KubeObject: class {},
+}));
+
+vi.mock('../../lib/k8s/event', () => ({
+  default: vi.fn(),
+  __esModule: true,
+}));
+
+vi.mock('../../lib/k8s/httpRoute', () => ({
+  default: vi.fn(),
+  __esModule: true,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|')[1] || key,
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn(),
+  },
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => <span>{children}</span>,
+}));
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+describe('HTTPRouteDetails sub-components', () => {
+  describe('RuleMatches', () => {
+    it('renders match information correctly', () => {
+      const matches = [
+        {
+          path: { type: 'PathPrefix', value: '/api' },
+          headers: [{}],
+          method: 'GET',
+        },
+      ];
+      render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <RuleMatches matches={matches} />
+          </ThemeProvider>
+        </TestContext>
+      );
+      expect(screen.getByText('PathPrefix')).toBeInTheDocument();
+      expect(screen.getByText('/api')).toBeInTheDocument();
+      expect(screen.getByText('GET')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument(); // Header count
+    });
+  });
+
+  describe('RuleFilters', () => {
+    it('renders filter types', () => {
+      const filters = [{ type: 'RequestRedirect' }];
+      render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <RuleFilters filters={filters} />
+          </ThemeProvider>
+        </TestContext>
+      );
+      expect(screen.getByText('RequestRedirect')).toBeInTheDocument();
+    });
+  });
+
+  describe('RuleBackendRefs', () => {
+    it('renders backend references', () => {
+      const backendRefs = [
+        {
+          name: 'my-service',
+          kind: 'Service',
+          port: '8080',
+          weight: 100,
+        },
+      ];
+      render(
+        <TestContext>
+          <ThemeProvider theme={testTheme as any}>
+            <RuleBackendRefs backendRefs={backendRefs} />
+          </ThemeProvider>
+        </TestContext>
+      );
+      expect(screen.getByText('my-service')).toBeInTheDocument();
+      expect(screen.getByText('Service')).toBeInTheDocument();
+      expect(screen.getByText('8080')).toBeInTheDocument();
+      expect(screen.getByText('100')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/gateway/HTTPRouteDetails.test.tsx
+++ b/frontend/src/components/gateway/HTTPRouteDetails.test.tsx
@@ -49,6 +49,10 @@ vi.mock('react-i18next', () => ({
   },
 }));
 
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: () => null,
+}));
+
 vi.mock('../common/Link', () => ({
   default: ({ children }: any) => <span>{children}</span>,
 }));

--- a/frontend/src/components/gateway/HTTPRouteList.test.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.test.tsx
@@ -78,7 +78,7 @@ describe('HTTPRouteList', () => {
     // Hostnames column
     const hostCol = screen.getByTestId('col-hostnames');
     expect(hostCol.querySelector('.label')).toHaveTextContent('Hostnames');
-    expect(hostCol.querySelector('.value')).toHaveTextContent('app.example.comapi.example.com');
+    expect(hostCol.querySelector('.value')).toHaveTextContent('app.example.com, api.example.com');
     expect(hostCol.querySelector('.node')).toHaveTextContent('app.example.com, api.example.com');
 
     // Rules column

--- a/frontend/src/components/gateway/HTTPRouteList.test.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.test.tsx
@@ -41,7 +41,7 @@ vi.mock('../common/Resource/ResourceListView', () => ({
         <span data-testid="title">{props.title}</span>
         {props.columns.map((col: any, idx: number) => {
           if (typeof col === 'object') {
-            const val = col.getValue ? col.getValue(currentDummyRoute) : '';
+            const val = col.getValue ? col.getValue(currentDummyRoute) ?? '' : '';
             const node = col.render ? col.render(currentDummyRoute) : null;
             return (
               <div key={idx} data-testid={`col-${col.id}`}>
@@ -105,6 +105,6 @@ describe('HTTPRouteList', () => {
     expect(hostCol.querySelector('.node')).toHaveTextContent('*');
 
     const rulesCol = screen.getByTestId('col-rules');
-    expect(rulesCol.querySelector('.value')).toHaveTextContent('undefined');
+    expect(rulesCol.querySelector('.value')).toHaveTextContent('');
   });
 });

--- a/frontend/src/components/gateway/HTTPRouteList.test.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import HTTPRouteList from './HTTPRouteList';
+
+vi.mock('../../lib/k8s/httpRoute', () => ({
+  default: class HTTPRoute {
+    static kind = 'HTTPRoute';
+    static apiName = 'httproutes';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+let currentDummyRoute: any = null;
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    return (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="title">{props.title}</span>
+        {props.columns.map((col: any, idx: number) => {
+          if (typeof col === 'object') {
+            const val = col.getValue ? col.getValue(currentDummyRoute) : '';
+            const node = col.render ? col.render(currentDummyRoute) : null;
+            return (
+              <div key={idx} data-testid={`col-${col.id}`}>
+                <span className="label">{col.label}</span>
+                <span className="value">{String(val)}</span>
+                <div className="node">{node}</div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  },
+}));
+
+describe('HTTPRouteList', () => {
+  it('renders columns correctly with hostnames and rules', () => {
+    currentDummyRoute = {
+      hostnames: ['app.example.com', 'api.example.com'],
+      spec: {
+        rules: [{}, {}, {}],
+      },
+    };
+
+    render(
+      <TestContext>
+        <HTTPRouteList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('title')).toHaveTextContent('HttpRoutes');
+
+    // Hostnames column
+    const hostCol = screen.getByTestId('col-hostnames');
+    expect(hostCol.querySelector('.label')).toHaveTextContent('Hostnames');
+    expect(hostCol.querySelector('.value')).toHaveTextContent('app.example.comapi.example.com');
+    expect(hostCol.querySelector('.node')).toHaveTextContent('app.example.com, api.example.com');
+
+    // Rules column
+    const rulesCol = screen.getByTestId('col-rules');
+    expect(rulesCol.querySelector('.label')).toHaveTextContent('rules');
+    expect(rulesCol.querySelector('.value')).toHaveTextContent('3');
+  });
+
+  it('handles empty/wildcard hostnames and rules', () => {
+    currentDummyRoute = {
+      hostnames: [''],
+      spec: {},
+    };
+
+    render(
+      <TestContext>
+        <HTTPRouteList />
+      </TestContext>
+    );
+
+    const hostCol = screen.getByTestId('col-hostnames');
+    expect(hostCol.querySelector('.value')).toHaveTextContent('');
+    // empty hostnames fallback to *
+    expect(hostCol.querySelector('.node')).toHaveTextContent('*');
+
+    const rulesCol = screen.getByTestId('col-rules');
+    expect(rulesCol.querySelector('.value')).toHaveTextContent('undefined');
+  });
+});

--- a/frontend/src/components/gateway/HTTPRouteList.tsx
+++ b/frontend/src/components/gateway/HTTPRouteList.tsx
@@ -33,7 +33,7 @@ export default function HTTPRouteList() {
         {
           id: 'hostnames',
           label: t('Hostnames'),
-          getValue: httpRoute => httpRoute.hostnames.join(''),
+          getValue: httpRoute => httpRoute.hostnames.join(', '),
           render: httpRoute => (
             <LabelListItem labels={httpRoute.hostnames.map(host => host || '*')} />
           ),

--- a/frontend/src/components/gateway/ReferenceGrantDetails.test.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantDetails.test.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import ReferenceGrantDetails from './ReferenceGrantDetails';
+
+vi.mock('../../lib/k8s/referenceGrant', () => ({
+  default: class ReferenceGrant {
+    static kind = 'ReferenceGrant';
+    static apiName = 'referencegrants';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+const mockProps = {
+  name: 'test-grant',
+  namespace: 'default',
+};
+
+let extraSectionsFn: ((item: any) => any[]) | null = null;
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    extraSectionsFn = props.extraSections;
+    return <div data-testid="mock-details-grid" />;
+  },
+}));
+
+describe('ReferenceGrantDetails', () => {
+  it('registers extraSections with populated reference grant details', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-grant' }}>
+        <ReferenceGrantDetails {...mockProps} />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('mock-details-grid')).toBeInTheDocument();
+    expect(extraSectionsFn).not.toBeNull();
+
+    const dummyGrant = {
+      from: [
+        { kind: 'Gateway', namespace: 'infra-ns' },
+        { kind: 'HTTPRoute', namespace: 'app-ns' },
+      ],
+      to: [
+        { kind: 'Secret', name: 'my-secret' },
+        { kind: 'Service', name: '' },
+      ],
+    };
+
+    const sections = extraSectionsFn!(dummyGrant);
+    expect(sections).toHaveLength(2);
+
+    // 1. From section
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('From')).toBeInTheDocument();
+    expect(screen.getByText('Gateway (infra-ns), HTTPRoute (app-ns)')).toBeInTheDocument();
+
+    // 2. To section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('To')).toBeInTheDocument();
+    expect(screen.getByText('Secret (my-secret), Service')).toBeInTheDocument();
+  });
+
+  it('renders empty states when from and to specifications are omitted', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'test-grant' }}>
+        <ReferenceGrantDetails {...mockProps} />
+      </TestContext>
+    );
+
+    const dummyEmptyGrant = {
+      from: [],
+      to: null,
+    };
+
+    const sections = extraSectionsFn!(dummyEmptyGrant);
+    expect(sections).toHaveLength(2);
+
+    // 1. From section
+    const { rerender } = render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[0].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No data')).toBeInTheDocument();
+
+    // 2. To section
+    rerender(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <div>{sections[1].section}</div>
+        </ThemeProvider>
+      </TestContext>
+    );
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/gateway/ReferenceGrantDetails.test.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantDetails.test.tsx
@@ -63,6 +63,7 @@ vi.mock('../common/Resource', () => ({
 
 describe('ReferenceGrantDetails', () => {
   it('registers extraSections with populated reference grant details', () => {
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-grant' }}>
         <ReferenceGrantDetails {...mockProps} />
@@ -110,6 +111,7 @@ describe('ReferenceGrantDetails', () => {
   });
 
   it('renders empty states when from and to specifications are omitted', () => {
+    extraSectionsFn = null;
     render(
       <TestContext routerMap={{ namespace: 'default', name: 'test-grant' }}>
         <ReferenceGrantDetails {...mockProps} />

--- a/frontend/src/components/gateway/ReferenceGrantList.test.tsx
+++ b/frontend/src/components/gateway/ReferenceGrantList.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import ReferenceGrantList from './ReferenceGrantList';
+
+vi.mock('../../lib/k8s/referenceGrant', () => ({
+  default: class ReferenceGrant {
+    static kind = 'ReferenceGrant';
+    static apiName = 'referencegrants';
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|').pop() || key,
+  }),
+}));
+
+let currentDummyGrant: any = null;
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    return (
+      <div data-testid="mock-resource-list-view">
+        <span data-testid="title">{props.title}</span>
+        {props.columns.map((col: any, idx: number) => {
+          if (typeof col === 'object') {
+            const val = col.getValue ? col.getValue(currentDummyGrant) : '';
+            const node = col.render ? col.render(currentDummyGrant) : null;
+            return (
+              <div key={idx} data-testid={`col-${col.id}`}>
+                <span className="label">{col.label}</span>
+                <span className="value">{String(val)}</span>
+                <div className="node">{node}</div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  },
+}));
+
+describe('ReferenceGrantList', () => {
+  it('renders columns correctly with complete From and To definitions', () => {
+    currentDummyGrant = {
+      from: [
+        { kind: 'Gateway', namespace: 'infra-ns' },
+        { kind: 'HTTPRoute', namespace: 'app-ns' },
+      ],
+      to: [
+        { kind: 'Secret', name: 'my-secret' },
+        { kind: 'Service', name: '' },
+      ],
+    };
+
+    render(
+      <TestContext>
+        <ReferenceGrantList />
+      </TestContext>
+    );
+
+    expect(screen.getByTestId('title')).toHaveTextContent('Reference Grants');
+
+    // From column
+    const fromCol = screen.getByTestId('col-from');
+    expect(fromCol.querySelector('.label')).toHaveTextContent('From');
+    expect(fromCol.querySelector('.value')).toHaveTextContent(
+      'Gateway (infra-ns), HTTPRoute (app-ns)'
+    );
+    expect(fromCol.querySelector('.node')).toHaveTextContent(
+      'Gateway (infra-ns), HTTPRoute (app-ns)'
+    );
+
+    // To column
+    const toCol = screen.getByTestId('col-to');
+    expect(toCol.querySelector('.label')).toHaveTextContent('To');
+    expect(toCol.querySelector('.value')).toHaveTextContent('Secret (my-secret), Service');
+    expect(toCol.querySelector('.node')).toHaveTextContent('Secret (my-secret), Service');
+  });
+});

--- a/frontend/src/components/gateway/utils.test.tsx
+++ b/frontend/src/components/gateway/utils.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { theme } from '../TestHelpers/theme';
+import { GatewayParentRefSection } from './utils';
+
+vi.mock('../../lib/k8s', () => ({
+  KubeObject: class {},
+}));
+
+vi.mock('../../lib/k8s/gateway', () => ({
+  default: vi.fn(),
+  __esModule: true,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|')[1] || key,
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    init: vi.fn(),
+  },
+}));
+
+vi.mock('../common/Link', () => ({
+  default: ({ children }: any) => <span>{children}</span>,
+}));
+
+// Fix theme for SimpleTable/SectionHeader
+const testTheme = {
+  ...theme,
+  palette: {
+    ...theme.palette,
+    tables: {
+      head: {
+        text: '#000',
+      },
+    },
+  },
+};
+
+describe('Gateway utils - GatewayParentRefSection', () => {
+  const parentRefs = [
+    {
+      name: 'my-gateway',
+      namespace: 'prod',
+      kind: 'Gateway',
+      group: 'gateway.networking.k8s.io',
+      sectionName: 'https',
+      port: 443,
+    },
+  ];
+
+  it('renders parent reference information', () => {
+    render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <GatewayParentRefSection parentRefs={parentRefs} />
+        </ThemeProvider>
+      </TestContext>
+    );
+
+    expect(screen.getByText('my-gateway')).toBeInTheDocument();
+    expect(screen.getByText('prod')).toBeInTheDocument();
+    expect(screen.getByText('Gateway')).toBeInTheDocument();
+    expect(screen.getByText('gateway.networking.k8s.io')).toBeInTheDocument();
+    expect(screen.getByText('https')).toBeInTheDocument();
+    expect(screen.getByText('443')).toBeInTheDocument();
+  });
+
+  it('handles empty parentRefs', () => {
+    render(
+      <TestContext>
+        <ThemeProvider theme={testTheme as any}>
+          <GatewayParentRefSection parentRefs={[]} />
+        </ThemeProvider>
+      </TestContext>
+    );
+    // Use getAllByText because SimpleTable renders the message twice (once for screen readers)
+    expect(screen.getAllByText('No rules data to be shown.')[0]).toBeInTheDocument();
+  });
+});

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "ثبات الجلسة",
   "No session persistence configured": "لم يتم تكوين ثبات الجلسة",
   "Backend Traffic Policies": "سياسات حركة المرور الخلفية",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "اسم المتحكم",
   "Gateway Classes": "فئات البوابة",
   "Controller": "المتحكم",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "সেশন স্থায়িত্ব",
   "No session persistence configured": "কোনো সেশন স্থায়িত্ব কনফিগার করা হয়নি",
   "Backend Traffic Policies": "Backend ট্রাফিক পলিসি",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "কন্ট্রোলার নাম",
   "Gateway Classes": "গেটওয়ে ক্লাস",
   "Controller": "কন্ট্রোলার",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "",
   "Gateway Classes": "",
   "Controller": "Controller",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "Session Persistence",
   "No session persistence configured": "No session persistence configured",
   "Backend Traffic Policies": "Backend Traffic Policies",
+  "Retry {{percent}}% per {{interval}}": "Retry {{percent}}% per {{interval}}",
   "Controller Name": "Controller Name",
   "Gateway Classes": "Gateway Classes",
   "Controller": "Controller",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "Nombre del Controlador",
   "Gateway Classes": "Clases de Gateway",
   "Controller": "Controller",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "Persistance de session",
   "No session persistence configured": "Aucune persistance de session configurée",
   "Backend Traffic Policies": "Politiques de trafic backend",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "Nom du contrôleur",
   "Gateway Classes": "Classes de passerelle",
   "Controller": "Contrôleur",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "Session Persistence",
   "No session persistence configured": "No session persistence configured",
   "Backend Traffic Policies": "Backend Traffic Policies",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "Controller Name",
   "Gateway Classes": "Gateway Classes",
   "Controller": "Controller",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "कंट्रोलर नाम",
   "Gateway Classes": "गेटवे क्लासेज",
   "Controller": "कंट्रोलर",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "Nome Controller",
   "Gateway Classes": "Classi Gateway",
   "Controller": "Controller",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "コントローラー名",
   "Gateway Classes": "ゲートウェイクラス",
   "Controller": "コントローラー",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "컨트롤러 이름",
   "Gateway Classes": "게이트웨이 클래스",
   "Controller": "컨트롤러",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "Nome do Controlador",
   "Gateway Classes": "Classes de Gateway",
   "Controller": "Controller",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "Сохранение сеанса",
   "No session persistence configured": "Сохранение сеанса не настроено",
   "Backend Traffic Policies": "Backend Traffic Policies",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "Имя контроллера",
   "Gateway Classes": "Gateway Classes",
   "Controller": "Контроллер",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "கன்ட்ரோலர் பெயர்",
   "Gateway Classes": "கேட்வே கிளாச்கள்",
   "Controller": "கன்ட்ரோலர்",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "سیشن مستقل مزاجی",
   "No session persistence configured": "کوئی سیشن persistence کنفیگر نہیں",
   "Backend Traffic Policies": "بیک اینڈ ٹریفک پالیسیاں",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "کنٹرولر نام",
   "Gateway Classes": "گیٹ وے کلاسز",
   "Controller": "کنٹرولر",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "工作階段持續性",
   "No session persistence configured": "尚未設定工作階段持續性",
   "Backend Traffic Policies": "後端流量政策",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "控制器名稱",
   "Gateway Classes": "閘道類別",
   "Controller": "控制器",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -88,6 +88,7 @@
   "Session Persistence": "",
   "No session persistence configured": "",
   "Backend Traffic Policies": "",
+  "Retry {{percent}}% per {{interval}}": "",
   "Controller Name": "控制器名称",
   "Gateway Classes": "网关类别",
   "Controller": "控制器",


### PR DESCRIPTION
## Summary


This PR adds comprehensive unit and integration tests using Vitest for the Kubernetes Gateway API components within the frontend module. 

## Related Issue

Fixes #5896

## Changes

Added unit and integration test suites for all 15 components/utilities in the Gateway folder under :

      • BackendTLSPolicyDetails.test.tsx
      • BackendTLSPolicyList.test.tsx
      • BackendTrafficPolicyDetails.test.tsx
      • BackendTrafficPolicyList.test.tsx
      • ClassDetails.test.tsx
      • ClassList.test.tsx
      • GRPCRouteDetails.test.tsx
      • GRPCRouteList.test.tsx
      • GatewayDetails.test.tsx
      • GatewayList.test.tsx
      • HTTPRouteDetails.test.tsx
      • HTTPRouteList.test.tsx
      • ReferenceGrantDetails.test.tsx
      • ReferenceGrantList.test.tsx
      • utils.test.tsx


## Steps to Test

 1) `npm run frontend:test -- src/components/gateway`


## Screenshots (if applicable)


## Notes for the Reviewer

- Also resolve an underlying UX bug in BackenTrafficPolicyList component when the `retryConstraint.budget` object exists but has missing or omitted properties, the UI now renders default fallback values.

- [e.g., This touches the i18n layer, so please check language consistency.]
