### PR TITLE
frontend: runCommand: Fix IPC listener leak on command exit

### DIFF
--- a/frontend/src/components/App/runCommand.test.ts
+++ b/frontend/src/components/App/runCommand.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runCommand } from './runCommand';
+
+describe('runCommand', () => {
+  beforeEach(() => {
+    vi.stubGlobal('desktopApi', {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Creates a fake desktopApiReceive that tracks registered/unsubscribed listeners per channel. */
+  function createFakeDesktopApiReceive() {
+    const listenersByChannel: Record<string, Array<(...args: any[]) => void>> = {};
+
+    const desktopApiReceive = vi.fn((channel: string, listener: (...args: any[]) => void) => {
+      listenersByChannel[channel] = [...(listenersByChannel[channel] ?? []), listener];
+
+      return () => {
+        listenersByChannel[channel] = (listenersByChannel[channel] ?? []).filter(
+          it => it !== listener
+        );
+      };
+    });
+
+    return {
+      desktopApiReceive,
+      listenersByChannel,
+      emit(channel: string, ...args: any[]) {
+        (listenersByChannel[channel] ?? []).forEach(listener => listener(...args));
+      },
+      countListeners(channel: string) {
+        return (listenersByChannel[channel] ?? []).length;
+      },
+    };
+  }
+
+  it('removes all 3 listeners once the command exits', () => {
+    const { desktopApiReceive, emit, countListeners } = createFakeDesktopApiReceive();
+    const desktopApiSend = vi.fn();
+
+    const cmd = runCommand('minikube', ['status'], {}, {}, desktopApiSend, desktopApiReceive);
+
+    const exitListener = vi.fn();
+    cmd.on('exit', exitListener);
+
+    // The id sent to desktopApiSend is what the main process will echo back.
+    const sentId = desktopApiSend.mock.calls[0][1].id;
+
+    expect(countListeners('command-stdout')).toBe(1);
+    expect(countListeners('command-stderr')).toBe(1);
+    expect(countListeners('command-exit')).toBe(1);
+
+    emit('command-exit', sentId, 0);
+
+    expect(exitListener).toHaveBeenCalledWith(0);
+    expect(countListeners('command-stdout')).toBe(0);
+    expect(countListeners('command-stderr')).toBe(0);
+    expect(countListeners('command-exit')).toBe(0);
+  });
+
+  it('does not leak listeners across multiple sequential calls', () => {
+    const { desktopApiReceive, emit, countListeners } = createFakeDesktopApiReceive();
+    const desktopApiSend = vi.fn();
+
+    for (let i = 0; i < 5; i++) {
+      runCommand('minikube', ['status'], {}, {}, desktopApiSend, desktopApiReceive);
+      const sentId = desktopApiSend.mock.calls[i][1].id;
+      emit('command-exit', sentId, 0);
+    }
+
+    expect(countListeners('command-stdout')).toBe(0);
+    expect(countListeners('command-stderr')).toBe(0);
+    expect(countListeners('command-exit')).toBe(0);
+  });
+
+  it("does not remove a different in-flight command's listeners when this one exits", () => {
+    const { desktopApiReceive, emit, countListeners } = createFakeDesktopApiReceive();
+    const desktopApiSend = vi.fn();
+
+    runCommand('minikube', ['status'], {}, {}, desktopApiSend, desktopApiReceive);
+    runCommand('minikube', ['status'], {}, {}, desktopApiSend, desktopApiReceive);
+
+    expect(countListeners('command-exit')).toBe(2);
+    expect(countListeners('command-stdout')).toBe(2);
+    expect(countListeners('command-stderr')).toBe(2);
+
+    const firstId = desktopApiSend.mock.calls[0][1].id;
+    emit('command-exit', firstId, 0);
+
+    // Only the first command's listeners should be gone; the second is still running.
+    expect(countListeners('command-exit')).toBe(1);
+    expect(countListeners('command-stdout')).toBe(1);
+    expect(countListeners('command-stderr')).toBe(1);
+  });
+});

--- a/frontend/src/components/App/runCommand.ts
+++ b/frontend/src/components/App/runCommand.ts
@@ -64,8 +64,8 @@ export function runCommand(
   ) => void,
   desktopApiReceive?: (
     channel: string,
-    listener: (cmdId: string, data: string | number) => void
-  ) => void
+    listener: (cmdId: string, data: string | number | null) => void
+  ) => (() => void) | void
 ): {
   stdout: { on: (event: string, listener: (chunk: any) => void) => void };
   stderr: { on: (event: string, listener: (chunk: any) => void) => void };
@@ -87,29 +87,44 @@ export function runCommand(
   const id = `${new Date().getTime()}-${Math.random().toString(36)}`;
 
   const stdout = new EventTarget();
-  desktopApiReceive('command-stdout', (cmdId: string, data: string | number) => {
-    if (cmdId === id) {
-      const event = new CustomEvent('data', { detail: data });
-      stdout.dispatchEvent(event);
+  const unsubscribeStdout = desktopApiReceive(
+    'command-stdout',
+    (cmdId: string, data: string | number | null) => {
+      if (cmdId === id) {
+        const event = new CustomEvent('data', { detail: data });
+        stdout.dispatchEvent(event);
+      }
     }
-  });
+  );
 
   const stderr = new EventTarget();
-  desktopApiReceive('command-stderr', (cmdId: string, data: string | number) => {
-    if (cmdId === id) {
-      const event = new CustomEvent('data', { detail: data });
-      stderr.dispatchEvent(event);
+  const unsubscribeStderr = desktopApiReceive(
+    'command-stderr',
+    (cmdId: string, data: string | number | null) => {
+      if (cmdId === id) {
+        const event = new CustomEvent('data', { detail: data });
+        stderr.dispatchEvent(event);
+      }
     }
-  });
+  );
 
   const exit = new EventTarget();
-  desktopApiReceive('command-exit', (cmdId: string, code: string | number) => {
-    if (cmdId === id) {
-      const event = new CustomEvent('exit', { detail: code });
-      exit.dispatchEvent(event);
+  const unsubscribeExit = desktopApiReceive(
+    'command-exit',
+    (cmdId: string, code: string | number | null) => {
+      if (cmdId === id) {
+        const exitCode = typeof code === 'number' || code === null ? code : null;
+        const event = new CustomEvent('exit', { detail: exitCode });
+        try {
+          exit.dispatchEvent(event);
+        } finally {
+          unsubscribeStdout?.();
+          unsubscribeStderr?.();
+          unsubscribeExit?.();
+        }
+      }
     }
-  });
-
+  );
   // We use desktopApiReceive and desktopApiSend to communicate with the main process.
   // Because other plugins may change the global window.desktopApi functions
   // to snoop on the secrets that plugins are sending.


### PR DESCRIPTION
## Summary
This PR fixes a memory leak in runCommand (exposed to plugins as
pluginRunCommand) where the three IPC listeners registered per call were
never cleaned up, even after the command's own exit event fired.

## Related Issue
Fixes #6252

## Changes
- Captured the unsubscribe functions returned by desktopApiReceive for the
  command-stdout, command-stderr, and command-exit listeners
- Called all three unsubscribe functions once the command-exit event fires
  for the matching command id
- Updated the desktopApiReceive parameter type to reflect that it can return
  an unsubscribe function
- Added a regression test file (runCommand.test.ts) verifying listeners are
  removed after exit, no leaks across repeated calls, and that one command's
  cleanup doesn't affect another still-running command's listeners

## Steps to Test
1. Run the new test file: npx vitest run src/components/App/runCommand.test.ts
2. All 3 tests should pass
3. (Optional) Revert the fix locally and re-run the tests to confirm they
   fail against the old behavior, demonstrating the regression test catches
   the original bug

## Notes for the Reviewer
- This only touches runCommand.ts and its new test file — no unrelated files
- No existing test file existed for runCommand.ts prior to this PR