### PR TITLE
frontend: node: Add Storybook stories for UpgradeVisualizationPanel

### DIFF
--- a/frontend/src/components/node/UpgradeVisualizationPanel.stories.tsx
+++ b/frontend/src/components/node/UpgradeVisualizationPanel.stories.tsx
@@ -25,7 +25,7 @@ import { UpgradeProgress } from './UpgradeVisualizationPanel';
 // upgrade events; UpgradeProgress is the pure renderer it ends up showing, so
 // the stories drive it directly with the nodes and events as fixtures.
 const nodes = AKS_UPGRADE_NODES.map(data => new Node(data));
-const events = AKS_UPGRADE_EVENTS.map(data => new Event(data as any));
+const events = AKS_UPGRADE_EVENTS.map(data => new Event(data));
 
 export default {
   title: 'node/UpgradeVisualizationPanel',

--- a/frontend/src/components/node/UpgradeVisualizationPanel.stories.tsx
+++ b/frontend/src/components/node/UpgradeVisualizationPanel.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import Event from '../../lib/k8s/event';
+import Node from '../../lib/k8s/node';
+import { TestContext } from '../../test';
+import { AKS_UPGRADE_EVENTS, AKS_UPGRADE_NODES } from './storyHelper';
+import { UpgradeProgress } from './UpgradeVisualizationPanel';
+
+// The top-level UpgradeVisualizationPanel gates on AKS detection then fetches
+// upgrade events; UpgradeProgress is the pure renderer it ends up showing, so
+// the stories drive it directly with the nodes and events as fixtures.
+const nodes = AKS_UPGRADE_NODES.map(data => new Node(data));
+const events = AKS_UPGRADE_EVENTS.map(data => new Event(data as any));
+
+export default {
+  title: 'node/UpgradeVisualizationPanel',
+  component: UpgradeProgress,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+// An in-progress upgrade: one node mid-upgrade (cordon/drain stepper), one
+// surge node, and one idle node.
+export const Upgrading: StoryFn = () => <UpgradeProgress nodes={nodes} nodeEvents={events} />;
+
+// No upgrade events: every node renders as idle.
+export const AllIdle: StoryFn = () => <UpgradeProgress nodes={nodes} nodeEvents={[]} />;

--- a/frontend/src/components/node/UpgradeVisualizationPanel.tsx
+++ b/frontend/src/components/node/UpgradeVisualizationPanel.tsx
@@ -316,7 +316,7 @@ function UpgradeVisualizationPanelInner({ nodes }: { nodes: Node[] }) {
  * Only mounted when an upgrade is detected, so the Node event fetch
  * is avoided on idle AKS clusters.
  */
-export function UpgradeVisualizationPanelContent({ nodes }: { nodes: Node[] }) {
+function UpgradeVisualizationPanelContent({ nodes }: { nodes: Node[] }) {
   // fetch for all Node events to buildNodeUpgradeStates
   const { items: nodeEvents } = Event.useList({
     limit: Event.maxLimit,

--- a/frontend/src/components/node/UpgradeVisualizationPanel.tsx
+++ b/frontend/src/components/node/UpgradeVisualizationPanel.tsx
@@ -316,14 +316,22 @@ function UpgradeVisualizationPanelInner({ nodes }: { nodes: Node[] }) {
  * Only mounted when an upgrade is detected, so the Node event fetch
  * is avoided on idle AKS clusters.
  */
-function UpgradeVisualizationPanelContent({ nodes }: { nodes: Node[] }) {
-  const { t } = useTranslation(['translation']);
-
+export function UpgradeVisualizationPanelContent({ nodes }: { nodes: Node[] }) {
   // fetch for all Node events to buildNodeUpgradeStates
   const { items: nodeEvents } = Event.useList({
     limit: Event.maxLimit,
     fieldSelector: 'involvedObject.kind=Node',
   });
+
+  return <UpgradeProgress nodes={nodes} nodeEvents={nodeEvents ?? []} />;
+}
+
+/**
+ * Pure renderer for the upgrade progress sections. Takes the nodes and their
+ * events directly so it can be rendered without fetching (e.g. in stories).
+ */
+export function UpgradeProgress({ nodes, nodeEvents }: { nodes: Node[]; nodeEvents: Event[] }) {
+  const { t } = useTranslation(['translation']);
 
   const nodeStates = useMemo(() => {
     if (!nodes || !nodeEvents) return new Map<string, NodeUpgradeState>();

--- a/frontend/src/components/node/UpgradeVisualizationPanel.tsx
+++ b/frontend/src/components/node/UpgradeVisualizationPanel.tsx
@@ -323,14 +323,20 @@ function UpgradeVisualizationPanelContent({ nodes }: { nodes: Node[] }) {
     fieldSelector: 'involvedObject.kind=Node',
   });
 
-  return <UpgradeProgress nodes={nodes} nodeEvents={nodeEvents ?? []} />;
+  return <UpgradeProgress nodes={nodes} nodeEvents={nodeEvents} />;
 }
 
 /**
  * Pure renderer for the upgrade progress sections. Takes the nodes and their
  * events directly so it can be rendered without fetching (e.g. in stories).
  */
-export function UpgradeProgress({ nodes, nodeEvents }: { nodes: Node[]; nodeEvents: Event[] }) {
+export function UpgradeProgress({
+  nodes,
+  nodeEvents,
+}: {
+  nodes: Node[];
+  nodeEvents?: Event[] | null;
+}) {
   const { t } = useTranslation(['translation']);
 
   const nodeStates = useMemo(() => {

--- a/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.AllIdle.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.AllIdle.stories.storyshot
@@ -1,0 +1,98 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1qgzacq"
+    >
+      <div
+        class="MuiBox-root css-1qm1lh"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-ofbfey-MuiTypography-root"
+        >
+          Idle Nodes
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-m11i2x-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-axw7ok"
+          >
+            <h6
+              class="MuiTypography-root MuiTypography-subtitle2 css-l62m0z-MuiTypography-root"
+            >
+              aks-node-upgrading
+            </h6>
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-s5qog2-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+              >
+                Ready
+              </span>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-plok08-MuiTypography-root"
+          >
+            Version: v1.29.0
+          </p>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-m11i2x-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-axw7ok"
+          >
+            <h6
+              class="MuiTypography-root MuiTypography-subtitle2 css-l62m0z-MuiTypography-root"
+            >
+              aks-node-surge
+            </h6>
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-s5qog2-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+              >
+                Ready
+              </span>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-plok08-MuiTypography-root"
+          >
+            Version: v1.29.0
+          </p>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-m11i2x-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-axw7ok"
+          >
+            <h6
+              class="MuiTypography-root MuiTypography-subtitle2 css-l62m0z-MuiTypography-root"
+            >
+              aks-node-idle
+            </h6>
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-s5qog2-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+              >
+                Ready
+              </span>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-plok08-MuiTypography-root"
+          >
+            Version: v1.29.0
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.Upgrading.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.Upgrading.stories.storyshot
@@ -65,11 +65,6 @@
                   >
                     Cordon
                   </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-caption css-19f89s9-MuiTypography-root"
-                  >
-                    05:30:00
-                  </span>
                 </span>
               </span>
             </div>
@@ -100,11 +95,6 @@
                     class="MuiStepLabel-label Mui-active MuiStepLabel-alternativeLabel css-172s6dr-MuiStepLabel-label"
                   >
                     Drain
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-caption css-19f89s9-MuiTypography-root"
-                  >
-                    05:30:00
                   </span>
                 </span>
               </span>

--- a/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.Upgrading.stories.storyshot
+++ b/frontend/src/components/node/__snapshots__/UpgradeVisualizationPanel.Upgrading.stories.storyshot
@@ -1,0 +1,291 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1qgzacq"
+    >
+      <div
+        class="MuiBox-root css-1qm1lh"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-ofbfey-MuiTypography-root"
+        >
+          Upgrading Nodes
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-111shyz-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-1sl8bg8"
+          >
+            <div
+              class="MuiBox-root css-axw7ok"
+            >
+              <h6
+                class="MuiTypography-root MuiTypography-subtitle1 css-1p3zzy4-MuiTypography-root"
+              >
+                aks-node-upgrading
+              </h6>
+              <div
+                class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-s5qog2-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+                >
+                  Ready
+                </span>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-plok08-MuiTypography-root"
+            >
+              Version: v1.29.0
+            </p>
+          </div>
+          <div
+            class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
+          >
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel Mui-completed css-n7tliy-MuiStep-root"
+            >
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal MuiStepLabel-alternativeLabel css-sir6m0-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer Mui-completed MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="MuiBox-root css-1j6q5jz"
+                  />
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer MuiStepLabel-alternativeLabel css-1vyamtt-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-completed MuiStepLabel-alternativeLabel css-172s6dr-MuiStepLabel-label"
+                  >
+                    Cordon
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiTypography-caption css-19f89s9-MuiTypography-root"
+                  >
+                    05:30:00
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel css-n7tliy-MuiStep-root"
+            >
+              <div
+                class="MuiStepConnector-root MuiStepConnector-horizontal MuiStepConnector-alternativeLabel Mui-active css-h3mslu-MuiStepConnector-root"
+              >
+                <span
+                  class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-z7uhs0-MuiStepConnector-line"
+                />
+              </div>
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal MuiStepLabel-alternativeLabel css-pdevfk-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer Mui-active MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="MuiBox-root css-1y1xhmb"
+                  />
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer MuiStepLabel-alternativeLabel css-1vyamtt-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-active MuiStepLabel-alternativeLabel css-172s6dr-MuiStepLabel-label"
+                  >
+                    Drain
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiTypography-caption css-19f89s9-MuiTypography-root"
+                  >
+                    05:30:00
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel css-n7tliy-MuiStep-root"
+            >
+              <div
+                class="MuiStepConnector-root MuiStepConnector-horizontal MuiStepConnector-alternativeLabel Mui-disabled css-h3mslu-MuiStepConnector-root"
+              >
+                <span
+                  class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-z7uhs0-MuiStepConnector-line"
+                />
+              </div>
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal Mui-disabled MuiStepLabel-alternativeLabel css-3zc5vx-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer Mui-disabled MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="MuiBox-root css-o5ezry"
+                  />
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer MuiStepLabel-alternativeLabel css-1vyamtt-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-disabled MuiStepLabel-alternativeLabel css-172s6dr-MuiStepLabel-label"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel css-n7tliy-MuiStep-root"
+            >
+              <div
+                class="MuiStepConnector-root MuiStepConnector-horizontal MuiStepConnector-alternativeLabel Mui-disabled css-h3mslu-MuiStepConnector-root"
+              >
+                <span
+                  class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-z7uhs0-MuiStepConnector-line"
+                />
+              </div>
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal Mui-disabled MuiStepLabel-alternativeLabel css-3zc5vx-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer Mui-disabled MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="MuiBox-root css-o5ezry"
+                  />
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer MuiStepLabel-alternativeLabel css-1vyamtt-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-disabled MuiStepLabel-alternativeLabel css-172s6dr-MuiStepLabel-label"
+                  >
+                    Reimage
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              class="MuiStep-root MuiStep-horizontal MuiStep-alternativeLabel css-n7tliy-MuiStep-root"
+            >
+              <div
+                class="MuiStepConnector-root MuiStepConnector-horizontal MuiStepConnector-alternativeLabel Mui-disabled css-h3mslu-MuiStepConnector-root"
+              >
+                <span
+                  class="MuiStepConnector-line MuiStepConnector-lineHorizontal css-z7uhs0-MuiStepConnector-line"
+                />
+              </div>
+              <span
+                class="MuiStepLabel-root MuiStepLabel-horizontal Mui-disabled MuiStepLabel-alternativeLabel css-3zc5vx-MuiStepLabel-root"
+              >
+                <span
+                  class="MuiStepLabel-iconContainer Mui-disabled MuiStepLabel-alternativeLabel css-vnkopk-MuiStepLabel-iconContainer"
+                >
+                  <div
+                    class="MuiBox-root css-o5ezry"
+                  />
+                </span>
+                <span
+                  class="MuiStepLabel-labelContainer MuiStepLabel-alternativeLabel css-1vyamtt-MuiStepLabel-labelContainer"
+                >
+                  <span
+                    class="MuiStepLabel-label Mui-disabled MuiStepLabel-alternativeLabel css-172s6dr-MuiStepLabel-label"
+                  >
+                    Complete
+                  </span>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1qm1lh"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-ofbfey-MuiTypography-root"
+        >
+          Surge Nodes
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-m11i2x-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-axw7ok"
+          >
+            <h6
+              class="MuiTypography-root MuiTypography-subtitle2 css-l62m0z-MuiTypography-root"
+            >
+              aks-node-surge
+            </h6>
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-s5qog2-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+              >
+                Ready
+              </span>
+            </div>
+            <div
+              class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorInfo MuiChip-filledInfo css-1qavl4s-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+              >
+                Surge Node
+              </span>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-plok08-MuiTypography-root"
+          >
+            Version: v1.29.0
+          </p>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1qm1lh"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-ofbfey-MuiTypography-root"
+        >
+          Idle Nodes
+        </h6>
+        <div
+          class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-m11i2x-MuiPaper-root"
+        >
+          <div
+            class="MuiBox-root css-axw7ok"
+          >
+            <h6
+              class="MuiTypography-root MuiTypography-subtitle2 css-l62m0z-MuiTypography-root"
+            >
+              aks-node-idle
+            </h6>
+            <div
+              class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-outlinedSuccess css-s5qog2-MuiChip-root"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelSmall css-rrn746-MuiChip-label"
+              >
+                Ready
+              </span>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body2 css-plok08-MuiTypography-root"
+          >
+            Version: v1.29.0
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/node/storyHelper.ts
+++ b/frontend/src/components/node/storyHelper.ts
@@ -253,9 +253,10 @@ export const AKS_UPGRADE_NODES: KubeNode[] = [
   makeAKSNode('aks-node-idle'),
 ];
 
-const eventTime = new Date('2025-01-01T00:00:00Z').toISOString();
-
 function makeUpgradeEvent(reason: string, message: string, nodeName: string) {
+  // No timestamps: the stepper renders stage times via toLocaleTimeString, which
+  // is timezone-dependent and would make snapshots differ between machines/CI.
+  // Omitting them keeps the snapshot deterministic; event order below is fixed.
   return {
     kind: 'Event',
     apiVersion: 'v1',
@@ -263,12 +264,10 @@ function makeUpgradeEvent(reason: string, message: string, nodeName: string) {
     reason,
     message,
     involvedObject: { kind: 'Node', name: nodeName },
-    firstTimestamp: eventTime,
     metadata: {
       name: `${nodeName}-${reason}`,
       namespace: 'default',
       uid: `${nodeName}-${reason}-uid`,
-      creationTimestamp: eventTime,
     },
   };
 }

--- a/frontend/src/components/node/storyHelper.ts
+++ b/frontend/src/components/node/storyHelper.ts
@@ -206,3 +206,81 @@ export const NODE_DUMMY_DATA_NO_POOLS: KubeNode[] = NODE_DUMMY_DATA.map(node => 
     ),
   },
 }));
+
+function makeAKSNode(name: string): KubeNode {
+  return {
+    kind: 'Node',
+    apiVersion: 'v1',
+    metadata: {
+      name,
+      creationTimestamp,
+      uid: `${name}-uid`,
+      labels: { 'kubernetes.azure.com/cluster': 'aks-cluster' },
+    },
+    spec: {
+      podCIDR: '',
+      podCIDRs: [],
+      providerID: `azure:///subscriptions/123/${name}`,
+      taints: [],
+      unschedulable: false,
+    },
+    status: {
+      addresses: [],
+      allocatable: {},
+      capacity: {},
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          lastHeartbeatTime: creationTimestamp,
+          lastTransitionTime: creationTimestamp,
+          reason: 'KubeletReady',
+          message: 'kubelet is posting ready status',
+        },
+      ],
+      nodeInfo: { kubeletVersion: 'v1.29.0' } as KubeNode['status']['nodeInfo'],
+    },
+  } as KubeNode;
+}
+
+/**
+ * AKS-managed nodes used by the UpgradeVisualizationPanel stories: one node
+ * mid-upgrade, one surge node, and one idle node.
+ */
+export const AKS_UPGRADE_NODES: KubeNode[] = [
+  makeAKSNode('aks-node-upgrading'),
+  makeAKSNode('aks-node-surge'),
+  makeAKSNode('aks-node-idle'),
+];
+
+const eventTime = new Date('2025-01-01T00:00:00Z').toISOString();
+
+function makeUpgradeEvent(reason: string, message: string, nodeName: string) {
+  return {
+    kind: 'Event',
+    apiVersion: 'v1',
+    type: 'Normal',
+    reason,
+    message,
+    involvedObject: { kind: 'Node', name: nodeName },
+    firstTimestamp: eventTime,
+    metadata: {
+      name: `${nodeName}-${reason}`,
+      namespace: 'default',
+      uid: `${nodeName}-${reason}-uid`,
+      creationTimestamp: eventTime,
+    },
+  };
+}
+
+/**
+ * Upgrade events that drive the UpgradeVisualizationPanel: an upgrade-started
+ * event (so an upgrade is detected), cordon + drain events for the upgrading
+ * node, and a surge event for the surge node.
+ */
+export const AKS_UPGRADE_EVENTS = [
+  makeUpgradeEvent('Upgrade', 'Upgrade started for agent pool nodepool1', 'aks-node-upgrading'),
+  makeUpgradeEvent('Cordon', 'Cordoning node aks-node-upgrading', 'aks-node-upgrading'),
+  makeUpgradeEvent('Drain', 'Draining node aks-node-upgrading', 'aks-node-upgrading'),
+  makeUpgradeEvent('Surge', 'Created a surge node aks-node-surge', 'aks-node-surge'),
+];

--- a/frontend/src/components/node/storyHelper.ts
+++ b/frontend/src/components/node/storyHelper.ts
@@ -15,6 +15,7 @@
  */
 
 import type { KubeMetrics } from '../../lib/k8s/cluster';
+import type { KubeEvent } from '../../lib/k8s/event';
 import type { KubeNode } from '../../lib/k8s/node';
 import { NODE_POOL_LABEL_KEYS } from '../../lib/k8s/nodeConstants';
 
@@ -253,21 +254,31 @@ export const AKS_UPGRADE_NODES: KubeNode[] = [
   makeAKSNode('aks-node-idle'),
 ];
 
-function makeUpgradeEvent(reason: string, message: string, nodeName: string) {
-  // No timestamps: the stepper renders stage times via toLocaleTimeString, which
-  // is timezone-dependent and would make snapshots differ between machines/CI.
-  // Omitting them keeps the snapshot deterministic; event order below is fixed.
+function makeUpgradeEvent(reason: string, message: string, nodeName: string): KubeEvent {
+  // Timestamps are left empty: the stepper renders stage times via
+  // toLocaleTimeString, which is timezone-dependent and would make snapshots
+  // differ between machines/CI. Empty keeps the snapshot deterministic; event
+  // order below is fixed.
   return {
     kind: 'Event',
     apiVersion: 'v1',
     type: 'Normal',
     reason,
     message,
-    involvedObject: { kind: 'Node', name: nodeName },
+    involvedObject: {
+      kind: 'Node',
+      namespace: '',
+      name: nodeName,
+      uid: `${nodeName}-uid`,
+      apiVersion: 'v1',
+      resourceVersion: '',
+      fieldPath: '',
+    },
     metadata: {
       name: `${nodeName}-${reason}`,
       namespace: 'default',
       uid: `${nodeName}-${reason}-uid`,
+      creationTimestamp: '',
     },
   };
 }
@@ -277,7 +288,7 @@ function makeUpgradeEvent(reason: string, message: string, nodeName: string) {
  * event (so an upgrade is detected), cordon + drain events for the upgrading
  * node, and a surge event for the surge node.
  */
-export const AKS_UPGRADE_EVENTS = [
+export const AKS_UPGRADE_EVENTS: KubeEvent[] = [
   makeUpgradeEvent('Upgrade', 'Upgrade started for agent pool nodepool1', 'aks-node-upgrading'),
   makeUpgradeEvent('Cordon', 'Cordoning node aks-node-upgrading', 'aks-node-upgrading'),
   makeUpgradeEvent('Drain', 'Draining node aks-node-upgrading', 'aks-node-upgrading'),


### PR DESCRIPTION
## Description

Adds Storybook stories (which double as snapshot tests via `frontend/src/storybook.test.tsx`) for `node/UpgradeVisualizationPanel.tsx`, which had none. Part of the umbrella stories effort (#931).

Fixes #6283.

Two stories cover the panel's main states:
- **Upgrading** — a node mid-upgrade (cordon/drain stepper), a surge node, and an idle node.
- **AllIdle** — no upgrade events, every node rendered as idle.

### Note on the small refactor

The top-level `UpgradeVisualizationPanel` gates through a multi-stage fetch waterfall (AKS detection → upgrade detection → event fetch). The snapshot harness settles requests between stages, so the panel snapshots as empty. To make the stories deterministic, the render logic is extracted into a pure `UpgradeProgress({ nodes, nodeEvents })` component (no fetching); `UpgradeVisualizationPanelContent` now just fetches the events and renders it. The stories drive `UpgradeProgress` directly with fixtures (`AKS_UPGRADE_NODES`, `AKS_UPGRADE_EVENTS` added to `storyHelper.ts`), so no MSW is needed.

## Testing

- Full storyshot suite passes (593), zero drift.
- Existing `UpgradeVisualizationPanel.test.ts` passes (18).
- eslint / prettier / tsc clean.