### PR TITLE
chart: Headlamp: Support multiple custom kubeconfig during helm install

### DIFF
--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -144,6 +144,10 @@ config:
 | config.clusterInventory.labelSelector | string | `"!headlamp.dev/ignore"` | Kubernetes label selector used to filter experimental/alpha ClusterProfile resources |
 | config.clusterInventory.rootReconcileInterval | string | `""` | Override the experimental/alpha Cluster Inventory root reconcile interval. Empty uses the Headlamp default |
 | config.clusterInventory.noCRDCacheTTL | string | `""` | Override the experimental/alpha Cluster Inventory no-CRD cache TTL. Empty uses the Headlamp default |
+| kubeconfigSecret.create | bool | `false` | Generate a kubeconfig Secret from files under the chart `kubeconfig/` directory |
+| kubeconfigSecret.skipIfExists | bool | `true` | Skip creating the Secret if one with the same name already exists |
+| kubeconfigSecret.name | string | `""` | Name of the Secret mounted into the Headlamp pod. When empty and `create=true`, defaults to `headlamp-kubeconfig` |
+| kubeconfigSecret.selectedKubeconfigs | list | `[]` | Optional list of kubeconfig files to merge from the chart `kubeconfig/` directory |
 | config.extraArgs   | array  | `[]`                  | Additional arguments for Headlamp server                                  |
 | config.tlsCertPath | string | `""`                  | Certificate for serving TLS                                               |
 | config.tlsKeyPath  | string | `""`                  | Key for serving TLS                                                       |
@@ -245,6 +249,34 @@ plugins. Each entry renders as a Kubernetes `image` volume and is mounted
 read-only into the Headlamp container. If an access provider `execConfig.command`
 is configured, the command must be under one of the absolute
 `plugins[].mountPath` values.
+
+### Kubeconfig Secret Merge
+
+The chart can merge one or more kubeconfig files bundled in the chart's
+`kubeconfig/` directory into a single Secret, then mount it into the Headlamp
+container and set `KUBECONFIG` automatically.
+
+```yaml
+kubeconfigSecret:
+  create: false
+  skipIfExists: true
+  # Leave empty by default. Set a value when referencing an existing Secret.
+  name: ""
+  selectedKubeconfigs:
+    - cluster1.yaml
+    - cluster2
+    - cluster3
+```
+
+ When `kubeconfigSecret.create=true` and `selectedKubeconfigs` is non-empty, each entry is loaded from
+ `kubeconfig/<entry>` (with optional `.yaml` suffix), merged into one kubeconfig, stored in a Secret, and mounted.
+ If `selectedKubeconfigs` is empty, the chart creates an empty kubeconfig Secret payload and still mounts it.
+ If `skipIfExists=true` and a Secret already exists, that Secret must contain a key named `multi-cluster-kubeconfig.yaml`.
+ If `kubeconfigSecret.name` is empty, the chart uses `headlamp-kubeconfig` as the Secret name.
+The Secret key/file name and mounted `KUBECONFIG` path are fixed to
+`multi-cluster-kubeconfig.yaml`.
+When `kubeconfigSecret.create=false`, set `kubeconfigSecret.name` to an existing
+Secret. That Secret must contain a key named `multi-cluster-kubeconfig.yaml`.
 
 ### Deployment Configuration
 

--- a/charts/headlamp/README.md
+++ b/charts/headlamp/README.md
@@ -254,7 +254,7 @@ is configured, the command must be under one of the absolute
 
 The chart can merge one or more kubeconfig files bundled in the chart's
 `kubeconfig/` directory into a single Secret, then mount it into the Headlamp
