### PR TITLE
frontend: units: Parse decimal-core CPU quantities with parseFloat

### DIFF
--- a/frontend/src/lib/units.test.ts
+++ b/frontend/src/lib/units.test.ts
@@ -144,6 +144,12 @@ describe('parseCpu', () => {
     expect(parseCpu('1000')).toBe(1000000000000);
   });
 
+  it('should keep the fractional part of decimal-core quantities', () => {
+    expect(parseCpu('0.5')).toBe(500000000);
+    expect(parseCpu('1.5')).toBe(1500000000);
+    expect(parseCpu('2.5')).toBe(2500000000);
+  });
+
   it('should scale correctly between units', () => {
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 1000 }), num => {

--- a/frontend/src/lib/units.ts
+++ b/frontend/src/lib/units.ts
@@ -78,7 +78,9 @@ export function unparseRam(value: number) {
 export function parseCpu(value: string) {
   if (!value) return 0;
 
-  const number = parseInt(value, 10);
+  // parseFloat (not parseInt) so decimal-core quantities like "0.5" or "1.5"
+  // keep their fractional part. Suffixed forms still parse ("500m" -> 500).
+  const number = parseFloat(value);
   if (value.endsWith('n')) return number;
   if (value.endsWith('u')) return number * 1000;
   if (value.endsWith('m')) return number * 1000 * 1000;


### PR DESCRIPTION
## What this does

Fixes `parseCpu()` so decimal-core CPU quantities keep their fractional part.

`parseCpu` used `parseInt(value, 10)`, which stops at the decimal point. Kubernetes allows CPU as decimal cores (`cpu: "0.5"`, `"1.5"`, `"2.5"`), so these were silently truncated:

| input    | before      | after |
|----------|-------------|-------|
| `"0.5"`  | 0 cores     | 0.5   |
| `"1.5"`  | 1 core      | 1.5   |
| `"2.5"`  | 2 cores     | 2.5   |
| `"500m"` | 0.5 ✓       | 0.5   |

Suffixed forms (`m`/`u`/`n`) are unaffected since `parseFloat("500m") === 500`.

This undercounted CPU in node detail aggregation (`node/Details.tsx`) and cluster resource charts (`cluster/Charts/ResourceCharts.tsx`) whenever a pod declared CPU as decimal cores.

## Fix

Use `parseFloat` instead of `parseInt`.

## Testing

Added a regression test for decimal-core parsing in `units.test.ts`. All `units` tests pass.

Fixes #6258
