### PR TITLE
frontend: Fix token paste blocked in Chrome on password input

### DIFF
--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -117,9 +117,8 @@ export function PureAuthToken({
 }: PureAuthTokenProps) {
   const { t } = useTranslation();
   const cluster = getCluster();
-  const focusedRef = React.useCallback((node: HTMLDivElement) => {
+  const inputRef = React.useCallback((node: HTMLInputElement | null) => {
     if (node !== null) {
-      // node.setAttribute('tabindex', '-1');
       node.focus();
     }
   }, []);
@@ -146,7 +145,7 @@ export function PureAuthToken({
             value={token}
             onChange={onChangeToken}
             fullWidth
-            ref={focusedRef}
+            inputRef={inputRef}
           />
         </DialogContent>
         <DialogActions>

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowActions.stories.storyshot
@@ -108,7 +108,7 @@
               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth MuiTextField-root css-1z10yd4-MuiFormControl-root-MuiTextField-root"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="token"
                 id="token-label"
@@ -116,7 +116,7 @@
                 ID token
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-u775sc-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall css-u775sc-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"

--- a/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
+++ b/frontend/src/components/account/__snapshots__/AuthToken.ShowError.stories.storyshot
@@ -131,7 +131,7 @@
               class="MuiFormControl-root MuiFormControl-marginDense MuiFormControl-fullWidth MuiTextField-root css-1z10yd4-MuiFormControl-root-MuiTextField-root"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1f7ywh2-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="token"
                 id="token-label"
@@ -139,7 +139,7 @@
                 ID token
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-u775sc-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall css-u775sc-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"

--- a/frontend/src/lib/useShortcut.test.ts
+++ b/frontend/src/lib/useShortcut.test.ts
@@ -14,7 +14,80 @@
  * limitations under the License.
  */
 
-import { formatShortcutKey } from './useShortcut';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-hotkeys-hook', async () => {
+  const actual = await vi.importActual<typeof import('react-hotkeys-hook')>('react-hotkeys-hook');
+  return { ...actual, useHotkeys: vi.fn() };
+});
+
+import { configureStore } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { Provider } from 'react-redux';
+import { formatShortcutKey, useShortcut } from './useShortcut';
+
+// A minimal fixed reducer, instead of the real shortcutsSlice, so the test isn't
+// order-dependent on whatever localStorage happened to hold when that module's
+// initialState was computed at import time.
+function shortcutsReducer(
+  state = { shortcuts: { GLOBAL_SEARCH: { id: 'GLOBAL_SEARCH', key: '/' } } }
+) {
+  return state;
+}
+
+function makeStore() {
+  return configureStore({ reducer: { shortcuts: shortcutsReducer } });
+}
+
+function makeWrapper() {
+  const store = makeStore();
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(Provider, { store, children });
+  };
+}
+
+describe('useShortcut', () => {
+  beforeEach(() => {
+    vi.mocked(useHotkeys).mockReset();
+  });
+
+  it('calls event.preventDefault() when the shortcut fires', () => {
+    let hotkeyCallback: ((e: KeyboardEvent) => void) | undefined;
+    vi.mocked(useHotkeys).mockImplementation((_key: any, cb: any) => {
+      hotkeyCallback = cb;
+      return undefined as any;
+    });
+
+    renderHook(() => useShortcut('GLOBAL_SEARCH', () => {}), {
+      wrapper: makeWrapper(),
+    });
+
+    const event = { preventDefault: vi.fn() } as unknown as KeyboardEvent;
+    hotkeyCallback!(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('forwards other options to useHotkeys', () => {
+    renderHook(() => useShortcut('GLOBAL_SEARCH', () => {}, { enabled: true }), {
+      wrapper: makeWrapper(),
+    });
+
+    const [, , opts] = vi.mocked(useHotkeys).mock.calls[0] as any[];
+    expect(opts).toEqual({ enabled: true });
+  });
+
+  it('never forwards preventDefault to useHotkeys options', () => {
+    // Typed out of the signature, so this only guards against untyped JS callers.
+    renderHook(() => useShortcut('GLOBAL_SEARCH', () => {}, { preventDefault: false } as any), {
+      wrapper: makeWrapper(),
+    });
+
+    const [, , opts] = vi.mocked(useHotkeys).mock.calls[0] as any[];
+    expect(opts).not.toHaveProperty('preventDefault');
+  });
+});
 
 describe('formatShortcutKey', () => {
   describe('single keys', () => {

--- a/frontend/src/lib/useShortcut.ts
+++ b/frontend/src/lib/useShortcut.ts
@@ -28,20 +28,27 @@ import { useTypedSelector } from '../redux/hooks';
 export function useShortcut(
   shortcutId: string,
   callback: (event: KeyboardEvent) => void,
-  options?: Options,
+  options?: Omit<Options, 'preventDefault'>,
   deps?: any[]
 ) {
   const shortcut = useTypedSelector(state => state.shortcuts.shortcuts[shortcutId]);
   const key = shortcut?.key || '';
 
+  // preventDefault must never reach useHotkeys: as an option there, Chrome treats it as
+  // blanket key interception and drops paste events on password inputs. It is called on
+  // the event instead, so it only applies once a shortcut has actually matched.
+  const restOptions: Options = { ...options };
+  delete restOptions.preventDefault;
+
   return useHotkeys(
     key,
     (event: KeyboardEvent) => {
       if (key) {
+        event.preventDefault();
         callback(event);
       }
     },
-    { preventDefault: true, ...options },
+    restOptions,
     deps
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes the inability to paste authentication tokens into Headlamp's ID token field in Chrome on macOS and other platforms.

## Related Issue

Relates to #6003

## Root Cause

Two separate issues combine to block paste in Chrome:

**1. Global `preventDefault: true` in `useShortcut`**

`useShortcut.ts` passed `{ preventDefault: true }` as a static option to `useHotkeys`. Chrome treats broad keyboard-interception flags on password fields as a security signal and silently drops paste events on `type="password"` inputs when such listeners are active. Calling `preventDefault()` inside the callback instead ensures it only fires when a registered shortcut actually matches a key event — not as a blanket option that Chrome sees unconditionally.

**2. Wrong element receiving focus on dialog open**

The token `TextField` used a `ref` callback that called `.focus()` on the MUI root wrapper `<div>` (since MUI TextField's `ref` points to the container element, not the native `<input>`). When the auth dialog opened, the div held focus rather than the input. Pressing Ctrl+V/Cmd+V dispatched the paste event to the div, which silently ignores it. Switching to MUI's `inputRef` prop wires the callback directly to the native `<input type="password">` element, so it receives focus and paste events correctly.

## Changes

- `frontend/src/lib/useShortcut.ts`: Calls `event.preventDefault()` inside the callback (only once a shortcut has matched) rather than passing `preventDefault` as an option to `useHotkeys`. The `preventDefault` option is removed from the hook's public signature — no call site used it. `options` is now typed `Omit<Options, 'preventDefault'>`, so a caller cannot reach `useHotkeys` with it even by accident, and it is stripped from the forwarded options to guard against untyped JS callers.
- `frontend/src/components/account/Auth.tsx`: Replaced `ref={focusedRef}` (focused wrapper div) with `inputRef={inputRef}` (focuses the native input element directly)
- `frontend/src/lib/useShortcut.test.ts`: Unit tests covering the above.

## Steps to Test

1. Open Headlamp in Chrome on macOS (or any Chrome build that shows the issue)
2. Navigate to a cluster that requires token authentication — the ID token dialog appears
3. Copy a token to the clipboard
4. Click the **ID token** field and press Cmd+V (or Ctrl+V) to paste
5. Verify the token appears in the field
6. Confirm that the `/` global search shortcut still works when pressed outside any input field
7. Confirm that pressing `/` inside an input field types the character normally (shortcut does not fire)

## Manual Verification

@illume — on your question about whether the shortcuts still work: yes, checked in Chrome against this branch (dev server, `/` = `GLOBAL_SEARCH`).

- With focus on `<body>` (outside any input), pressing `/` focuses the Global Search input and the field stays **empty** — so the shortcut fires and `event.preventDefault()` still suppresses the character. That's the behaviour that would break if `preventDefault` were dropped rather than moved into the callback.
- Typing `pod/test` into that input produces exactly `pod/test` — a `/` typed while already inside an input is entered literally and does not re-trigger the shortcut.
- Checked all four call sites (`GLOBAL_SEARCH` in `GlobalSearch.tsx`, `CLUSTER_CHOOSER` in `Chooser.tsx`, `TABLE_COLUMN_FILTERS` in `Table.tsx`, `LOG_VIEWER_SEARCH` in `LogViewer.tsx`) — none passed a `preventDefault` option, so removing it changes no runtime behaviour for any of them.
- `useShortcut` unit tests and the `Auth.test.tsx` suite pass; the token-field focus change is covered by those and the updated storyshots.

## Screenshots (if applicable)

N/A — behavioural fix; no visual change to the UI.

## Notes for the Reviewer

- The password-masking (`type="password"`) is preserved — no security regression.
- Shortcut behaviour for all registered shortcuts is unchanged: `event.preventDefault()` is still called when a shortcut matches, just from inside the callback rather than as a `useHotkeys` option.
- @illume — the `preventDefault` option is now removed as you asked. Copilot had flagged that the option could leak into `useHotkeys` and reintroduce the paste bug; removing it from the signature addresses both points at once, since an option that doesn't exist can't be forwarded.

