### PR TITLE
frontend: fix AppLogo themeName documentation typo

### DIFF
--- a/docs/development/api/interfaces/plugin_registry.AppLogoProps.md
+++ b/docs/development/api/interfaces/plugin_registry.AppLogoProps.md
@@ -50,7 +50,7 @@ ___
 
 • `Optional` **themeName**: ``"dark"`` \| ``"light"``
 
-User selected theme. By default it checks which is is active.
+User selected theme. By default it checks which theme is active.
 
 #### Defined in
 

--- a/frontend/src/components/App/AppLogo.tsx
+++ b/frontend/src/components/App/AppLogo.tsx
@@ -29,8 +29,8 @@ import ErrorBoundary from '../common/ErrorBoundary';
 export interface AppLogoProps {
   /** The size of the logo. 'small' for in mobile view, and 'large' for tablet and desktop sizes. By default the 'large' is used. */
   logoType?: 'small' | 'large';
-  /** User selected theme. By default it checks which is is active. */
-  themeName?: string;
+  /** User selected theme. By default it checks which theme is active. */
+  themeName?: 'dark' | 'light';
   /** A class to use on your SVG. */
   className?: string;
   /** SxProps to use on your SVG. */


### PR DESCRIPTION
Summary
This PR fixes a typo in the AppLogo themeName documentation by replacing
"which is is active" with "which theme is active".

Related Issue
None

Changes
Updated AppLogoProps themeName comment in AppLogo.tsx
Updated generated API documentation for AppLogoProps themeName

Steps to Test
Run npm run frontend:lint
Verify the AppLogoProps themeName documentation reads: "User selected theme. By default it checks which theme is active."