### PR TITLE
frontend: fix race condition in stream() cancel and retry timer

### DIFF
--- a/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
+++ b/frontend/src/lib/k8s/api/v1/apiProxy.test.ts
@@ -652,6 +652,53 @@ describe('apiProxy', () => {
           done();
         });
       }));
+
+    it('Does not reconnect or call connectCb after cancel during retry delay', () =>
+      new Promise<void>(done => {
+        expect.assertions(4);
+
+        const { cancel } = apiProxy.stream(testPath, cb, {
+          connectCb,
+          reconnectOnFailure: true,
+          isJson: true,
+        });
+
+        mockServer.on('connection', async (socket: any) => {
+          try {
+            // Initial connection established with real timers
+            expect(connectCb).toHaveBeenCalledTimes(1);
+
+            // Switch to fake timers now so we can control the 3-second retry delay
+            vi.useFakeTimers();
+
+            // Capture baseline so any pre-existing timers don't skew the assertions
+            const timerBaseline = vi.getTimerCount();
+
+            // Close server-side to trigger onClose → onFail → retryOnFail → setTimeout(connect, 3000)
+            socket.close();
+
+            // Advance fake timers so the close event propagates and the retry timer is scheduled
+            await vi.advanceTimersByTimeAsync(100);
+
+            // The 3-second reconnect timer must now be pending (one more than baseline)
+            expect(vi.getTimerCount()).toBe(timerBaseline + 1);
+
+            // Cancel before the 3-second retry fires; this clears the pending timer
+            cancel();
+
+            // The pending timer must have been cleared by cancel()
+            expect(vi.getTimerCount()).toBe(timerBaseline);
+
+            // Advance past the retry window — the cleared timer must not invoke connect() or connectCb
+            await vi.advanceTimersByTimeAsync(5000);
+
+            expect(connectCb).toHaveBeenCalledTimes(1);
+            done();
+          } finally {
+            vi.useRealTimers();
+          }
+        });
+      }));
   });
 
   describe('apply', () => {

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -319,6 +319,7 @@ export interface StreamArgs {
 export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs) {
   let connection: StreamConnection | null = null;
   let isCancelled = false;
+  let retryTimeout: ReturnType<typeof setTimeout> | null = null;
   const { failCb, cluster = '' } = args;
   // We only set reconnectOnFailure as true by default if the failCb has not been provided.
   const { isJson = false, additionalProtocols, connectCb, reconnectOnFailure = !failCb } = args;
@@ -338,12 +339,22 @@ export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs)
   function cancel() {
     if (connection) connection.close();
     isCancelled = true;
+    if (retryTimeout !== null) {
+      clearTimeout(retryTimeout);
+      retryTimeout = null;
+    }
   }
 
   async function connect() {
+    if (isCancelled) return;
     if (connectCb) connectCb();
     try {
-      connection = await connectStream(url, cb, onFail, isJson, additionalProtocols, cluster);
+      const conn = await connectStream(url, cb, onFail, isJson, additionalProtocols, cluster);
+      if (isCancelled) {
+        conn.close();
+        return;
+      }
+      connection = conn;
     } catch (error) {
       console.error('Error connecting stream:', error);
       onFail();
@@ -358,7 +369,10 @@ export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs)
         console.debug('k8s/apiProxy@stream retryOnFail', 'Reconnecting in 3 seconds', { url });
       }
 
-      setTimeout(connect, 3000);
+      retryTimeout = setTimeout(() => {
+        retryTimeout = null;
+        connect();
+      }, 3000);
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a race condition in `stream()` where a pending reconnect could execute after the stream had already been cancelled.

The fix stores the reconnect timer handle so it can be cleared during cancellation, and adds an early cancellation check in `connect()` to prevent callbacks or connection attempts from occurring after the stream has been cancelled.

## Related Issue

Fixes #6272 

## Changes

- Added a `retryTimeout` handle to track scheduled reconnects.
- Cleared pending reconnect timers in `cancel()`.
- Added an early `isCancelled` guard at the start of `connect()`.
- Prevented reconnect callbacks and connection attempts from executing after cancellation.

## Steps to Test

1. Run the existing frontend test suite.
2. Create a stream with `reconnectOnFailure` enabled.
3. Trigger a connection failure to schedule a reconnect.
4. Call `cancel()` before the 3-second retry delay expires.
5. Verify that:
   - No reconnect attempt occurs after cancellation.
   - `connectCb` is not invoked after cancellation.
   - Existing reconnect behavior remains unchanged when the stream is active.

### Why the race condition existed

The race condition stemmed from two independent issues:

1. **Uncleared retry timer**

   `retryOnFail()` scheduled reconnects using `setTimeout(connect, 3000)` but discarded the returned timer handle. If `cancel()` was called during the retry delay, there was no way to cancel the pending timer, allowing `connect()` to execute after the stream had already been cancelled.

2. **`connectCb` invoked before checking cancellation**

   `connect()` invoked `connectCb` before checking whether the stream had already been cancelled. As a result, if the scheduled reconnect executed after cancellation, the callback could still run even though the caller had already abandoned the stream.

### Why the fix works

The fix introduces three minimal changes:

| Change | Effect |
|--------|--------|
| Add `let retryTimeout: ReturnType<typeof setTimeout> \| null = null` | Retains the reconnect timer handle. |
| Store the result of `setTimeout()` in `retryTimeout` | Allows the pending reconnect to be cancelled later. |
| Call `clearTimeout(retryTimeout)` and reset it in `cancel()` | Prevents the scheduled reconnect from executing after cancellation. |
| Add `if (isCancelled) return;` at the start of `connect()` | Provides defense-in-depth by preventing callbacks or connection attempts even if `connect()` is invoked after cancellation. |

### Edge cases

- `retryOnFail()` already checks `isCancelled` before scheduling a reconnect. The new guard in `connect()` provides an additional layer of protection with negligible overhead.
- `retryTimeout` is only assigned within `retryOnFail()`, so there is no risk of conflicting timer handles.
- `connectStream()` remains responsible for handling cancellation after the asynchronous connection process has begun, so no additional changes are required there.

### Testing

All existing tests continue to pass.

A dedicated regression test would be valuable to cover this timing scenario:

1. Create a stream with `reconnectOnFailure: true`.
2. Trigger a connection failure to schedule a reconnect.
3. Call `cancel()` before the retry delay expires.
4. Advance fake timers by 3 seconds.
5. Verify that `connectCb` is not invoked again and no reconnect is attempted.

This test would fit naturally alongside the existing WebSocket tests in `apiProxy.test.ts`.