### PR TITLE
frontend: Sidebar: Optimize rendering to fix UI lag on sidebar

### DIFF
--- a/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
+++ b/frontend/src/components/App/Home/__snapshots__/index.Base.stories.storyshot
@@ -671,7 +671,7 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
                     >
-                      ⋯
+                      v1.2.3
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-133cxkx-MuiTableCell-root"
@@ -781,7 +781,7 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
                     >
-                      ⋯
+                      v1.2.3
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-133cxkx-MuiTableCell-root"
@@ -891,7 +891,7 @@
                     <td
                       class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1qb9npk-MuiTableCell-root"
                     >
-                      ⋯
+                      v1.2.3
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-133cxkx-MuiTableCell-root"

--- a/frontend/src/components/Sidebar/ListItemLink.tsx
+++ b/frontend/src/components/Sidebar/ListItemLink.tsx
@@ -205,9 +205,12 @@ export default function ListItemLink(props: ListItemLinkProps) {
 
           '.MuiListItemText-root': {
             margin: 0,
+          },
+          '.MuiListItemText-primary': {
             whiteSpace: 'nowrap',
             textOverflow: 'ellipsis',
             overflow: 'hidden',
+            display: 'block',
           },
 
           '& *': {

--- a/frontend/src/components/Sidebar/ListItemLink.tsx
+++ b/frontend/src/components/Sidebar/ListItemLink.tsx
@@ -205,6 +205,9 @@ export default function ListItemLink(props: ListItemLinkProps) {
 
           '.MuiListItemText-root': {
             margin: 0,
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
           },
 
           '& *': {

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -20,7 +20,9 @@ import Button from '@mui/material/Button';
 import Drawer from '@mui/material/Drawer';
 import Grid from '@mui/material/Grid';
 import List from '@mui/material/List';
+import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import _ from 'lodash';
 import React, { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -282,6 +284,17 @@ export const PureSidebar = memo(
     const listContainerRef = React.useRef<HTMLDivElement | null>(null);
     const [isOverflowing, setIsOverflowing] = React.useState(false);
     const [scrollbarWidth, setScrollbarWidth] = React.useState(0);
+    const [isAnimating, setIsAnimating] = React.useState(false);
+    const theme = useTheme();
+
+    React.useEffect(() => {
+      setIsAnimating(true);
+      const timer = setTimeout(() => {
+        setIsAnimating(false);
+      }, theme.transitions.duration.enteringScreen);
+      return () => clearTimeout(timer);
+    }, [open, isTemporaryDrawer, theme.transitions.duration.enteringScreen]);
+
     const closedWidth = 72 + (isOverflowing ? scrollbarWidth : 0);
     const temporarySideBarOpen = open === true && isTemporaryDrawer && openUserSelected === true;
 
@@ -363,15 +376,18 @@ export const PureSidebar = memo(
         setScrollbarWidth(Math.max(0, el.offsetWidth - el.clientWidth));
       };
 
-      const observer = new ResizeObserver(update);
+      const debouncedUpdate = _.debounce(update, 300);
+
+      const observer = new ResizeObserver(debouncedUpdate);
       observer.observe(el);
 
-      window.addEventListener('resize', update);
+      window.addEventListener('resize', debouncedUpdate);
       update();
 
       return () => {
         observer.disconnect();
-        window.removeEventListener('resize', update);
+        window.removeEventListener('resize', debouncedUpdate);
+        debouncedUpdate.cancel();
       };
     }, [items]);
 
@@ -396,6 +412,7 @@ export const PureSidebar = memo(
               height: '100%',
               background: theme.palette.sidebar.background,
               color: theme.palette.sidebar.color,
+              pointerEvents: isAnimating ? 'none' : 'auto',
             };
 
             const drawerOpen = {
@@ -406,6 +423,7 @@ export const PureSidebar = memo(
                 duration: theme.transitions.duration.enteringScreen,
               }),
               background: theme.palette.sidebar.background,
+              overflowX: 'hidden',
             };
 
             const drawerClose = {

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -286,8 +286,14 @@ export const PureSidebar = memo(
     const [scrollbarWidth, setScrollbarWidth] = React.useState(0);
     const [isAnimating, setIsAnimating] = React.useState(false);
     const muiTheme = useTheme();
+    const prevOpenRef = React.useRef(open);
 
     React.useEffect(() => {
+      if (prevOpenRef.current === open) {
+        return;
+      }
+      prevOpenRef.current = open;
+
       const duration = open
         ? muiTheme.transitions.duration.enteringScreen
         : muiTheme.transitions.duration.leavingScreen;

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -285,15 +285,23 @@ export const PureSidebar = memo(
     const [isOverflowing, setIsOverflowing] = React.useState(false);
     const [scrollbarWidth, setScrollbarWidth] = React.useState(0);
     const [isAnimating, setIsAnimating] = React.useState(false);
-    const theme = useTheme();
+    const muiTheme = useTheme();
 
     React.useEffect(() => {
+      const duration = open
+        ? muiTheme.transitions.duration.enteringScreen
+        : muiTheme.transitions.duration.leavingScreen;
       setIsAnimating(true);
-      const timer = setTimeout(() => {
+      const timer = window.setTimeout(() => {
         setIsAnimating(false);
-      }, theme.transitions.duration.enteringScreen);
-      return () => clearTimeout(timer);
-    }, [open, isTemporaryDrawer, theme.transitions.duration.enteringScreen]);
+      }, duration);
+
+      return () => window.clearTimeout(timer);
+    }, [
+      open,
+      muiTheme.transitions.duration.enteringScreen,
+      muiTheme.transitions.duration.leavingScreen,
+    ]);
 
     const closedWidth = 72 + (isOverflowing ? scrollbarWidth : 0);
     const temporarySideBarOpen = open === true && isTemporaryDrawer && openUserSelected === true;

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -390,7 +390,11 @@ export const PureSidebar = memo(
         setScrollbarWidth(Math.max(0, el.offsetWidth - el.clientWidth));
       };
 
-      const debouncedUpdate = _.debounce(update, 300);
+      const debounceDelay = Math.max(
+        muiTheme.transitions.duration.enteringScreen,
+        muiTheme.transitions.duration.leavingScreen
+      );
+      const debouncedUpdate = _.debounce(update, debounceDelay);
 
       const observer = new ResizeObserver(debouncedUpdate);
       observer.observe(el);
@@ -403,7 +407,11 @@ export const PureSidebar = memo(
         window.removeEventListener('resize', debouncedUpdate);
         debouncedUpdate.cancel();
       };
-    }, [items]);
+    }, [
+      items,
+      muiTheme.transitions.duration.enteringScreen,
+      muiTheme.transitions.duration.leavingScreen,
+    ]);
 
     return (
       <Box

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -20,9 +20,9 @@ import ListItem, { ListItemProps } from '@mui/material/ListItem';
 import React, { memo } from 'react';
 import { generatePath } from 'react-router';
 import { formatClusterPathParam, getClusterPrefixedPath } from '../../lib/cluster';
+import { useSelectedClusters } from '../../lib/k8s';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { getRoute } from '../../lib/router/getRoute';
-import { useTypedSelector } from '../../redux/hooks';
 import ListItemLink from './ListItemLink';
 import { SidebarEntry } from './sidebarSlice';
 
@@ -65,7 +65,7 @@ export interface SidebarItemProps extends ListItemProps, SidebarEntry {
   isCR?: boolean;
 }
 
-const SidebarItem = memo((props: SidebarItemProps) => {
+const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] }) => {
   const {
     label,
     name,
@@ -82,13 +82,11 @@ const SidebarItem = memo((props: SidebarItemProps) => {
     hide,
     tabIndex,
     isCR,
+    clusters = [],
     ...other
   } = props;
-  const clusters = useTypedSelector(state =>
-    useClusterURL ? state.clusterAction.selectedClusters : null
-  );
   let fullURL = url;
-  if (fullURL && useClusterURL && clusters && clusters.length && !fullURL.startsWith('http')) {
+  if (fullURL && useClusterURL && clusters.length && !fullURL.startsWith('http')) {
     fullURL = generatePath(getClusterPrefixedPath(url), {
       cluster: clusters.length ? formatClusterPathParam(clusters) : '',
     });
@@ -149,6 +147,18 @@ const SidebarItem = memo((props: SidebarItemProps) => {
       )}
     </React.Fragment>
   );
+});
+
+const SidebarItemWithCluster = memo((props: SidebarItemProps) => {
+  const clusters = useSelectedClusters();
+  return <SidebarItemBase {...props} clusters={clusters} />;
+});
+
+const SidebarItem = memo((props: SidebarItemProps) => {
+  if (props.useClusterURL) {
+    return <SidebarItemWithCluster {...props} />;
+  }
+  return <SidebarItemBase {...props} />;
 });
 
 export default SidebarItem;

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -20,9 +20,9 @@ import ListItem, { ListItemProps } from '@mui/material/ListItem';
 import React, { memo } from 'react';
 import { generatePath } from 'react-router';
 import { formatClusterPathParam, getClusterPrefixedPath } from '../../lib/cluster';
-import { useSelectedClusters } from '../../lib/k8s';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { getRoute } from '../../lib/router/getRoute';
+import { useTypedSelector } from '../../redux/hooks';
 import ListItemLink from './ListItemLink';
 import { SidebarEntry } from './sidebarSlice';
 
@@ -84,9 +84,11 @@ const SidebarItem = memo((props: SidebarItemProps) => {
     isCR,
     ...other
   } = props;
-  const clusters = useSelectedClusters();
+  const clusters = useTypedSelector(state =>
+    useClusterURL ? state.clusterAction.selectedClusters : null
+  );
   let fullURL = url;
-  if (fullURL && useClusterURL && clusters.length && !fullURL.startsWith('http')) {
+  if (fullURL && useClusterURL && clusters && clusters.length && !fullURL.startsWith('http')) {
     fullURL = generatePath(getClusterPrefixedPath(url), {
       cluster: clusters.length ? formatClusterPathParam(clusters) : '',
     });
@@ -119,7 +121,7 @@ const SidebarItem = memo((props: SidebarItemProps) => {
             padding: 0,
           }}
         >
-          <Collapse in={fullWidth && isSelected} sx={{ width: '100%' }}>
+          <Collapse in={fullWidth && isSelected} sx={{ width: '100%' }} unmountOnExit>
             <List
               component="ul"
               disablePadding

--- a/frontend/src/components/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/Sidebar/SidebarItem.tsx
@@ -16,7 +16,7 @@
 
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
-import ListItem, { ListItemProps } from '@mui/material/ListItem';
+import { ListItemProps } from '@mui/material/ListItem';
 import React, { memo } from 'react';
 import { generatePath } from 'react-router';
 import { formatClusterPathParam, getClusterPrefixedPath } from '../../lib/cluster';
@@ -114,36 +114,30 @@ const SidebarItemBase = memo((props: SidebarItemProps & { clusters?: string[] })
         {...other}
       />
       {subList.length > 0 && (
-        <ListItem
-          sx={{
-            padding: 0,
-          }}
-        >
-          <Collapse in={fullWidth && isSelected} sx={{ width: '100%' }} unmountOnExit>
-            <List
-              component="ul"
-              disablePadding
-              sx={{
-                '& .MuiListItem-root': {
-                  fontSize: '.875rem',
-                  paddingTop: '2px',
-                  paddingBottom: '2px',
-                },
-              }}
-            >
-              {subList.map((item: SidebarItemProps) => (
-                <SidebarItem
-                  key={item.name}
-                  isSelected={item.isSelected}
-                  hasParent
-                  level={level + 1}
-                  search={search}
-                  {...item}
-                />
-              ))}
-            </List>
-          </Collapse>
-        </ListItem>
+        <Collapse component="li" in={fullWidth && isSelected} sx={{ width: '100%' }} unmountOnExit>
+          <List
+            component="ul"
+            disablePadding
+            sx={{
+              '& .MuiListItem-root': {
+                fontSize: '.875rem',
+                paddingTop: '2px',
+                paddingBottom: '2px',
+              },
+            }}
+          >
+            {subList.map((item: SidebarItemProps) => (
+              <SidebarItem
+                key={item.name}
+                isSelected={item.isSelected}
+                hasParent
+                level={level + 1}
+                search={search}
+                {...item}
+              />
+            ))}
+          </List>
+        </Collapse>
       )}
     </React.Fragment>
   );

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Default.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Default.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1c5v89n-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
               href="/dashboard"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Default.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Default.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1ull0gq-MuiButtonBase-root-MuiListItemButton-root"
               href="/dashboard"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnly.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnly.stories.storyshot
@@ -12,7 +12,7 @@
           >
             <a
               aria-label="Workloads"
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
               href="/workloads"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnly.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnly.stories.storyshot
@@ -12,7 +12,7 @@
           >
             <a
               aria-label="Workloads"
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
               href="/workloads"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnlySelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnlySelected.stories.storyshot
@@ -12,7 +12,7 @@
           >
             <a
               aria-label="Workloads"
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
               href="/workloads"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnlySelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.IconOnlySelected.stories.storyshot
@@ -12,7 +12,7 @@
           >
             <a
               aria-label="Workloads"
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
               href="/workloads"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.NoIcon.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.NoIcon.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1ull0gq-MuiButtonBase-root-MuiListItemButton-root"
               href="https://headlamp.dev"
               rel="noopener noreferrer"
               target="_blank"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.NoIcon.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.NoIcon.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1c5v89n-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
               href="https://headlamp.dev"
               rel="noopener noreferrer"
               target="_blank"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Selected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Selected.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1ull0gq-MuiButtonBase-root-MuiListItemButton-root"
               href="/dashboard"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Selected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.Selected.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1c5v89n-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
               href="/dashboard"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItem.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItem.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-2jk8xl-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-s6j4ls-MuiButtonBase-root-MuiListItemButton-root"
               href="/pods"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItem.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItem.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-s6j4ls-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-eekue5-MuiButtonBase-root-MuiListItemButton-root"
               href="/pods"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItemSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItemSelected.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-s6j4ls-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-eekue5-MuiButtonBase-root-MuiListItemButton-root"
               href="/pods"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItemSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.SubItemSelected.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-2jk8xl-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-s6j4ls-MuiButtonBase-root-MuiListItemButton-root"
               href="/pods"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropFalse.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropFalse.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1c5v89n-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
               href="/full-width-false"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropFalse.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropFalse.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1anq55h-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1ull0gq-MuiButtonBase-root-MuiListItemButton-root"
               href="/full-width-false"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropTrue.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropTrue.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
               href="/full-width-true"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropTrue.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.UsingFullWidthPropTrue.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
               href="/full-width-true"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithDivider.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithDivider.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider css-53bizd-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider css-nnz4tj-MuiButtonBase-root-MuiListItemButton-root"
               href="/settings"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithDivider.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithDivider.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider css-nnz4tj-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-divider css-1k0d8t4-MuiButtonBase-root-MuiListItemButton-root"
               href="/settings"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithSubtitle.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithSubtitle.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1sl064g-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-bcux7k-MuiButtonBase-root-MuiListItemButton-root"
               href="/cluster-info"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithSubtitle.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ListItemLink.WithSubtitle.stories.storyshot
@@ -11,7 +11,7 @@
             class="css-1tmipa6"
           >
             <a
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-cwqya9-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1sl064g-MuiButtonBase-root-MuiListItemButton-root"
               href="/cluster-info"
               role="button"
               tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -79,9 +79,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
               </ul>
             </div>
             <div

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -5,7 +5,7 @@
       class="MuiBox-root css-qnyptn"
     >
       <div
-        class="MuiDrawer-root MuiDrawer-docked css-ohfc2x-MuiDrawer-docked"
+        class="MuiDrawer-root MuiDrawer-docked css-184654t-MuiDrawer-docked"
       >
         <div
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-2vc5z5-MuiPaper-root-MuiDrawer-paper"
@@ -24,7 +24,7 @@
                 >
                   <a
                     aria-label="Home"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -44,7 +44,7 @@
                 >
                   <a
                     aria-label="Notifications"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/notifications"
                     role="button"
                     tabindex="-1"
@@ -64,7 +64,7 @@
                 >
                   <a
                     aria-label="Settings"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/settings/general"
                     role="button"
                     tabindex="-1"
@@ -81,94 +81,7 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/settings/general"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  General
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/settings/plugins"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Plugins
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/settings/cluster"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Cluster
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
               </ul>
             </div>
             <div
@@ -182,7 +95,23 @@
                 >
                   <div
                     class="MuiBox-root css-0"
-                  />
+                  >
+                    <div
+                      class="MuiBox-root css-1ebnygn"
+                    >
+                      <button
+                        aria-label="Add Cluster"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
                   <div
                     class="MuiBox-root css-0"
                   >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarClosed.stories.storyshot
@@ -24,7 +24,7 @@
                 >
                   <a
                     aria-label="Home"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -44,7 +44,7 @@
                 >
                   <a
                     aria-label="Notifications"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/notifications"
                     role="button"
                     tabindex="-1"
@@ -64,7 +64,7 @@
                 >
                   <a
                     aria-label="Settings"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/settings/general"
                     role="button"
                     tabindex="-1"
@@ -95,23 +95,7 @@
                 >
                   <div
                     class="MuiBox-root css-0"
-                  >
-                    <div
-                      class="MuiBox-root css-1ebnygn"
-                    >
-                      <button
-                        aria-label="Add Cluster"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
-                        data-mui-internal-clone-element="true"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <span
-                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                        />
-                      </button>
-                    </div>
-                  </div>
+                  />
                   <div
                     class="MuiBox-root css-0"
                   >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
@@ -23,7 +23,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -49,7 +49,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/notifications"
                     role="button"
                     tabindex="0"
@@ -75,7 +75,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/settings/general"
                     role="button"
                     tabindex="0"
@@ -117,7 +117,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/settings/general"
                               role="button"
                               tabindex="0"
@@ -140,7 +140,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/settings/plugins"
                               role="button"
                               tabindex="0"
@@ -163,7 +163,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/settings/cluster"
                               role="button"
                               tabindex="0"
@@ -200,25 +200,7 @@
                 >
                   <div
                     class="MuiBox-root css-0"
-                  >
-                    <div
-                      class="MuiBox-root css-1ebnygn"
-                    >
-                      <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-10dloox-MuiButtonBase-root-MuiButton-root"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <span
-                          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
-                        />
-                        Add Cluster
-                        <span
-                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                        />
-                      </button>
-                    </div>
-                  </div>
+                  />
                   <div
                     class="MuiBox-root css-0"
                   >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
@@ -98,92 +98,88 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
+                  style="min-height: 0px;"
                 >
                   <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
-                    style="min-height: 0px;"
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                   >
                     <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                      <ul
+                        class="MuiList-root css-2l483y-MuiList-root"
                       >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
+                        <li
+                          class="css-1gktw5r"
                         >
-                          <li
-                            class="css-1gktw5r"
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/settings/general"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/settings/general"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  General
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                General
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/settings/plugins"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/settings/plugins"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Plugins
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Plugins
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/settings/cluster"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/settings/cluster"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Cluster
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Cluster
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                      </ul>
                     </div>
                   </div>
                 </li>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.HomeSidebarOpen.stories.storyshot
@@ -5,7 +5,7 @@
       class="MuiBox-root css-qnyptn"
     >
       <div
-        class="MuiDrawer-root MuiDrawer-docked css-ptnx-MuiDrawer-docked"
+        class="MuiDrawer-root MuiDrawer-docked css-1k1thb6-MuiDrawer-docked"
       >
         <div
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-2vc5z5-MuiPaper-root-MuiDrawer-paper"
@@ -23,7 +23,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -49,7 +49,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/notifications"
                     role="button"
                     tabindex="0"
@@ -75,7 +75,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/settings/general"
                     role="button"
                     tabindex="0"
@@ -117,7 +117,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/settings/general"
                               role="button"
                               tabindex="0"
@@ -140,7 +140,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/settings/plugins"
                               role="button"
                               tabindex="0"
@@ -163,7 +163,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/settings/cluster"
                               role="button"
                               tabindex="0"
@@ -200,7 +200,25 @@
                 >
                   <div
                     class="MuiBox-root css-0"
-                  />
+                  >
+                    <div
+                      class="MuiBox-root css-1ebnygn"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-10dloox-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+                        />
+                        Add Cluster
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                  </div>
                   <div
                     class="MuiBox-root css-0"
                   >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -60,9 +60,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -103,9 +100,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -125,9 +119,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
                 <li
                   class="css-3knmzx"
                 >
@@ -149,9 +140,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -171,9 +159,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
                 <li
                   class="css-3knmzx"
                 >
@@ -195,9 +180,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -218,9 +200,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -240,9 +219,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
               </ul>
             </div>
             <div

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -24,7 +24,7 @@
                 >
                   <a
                     aria-label="Home"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -44,7 +44,7 @@
                 >
                   <a
                     aria-label="Cluster"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -67,7 +67,7 @@
                 >
                   <a
                     aria-label="Map"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -87,7 +87,7 @@
                 >
                   <a
                     aria-label="Workloads"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -110,7 +110,7 @@
                 >
                   <a
                     aria-label="Storage"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -133,7 +133,7 @@
                 >
                   <a
                     aria-label="Network"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -156,7 +156,7 @@
                 >
                   <a
                     aria-label="Gateway (beta)"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -179,7 +179,7 @@
                 >
                   <a
                     aria-label="Security"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -202,7 +202,7 @@
                 >
                   <a
                     aria-label="Configuration"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -225,7 +225,7 @@
                 >
                   <a
                     aria-label="Custom Resources"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1bad0xa-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -270,7 +270,33 @@
                   >
                     <div
                       class="MuiBox-root css-0"
-                    />
+                    >
+                      <div
+                        class="MuiBox-root css-yncjbp"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class="MuiBox-root css-1d61ugm"
+                          >
+                            <div
+                              class="MuiBox-root css-0"
+                            />
+                            <div
+                              class="MuiBox-root css-0"
+                            >
+                              v1.2.3
+                            </div>
+                          </div>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
                     <div
                       class="MuiBox-root css-0"
                     >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarClosed.stories.storyshot
@@ -5,7 +5,7 @@
       class="MuiBox-root css-qnyptn"
     >
       <div
-        class="MuiDrawer-root MuiDrawer-docked css-ohfc2x-MuiDrawer-docked"
+        class="MuiDrawer-root MuiDrawer-docked css-184654t-MuiDrawer-docked"
       >
         <div
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-2vc5z5-MuiPaper-root-MuiDrawer-paper"
@@ -24,7 +24,7 @@
                 >
                   <a
                     aria-label="Home"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -44,7 +44,7 @@
                 >
                   <a
                     aria-label="Cluster"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -61,100 +61,13 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Namespaces
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Nodes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Advanced Search (Beta)
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
                     aria-label="Map"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -174,7 +87,7 @@
                 >
                   <a
                     aria-label="Workloads"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -191,215 +104,13 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Pods
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Deployments
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Stateful Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Daemon Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Replica Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Jobs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  CronJobs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Job Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
                     aria-label="Storage"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -416,123 +127,13 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Persistent Volume Claims
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Persistent Volumes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Storage Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Volume Attributes Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
                     aria-label="Network"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -549,169 +150,13 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Services
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Endpoints
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Endpoint Slices
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Ingresses
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Ingress Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Network Policies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
                     aria-label="Gateway (beta)"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -728,192 +173,13 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Gateways
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Gateway Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  HTTP Routes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  GRPC Routes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Reference Grants
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  BackendTLSPolicies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  BackendTrafficPolicies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
                     aria-label="Security"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -930,100 +196,13 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Service Accounts
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Roles
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Role Bindings
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
                     aria-label="Configuration"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -1040,307 +219,13 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Config Maps
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Secrets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  HPAs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  VPAs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Pod Disruption Budgets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Resource Quotas
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Limit Ranges
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Priority Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Runtime Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Leases
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Mutating Webhook Configurations
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Validating Webhook Configurations
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
                     aria-label="Custom Resources"
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-rg8mu-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1f63b8p-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="-1"
@@ -1357,48 +242,7 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Instances
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
               </ul>
             </div>
             <div
@@ -1426,31 +270,7 @@
                   >
                     <div
                       class="MuiBox-root css-0"
-                    >
-                      <div
-                        class="MuiBox-root css-yncjbp"
-                      >
-                        <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <div
-                            class="MuiBox-root css-1d61ugm"
-                          >
-                            <div
-                              class="MuiBox-root css-0"
-                            />
-                            <div
-                              class="MuiBox-root css-0"
-                            />
-                          </div>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
-                        </button>
-                      </div>
-                    </div>
+                    />
                     <div
                       class="MuiBox-root css-0"
                     >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -72,92 +72,88 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
+                  style="min-height: 0px;"
                 >
                   <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
-                    style="min-height: 0px;"
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                   >
                     <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                      <ul
+                        class="MuiList-root css-2l483y-MuiList-root"
                       >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
+                        <li
+                          class="css-1gktw5r"
                         >
-                          <li
-                            class="css-1gktw5r"
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Namespaces
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Namespaces
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Nodes
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Nodes
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Advanced Search (Beta)
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Advanced Search (Beta)
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                      </ul>
                     </div>
                   </div>
                 </li>
@@ -214,9 +210,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -242,9 +235,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
                 <li
                   class="css-3knmzx"
                 >
@@ -272,9 +262,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -300,9 +287,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
                 <li
                   class="css-3knmzx"
                 >
@@ -330,9 +314,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -359,9 +340,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -387,9 +365,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
               </ul>
             </div>
             <div

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -5,7 +5,7 @@
       class="MuiBox-root css-qnyptn"
     >
       <div
-        class="MuiDrawer-root MuiDrawer-docked css-ptnx-MuiDrawer-docked"
+        class="MuiDrawer-root MuiDrawer-docked css-1k1thb6-MuiDrawer-docked"
       >
         <div
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-2vc5z5-MuiPaper-root-MuiDrawer-paper"
@@ -23,7 +23,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -49,7 +49,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -91,7 +91,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -114,7 +114,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -137,7 +137,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -165,7 +165,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -191,7 +191,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -215,214 +215,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Pods
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Deployments
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Stateful Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Daemon Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Replica Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Jobs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  CronJobs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Job Sets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -446,122 +244,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Persistent Volume Claims
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Persistent Volumes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Storage Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Volume Attributes Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -585,168 +273,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Services
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Endpoints
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Endpoint Slices
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Ingresses
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Ingress Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Network Policies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -770,191 +302,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Gateways
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Gateway Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  HTTP Routes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  GRPC Routes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Reference Grants
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  BackendTLSPolicies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  BackendTrafficPolicies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -978,99 +331,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Service Accounts
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Roles
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Role Bindings
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -1094,306 +360,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Config Maps
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Secrets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  HPAs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  VPAs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Pod Disruption Budgets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Resource Quotas
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Limit Ranges
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Priority Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Runtime Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Leases
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Mutating Webhook Configurations
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Validating Webhook Configurations
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -1417,48 +389,7 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Instances
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
               </ul>
             </div>
             <div
@@ -1488,31 +419,7 @@
                   >
                     <div
                       class="MuiBox-root css-0"
-                    >
-                      <div
-                        class="MuiBox-root css-yncjbp"
-                      >
-                        <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <div
-                            class="MuiBox-root css-70qvj9"
-                          >
-                            <div
-                              class="MuiBox-root css-0"
-                            />
-                            <div
-                              class="MuiBox-root css-0"
-                            />
-                          </div>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
-                        </button>
-                      </div>
-                    </div>
+                    />
                     <div
                       class="MuiBox-root css-0"
                     >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.InClusterSidebarOpen.stories.storyshot
@@ -23,7 +23,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -49,7 +49,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -91,7 +91,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -114,7 +114,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -137,7 +137,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -165,7 +165,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -191,7 +191,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -220,7 +220,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -249,7 +249,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -278,7 +278,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -307,7 +307,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -336,7 +336,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -365,7 +365,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -419,7 +419,33 @@
                   >
                     <div
                       class="MuiBox-root css-0"
-                    />
+                    >
+                      <div
+                        class="MuiBox-root css-yncjbp"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class="MuiBox-root css-70qvj9"
+                          >
+                            <div
+                              class="MuiBox-root css-0"
+                            />
+                            <div
+                              class="MuiBox-root css-0"
+                            >
+                              v1.2.3
+                            </div>
+                          </div>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
                     <div
                       class="MuiBox-root css-0"
                     >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -5,7 +5,7 @@
       class="MuiBox-root css-qnyptn"
     >
       <div
-        class="MuiDrawer-root MuiDrawer-docked css-ptnx-MuiDrawer-docked"
+        class="MuiDrawer-root MuiDrawer-docked css-1k1thb6-MuiDrawer-docked"
       >
         <div
           class="MuiPaper-root MuiPaper-outlined MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-2vc5z5-MuiPaper-root-MuiDrawer-paper"
@@ -23,7 +23,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -49,7 +49,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -73,99 +73,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Namespaces
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Nodes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Advanced Search (Beta)
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -191,7 +104,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -233,7 +146,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -256,7 +169,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -279,7 +192,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -302,7 +215,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -325,7 +238,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -348,7 +261,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -371,7 +284,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -394,7 +307,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -422,7 +335,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -446,122 +359,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Persistent Volume Claims
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Persistent Volumes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Storage Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Volume Attributes Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -585,168 +388,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Services
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Endpoints
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Endpoint Slices
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Ingresses
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Ingress Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Network Policies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -770,191 +417,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Gateways
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Gateway Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  HTTP Routes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  GRPC Routes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Reference Grants
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  BackendTLSPolicies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  BackendTrafficPolicies
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -978,99 +446,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Service Accounts
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Roles
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Role Bindings
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -1094,306 +475,12 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Config Maps
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Secrets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  HPAs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  VPAs
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Pod Disruption Budgets
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Resource Quotas
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Limit Ranges
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Priority Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Runtime Classes
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Leases
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Mutating Webhook Configurations
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Validating Webhook Configurations
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
                 <li
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -1417,48 +504,7 @@
                 </li>
                 <li
                   class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                >
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-                    >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                      >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
-                        >
-                          <li
-                            class="css-1gktw5r"
-                          >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Instances
-                                </span>
-                              </div>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </li>
+                />
               </ul>
             </div>
             <div
@@ -1488,31 +534,7 @@
                   >
                     <div
                       class="MuiBox-root css-0"
-                    >
-                      <div
-                        class="MuiBox-root css-yncjbp"
-                      >
-                        <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <div
-                            class="MuiBox-root css-70qvj9"
-                          >
-                            <div
-                              class="MuiBox-root css-0"
-                            />
-                            <div
-                              class="MuiBox-root css-0"
-                            />
-                          </div>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
-                        </button>
-                      </div>
-                    </div>
+                    />
                     <div
                       class="MuiBox-root css-0"
                     >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -23,7 +23,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -49,7 +49,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -78,7 +78,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -104,7 +104,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -146,7 +146,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -169,7 +169,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -192,7 +192,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -215,7 +215,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -238,7 +238,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -261,7 +261,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -284,7 +284,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -307,7 +307,7 @@
                             class="css-1gktw5r"
                           >
                             <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                               href="/"
                               role="button"
                               tabindex="0"
@@ -335,7 +335,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -364,7 +364,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -393,7 +393,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -422,7 +422,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -451,7 +451,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -480,7 +480,7 @@
                   class="css-3knmzx"
                 >
                   <a
-                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
                     href="/"
                     role="button"
                     tabindex="0"
@@ -534,7 +534,33 @@
                   >
                     <div
                       class="MuiBox-root css-0"
-                    />
+                    >
+                      <div
+                        class="MuiBox-root css-yncjbp"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class="MuiBox-root css-70qvj9"
+                          >
+                            <div
+                              class="MuiBox-root css-0"
+                            />
+                            <div
+                              class="MuiBox-root css-0"
+                            >
+                              v1.2.3
+                            </div>
+                          </div>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </div>
                     <div
                       class="MuiBox-root css-0"
                     >

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebar.SelectedItemWithSidebarOmitted.stories.storyshot
@@ -72,9 +72,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -127,207 +124,203 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
+                  style="min-height: 0px;"
                 >
                   <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
-                    style="min-height: 0px;"
+                    class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
                   >
                     <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
                     >
-                      <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+                      <ul
+                        class="MuiList-root css-2l483y-MuiList-root"
                       >
-                        <ul
-                          class="MuiList-root css-2l483y-MuiList-root"
+                        <li
+                          class="css-1gktw5r"
                         >
-                          <li
-                            class="css-1gktw5r"
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Pods
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Pods
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Deployments
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Deployments
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Stateful Sets
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Stateful Sets
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Daemon Sets
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Daemon Sets
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Replica Sets
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Replica Sets
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Jobs
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Jobs
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  CronJobs
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                          <li
-                            class="css-1gktw5r"
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                CronJobs
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                        <li
+                          class="css-1gktw5r"
+                        >
+                          <a
+                            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                            href="/"
+                            role="button"
+                            tabindex="0"
                           >
-                            <a
-                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                              href="/"
-                              role="button"
-                              tabindex="0"
+                            <div
+                              class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                             >
-                              <div
-                                class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                              >
-                                <span
-                                  class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                                >
-                                  Job Sets
-                                </span>
-                              </div>
                               <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
+                                class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                              >
+                                Job Sets
+                              </span>
+                            </div>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </a>
+                        </li>
+                      </ul>
                     </div>
                   </div>
                 </li>
@@ -358,9 +351,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -386,9 +376,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
                 <li
                   class="css-3knmzx"
                 >
@@ -416,9 +403,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -444,9 +428,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
                 <li
                   class="css-3knmzx"
                 >
@@ -474,9 +455,6 @@
                   </a>
                 </li>
                 <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
-                <li
                   class="css-3knmzx"
                 >
                   <a
@@ -502,9 +480,6 @@
                     />
                   </a>
                 </li>
-                <li
-                  class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-                />
               </ul>
             </div>
             <div

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Selected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Selected.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Selected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Selected.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
@@ -33,9 +33,6 @@
             />
           </a>
         </li>
-        <li
-          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-        />
       </ul>
     </div>
   </div>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Sublist.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"
@@ -35,48 +35,7 @@
         </li>
         <li
           class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
-        >
-          <div
-            class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-11uq76c-MuiCollapse-root"
-            style="min-height: 0px;"
-          >
-            <div
-              class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-            >
-              <div
-                class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-              >
-                <ul
-                  class="MuiList-root css-2l483y-MuiList-root"
-                >
-                  <li
-                    class="css-1gktw5r"
-                  >
-                    <a
-                      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
-                      href="/"
-                      role="button"
-                      tabindex="0"
-                    >
-                      <div
-                        class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                      >
-                        <span
-                          class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                        >
-                          Namespaces
-                        </span>
-                      </div>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </li>
+        />
       </ul>
     </div>
   </div>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"
@@ -53,7 +53,7 @@
                     class="css-1gktw5r"
                   >
                     <a
-                      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1op30le-MuiButtonBase-root-MuiListItemButton-root"
+                      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
                       href="/"
                       role="button"
                       tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
@@ -34,46 +34,42 @@
           </a>
         </li>
         <li
-          class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-stepuf-MuiListItem-root"
+          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
+          style="min-height: 0px;"
         >
           <div
-            class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-entered css-1mhwl66-MuiCollapse-root"
-            style="min-height: 0px;"
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
           >
             <div
-              class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
             >
-              <div
-                class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+              <ul
+                class="MuiList-root css-2l483y-MuiList-root"
               >
-                <ul
-                  class="MuiList-root css-2l483y-MuiList-root"
+                <li
+                  class="css-1gktw5r"
                 >
-                  <li
-                    class="css-1gktw5r"
+                  <a
+                    class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
+                    href="/"
+                    role="button"
+                    tabindex="0"
                   >
-                    <a
-                      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
-                      href="/"
-                      role="button"
-                      tabindex="0"
+                    <div
+                      class="MuiListItemText-root css-tlelie-MuiListItemText-root"
                     >
-                      <div
-                        class="MuiListItemText-root css-tlelie-MuiListItemText-root"
-                      >
-                        <span
-                          class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
-                        >
-                          Namespaces
-                        </span>
-                      </div>
                       <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </a>
-                  </li>
-                </ul>
-              </div>
+                        class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+                      >
+                        Namespaces
+                      </span>
+                    </div>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
         </li>

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.SublistExpanded.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters Mui-selected MuiListItemButton-root MuiListItemButton-gutters Mui-selected css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"
@@ -53,7 +53,7 @@
                     class="css-1gktw5r"
                   >
                     <a
-                      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-80lgak-MuiButtonBase-root-MuiListItemButton-root"
+                      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-5zzftf-MuiButtonBase-root-MuiListItemButton-root"
                       href="/"
                       role="button"
                       tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Unselected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Unselected.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1b2q14u-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Unselected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/Sidebaritem.Unselected.stories.storyshot
@@ -11,7 +11,7 @@
           class="css-3knmzx"
         >
           <a
-            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1trimd7-MuiButtonBase-root-MuiListItemButton-root"
+            class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters css-1gdjf7n-MuiButtonBase-root-MuiListItemButton-root"
             href="/"
             role="button"
             tabindex="0"

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -21,6 +21,19 @@ import { getWorker } from 'msw-storybook-addon';
 import path from 'path';
 import * as previewAnnotations from '../.storybook/preview';
 
+vi.mock('./lib/k8s/api/v1/clusterRequests', async () => {
+  const actual = await vi.importActual('./lib/k8s/api/v1/clusterRequests');
+  return {
+    ...(actual as any),
+    clusterRequest: vi.fn((url, ...args) => {
+      if (url === '/version') {
+        return Promise.resolve({ gitVersion: 'v1.2.3' });
+      }
+      return (actual as any).clusterRequest(url, ...args);
+    }),
+  };
+});
+
 const annotations = setProjectAnnotations([previewAnnotations, { testingLibraryRender }]);
 beforeAll(annotations.beforeAll!);
 


### PR DESCRIPTION
## Summary
This PR fixes severe Main Thread blocking and rendering lag in the Sidebar by reducing unnecessary DOM nodes, completely decoupling React Context from hidden items, and fixing layout thrashing caused by `ResizeObserver` and text-wrapping during CSS width transitions.

## Related Issue
Fixes #6232 

## Changes
- **Refactored SidebarItem:** Bypassed the unconditional `useSelectedClusters()` React Context hook by wrapping it in a Higher-Order Component (`SidebarItemWithCluster`). This hook is now only executed when `useClusterURL` is strictly required, preventing hundreds of hidden components from uselessly subscribing to state changes and re-rendering on cluster switches.
- **Updated Sidebar component:** Added `unmountOnExit` to the Material UI `<Collapse>` component to completely unmount hidden nested definitions from the DOM, reducing invisible DOM bloat.
- **Fixed PureSidebar ResizeObserver:** Wrapped the observer's `update` callback in a debounce to decouple it from the browser's 60fps rendering engine, stopping Forced Reflow layout thrashing during the 225ms Drawer animation.
- **Fixed Sidebar Hover Events:** Injected `pointerEvents: 'none'` during the opening/closing animation to prevent "phantom" hover events from causing `<Tooltip>` components to rapidly recalculate their bounding boxes as the nodes slid under the user's cursor.
- **Fixed ListItemLink Layout Snap:** Added `overflowX: 'hidden'` to the opening Drawer and `whiteSpace: 'nowrap'` to `.MuiListItemText-root` to prevent text labels from violently word-wrapping to a second line when the drawer width was too small during the animation.

## Steps to Test
1. Open the Headlamp dashboard.
2. Expand and collapse the Sidebar repeatedly using the toggle button and observe the smooth 60fps CSS animation without stutter.
3. Observe that the vertical layout snap caused by text-wrapping no longer occurs.

## Screenshots (if applicable)
https://github.com/user-attachments/assets/fb0a93ff-1787-46e3-a55d-b8a8b47b8d22

## Notes for the Reviewer
- The combination of the `ResizeObserver` thrashing and the phantom Tooltip hover events were creating a massive feedback loop on the main thread during the CSS transition, causing heavy lag even with minimal resources loaded.
