### PR TITLE
frontend: TimezoneSelect: Fix duplicate HTML id attribute in Autocomplete

### DIFF
--- a/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/Settings.General.stories.storyshot
@@ -285,14 +285,14 @@
                   >
                     <input
                       aria-autocomplete="both"
-                      aria-describedby="cluster-selector-autocomplete-helper-text"
+                      aria-describedby="timezone-selector-autocomplete-helper-text"
                       aria-expanded="false"
                       aria-invalid="false"
                       aria-labelledby="timezone-label"
                       autocapitalize="none"
                       autocomplete="off"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
-                      id="cluster-selector-autocomplete"
+                      id="timezone-selector-autocomplete"
                       role="combobox"
                       spellcheck="false"
                       type="text"
@@ -341,7 +341,7 @@
                   </div>
                   <p
                     class="MuiFormHelperText-root MuiFormHelperText-sizeSmall MuiFormHelperText-contained MuiFormHelperText-filled css-153yz37-MuiFormHelperText-root"
-                    id="cluster-selector-autocomplete-helper-text"
+                    id="timezone-selector-autocomplete-helper-text"
                   >
                     Timezone
                   </p>

--- a/frontend/src/components/common/TimezoneSelect/TimezoneSelect.tsx
+++ b/frontend/src/components/common/TimezoneSelect/TimezoneSelect.tsx
@@ -44,7 +44,7 @@ export default function TimezoneSelect(props: TimezoneSelectorProps) {
 
   return (
     <Autocomplete
-      id="cluster-selector-autocomplete"
+      id="timezone-selector-autocomplete"
       options={timezoneOptions}
       getOptionLabel={option =>
         `(UTC${option.offset >= 0 ? '+' : ''}${option.offset}) ${option.name}`

--- a/frontend/src/components/common/TimezoneSelect/__snapshots__/TimezoneSelect.Default.stories.storyshot
+++ b/frontend/src/components/common/TimezoneSelect/__snapshots__/TimezoneSelect.Default.stories.storyshot
@@ -11,14 +11,14 @@
         >
           <input
             aria-autocomplete="both"
-            aria-describedby="cluster-selector-autocomplete-helper-text"
+            aria-describedby="timezone-selector-autocomplete-helper-text"
             aria-expanded="false"
             aria-invalid="false"
             aria-label="Timezone"
             autocapitalize="none"
             autocomplete="off"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
-            id="cluster-selector-autocomplete"
+            id="timezone-selector-autocomplete"
             role="combobox"
             spellcheck="false"
             type="text"
@@ -67,7 +67,7 @@
         </div>
         <p
           class="MuiFormHelperText-root MuiFormHelperText-sizeSmall MuiFormHelperText-contained css-153yz37-MuiFormHelperText-root"
-          id="cluster-selector-autocomplete-helper-text"
+          id="timezone-selector-autocomplete-helper-text"
         >
           Timezone
         </p>

--- a/frontend/src/components/common/TimezoneSelect/__snapshots__/TimezoneSelect.NoInitialValue.stories.storyshot
+++ b/frontend/src/components/common/TimezoneSelect/__snapshots__/TimezoneSelect.NoInitialValue.stories.storyshot
@@ -11,14 +11,14 @@
         >
           <input
             aria-autocomplete="both"
-            aria-describedby="cluster-selector-autocomplete-helper-text"
+            aria-describedby="timezone-selector-autocomplete-helper-text"
             aria-expanded="false"
             aria-invalid="false"
             aria-label="Timezone"
             autocapitalize="none"
             autocomplete="off"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
-            id="cluster-selector-autocomplete"
+            id="timezone-selector-autocomplete"
             role="combobox"
             spellcheck="false"
             type="text"
@@ -67,7 +67,7 @@
         </div>
         <p
           class="MuiFormHelperText-root MuiFormHelperText-sizeSmall MuiFormHelperText-contained css-153yz37-MuiFormHelperText-root"
-          id="cluster-selector-autocomplete-helper-text"
+          id="timezone-selector-autocomplete-helper-text"
         >
           Timezone
         </p>


### PR DESCRIPTION
## Summary
This PR fixes a duplicate HTML `id` issue in `TimezoneSelect`. The `Autocomplete` component was using the same hardcoded `id` as `Chooser.tsx`, which could lead to duplicate IDs if both components were rendered on the same page.

## Related Issue
Fixes #6278 

## Changes
- Changed the `id` attribute on the Autocomplete component in
  `TimezoneSelect.tsx` from `"cluster-selector-autocomplete"` to
  `"timezone-selector-autocomplete"`
- Updated three affected Storybook snapshots since MUI auto-derives
  `aria-describedby` and the helper-text element id from this `id` prop:
  - `TimezoneSelect.Default.stories.storyshot`
  - `TimezoneSelect.NoInitialValue.stories.storyshot`
  - `Settings.General.stories.storyshot` (Settings page renders
    TimezoneSelect, so this snapshot also referenced the old id)

## Steps to Test
1. Run `npm run storybook` and open the `TimezoneSelect` story.
2. Inspect the rendered input in DevTools and verify it uses `id="timezone-selector-autocomplete"`.
3. Check that `Chooser.tsx` is unchanged and still uses `id="cluster-selector-autocomplete"`.
4. Run `npm run lint` and confirm it passes without errors.


## Notes for the Reviewer
- `TimezoneSelect.tsx` and `Chooser.tsx` are separate components, but both were using the same hardcoded `id`. If they appeared on the same page, such as in Settings, that resulted in duplicate HTML IDs.
- This is intentionally a one-line code change. `Chooser.tsx` wasn't modified because it already owns the `"cluster-selector-autocomplete"` `id`.
- Only the two affected `TimezoneSelect` storyshot snapshots were updated. I left the rest of the snapshot suite as-is since there are unrelated existing snapshot changes, and I wanted to keep this PR focused on the reported issue.
