### PR TITLE
app: Don't log ENOENT as error when loading zoom factor on first launch

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -1351,7 +1351,13 @@ async function loadZoomFactor(): Promise<number> {
     const { zoomFactor = 1.0 } = JSON.parse(content);
     return typeof zoomFactor === 'number' ? zoomFactor : 1.0;
   } catch (err) {
-    console.error('Failed to load zoom factor, defaulting to 1.0:', err);
+    // ENOENT is expected on first launch, before any zoom change has been
+    // saved — the config file simply doesn't exist yet. Only log genuine
+    // failures (corrupted JSON, permission errors, etc).
+    const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
+    if (code !== 'ENOENT') {
+      console.error('Failed to load zoom factor, defaulting to 1.0:', err);
+    }
     return 1.0;
   }
 }


### PR DESCRIPTION
Headlamp's zoom config file is only written the first time a user changes the zoom level. On a fresh install, loadZoomFactor() always hits the file-not-found case and logs a full error stack trace for what is actually expected, normal behavior.

Only log when the failure is something other than the file simply not existing yet (e.g. corrupted JSON, permission errors), so the console stays clean on a clean first run while real problems are still surfaced.

Fixes #6261

## Summary

This PR adds/fixes [feature/bug] by [brief description of what the change does].

## Related Issue

Fixes #ISSUE_NUMBER  

## Changes

- Added/Updated [component/file/logic]
- Fixed [bug/issue/typo]
- Refactored [code/module] for clarity/performance

## Steps to Test

1. Delete `~/Library/Application Support/Headlamp/headlamp-config.json` (or wherever it lives on your OS)
2. Launch Headlamp — confirm no error is logged for the missing file
3. Replace the file with invalid JSON and relaunch — confirm the error *is* still logged



## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
