### PR TITLE
frontend: NavigationTabs: Fix active tab index when sidebar items are hidden

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,6 @@ default_agent: "@dev-agent"
 > **Consulted files (agent must populate before committing):**
 > - `/backend/pkg/k8cache/cacheInvalidation.go`
 > - `/backend/pkg/kubeconfig/contextStore.go`
-> - `/frontend/src/components/Sidebar/NavigationTabs.tsx`
 >
 > **README.md files:**
 > - `/README.md` - Main project README

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ default_agent: "@dev-agent"
 > **Consulted files (agent must populate before committing):**
 > - `/backend/pkg/k8cache/cacheInvalidation.go`
 > - `/backend/pkg/kubeconfig/contextStore.go`
+> - `/frontend/src/components/Sidebar/NavigationTabs.tsx`
 >
 > **README.md files:**
 > - `/README.md` - Main project README

--- a/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.stories.tsx
@@ -270,3 +270,16 @@ SidebarOpen.args = {
   },
 };
 SidebarOpen.storyName = 'Sidebar Open (Should Render Nothing)';
+
+export const NetworkPoliciesSelected = Template.bind({});
+NetworkPoliciesSelected.args = {
+  mockSidebarState: {
+    selected: {
+      item: 'NetworkPolicies',
+      sidebar: DefaultSidebars.IN_CLUSTER,
+    },
+    isSidebarOpen: false,
+  },
+};
+NetworkPoliciesSelected.storyName =
+  "Network View (Child 'Network Policies' Selected, After Hidden Item)";

