### PR TITLE
backend: kubeconfig: Guard against nil AuthInfo in OidcConfig()

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -342,7 +342,7 @@ func (c *Context) OidcConfig() (*OidcConfig, error) {
 		return c.OidcConf, nil
 	}
 
-	if c.AuthInfo.AuthProvider == nil {
+	if c.AuthInfo == nil || c.AuthInfo.AuthProvider == nil {
 		return nil, errors.New("authProvider is nil")
 	}
 

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -328,6 +328,16 @@ users:
 	})
 }
 
+func TestOidcConfigWithNilAuthInfo(t *testing.T) {
+	context := &kubeconfig.Context{AuthInfo: nil}
+
+	oidcConfig, err := context.OidcConfig()
+
+	require.Error(t, err, "Expected an error when AuthInfo is nil")
+	assert.Nil(t, oidcConfig, "Expected nil OIDC config when AuthInfo is nil")
+	assert.EqualError(t, err, "authProvider is nil")
+}
+
 // createTempKubeconfig creates a temporary kubeconfig file for testing.
 func createTempKubeconfig(t *testing.T, content string) string {
 	t.Helper()


### PR DESCRIPTION
## Summary

This PR fixes a nil pointer dereference panic in `Context.OidcConfig()`. The function dereferenced `c.AuthInfo.AuthProvider` without first checking whether `c.AuthInfo` itself was `nil`. Since a `nil` `AuthInfo` is a valid state in the codebase (e.g. token-based authentication or a context whose user does not resolve to an `authInfos` entry), this path was reachable in normal execution and caused the request to panic instead of returning the intended `"authProvider is nil"` error.

## Related Issue

Fixes #6228

## Changes

* **`backend/pkg/kubeconfig/kubeconfig.go`**

  * Added a `c.AuthInfo == nil` guard to the existing nil check in `OidcConfig()`:

    ```go
    if c.AuthInfo == nil || c.AuthInfo.AuthProvider == nil
    ```
  * This ensures the function returns a clean error instead of panicking.

* **`backend/pkg/kubeconfig/kubeconfig_test.go`**

  * Added a regression test, `TestOidcConfigWithNilAuthInfo`, which calls `OidcConfig()` on a `Context{AuthInfo: nil}`.
  * Verifies that the function returns the `"authProvider is nil"` error and does not panic.
  * No existing test covered this code path.

## Steps to Test

1. From `backend/`, run:

   ```bash
   go test ./pkg/kubeconfig/ -run TestOidcConfigWithNilAuthInfo -v
   ```

2. Verify the test passes (`PASS`).

3. To confirm the regression is covered, temporarily remove the `c.AuthInfo == nil ||` guard and re-run the test. It should panic with a nil pointer dereference, demonstrating the bug the test protects against.


## Notes for the Reviewer

* This is not a regression in the traditional sense; the `nil` `AuthInfo` case has always been valid but was never guarded in `OidcConfig()`.
* The fix is intentionally minimal (a single added nil check) to preserve the existing error path that returns `"authProvider is nil"`.
