### PR TITLE
Synchronize placeholders for `Node` debugger settings with back-end configuration

### DIFF
--- a/frontend/src/components/App/Settings/NodeShellSettings.tsx
+++ b/frontend/src/components/App/Settings/NodeShellSettings.tsx
@@ -24,6 +24,7 @@ import {
   DEFAULT_NODE_SHELL_LINUX_IMAGE,
   DEFAULT_NODE_SHELL_NAMESPACE,
 } from '../../../helpers/clusterSettings';
+import { useTypedSelector } from '../../../redux/hooks';
 import { NameValueTable } from '../../common/NameValueTable';
 import SectionBox from '../../common/SectionBox';
 import { isValidNamespaceFormat } from './util';
@@ -37,6 +38,12 @@ interface SettingsProps {
 export default function NodeShellSettings(props: SettingsProps) {
   const { clusterSettings, setClusterSettings } = props;
   const { t } = useTranslation(['translation']);
+  const defaultNodeShellImage =
+    useTypedSelector(state => state.config?.defaultNodeShellImage) ||
+    DEFAULT_NODE_SHELL_LINUX_IMAGE;
+  const defaultNodeShellNamespace =
+    useTypedSelector(state => state.config?.defaultNodeShellNamespace) ||
+    DEFAULT_NODE_SHELL_NAMESPACE;
 
   const nodeShellLabelID = 'node-shell-enabled-label';
 
@@ -84,7 +91,7 @@ export default function NodeShellSettings(props: SettingsProps) {
                   updateNodeShell({ linuxImage: value });
                 }}
                 value={image}
-                placeholder={DEFAULT_NODE_SHELL_LINUX_IMAGE}
+                placeholder={defaultNodeShellImage}
                 helperText={t(
                   'translation|The default image is used for dropping a shell into a node (when not specified directly).'
                 )}
@@ -111,11 +118,13 @@ export default function NodeShellSettings(props: SettingsProps) {
                   }
                 }}
                 value={namespaceInput}
-                placeholder={DEFAULT_NODE_SHELL_NAMESPACE}
+                placeholder={defaultNodeShellNamespace}
                 error={!isValidNamespace}
                 helperText={
                   isValidNamespace
-                    ? t('translation|The default namespace is default.')
+                    ? t('translation|The default namespace is {{ namespace }}.', {
+                        namespace: defaultNodeShellNamespace,
+                      })
                     : invalidNamespaceMessage
                 }
                 variant="outlined"

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "إعدادات Node Shell",
   "The default image is used for dropping a shell into a node (when not specified directly).": "تُستخدم الصورة الافتراضية لفتح shell داخل العقدة (عند عدم تحديدها مباشرة)",
   "Linux image": "صورة لينكس",
-  "The default namespace is default.": "النطاق الافتراضي هو default.",
+  "The default namespace is {{ namespace }}.": "النطاق الافتراضي هو {{ namespace }}.",
   "Namespace": "النطاق",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "أدخل قيمة بين {{ minRows }} و {{ maxRows }}.",
   "Custom row value": "قيمة صف مخصصة",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "Node Shell সেটিংস",
   "The default image is used for dropping a shell into a node (when not specified directly).": "Default চিত্রটি একটি Node Shell ফেলে দেওয়ার জন্য ব্যবহৃত হয় (যখন সরাসরি নির্দিষ্ট করা হয় না)।",
   "Linux image": "Linux ইমেজ",
-  "The default namespace is default.": "ডিফল্ট নেমস্পেস হলো default।",
+  "The default namespace is {{ namespace }}.": "ডিফল্ট নেমস্পেস হলো {{ namespace }}।",
   "Namespace": "namespace",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "মধ্যে একটি মান লিখুন {{ minRows }} এবং {{ maxRows }}।",
   "Custom row value": "Custom সারি মান",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is {{ namespace }}.": "",
+  "The default namespace is {{ namespace }}.": "Der Standard-Namespace ist {{ namespace }}.",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "Node Shell Settings",
   "The default image is used for dropping a shell into a node (when not specified directly).": "The default image is used for dropping a shell into a node (when not specified directly).",
   "Linux image": "Linux image",
-  "The default namespace is default.": "The default namespace is default.",
+  "The default namespace is {{ namespace }}.": "The default namespace is {{ namespace }}.",
   "Namespace": "Namespace",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "Enter a value between {{ minRows }} and {{ maxRows }}.",
   "Custom row value": "Custom row value",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "Node Shell Settings",
   "The default image is used for dropping a shell into a node (when not specified directly).": "The default image is used for dropping a shell into a node (when not specified directly).",
   "Linux image": "Linux image",
-  "The default namespace is default.": "The default namespace is default.",
+  "The default namespace is {{ namespace }}.": "The default namespace is {{ namespace }}.",
   "Namespace": "Namespace",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "Enter a value between {{ minRows }} and {{ maxRows }}.",
   "Custom row value": "Custom row value",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is {{ namespace }}.": "",
+  "The default namespace is {{ namespace }}.": "Il namespace predefinito è {{ namespace }}.",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "Настройки оболочки узла",
   "The default image is used for dropping a shell into a node (when not specified directly).": "Образ по умолчанию используется для размещения оболочки в узле (если не указано напрямую).",
   "Linux image": "Образ Linux",
-  "The default namespace is default.": "Пространство имён по умолчанию — default.",
+  "The default namespace is {{ namespace }}.": "Пространство имён по умолчанию — {{ namespace }}.",
   "Namespace": "Пространство имён",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "Введите значение от {{ minRows }} до {{ maxRows }}.",
   "Custom row value": "Пользовательское значение строки",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "نوڈ شیل کی ترتیبات",
   "The default image is used for dropping a shell into a node (when not specified directly).": "ڈیفالٹ امیج نوڈ میں شیل کھولنے کے لیے استعمال ہوتی ہے جب براہ راست کوئی امیج متعین نہ کی گئی ہو",
   "Linux image": "لینکس امیج",
-  "The default namespace is default.": "ڈیفالٹ نیم اسپیس default ہے",
+  "The default namespace is {{ namespace }}.": "ڈیفالٹ نیم اسپیس {{ namespace }} ہے",
   "Namespace": "نیم اسپیس",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "{{ minRows }} اور {{ maxRows }} کے درمیان کوئی قدر درج کریں",
   "Custom row value": "حسب ضرورت قطار کی قدر",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -152,7 +152,7 @@
   "Node Shell Settings": "",
   "The default image is used for dropping a shell into a node (when not specified directly).": "",
   "Linux image": "",
-  "The default namespace is default.": "",
+  "The default namespace is {{ namespace }}.": "",
   "Namespace": "",
   "Enter a value between {{ minRows }} and {{ maxRows }}.": "",
   "Custom row value": "",


### PR DESCRIPTION
## Summary

Cluster settings for `Node` will always display the default Docker image and namespace as placeholders, even when deployed with custom image / namespace overrides.

## Changes

- Updated `NodeShellSettings` component to source placeholder using the same pattern used in `PodDebugSettings`.
- Updated translation files to parametrize the namespace instead of hardcoding it.
- Added translations for German and Italian.

## Steps to Test

1. Launch locally, specifying a custom `node-shell-image` and `node-shell-namespace` on the back-end.
2. Open Headlamp UI in the browser.
3. Navigate to `/settings/cluster`, and ensure the placeholder text in <kbd>Node Shell Settings</kbd> fields matches what was passed to the back-end.