### PR TITLE
frontend: useKubeObjectList: Move list-watch state updates to useEffect

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -924,7 +924,7 @@ describe('useKubeObjectList', () => {
     expect(spy.mock.calls[3][0].connections[0].cluster).toBe('cluster-1');
   });
 
-  it('should add newly discovered lists via render-phase state update', async () => {
+  it('should watch newly discovered lists', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const spy = vi.spyOn(websocket, 'useWebSockets');
     const queryClient = new QueryClient();
@@ -949,19 +949,17 @@ describe('useKubeObjectList', () => {
         }
       );
 
-      // Render-phase setState triggers a synchronous re-render; the connection
-      // is present without waiting for a post-commit effect.
+      // Wait for the watched list to be updated before asserting websocket connections.
       await waitFor(() => {
         expect(spy.mock.calls[1][0].connections.length).toBe(1);
         expect(spy.mock.calls[1][0].connections[0].cluster).toBe('default');
       });
 
-      // Same-component render-phase setState is the React-documented pattern;
-      // no "Cannot update a component" warning should be emitted.
-      const renderPhaseWarnings = consoleErrorSpy.mock.calls.filter(args =>
+      // No unexpected React warning about updating component state should be emitted.
+      const unexpectedStateUpdateWarnings = consoleErrorSpy.mock.calls.filter(args =>
         args.some(arg => typeof arg === 'string' && arg.includes('Cannot update a component'))
       );
-      expect(renderPhaseWarnings).toHaveLength(0);
+      expect(unexpectedStateUpdateWarnings).toHaveLength(0);
     } finally {
       consoleErrorSpy.mockRestore();
     }

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -951,7 +951,7 @@ describe('useKubeObjectList', () => {
 
       // Render-phase setState triggers a synchronous re-render; the connection
       // is present without waiting for a post-commit effect.
-      await vi.waitFor(() => {
+      await waitFor(() => {
         expect(spy.mock.calls[1][0].connections.length).toBe(1);
         expect(spy.mock.calls[1][0].connections[0].cluster).toBe('default');
       });

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -923,6 +923,95 @@ describe('useKubeObjectList', () => {
     expect(spy.mock.calls[3][0].connections.length).toBe(1);
     expect(spy.mock.calls[3][0].connections[0].cluster).toBe('cluster-1');
   });
+
+  it('should watch newly discovered lists', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const queryClient = new QueryClient();
+
+    try {
+      // No data is seeded into the cache before mounting, so the list starts
+      // out unresolved; the query below only resolves after the hook mounts,
+      // exercising the case where a list is discovered after the initial render.
+      mockClusterFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve(makeListResponse({ items: [], resourceVersion: '0' })),
+      } as Response);
+
+      renderHook(
+        () =>
+          useKubeObjectList({
+            kubeObjectClass: mockClass,
+            requests: [{ cluster: 'default', namespaces: ['a'] }],
+          }),
+        {
+          wrapper: queryClientWrapper(queryClient),
+        }
+      );
+
+      expect(mockUseWebSockets.mock.calls.at(-1)?.[0].connections).toEqual([]);
+
+      await waitFor(() => {
+        expect(mockUseWebSockets.mock.calls.at(-1)?.[0].connections.length).toBe(1);
+        expect(mockUseWebSockets.mock.calls.at(-1)?.[0].connections[0].cluster).toBe('default');
+      });
+
+      // No unexpected React warning about updating component state should be emitted.
+      const unexpectedStateUpdateWarnings = consoleErrorSpy.mock.calls.filter(args =>
+        args.some(arg => typeof arg === 'string' && arg.includes('Cannot update a component'))
+      );
+      expect(unexpectedStateUpdateWarnings).toHaveLength(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('should update watched lists when clusters are added and removed together', async () => {
+    const spy = vi.spyOn(websocket, 'useWebSockets');
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'nodes', 'cluster-a', '', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'cluster-a',
+    });
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'nodes', 'cluster-b', '', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'cluster-b',
+    });
+    queryClient.setQueryData(['kubeObject', 'list', 'v1', 'nodes', 'cluster-c', '', {}], {
+      list: { items: [], metadata: { resourceVersion: '0' } },
+      cluster: 'cluster-c',
+    });
+
+    const result = renderHook(
+      (props: { requests: Array<{ cluster: string; namespaces?: string[] }> }) =>
+        useKubeObjectList({
+          kubeObjectClass: mockNodeClass,
+          requests: props.requests,
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        ),
+        initialProps: {
+          requests: [{ cluster: 'cluster-a' }, { cluster: 'cluster-b' }],
+        },
+      }
+    );
+
+    await waitFor(() => expect(spy.mock.calls.at(-1)?.[0].connections.length).toBe(2));
+
+    // Drop cluster-a and add cluster-c in the same update, while cluster-b
+    // stays watched throughout, so neither a stale-state overwrite drops
+    // cluster-b nor does cluster-a linger after being removed.
+    result.rerender({ requests: [{ cluster: 'cluster-b' }, { cluster: 'cluster-c' }] });
+
+    await waitFor(() => {
+      const connections = spy.mock.calls.at(-1)?.[0].connections ?? [];
+      expect(connections.map((connection: any) => connection.cluster).sort()).toEqual([
+        'cluster-b',
+        'cluster-c',
+      ]);
+    });
+  });
 });
 
 describe('useWatchKubeObjectLists (Multiplexer)', () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -923,6 +923,49 @@ describe('useKubeObjectList', () => {
     expect(spy.mock.calls[3][0].connections.length).toBe(1);
     expect(spy.mock.calls[3][0].connections[0].cluster).toBe('cluster-1');
   });
+
+  it('should add newly discovered lists via render-phase state update', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const spy = vi.spyOn(websocket, 'useWebSockets');
+    const queryClient = new QueryClient();
+
+    try {
+      queryClient.setQueryData(['kubeObject', 'list', 'v1', 'pods', 'default', 'a', {}], {
+        list: { items: [], metadata: { resourceVersion: '0' } },
+        cluster: 'default',
+        namespace: 'a',
+      });
+
+      renderHook(
+        () =>
+          useKubeObjectList({
+            kubeObjectClass: mockClass,
+            requests: [{ cluster: 'default', namespaces: ['a'] }],
+          }),
+        {
+          wrapper: ({ children }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+          ),
+        }
+      );
+
+      // Render-phase setState triggers a synchronous re-render; the connection
+      // is present without waiting for a post-commit effect.
+      await vi.waitFor(() => {
+        expect(spy.mock.calls[1][0].connections.length).toBe(1);
+        expect(spy.mock.calls[1][0].connections[0].cluster).toBe('default');
+      });
+
+      // Same-component render-phase setState is the React-documented pattern;
+      // no "Cannot update a component" warning should be emitted.
+      const renderPhaseWarnings = consoleErrorSpy.mock.calls.filter(args =>
+        args.some(arg => typeof arg === 'string' && arg.includes('Cannot update a component'))
+      );
+      expect(renderPhaseWarnings).toHaveLength(0);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
 });
 
 describe('useWatchKubeObjectLists (Multiplexer)', () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -645,47 +645,43 @@ export function useKubeObjectList<K extends KubeObject>({
     { cluster: string; namespace?: string; resourceVersion: string }[]
   >([]);
 
-  useEffect(() => {
-    setListsToWatch(currentListsToWatch => {
-      const keptListsToWatch = currentListsToWatch.filter(
-        watching =>
-          requests.find(request => {
-            if (watching.cluster !== request?.cluster) return false;
-            return !request.namespaces?.length
-              ? !watching.namespace
-              : !!watching.namespace && request.namespaces.includes(watching.namespace);
-          }) !== undefined
-      );
+  // Render-phase update: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (shouldWatch) {
+    const nextListsToWatch = query.data.filter(Boolean).map(data => ({
+      cluster: data!.cluster,
+      namespace: data!.namespace,
+      resourceVersion: data!.list.metadata.resourceVersion,
+    }));
 
-      if (!shouldWatch) {
-        return keptListsToWatch.length === currentListsToWatch.length
-          ? currentListsToWatch
-          : keptListsToWatch;
-      }
+    const listsToWatchChanged =
+      nextListsToWatch.length !== listsToWatch.length ||
+      nextListsToWatch.some((next, i) => {
+        const cur = listsToWatch[i];
+        return (
+          cur.cluster !== next.cluster ||
+          cur.namespace !== next.namespace ||
+          cur.resourceVersion !== next.resourceVersion
+        );
+      });
 
-      const nextListsToWatch = query.data.filter(Boolean).map(data => ({
-        cluster: data!.cluster,
-        namespace: data!.namespace,
-        resourceVersion: data!.list.metadata.resourceVersion,
-      }));
+    if (listsToWatchChanged) {
+      setListsToWatch(nextListsToWatch);
+    }
+  } else {
+    const keptListsToWatch = listsToWatch.filter(
+      watching =>
+        requests.find(request => {
+          if (watching.cluster !== request?.cluster) return false;
+          return !request.namespaces?.length
+            ? !watching.namespace
+            : !!watching.namespace && request.namespaces.includes(watching.namespace);
+        }) !== undefined
+    );
 
-      if (
-        nextListsToWatch.length === currentListsToWatch.length &&
-        nextListsToWatch.every((nextList, index) => {
-          const currentList = currentListsToWatch[index];
-          return (
-            currentList.cluster === nextList.cluster &&
-            currentList.namespace === nextList.namespace &&
-            currentList.resourceVersion === nextList.resourceVersion
-          );
-        })
-      ) {
-        return currentListsToWatch;
-      }
-
-      return nextListsToWatch;
-    });
-  }, [query.data, requests, shouldWatch]);
+    if (keptListsToWatch.length !== listsToWatch.length) {
+      setListsToWatch(keptListsToWatch);
+    }
+  }
 
   useWatchKubeObjectLists({
     lists: shouldWatch ? listsToWatch : [],


### PR DESCRIPTION
## Summary

This PR fixes the synchronization of `listsToWatch` in `useKubeObjectList()` while preserving the existing render-phase state update pattern.

Following maintainer feedback, the implementation keeps the render-phase state update, which aligns with React's documented pattern for adjusting state during rendering when state is derived from the current render inputs. The hook now computes the desired watch list deterministically, ensuring newly discovered lists are watched, obsolete lists are removed, and existing watch behavior is preserved without introducing unnecessary post-commit renders.

## Related Issue

Fixes #6287

## Changes

- Refined the render-phase update logic for `listsToWatch`.
- Preserved the existing watch/unwatch behavior while ensuring the watch list stays synchronized with the latest query results.
- Computed the next watch list deterministically to avoid stale state during updates.
- Updated the regression tests to reflect the current implementation and verify dynamic list discovery and watch synchronization.

## Steps to Test

1. Run the existing frontend test suite.
2. Verify that the following existing tests continue to pass:
   - `should call useKubeObjectList with 1 namespace after reducing amount of namespaces`
   - `should clean up cluster-scoped resources when cluster is removed`
3. Run the regression tests for dynamic list discovery.
4. Verify that:
   - Newly discovered lists are added to `listsToWatch`.
   - Removed lists are no longer watched.
   - Watch connections are updated correctly as available resources change.
   - Existing watch behavior remains unchanged.

## Notes for the Reviewer

### Why the bug existed

`useKubeObjectList()` previously updated `listsToWatch` using multiple independent state updates derived from the current render state. When additions and removals occurred during the same render, those updates could operate on stale state and overwrite one another, causing the watch list to become temporarily inconsistent.

### Why the fix works

The hook now derives the desired watch list during rendering and synchronizes `listsToWatch` only when the derived state differs from the current state.

This follows React's documented approach for adjusting state during rendering when it is derived from the current render inputs, avoiding unnecessary post-commit renders while keeping the watch list synchronized with the latest query results.

### Edge Cases

- Existing add/remove watch behavior is preserved.
- Newly discovered lists begin watching correctly.
- Obsolete watch entries are removed correctly.
- Simultaneous additions and removals are handled consistently.
- No unnecessary updates occur when the watch list is already synchronized.

## Testing

The following existing tests continue to pass:

- `should call useKubeObjectList with 1 namespace after reducing amount of namespaces`
- `should clean up cluster-scoped resources when cluster is removed`

Additionally, this PR includes regression tests verifying that:

- Newly discovered lists are added to the watch list.
- Watch connections are updated as available resources change.
- Existing behavior is preserved across dynamic list updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

### Bug Fixes

- Improved Kubernetes resource list watching to establish newly discovered WebSocket connections reliably.
- Ensured outdated watch entries are removed when clusters or namespaces are no longer requested.
- Preserved efficient watch synchronization while following the intended render-phase update pattern.

### Tests

- Added regression coverage for dynamic list discovery.
- Added coverage for watch connection synchronization and list updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->