### PR TITLE
frontend: k8s/api: Resolve obsolete return-type @todos

### DIFF
--- a/frontend/src/lib/k8s/api/v1/factories.ts
+++ b/frontend/src/lib/k8s/api/v1/factories.ts
@@ -358,8 +358,6 @@ export interface ApiInfo {
   resource: string;
 }
 
-// @todo: singleApiFactory should have a return type rather than just what it returns.
-
 /**
  * @returns An object with methods for interacting with a single API endpoint.
  *

--- a/frontend/src/lib/k8s/api/v1/portForward.ts
+++ b/frontend/src/lib/k8s/api/v1/portForward.ts
@@ -20,9 +20,6 @@ import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLo
 import { clusterFetch } from '../v2/fetch';
 import { JSON_HEADERS } from './constants';
 
-// @todo: the return type is missing for the following functions.
-//       See PortForwardState in PortForward.tsx
-
 export interface PortForward {
   id: string;
   pod: string;
@@ -162,8 +159,6 @@ export async function stopOrDeletePortForward(
     return text;
   });
 }
-
-// @todo: needs a return type.
 
 /**
  * Lists the port forwards for the specified cluster.

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -265,6 +265,16 @@ export function streamResultsForCluster(
 }
 
 /**
+ * The connection handle returned by the stream connection helpers.
+ */
+export interface StreamConnection {
+  /** Closes the underlying WebSocket connection. */
+  close: () => void;
+  /** The underlying WebSocket, or null if it could not be created. */
+  socket: WebSocket | null;
+}
+
+/**
  * Configure a stream with... StreamArgs.
  */
 export interface StreamArgs {
@@ -297,7 +307,7 @@ export interface StreamArgs {
  * the stream, and `getSocket`, which returns the WebSocket object.
  */
 export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs) {
-  let connection: { close: () => void; socket: WebSocket | null } | null = null;
+  let connection: StreamConnection | null = null;
   let isCancelled = false;
   const { failCb, cluster = '' } = args;
   // We only set reconnectOnFailure as true by default if the failCb has not been provided.
@@ -353,8 +363,6 @@ export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs)
   }
 }
 
-// @todo: needs a return type.
-
 /**
  * Connects to a WebSocket stream at the specified path and returns an object
  * with a `close` function and a `socket` property. Sends messages to `cb` callback.
@@ -365,7 +373,7 @@ export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs)
  * @param isJson - Whether the messages should be parsed as JSON.
  * @param additionalProtocols - An optional array of additional WebSocket protocols to use.
  *
- * @returns An object with a `close` function and a `socket` property.
+ * @returns A promise that resolves to an object with a `close` function and a `socket` property.
  */
 export async function connectStream<T>(
   path: string,
@@ -374,7 +382,7 @@ export async function connectStream<T>(
   isJson: boolean,
   additionalProtocols: string[] = [],
   cluster = ''
-) {
+): Promise<StreamConnection> {
   return connectStreamWithParams(path, cb, onFail, {
     isJson,
     cluster: cluster || getCluster() || '',
@@ -412,10 +420,7 @@ export async function connectStreamWithParams<T>(
   cb: StreamResultsCb<T>,
   onFail: () => void,
   params?: StreamParams
-): Promise<{
-  close: () => void;
-  socket: WebSocket | null;
-}> {
+): Promise<StreamConnection> {
   const { isJson = false, additionalProtocols = [], cluster = '' } = params || {};
   let isClosing = false;
 


### PR DESCRIPTION
## Summary

This PR resolves obsolete `@todo` comments about missing TypeScript return types in three core frontend API library modules. It adds an explicit return type to `connectStream`, extracts the repeated connection shape into a named `StreamConnection` type, and removes stale `@todo`s that pointed at return types which are already declared. Comments and types only, no behavior change.

## Related Issue

Fixes #6243

## Changes

- Updated `streamingApi.ts`: added an explicit return type to `connectStream`, updated its `@returns` doc, and removed the now-resolved `@todo`. Extracted the repeated `{ close: () => void; socket: WebSocket | null }` shape into a named `StreamConnection` interface, reused by `connectStream`, `connectStreamWithParams`, and the `stream()` connection handle.
- Fixed `portForward.ts`: removed two stale `@todo`s about missing return types — `startPortForward` and `listPortForward` already return `Promise<PortForward>` and `Promise<PortForward[]>`
- Fixed `factories.ts`: removed the stale `@todo` about `singleApiFactory` needing a return type it (and `multipleApiFactory`) already declare `: ApiClient<T>`

## Steps to Test

1. From `frontend/`, run `npm run frontend:tsc` (or `npx tsgo --noEmit`) and confirm it passes with no errors
2. Run `npm run frontend:lint` and confirm no lint/format warnings
3. Run `npm run frontend:test` (e.g. `npx vitest run src/lib/k8s/api`) and confirm all tests pass (155 passed locally)
4. Inspect the diff and verify each removed `@todo` corresponds to a return type that is already present in the function signature

## Notes for the Reviewer

No public API or runtime behavior changes; this is purely typing and comment cleanup.