### PR TITLE
frontend: ProjectResourcesTab: Fall back to Unknown for missing pod phase

### DIFF
--- a/frontend/src/components/project/ProjectResourcesTab.tsx
+++ b/frontend/src/components/project/ProjectResourcesTab.tsx
@@ -248,7 +248,7 @@ export function ProjectResourcesTab({
           }
           if (kind === 'Pod') {
             const res = resource as Pod;
-            return `Phase: ${res.status?.phase}`;
+            return `Phase: ${res.status?.phase ?? 'Unknown'}`;
           }
           return '';
         },
@@ -280,7 +280,7 @@ export function ProjectResourcesTab({
             const res = resource as Pod;
             return (
               <Typography variant="body2" color="text.secondary" whiteSpace="nowrap">
-                {`Phase: ${res.status?.phase}`}
+                {`Phase: ${res.status?.phase ?? 'Unknown'}`}
               </Typography>
             );
           }


### PR DESCRIPTION
## Summary

Project Resources tab showed "Phase: undefined" for pods sometimes - happens
right after a pod is created, before the scheduler/kubelet have reported
anything back, so status is briefly empty.

## Related Issue

Fixes #6207

## Changes

- Both the accessorFn (sort/filter) and the Cell renderer (display) in
  ProjectResourcesTab.tsx now fall back to "Unknown" when status.phase isn't
  there yet, same as the Deployment/StatefulSet/DaemonSet branches right
  above it already do (they fall back to 0).

## Steps to Test

1. Create or scale a Deployment in a Project so new pods spin up.
2. Open the Project's Resources tab while a pod is brand new.
3. Should show "Phase: Unknown" instead of "Phase: undefined" during that
   window.

## Screenshots (if applicable)

N/A - text fallback only, visible during a brief transient state.

## Notes for the Reviewer

Small one, just matching the fallback pattern the other branches in the same
function already use.