-container and set `KUBECONFIG` automatically.
+ container and set `HEADLAMP_CONFIG_KUBECONFIG` (and `KUBECONFIG`) automatically.
 
 ```yaml
 kubeconfigSecret:

--- a/charts/headlamp/kubeconfig/cluster1.yaml
+++ b/charts/headlamp/kubeconfig/cluster1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster1
+    cluster:
+      server: https://cluster1.example.invalid
+contexts:
+  - name: cluster1
+    context:
+      cluster: cluster1
+      user: cluster1-user
+users:
+  - name: cluster1-user
+    user:
+      token: ""
+current-context: cluster1

--- a/charts/headlamp/kubeconfig/cluster2.yaml
+++ b/charts/headlamp/kubeconfig/cluster2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster2
+    cluster:
+      server: https://cluster2.example.invalid
+contexts:
+  - name: cluster2
+    context:
+      cluster: cluster2
+      user: cluster2-user
+users:
+  - name: cluster2-user
+    user:
+      token: ""
+current-context: cluster2

--- a/charts/headlamp/kubeconfig/cluster3.yaml
+++ b/charts/headlamp/kubeconfig/cluster3.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster3
+    cluster:
+      server: https://cluster3.example.invalid
+contexts:
+  - name: cluster3
+    context:
+      cluster: cluster3
+      user: cluster3-user
+users:
+  - name: cluster3-user
+    user:
+      token: ""
+current-context: cluster3

--- a/charts/headlamp/kubeconfig/cluster4.yaml
+++ b/charts/headlamp/kubeconfig/cluster4.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster4
+    cluster:
+      server: https://cluster4.example.invalid
+contexts:
+  - name: cluster4
+    context:
+      cluster: cluster4
+      user: cluster4-user
+users:
+  - name: cluster4-user
+    user:
+      token: ""
+current-context: cluster4

--- a/charts/headlamp/kubeconfig/cluster5.yaml
+++ b/charts/headlamp/kubeconfig/cluster5.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster5
+    cluster:
+      server: https://cluster5.example.invalid
+contexts:
+  - name: cluster5
+    context:
+      cluster: cluster5
+      user: cluster5-user
+users:
+  - name: cluster5-user
+    user:
+      token: ""
+current-context: cluster5

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -144,6 +144,8 @@ spec:
               value: ""
             {{- end }}
             {{- if $kubeconfigSecretEnabled }}
+            - name: HEADLAMP_CONFIG_KUBECONFIG
+              value: {{ $kubeconfigMountedFilePath | quote }}
             - name: KUBECONFIG
               value: {{ $kubeconfigMountedFilePath | quote }}
             {{- end }}
@@ -271,6 +273,8 @@ spec:
               value: ""
             {{- end }}
             {{- if $kubeconfigSecretEnabled }}
+            - name: HEADLAMP_CONFIG_KUBECONFIG
+              value: {{ $kubeconfigMountedFilePath | quote }}
             - name: KUBECONFIG
               value: {{ $kubeconfigMountedFilePath | quote }}
             {{- end }}

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -22,6 +22,14 @@
 {{- $clusterInventoryProviderFile := "/etc/cluster-inventory/config.json" }}
 {{- $clusterInventoryProviderMountDir := "/etc/cluster-inventory" }}
 {{- $clusterInventoryProviderConfigPath := "config.json" }}
+{{- $kubeconfigSecret := .Values.kubeconfigSecret | default dict }}
+{{- $kubeconfigSecretCreate := $kubeconfigSecret.create | default false }}
+{{- $kubeconfigSecretRawName := (($kubeconfigSecret.name | default "") | toString) }}
+{{- $kubeconfigSecretName := ternary "headlamp-kubeconfig" $kubeconfigSecretRawName (and $kubeconfigSecretCreate (eq $kubeconfigSecretRawName "")) }}
+{{- $kubeconfigSecretEnabled := ne $kubeconfigSecretName "" }}
+{{- $kubeconfigMountDir := "/headlamp-kubeconfig" }}
+{{- $kubeconfigFileName := "multi-cluster-kubeconfig.yaml" }}
+{{- $kubeconfigMountedFilePath := printf "%s/%s" $kubeconfigMountDir $kubeconfigFileName }}
 {{- $readOnlyRootFs := eq (include "headlamp.readOnlyRootFilesystem" .Values) "true" }}
 {{- $pluginManagerSecurityContext := dict }}
 {{- if .Values.pluginsManager.securityContext }}
@@ -120,13 +128,13 @@ spec:
             {{- end }}
           image: "{{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{ if or $oidc .Values.env $staticPluginsDisabled }}
+          {{ if or $oidc .Values.env $staticPluginsDisabled $kubeconfigSecretEnabled }}
           {{- if $oidc.externalSecret.enabled }}
           # Check if externalSecret is enabled
           envFrom:
           - secretRef:
               name: {{ $oidc.externalSecret.name }}
-          {{- if or .Values.env $staticPluginsDisabled }}
+          {{- if or .Values.env $staticPluginsDisabled $kubeconfigSecretEnabled }}
           env:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -134,6 +142,10 @@ spec:
             {{- if $staticPluginsDisabled }}
             - name: HEADLAMP_STATIC_PLUGINS_DIR
               value: ""
+            {{- end }}
+            {{- if $kubeconfigSecretEnabled }}
+            - name: KUBECONFIG
+              value: {{ $kubeconfigMountedFilePath | quote }}
             {{- end }}
           {{- end }}
           {{- else }}
@@ -257,6 +269,10 @@ spec:
             {{- if $staticPluginsDisabled }}
             - name: HEADLAMP_STATIC_PLUGINS_DIR
               value: ""
+            {{- end }}
+            {{- if $kubeconfigSecretEnabled }}
+            - name: KUBECONFIG
+              value: {{ $kubeconfigMountedFilePath | quote }}
             {{- end }}
           {{- end }}
           {{- end }}
@@ -418,11 +434,16 @@ spec:
             failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled .Values.volumeMounts $tmpCtx.addMount }}
+          {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled $kubeconfigSecretEnabled .Values.volumeMounts $tmpCtx.addMount }}
           volumeMounts:
             {{- if .Values.pluginsManager.enabled }}
             - name: plugins-dir
               mountPath: {{ .Values.config.pluginsDir }}
+            {{- end }}
+            {{- if $kubeconfigSecretEnabled }}
+            - name: kubeconfig-secret
+              mountPath: {{ $kubeconfigMountDir }}
+              readOnly: true
             {{- end }}
             {{- if $clusterInventoryEnabled }}
             - name: cluster-inventory-config
@@ -523,7 +544,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled .Values.volumes $tmpCtx.addVolume $pluginsTmpCtx.addVolume }}
+      {{- if or .Values.pluginsManager.enabled $clusterInventoryEnabled $kubeconfigSecretEnabled .Values.volumes $tmpCtx.addVolume $pluginsTmpCtx.addVolume }}
       volumes:
         {{- if .Values.pluginsManager.enabled }}
         - name: plugins-dir
@@ -548,6 +569,14 @@ spec:
           image:
             reference: {{ $plugin.image | quote }}
         {{- end }}
+        {{- end }}
+        {{- if $kubeconfigSecretEnabled }}
+        - name: kubeconfig-secret
+          secret:
+            secretName: {{ $kubeconfigSecretName }}
+            items:
+              - key: {{ $kubeconfigFileName }}
+                path: {{ $kubeconfigFileName }}
         {{- end }}
         {{- if $tmpCtx.addVolume }}
         - name: headlamp-tmp

--- a/charts/headlamp/templates/secret.yaml
+++ b/charts/headlamp/templates/secret.yaml
@@ -39,3 +39,104 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- $kubeconfigSecret := .Values.kubeconfigSecret | default dict }}
+{{- $kubeconfigSecretCreate := $kubeconfigSecret.create | default false }}
+{{- $kubeconfigSecretRawName := (($kubeconfigSecret.name | default "") | toString) }}
+{{- $kubeconfigSecretName := ternary "headlamp-kubeconfig" $kubeconfigSecretRawName (and $kubeconfigSecretCreate (eq $kubeconfigSecretRawName "")) }}
+{{- if and $kubeconfigSecretCreate $kubeconfigSecretName }}
+{{- $secretFileName := "multi-cluster-kubeconfig.yaml" }}
+{{- $skipIfExists := $kubeconfigSecret.skipIfExists | default false }}
+{{- $existingSecret := dict }}
+{{- if $skipIfExists }}
+{{- $existingSecret = (lookup "v1" "Secret" (include "headlamp.namespace" .) $kubeconfigSecretName) }}
+{{- end }}
+{{- if and $skipIfExists (not (empty $existingSecret)) }}
+{{- $existingData := (get $existingSecret "data") | default dict }}
+{{- if not (hasKey $existingData $secretFileName) }}
+{{- fail (printf "kubeconfigSecret.skipIfExists=true: existing Secret %q must contain key %q" $kubeconfigSecretName $secretFileName) }}
+{{- end }}
+{{- end }}
+{{- if or (not $skipIfExists) (empty $existingSecret) }}
+{{- $resolvedFiles := list }}
+{{- $selected := $kubeconfigSecret.selectedKubeconfigs | default list }}
+{{- if gt (len $selected) 0 }}
+  {{- range $entry := $selected }}
+    {{- $normalized := trimPrefix "kubeconfig/" (($entry | toString) | trim) }}
+    {{- if or (contains "*" $normalized) (contains "?" $normalized) (contains "[" $normalized) (contains "]" $normalized) (contains "{" $normalized) (contains "}" $normalized) }}
+      {{- fail (printf "kubeconfigSecret.selectedKubeconfigs entry %q must be an exact file name (glob patterns are not supported)" ($entry | toString)) }}
+    {{- end }}
+    {{- $candidate := printf "kubeconfig/%s" $normalized }}
+    {{- if gt (len ($.Files.Glob $candidate)) 0 }}
+      {{- $resolvedFiles = append $resolvedFiles $candidate }}
+    {{- else }}
+      {{- $withYaml := printf "%s.yaml" $candidate }}
+      {{- if gt (len ($.Files.Glob $withYaml)) 0 }}
+        {{- $resolvedFiles = append $resolvedFiles $withYaml }}
+      {{- else }}
+        {{- fail (printf "kubeconfigSecret.selectedKubeconfigs entry %q not found in chart kubeconfig/ directory" ($entry | toString)) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $merged := dict "apiVersion" "v1" "kind" "Config" "preferences" (dict) "clusters" (list) "users" (list) "contexts" (list) "current-context" "" }}
+{{- $seenClusters := dict }}
+{{- $seenUsers := dict }}
+{{- $seenContexts := dict }}
+
+{{- range $path := $resolvedFiles }}
+  {{- $parsed := fromYaml ($.Files.Get $path) }}
+  {{- if not $parsed }}
+    {{- fail (printf "kubeconfig file %q is empty or invalid YAML" $path) }}
+  {{- end }}
+
+  {{- range $cluster := ((get $parsed "clusters") | default (list)) }}
+    {{- $clusterName := (get $cluster "name") | default "" }}
+    {{- if eq $clusterName "" }}
+      {{- fail (printf "kubeconfig file %q contains a cluster entry without name" $path) }}
+    {{- end }}
+    {{- if not (hasKey $seenClusters $clusterName) }}
+      {{- $_ := set $seenClusters $clusterName true }}
+      {{- $_ := set $merged "clusters" (append (get $merged "clusters") $cluster) }}
+    {{- end }}
+  {{- end }}
+
+  {{- range $user := ((get $parsed "users") | default (list)) }}
+    {{- $userName := (get $user "name") | default "" }}
+    {{- if eq $userName "" }}
+      {{- fail (printf "kubeconfig file %q contains a user entry without name" $path) }}
+    {{- end }}
+    {{- if not (hasKey $seenUsers $userName) }}
+      {{- $_ := set $seenUsers $userName true }}
+      {{- $_ := set $merged "users" (append (get $merged "users") $user) }}
+    {{- end }}
+  {{- end }}
+
+  {{- range $context := ((get $parsed "contexts") | default (list)) }}
+    {{- $contextName := (get $context "name") | default "" }}
+    {{- if eq $contextName "" }}
+      {{- fail (printf "kubeconfig file %q contains a context entry without name" $path) }}
+    {{- end }}
+    {{- if not (hasKey $seenContexts $contextName) }}
+      {{- $_ := set $seenContexts $contextName true }}
+      {{- $_ := set $merged "contexts" (append (get $merged "contexts") $context) }}
+    {{- end }}
+  {{- end }}
+
+  {{- $currentContext := (get $parsed "current-context") | default "" }}
+  {{- if and (eq ((get $merged "current-context") | default "") "") (ne $currentContext "") }}
+    {{- $_ := set $merged "current-context" $currentContext }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $kubeconfigSecretName }}
+  namespace: {{ include "headlamp.namespace" . }}
+type: Opaque
+data:
+  {{ $secretFileName }}: {{ toYaml $merged | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/headlamp/templates/secret.yaml
+++ b/charts/headlamp/templates/secret.yaml
@@ -46,7 +46,7 @@ data:
 {{- $kubeconfigSecretName := ternary "headlamp-kubeconfig" $kubeconfigSecretRawName (and $kubeconfigSecretCreate (eq $kubeconfigSecretRawName "")) }}
 {{- if and $kubeconfigSecretCreate $kubeconfigSecretName }}
 {{- $secretFileName := "multi-cluster-kubeconfig.yaml" }}
-{{- $skipIfExists := $kubeconfigSecret.skipIfExists | default false }}
+{{- $skipIfExists := $kubeconfigSecret.skipIfExists | default true }}
 {{- $existingSecret := dict }}
 {{- if $skipIfExists }}
 {{- $existingSecret = (lookup "v1" "Secret" (include "headlamp.namespace" .) $kubeconfigSecretName) }}
@@ -63,6 +63,9 @@ data:
 {{- if gt (len $selected) 0 }}
   {{- range $entry := $selected }}
     {{- $normalized := trimPrefix "kubeconfig/" (($entry | toString) | trim) }}
+     {{- if or (contains ".." $normalized) (contains "/" $normalized) (contains "\\" $normalized) }}
+       {{- fail (printf "kubeconfigSecret.selectedKubeconfigs entry %q must be a file name within the chart kubeconfig/ directory (no path separators or '..')" ($entry | toString)) }}
+     {{- end }}
     {{- if or (contains "*" $normalized) (contains "?" $normalized) (contains "[" $normalized) (contains "]" $normalized) (contains "{" $normalized) (contains "}" $normalized) }}
       {{- fail (printf "kubeconfigSecret.selectedKubeconfigs entry %q must be an exact file name (glob patterns are not supported)" ($entry | toString)) }}
     {{- end }}

--- a/charts/headlamp/tests/expected_templates/kubeconfig-selected-merge.yaml
+++ b/charts/headlamp/tests/expected_templates/kubeconfig-selected-merge.yaml
@@ -21,6 +21,16 @@ metadata:
 type: Opaque
 data:
 ---
+# Source: headlamp/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: selected-merge-kubeconfig
+  namespace: default
+type: Opaque
+data:
+  multi-cluster-kubeconfig.yaml: "YXBpVmVyc2lvbjogdjEKY2x1c3RlcnM6Ci0gY2x1c3RlcjoKICAgIHNlcnZlcjogaHR0cHM6Ly9jbHVzdGVyMS5leGFtcGxlLmludmFsaWQKICBuYW1lOiBjbHVzdGVyMQotIGNsdXN0ZXI6CiAgICBzZXJ2ZXI6IGh0dHBzOi8vY2x1c3RlcjIuZXhhbXBsZS5pbnZhbGlkCiAgbmFtZTogY2x1c3RlcjIKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGNsdXN0ZXIxCiAgICB1c2VyOiBjbHVzdGVyMS11c2VyCiAgbmFtZTogY2x1c3RlcjEKLSBjb250ZXh0OgogICAgY2x1c3RlcjogY2x1c3RlcjIKICAgIHVzZXI6IGNsdXN0ZXIyLXVzZXIKICBuYW1lOiBjbHVzdGVyMgpjdXJyZW50LWNvbnRleHQ6IGNsdXN0ZXIxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KdXNlcnM6Ci0gbmFtZTogY2x1c3RlcjEtdXNlcgogIHVzZXI6CiAgICB0b2tlbjogIiIKLSBuYW1lOiBjbHVzdGVyMi11c2VyCiAgdXNlcjoKICAgIHRva2VuOiAiIg=="
+---
 # Source: headlamp/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -60,7 +70,6 @@ spec:
     - port: 80
       targetPort: http
       protocol: TCP
-      appProtocol: "kubernetes.io/ws"
       name: http
   selector:
     app.kubernetes.io/name: headlamp
@@ -109,6 +118,8 @@ spec:
           imagePullPolicy: IfNotPresent
           
           env:
+            - name: KUBECONFIG
+              value: "/headlamp-kubeconfig/multi-cluster-kubeconfig.yaml"
           args:
             - "-in-cluster"
             - "-in-cluster-context-name=main"
@@ -141,3 +152,14 @@ spec:
             failureThreshold: 3
           resources:
             {}
+          volumeMounts:
+            - name: kubeconfig-secret
+              mountPath: /headlamp-kubeconfig
+              readOnly: true
+      volumes:
+        - name: kubeconfig-secret
+          secret:
+            secretName: selected-merge-kubeconfig
+            items:
+              - key: multi-cluster-kubeconfig.yaml
+                path: multi-cluster-kubeconfig.yaml

--- a/charts/headlamp/tests/failing_test_cases/kubeconfig-selected-glob-pattern.yaml
+++ b/charts/headlamp/tests/failing_test_cases/kubeconfig-selected-glob-pattern.yaml
@@ -1,0 +1,6 @@
+kubeconfigSecret:
+  create: true
+  skipIfExists: false
+  name: test-kubeconfig
+  selectedKubeconfigs:
+    - "*.yaml"

--- a/charts/headlamp/tests/test_cases/kubeconfig-selected-merge.yaml
+++ b/charts/headlamp/tests/test_cases/kubeconfig-selected-merge.yaml
@@ -1,0 +1,7 @@
+kubeconfigSecret:
+  create: true
+  skipIfExists: false
+  name: selected-merge-kubeconfig
+  selectedKubeconfigs:
+    - cluster1
+    - cluster2.yaml

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -48,6 +48,31 @@
       "type": "string",
       "description": "Override the name of the chart"
     },
+    "kubeconfigSecret": {
+      "type": "object",
+      "description": "Kubeconfig Secret settings for loading multiple external clusters",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Generate a kubeconfig Secret from files in the chart kubeconfig/ directory. Defaults to false (opt-in)"
+        },
+        "skipIfExists": {
+          "type": "boolean",
+          "description": "Skip creating Secret when one with the same name already exists"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the kubeconfig Secret to mount in the Headlamp pod. When empty and create=true, defaults to headlamp-kubeconfig. When create=false, set this to an existing Secret name"
+        },
+        "selectedKubeconfigs": {
+          "type": "array",
+          "description": "Optional list of kubeconfig files from the chart kubeconfig/ directory to merge",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "fullnameOverride": {
       "type": "string",
       "description": "Override the full name of the chart"

--- a/charts/headlamp/values.schema.json
+++ b/charts/headlamp/values.schema.json
@@ -54,10 +54,12 @@
       "properties": {
         "create": {
           "type": "boolean",
+          "default": false,
           "description": "Generate a kubeconfig Secret from files in the chart kubeconfig/ directory. Defaults to false (opt-in)"
         },
         "skipIfExists": {
           "type": "boolean",
+          "default": true,
           "description": "Skip creating Secret when one with the same name already exists"
         },
         "name": {

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -177,6 +177,28 @@ config:
   # Extra arguments that can be given to the container. See charts/headlamp/README.md for more information.
   extraArgs: []
 
+# -- Kubeconfig Secret settings for loading multiple external clusters.
+kubeconfigSecret:
+  # -- Generate a kubeconfig Secret from files in the chart's kubeconfig/ directory.
+  create: true
+  # -- Skip creating Secret when one with the same name already exists.
+  skipIfExists: true
+  # -- Name of the kubeconfig Secret to mount in the Headlamp pod.
+  # When empty and create=true, defaults to "headlamp-kubeconfig".
+  # Optional: set when referencing an existing Secret with create=false.
+  name: ""
+  # -- Optional list of kubeconfig files (from the chart's kubeconfig/ folder)
+  # to merge into a single Secret payload. Entries can be file names with or
+  # without the .yaml extension.
+  # If you have multiple kubeconfig files in the chart's kubeconfig/ folder and want to
+  # headlamp to load them while the pod starts, you can list them here.
+  selectedKubeconfigs: []
+    # - cluster1.yaml
+    # - cluster2.yaml
+    # - cluster3.yaml
+    # - cluster4.yaml
+    # - cluster5.yaml
+
 # -- An optional list of environment variables
 # env:
 #   - name: KUBERNETES_SERVICE_HOST

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -180,7 +180,7 @@ config:
 # -- Kubeconfig Secret settings for loading multiple external clusters.
 kubeconfigSecret:
   # -- Generate a kubeconfig Secret from files in the chart's kubeconfig/ directory.
-  create: true
+  create: false
   # -- Skip creating Secret when one with the same name already exists.
   skipIfExists: true
   # -- Name of the kubeconfig Secret to mount in the Headlamp pod.


### PR DESCRIPTION
# Summary

This PR adds support for managing multiple kubeconfig files through the Helm chart. Kubeconfig files placed under the `kubeconfig/` directory can be specified in `values.yaml`, automatically merged during `helm install` or `helm upgrade`, packaged into a Kubernetes Secret, and mounted into the Headlamp pod. This removes the need for users to manually merge kubeconfigs or create the Secret.

```yaml
kubeconfigSecret:
  selectedKubeconfigs:
    - cluster1.yaml
    - cluster2.yaml
    - cluster3.yaml