--- a/frontend/src/components/Sidebar/NavigationTabs.test.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.test.tsx
@@ -40,6 +40,7 @@ describe('NavigationTabs', () => {
         sidebar: {
           entries: {},
           filters: [],
+          homeFilters: [],
           selected: { item: selectedItem, sidebar: DefaultSidebars.IN_CLUSTER },
           isVisible: true,
           isSidebarOpen: false,

--- a/frontend/src/components/Sidebar/NavigationTabs.test.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import reducers from '../../redux/reducers/reducers';
+import { TestContext } from '../../test';
+import NavigationTabs from './NavigationTabs';
+import { DefaultSidebars } from './sidebarSlice';
+import { useSidebarItems } from './useSidebarItems';
+
+vi.mock('./useSidebarItems', () => ({
+  useSidebarItems: vi.fn(),
+}));
+
+vi.mock('../../lib/router', () => ({
+  getRoute: vi.fn().mockReturnValue(undefined),
+  createRouteURL: vi.fn().mockReturnValue('/mock-path'),
+}));
+
+describe('NavigationTabs', () => {
+  const mockStore = (selectedItem: string | null) => {
+    return configureStore({
+      reducer: reducers,
+      preloadedState: {
+        sidebar: {
+          entries: {},
+          filters: [],
+          selected: { item: selectedItem, sidebar: DefaultSidebars.IN_CLUSTER },
+          isVisible: true,
+          isSidebarOpen: false,
+        },
+      },
+    });
+  };
+
+  it('renders level 1 tabs correctly and highlights the correct active tab when some tabs are hidden', () => {
+    const mockItems = [
+      {
+        name: 'network',
+        label: 'Network',
+        subList: [
+          {
+            name: 'services',
+            label: 'Services',
+            hide: false,
+          },
+          {
+            name: 'endpoints',
+            label: 'Endpoints',
+            hide: true,
+          },
+          {
+            name: 'NetworkPolicies',
+            label: 'Network Policies',
+            hide: false,
+          },
+        ],
+      },
+    ];
+
+    vi.mocked(useSidebarItems).mockReturnValue(mockItems);
+
+    const store = mockStore('NetworkPolicies');
+
+    render(
+      <TestContext store={store}>
+        <NavigationTabs />
+      </TestContext>
+    );
+
+    // Services should be rendered as a tab
+    const servicesTab = screen.getByRole('tab', { name: 'Services' });
+    expect(servicesTab).toBeInTheDocument();
+    expect(servicesTab).toHaveAttribute('aria-selected', 'false');
+
+    // Endpoints should not be rendered as a tab since it is hidden
+    expect(screen.queryByRole('tab', { name: 'Endpoints' })).not.toBeInTheDocument();
+
+    // Network Policies should be rendered as a tab and should be selected
+    const netPoliciesTab = screen.getByRole('tab', { name: 'Network Policies' });
+    expect(netPoliciesTab).toBeInTheDocument();
+    expect(netPoliciesTab).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -145,9 +145,10 @@ export default function NavigationTabs() {
       <Tabs
         tabs={level1TabRoutes}
         onTabChanged={tabChangeHandler}
-        defaultIndex={
+        defaultIndex={Math.max(
+          0,
           level1SelectedItem ? level1Tabs.filter(item => !item.hide).indexOf(level1SelectedItem) : 0
-        }
+        )}
         sx={{
           maxWidth: '85vw',
           [theme.breakpoints.down('sm')]: {
@@ -161,11 +162,12 @@ export default function NavigationTabs() {
         <>
           <Tabs
             tabs={level2TabRoutes!!}
-            defaultIndex={
+            defaultIndex={Math.max(
+              0,
               level2Tabs && level2SelectedItem
                 ? level2Tabs.filter(item => !item.hide).indexOf(level2SelectedItem)
                 : 0
-            }
+            )}
             onTabChanged={tabSecondLevelChangeHandler}
             ariaLabel={t('translation|Navigation Tabs')}
           />

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -145,10 +145,12 @@ export default function NavigationTabs() {
       <Tabs
         tabs={level1TabRoutes}
         onTabChanged={tabChangeHandler}
-        defaultIndex={Math.max(
-          0,
-          level1SelectedItem ? level1Tabs.filter(item => !item.hide).indexOf(level1SelectedItem) : 0
-        )}
+        defaultIndex={(() => {
+          const idx = level1SelectedItem
+            ? level1Tabs.filter(item => !item.hide).indexOf(level1SelectedItem)
+            : 0;
+          return idx >= 0 ? idx : null;
+        })()}
         sx={{
           maxWidth: '85vw',
           [theme.breakpoints.down('sm')]: {
@@ -162,12 +164,13 @@ export default function NavigationTabs() {
         <>
           <Tabs
             tabs={level2TabRoutes!!}
-            defaultIndex={Math.max(
-              0,
-              level2Tabs && level2SelectedItem
-                ? level2Tabs.filter(item => !item.hide).indexOf(level2SelectedItem)
-                : 0
-            )}
+            defaultIndex={(() => {
+              const idx =
+                level2Tabs && level2SelectedItem
+                  ? level2Tabs.filter(item => !item.hide).indexOf(level2SelectedItem)
+                  : 0;
+              return idx >= 0 ? idx : null;
+            })()}
             onTabChanged={tabSecondLevelChangeHandler}
             ariaLabel={t('translation|Navigation Tabs')}
           />

--- a/frontend/src/components/Sidebar/NavigationTabs.tsx
+++ b/frontend/src/components/Sidebar/NavigationTabs.tsx
@@ -78,7 +78,7 @@ export default function NavigationTabs() {
 
   const tabChangeHandler = useCallback(
     (index: number) => {
-      const item = level1Tabs[index];
+      const item = level1Tabs.filter(it => !it.hide)[index];
       if (item.url && item.useClusterURL && getCluster()) {
         history.push({
           pathname: generatePath(getClusterPrefixedPath(item.url), { cluster: getCluster()! }),
@@ -98,7 +98,7 @@ export default function NavigationTabs() {
       if (!level2Tabs) {
         return;
       }
-      const tab = level2Tabs[index];
+      const tab = level2Tabs.filter(it => !it.hide)[index];
       const url = tab.url;
       const useClusterURL = !!tab.useClusterURL;
       if (url && useClusterURL && getCluster()) {
@@ -145,7 +145,9 @@ export default function NavigationTabs() {
       <Tabs
         tabs={level1TabRoutes}
         onTabChanged={tabChangeHandler}
-        defaultIndex={level1SelectedItem ? level1Tabs.indexOf(level1SelectedItem) : 0}
+        defaultIndex={
+          level1SelectedItem ? level1Tabs.filter(item => !item.hide).indexOf(level1SelectedItem) : 0
+        }
         sx={{
           maxWidth: '85vw',
           [theme.breakpoints.down('sm')]: {
@@ -160,7 +162,9 @@ export default function NavigationTabs() {
           <Tabs
             tabs={level2TabRoutes!!}
             defaultIndex={
-              level2Tabs && level2SelectedItem ? level2Tabs?.indexOf(level2SelectedItem) : 0
+              level2Tabs && level2SelectedItem
+                ? level2Tabs.filter(item => !item.hide).indexOf(level2SelectedItem)
+                : 0
             }
             onTabChanged={tabSecondLevelChangeHandler}
             ariaLabel={t('translation|Navigation Tabs')}

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
@@ -1,0 +1,165 @@
+<body>
+  <div>
+    <div
+      style="padding: 20px; background-color: rgb(245, 245, 245);"
+    >
+      <nav
+        aria-label="Main Navigation"
+        class="MuiBox-root css-1qm1lh"
+      >
+        <div
+          class="MuiTabs-root css-4u6pf8-MuiTabs-root"
+        >
+          <div
+            class="MuiTabs-scrollableX MuiTabs-hideScrollbar css-oqr85h"
+            style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+          />
+          <div
+            class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX css-69z67c-MuiTabs-scroller"
+            style="margin-bottom: 0px;"
+          >
+            <div
+              aria-label="Navigation Tabs"
+              class="MuiTabs-flexContainer css-heg063-MuiTabs-flexContainer"
+              role="tablist"
+            >
+              <button
+                aria-controls="full-width-tabpanel-0-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-0-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Services
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-1-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-1-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Endpoints
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-2-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-2-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Endpoint Slices
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-3-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-3-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Ingresses
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-4-NavigationTabs-tabs-id"
+                aria-selected="false"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-4-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                Ingress Classes
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                aria-controls="full-width-tabpanel-5-NavigationTabs-tabs-id"
+                aria-selected="true"
+                class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-f00lt7-MuiButtonBase-root-MuiTab-root"
+                id="full-width-tab-5-NavigationTabs-tabs-id"
+                role="tab"
+                tabindex="0"
+                type="button"
+              >
+                Network Policies
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <span
+              class="MuiTabs-indicator css-1s2zz1g-MuiTabs-indicator"
+              style="left: 0px; width: 0px;"
+            />
+          </div>
+        </div>
+        <div
+          aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-0-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-1-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-2-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-3-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-4-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          hidden=""
+          id="full-width-tabpanel-4-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <div
+          aria-labelledby="full-width-tab-5-NavigationTabs-tabs-id"
+          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          id="full-width-tabpanel-5-NavigationTabs-tabs-id"
+          role="tabpanel"
+        />
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+          role="separator"
+        />
+      </nav>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

Fixes the active tab calculation in `NavigationTabs` when rendering a filtered list of sidebar items.

In browser mode, hidden sidebar entries (such as `portforwards`) caused the selected tab index to be calculated from the unfiltered list while the rendered tabs came from the filtered list. As a result, the **Network Policies** tab was not highlighted and tab navigation could become inconsistent.

Fixes #6250

## Changes

- Compute active tab indices from the filtered tab arrays used for rendering.
- Keep the tab change handlers consistent with the filtered tab lists.
- Add a Storybook scenario covering the Network Policies regression.
- Update the corresponding snapshot.

## Verification

- ✅ TypeScript checks pass (`tsc --noEmit`)
- ✅ ESLint passes
- ✅ Storybook tests pass
- ✅ Added regression coverage for the affected navigation scenario