### PR TITLE
frontend: streamingApi: validate WebSocket URL before connecting

### DIFF
--- a/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { getUserIdFromLocalStorage } from '../../../../stateless/getUserIdFromLocalStorage';
+import { connectStreamWithParams } from './streamingApi';
+
+vi.mock('../../../../stateless/getUserIdFromLocalStorage', () => ({
+  getUserIdFromLocalStorage: vi.fn(),
+}));
+
+describe('connectStreamWithParams', () => {
+  let WebSocketSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    WebSocketSpy = vi.fn();
+    vi.stubGlobal('WebSocket', WebSocketSpy);
+    (getUserIdFromLocalStorage as Mock).mockReturnValue('test-user-id');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('calls onFail and returns null socket without constructing WebSocket when cluster is empty string', async () => {
+    const cb = vi.fn();
+    const onFail = vi.fn();
+
+    const result = await connectStreamWithParams('/api/v1/pods', cb, onFail, { cluster: '' });
+
+    expect(WebSocketSpy).not.toHaveBeenCalled();
+    expect(onFail).toHaveBeenCalledTimes(1);
+    expect(result.socket).toBeNull();
+    expect(typeof result.close).toBe('function');
+  });
+
+  it('calls onFail and returns null socket without constructing WebSocket when cluster is omitted', async () => {
+    const cb = vi.fn();
+    const onFail = vi.fn();
+
+    const result = await connectStreamWithParams('/api/v1/pods', cb, onFail, {});
+
+    expect(WebSocketSpy).not.toHaveBeenCalled();
+    expect(onFail).toHaveBeenCalledTimes(1);
+    expect(result.socket).toBeNull();
+    expect(typeof result.close).toBe('function');
+  });
+});

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -448,6 +448,17 @@ export async function connectStreamWithParams<T>(
   }
 
   let socket: WebSocket | null = null;
+
+  if (!url) {
+    console.error('connectStreamWithParams: empty WebSocket URL; refusing to open WebSocket', {
+      path,
+      cluster,
+      fullPath,
+    });
+    onFail();
+    return { close, socket };
+  }
+
   try {
     socket = new WebSocket(url, protocols);
     socket.binaryType = 'arraybuffer';
@@ -456,6 +467,7 @@ export async function connectStreamWithParams<T>(
     socket.addEventListener('error', onError);
   } catch (error) {
     console.error(error);
+    onFail();
   }
 
   return { close, socket };


### PR DESCRIPTION
## Summary

This PR fixes a bug in `connectStreamWithParams()` where an empty or unresolved cluster could result in `new WebSocket('')` being constructed.

Previously, if no cluster could be resolved, the WebSocket constructor threw a `SyntaxError` that was caught and logged, but the failure was not propagated through the normal `onFail()` path. As a result, callers received a `StreamConnection` with a `null` socket and no opportunity to handle or retry the failure.

The fix validates that a WebSocket URL has been constructed before creating the socket. If no valid URL is available, the function reports the failure via `onFail()` and returns a valid empty `StreamConnection`.

## Related Issue

Fixes #6274 

## Changes

- Added a guard to detect when no WebSocket URL could be constructed.
- Reported the failure through the existing `onFail()` callback.
- Returned a valid empty `StreamConnection` without attempting to construct an invalid `WebSocket`.
- Added regression tests covering empty and omitted cluster values.

## Steps to Test

1. Run the frontend test suite.
2. Invoke `connectStreamWithParams()` with:
   - `cluster: ''`
   - no `cluster` provided
3. Verify that:
   - `new WebSocket('')` is never called.
   - `onFail()` is invoked.
   - The returned `StreamConnection` has `socket === null`.
4. Verify that valid cluster values continue to establish WebSocket connections normally.

## Notes for the Reviewer

### Why the bug existed

`connectStreamWithParams()` initialized the WebSocket URL as an empty string and only populated it when `cluster` was truthy.

```ts
let url = '';

if (cluster) {
  url = combinePath(getBaseWsUrl(), fullPath);
}

socket = new WebSocket(url, protocols);
```

Tracing the call chain showed that `cluster` can legitimately be empty:

- `getCluster()` returns `null` when no cluster path parameter exists.
- Call sites use `cluster || getCluster() || ''`.
- As a result, `cluster` may be `''`.

When this occurred, `new WebSocket('')` threw a `SyntaxError`.

Although the exception was caught, the catch block only logged the error and never invoked `onFail()`, causing the stream to fail silently.

### Why the fix works

The implementation now validates that a WebSocket URL exists before constructing the socket.

If no URL can be generated:

- `onFail()` is invoked through the existing failure path.
- No invalid `WebSocket` is constructed.
- A valid empty `StreamConnection` is returned, preserving the function's API contract.

This makes unresolved clusters follow the same failure path as other connection failures.

### Edge cases

- Valid cluster values are unaffected.
- Invalid or missing clusters now fail immediately instead of attempting to construct an invalid WebSocket.
- Existing reconnect and failure handling remains unchanged.

### Testing

Added regression tests covering:

- Empty string cluster (`''`)
- Omitted cluster

Both verify that:

- `onFail()` is called.
- No `WebSocket` is created with an empty URL.
- The returned connection contains `socket === null`.

No existing tests required modification.