### PR TITLE
frontend: Sidebar: Minimize activities and close details drawer on click

### DIFF
--- a/frontend/src/components/Sidebar/ListItemLink.tsx
+++ b/frontend/src/components/Sidebar/ListItemLink.tsx
@@ -22,7 +22,10 @@ import { styled } from '@mui/material/styles';
 import Tooltip from '@mui/material/Tooltip';
 import { alpha } from '@mui/system/colorManipulator';
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import { setSelectedResource } from '../../redux/drawerModeSlice';
+import { Activity } from '../activity/Activity';
 
 const ExpandedIconSize = 20;
 const CollapsedIconSize = 24;
@@ -40,6 +43,7 @@ interface ListItemLinkProps {
   level?: number;
   fullWidth?: boolean;
   divider?: boolean;
+  onClick?: (event: React.MouseEvent<any, any>) => void;
   containerProps?: {
     [prop: string]: any;
   };
@@ -52,6 +56,7 @@ const StyledLi = styled('li')<{ level: number }>(({ level }) => ({
 }));
 
 export default function ListItemLink(props: ListItemLinkProps) {
+  const dispatch = useDispatch();
   const {
     primary,
     pathname,
@@ -131,6 +136,13 @@ export default function ListItemLink(props: ListItemLinkProps) {
         component={renderLink}
         aria-label={iconOnly ? name : undefined}
         {...other}
+        onClick={e => {
+          if (other.onClick) {
+            other.onClick(e);
+          }
+          dispatch(setSelectedResource(undefined));
+          Activity.minimizeAll();
+        }}
         sx={theme => ({
           color:
             theme.palette.sidebar.color ??

--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -104,6 +104,9 @@ export const Activity = {
   reset() {
     store.dispatch(activitySlice.actions.reset());
   },
+  minimizeAll() {
+    store.dispatch(activitySlice.actions.minimizeAll());
+  },
 };
 
 /** Context for the currently viewed activity */

--- a/frontend/src/components/activity/activitySlice.tsx
+++ b/frontend/src/components/activity/activitySlice.tsx
@@ -100,6 +100,17 @@ export const activitySlice = createSlice({
         window?.dispatchEvent?.(new Event('resize'));
       }, 200);
     },
+    minimizeAll(state) {
+      Object.values(state.activities).forEach(activity => {
+        if (activity.temporary) {
+          delete state.activities[activity.id];
+          state.history = state.history.filter(it => it !== activity.id);
+        } else if (!activity.minimized) {
+          activity.minimized = true;
+          state.history = state.history.filter(it => it !== activity.id);
+        }
+      });
+    },
     reset() {
       return initialState;
     },

--- a/frontend/src/plugin/__snapshots__/pluginLib.snapshot
+++ b/frontend/src/plugin/__snapshots__/pluginLib.snapshot
@@ -2,6 +2,7 @@
   "Activity": {
     "close": [Function],
     "launch": [Function],
+    "minimizeAll": [Function],
     "reset": [Function],
     "update": [Function],
   },


### PR DESCRIPTION
When navigating through the main sidebar, open details panels (split-right activities) and active log/terminal activities should be closed or minimized so the user is presented with a clean main view.

## Summary
This PR fixes issue #4792 by clearing or minimizing active panels and drawers upon sidebar link interaction.

## Related Issue
Fixes #4792

## Changes
- **`activitySlice`**: Added a `minimizeAll` action that removes temporary activities (such as split-right resource detail panels) and minimizes other active ones (such as logs or terminals).
- **`Activity` Helper**: Added the `minimizeAll()` method to dispatch this action.
- **`ListItemLink`**: Added an `onClick` handler to sidebar buttons that calls `Activity.minimizeAll()` and dispatches `setSelectedResource(undefined)` to reset the details drawer state.
- **`pluginLib.snapshot`**: Updated the snapshot file to include `minimizeAll` within the registered `Activity` library namespace.

## Steps to Test
1. Select a cluster and navigate to **Workloads** -> **Pods**.
2. Click on a pod name to show its details.
3. Click on the logs or terminal button to open log/terminal activities.
4. Click on **Workloads/Pods** (or any other item like **Workloads/Deployments**) in the sidebar.
5. Verify that the split-right details panel is closed and the logs activity gets minimized, returning you cleanly to the list view.

## Notes for the Reviewer
- The changes have been fully type-checked with TypeScript (`npm run frontend:tsc`) and verified with the test suite (`npm run frontend:test`).
