### PR TITLE
frontend: workload: Hide Job duration while the job is still running

### DIFF
--- a/frontend/src/components/workload/__snapshots__/extraInfo.Completed.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/extraInfo.Completed.stories.storyshot
@@ -1,0 +1,112 @@
+<body>
+  <div>
+    <dl
+      class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+    >
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Completions
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          1/1
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Parallelism
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        1
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Suspend
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          false
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Backoff Limit
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        6
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Pods Status
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          Succeeded: 1
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Start Time
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          2023-07-28T00:00:00.000Z
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Completion Time
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          2023-07-28T08:01:00.000Z
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+      >
+        Duration
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          8h 1m
+        </span>
+      </dd>
+    </dl>
+  </div>
+</body>

--- a/frontend/src/components/workload/__snapshots__/extraInfo.Running.stories.storyshot
+++ b/frontend/src/components/workload/__snapshots__/extraInfo.Running.stories.storyshot
@@ -1,0 +1,84 @@
+<body>
+  <div>
+    <dl
+      class="MuiGrid-root MuiGrid-container css-kxuems-MuiGrid-root"
+    >
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Completions
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          1/1
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Parallelism
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        1
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Suspend
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          false
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Backoff Limit
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        6
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-9i4s51-MuiGrid-root"
+      >
+        Pods Status
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-1dbzfsd-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          Succeeded: 1
+        </span>
+      </dd>
+      <dt
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-3 MuiGrid-grid-md-2 css-1hrqr1q-MuiGrid-root"
+      >
+        Start Time
+      </dt>
+      <dd
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-9 MuiGrid-grid-md-10 css-ui3itl-MuiGrid-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
+        >
+          2023-07-28T00:00:00.000Z
+        </span>
+      </dd>
+    </dl>
+  </div>
+</body>

--- a/frontend/src/components/workload/extraInfo.stories.tsx
+++ b/frontend/src/components/workload/extraInfo.stories.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { useTranslation } from 'react-i18next';
+import Job from '../../lib/k8s/job';
+import { TestContext } from '../../test';
+import NameValueTable from '../common/NameValueTable';
+import { jobs } from '../job/storyHelper';
+import { jobExtraInfo } from './extraInfo';
+
+// Completed job from storyHelper has both startTime and completionTime, so it
+// has a real duration. The running variant drops completionTime, so
+// getDuration() returns -1 and the Duration row is hidden.
+const completedJob = new Job(jobs[0] as any);
+const runningJob = new Job({
+  ...jobs[0],
+  status: { ...jobs[0].status, completionTime: undefined },
+} as any);
+
+// jobExtraInfo takes a translator; render through NameValueTable to show which
+// rows are actually displayed (hidden rows are dropped by the table).
+function JobExtraInfo({ job }: { job: Job }) {
+  const { t } = useTranslation();
+  return <NameValueTable rows={jobExtraInfo(job, t)} />;
+}
+
+export default {
+  title: 'workload/JobExtraInfo',
+  component: JobExtraInfo,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<{ job: Job }> = args => <JobExtraInfo {...args} />;
+
+// Completed job: the Duration row is shown.
+export const Completed = Template.bind({});
+Completed.args = { job: completedJob };
+
+// Running job: getDuration() is -1, so the Duration row is hidden.
+export const Running = Template.bind({});
+Running.args = { job: runningJob };

--- a/frontend/src/components/workload/extraInfo.test.ts
+++ b/frontend/src/components/workload/extraInfo.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import type Job from '../../lib/k8s/job';
+import { jobExtraInfo } from './extraInfo';
+
+// Passthrough translator: returns the key so rows can be matched by name.
+const t = ((key: string) => key) as TFunction;
+
+function jobWithDuration(durationMs: number): Job {
+  return { status: {}, spec: {}, getDuration: () => durationMs } as unknown as Job;
+}
+
+function durationRow(item: Job) {
+  return jobExtraInfo(item, t).find(row => row && row.name === 'glossary|Duration');
+}
+
+describe('jobExtraInfo duration', () => {
+  it('hides the Duration row for a running job (getDuration() === -1)', () => {
+    expect(durationRow(jobWithDuration(-1))?.hide).toBe(true);
+  });
+
+  it('shows the Duration row once the job has a real duration', () => {
+    const row = durationRow(jobWithDuration(5000));
+    expect(row?.hide).toBeFalsy();
+    expect(row?.value).toBeTruthy();
+  });
+});

--- a/frontend/src/components/workload/extraInfo.test.ts
+++ b/frontend/src/components/workload/extraInfo.test.ts
@@ -36,8 +36,11 @@ describe('jobExtraInfo duration', () => {
   });
 
   it('shows the Duration row once the job has a real duration', () => {
-    const row = durationRow(jobWithDuration(5000));
-    expect(row?.hide).toBeFalsy();
-    expect(row?.value).toBeTruthy();
+    // 0ms is a legitimate completed-job duration (startTime === completionTime).
+    for (const durationMs of [0, 5000]) {
+      const row = durationRow(jobWithDuration(durationMs));
+      expect(row?.hide).toBeFalsy();
+      expect(row?.value).toBeTruthy();
+    }
   });
 });

--- a/frontend/src/components/workload/extraInfo.tsx
+++ b/frontend/src/components/workload/extraInfo.tsx
@@ -93,7 +93,10 @@ export function jobExtraInfo(item: Job, t: TFunction): NameValueTableRow[] {
   ]
     .filter(Boolean)
     .join(', ');
-  const duration = formatDuration(item.getDuration());
+  // getDuration() returns -1 while a job is still running; formatting that
+  // yields a misleading "0s", so only show a duration once the job has one.
+  const durationMs = item.getDuration();
+  const duration = durationMs > 0 ? formatDuration(durationMs) : '';
 
   return [
     {

--- a/frontend/src/components/workload/extraInfo.tsx
+++ b/frontend/src/components/workload/extraInfo.tsx
@@ -93,10 +93,11 @@ export function jobExtraInfo(item: Job, t: TFunction): NameValueTableRow[] {
   ]
     .filter(Boolean)
     .join(', ');
-  // getDuration() returns -1 while a job is still running; formatting that
-  // yields a misleading "0s", so only show a duration once the job has one.
+  // getDuration() returns -1 while a job is still running (no completionTime yet);
+  // hide the duration in that case. A completed job with startTime === completionTime
+  // legitimately has a 0ms duration and stays visible as "0s".
   const durationMs = item.getDuration();
-  const duration = durationMs > 0 ? formatDuration(durationMs) : '';
+  const duration = durationMs >= 0 ? formatDuration(durationMs) : '';
 
   return [
     {


### PR DESCRIPTION
Fixes #6229.

On a Job detail page, a Job that is still running showed `Duration: 0s` instead of no Duration row.

`Job.getDuration()` returns `-1` while a job has no `completionTime`. `jobExtraInfo` passed that into `formatDuration`, which returns the truthy string `"0s"` (because `Math.trunc(-1 / 1000) === -0`, not `< 0`), so the `hide: !duration` guard never fired.

This guards on the numeric value first — only formatting a duration once `getDuration() > 0` — matching how the Jobs list view already handles running jobs. Added a small unit test for the running and completed cases.