```

## Related Issue

Fixes #6222

## Changes

* Added support for merging multiple kubeconfig files specified in `kubeconfigSecret.selectedKubeconfigs`.
* The merged kubeconfig is always generated as `multi-cluster-kubeconfig.yaml` and mounted into the Headlamp pod.
* When `selectedKubeconfigs` is empty, an empty kubeconfig is generated and mounted.
* Added a default Secret name (`headlamp-kubeconfig`) when `kubeconfigSecret.create=true` and `kubeconfigSecret.name` is not specified.
* Updated `README.md`, `values.yaml`, `values.schema.json`, templates, and expected template fixtures to reflect the new behavior.

## Files Updated

* `templates/secret.yaml`
* `templates/deployment.yaml`
* `values.yaml`
* `values.schema.json`
* `README.md`
* `expected_templates`

## Validation

* Verified merged kubeconfig generation and mounting.
* Verified default Secret name fallback (`headlamp-kubeconfig`).
* Verified empty `selectedKubeconfigs` behavior.
* Ran `./test.sh`; all template tests passed, including expected failure cases.

## Steps to Test

1. Add kubeconfig files to the `kubeconfig/` directory.
2. Configure `kubeconfigSecret.selectedKubeconfigs` in `values.yaml`.
3. Run `helm install` or `helm upgrade`.
4. Verify:

   * A Secret containing `multi-cluster-kubeconfig.yaml` is created.
   * The Secret is mounted into the Headlamp pod.
   * Headlamp can access all configured clusters.

## Notes for the Reviewer

* This PR only affects the Helm chart and related documentation.
* Existing deployments remain unchanged unless the new multi-kubeconfig feature is used.
