### PR TITLE
perf(multiplexer): reduce allocations in WebSocket message routing hot path

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -933,6 +933,35 @@ func (m *Multiplexer) processClusterMessage(
 //   - clientConn: The WebSocket connection to the client.
 //   - lastResourceVersion: A pointer to the last known resource version string.
 //
+// resourceVersionExtractor is a minimal struct used to extract resourceVersion from
+// Kubernetes messages (either metadata.resourceVersion or object.metadata.resourceVersion).
+// Using a typed struct instead of map[string]interface{} avoids reflect-heavy
+// decoding and reduces allocations by skipping per-field map/interface values.
+type resourceVersionExtractor struct {
+	Metadata struct {
+		ResourceVersion string `json:"resourceVersion"`
+	} `json:"metadata"`
+	Object struct {
+		Metadata struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+	} `json:"object"`
+}
+
+// sendIfNewResourceVersion checks if a message contains a new resource version
+// and sends a COMPLETE message to the client if it does.
+//
+// This function is called on every incoming WebSocket message from Kubernetes
+// cluster watches — it is the hottest path in the multiplexer. It uses a minimal
+// typed struct for JSON unmarshalling to avoid the allocation overhead of
+// map[string]interface{}.
+//
+// Parameters:
+//   - message: The raw WebSocket message bytes.
+//   - conn: The connection associated with this message.
+//   - clientConn: The client WebSocket connection to notify.
+//   - lastResourceVersion: Pointer to the last known resource version for comparison.
+//
 // Returns:
 //   - An error if any issues occur while writing to the client, or nil if successful/ignored.
 func (m *Multiplexer) sendIfNewResourceVersion(
@@ -941,31 +970,21 @@ func (m *Multiplexer) sendIfNewResourceVersion(
 	clientConn *WSConnLock,
 	lastResourceVersion *string,
 ) error {
-	var obj map[string]interface{}
-	if err := json.Unmarshal(message, &obj); err != nil {
+	var ext resourceVersionExtractor
+	if err := json.Unmarshal(message, &ext); err != nil {
 		// If we can't unmarshal as JSON, it might be binary data (e.g. from a terminal)
 		// We just return nil here to indicate no new resource version was found,
 		// but we don't want to stop processing messages.
 		return nil
 	}
 
-	// Try to find metadata directly
-	metadata, ok := obj["metadata"].(map[string]interface{})
-	if !ok {
-		// Try to find metadata in object field
-		if objField, ok := obj["object"].(map[string]interface{}); ok {
-			if metadata, ok = objField["metadata"].(map[string]interface{}); !ok {
-				// No metadata field found, nothing to do
-				return nil
-			}
-		} else {
-			// No metadata field found, nothing to do
-			return nil
-		}
+	// Try to find resourceVersion directly in metadata, then fall back to object.metadata
+	rv := ext.Metadata.ResourceVersion
+	if rv == "" {
+		rv = ext.Object.Metadata.ResourceVersion
 	}
 
-	rv, ok := metadata["resourceVersion"].(string)
-	if !ok {
+	if rv == "" {
 		// No resourceVersion field, nothing to do
 		return nil
 	}
@@ -1106,8 +1125,10 @@ func (m *Multiplexer) CloseConnection(clusterID, path, userID string) {
 }
 
 // createConnectionKey creates a unique key for a connection based on cluster ID, path, and user ID.
+// Uses string concatenation instead of fmt.Sprintf to avoid allocation overhead
+// on this hot path (called on every WebSocket message routing).
 func (m *Multiplexer) createConnectionKey(clusterID, path, userID string) string {
-	return fmt.Sprintf("%s:%s:%s", clusterID, path, userID)
+	return clusterID + ":" + path + ":" + userID
 }
 
 // createWebSocketURL creates a WebSocket URL from the given parameters.

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -1801,3 +1801,136 @@ func TestConcurrentUpdateStatusAndSendDataMessage(t *testing.T) {
 		t.Fatal("deadlock detected: concurrent updateStatus and sendDataMessage blocked for 5s")
 	}
 }
+
+// =============================================================================
+// Benchmarks — validate hot-path performance optimizations.
+// =============================================================================
+
+// newBenchmarkWSClient creates a mock WebSocket server and returns a connected
+// WSConnLock for use in benchmarks. Registers cleanup on b.Cleanup.
+func newBenchmarkWSClient(b *testing.B) *WSConnLock {
+	b.Helper()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		defer func() { _ = c.Close() }()
+
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+
+	b.Cleanup(mockServer.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(mockServer.URL, "http")
+
+	wsConn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		b.Fatalf("failed to dial mock server: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+
+	b.Cleanup(func() { _ = wsConn.Close() })
+
+	return NewWSConnLock(wsConn)
+}
+
+// benchWatchEventMsg is a typical Kubernetes watch event message used in benchmarks.
+var benchWatchEventMsg = []byte(`{
+	"type": "MODIFIED",
+	"object": {
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {
+			"name": "nginx-5d87f4f9b4-abc12", "namespace": "default",
+			"resourceVersion": "123456", "uid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"labels": {"app": "nginx", "pod-template-hash": "5d87f4f9b4"}
+		},
+		"spec": {"containers": [{"name": "nginx", "image": "nginx:1.21"}]},
+		"status": {"phase": "Running"}
+	}
+}`)
+
+// BenchmarkSendIfNewResourceVersion measures the allocation overhead of
+// extracting metadata.resourceVersion from a typical Kubernetes watch event.
+// This is the hottest path in the multiplexer.
+func BenchmarkSendIfNewResourceVersion(b *testing.B) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+	conn := &Connection{
+		ClusterID: "test-cluster",
+		Path:      "/api/v1/namespaces/default/pods",
+		Query:     "watch=true",
+		UserID:    "user-1",
+	}
+
+	clientConn := newBenchmarkWSClient(b)
+	lastRV := "123456"
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_ = m.sendIfNewResourceVersion(benchWatchEventMsg, conn, clientConn, &lastRV)
+	}
+}
+
+// BenchmarkSendIfNewResourceVersion_DirectMetadata benchmarks the case where
+// resourceVersion is at the top-level metadata (non-watch event format).
+func BenchmarkSendIfNewResourceVersion_DirectMetadata(b *testing.B) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	directMsg := []byte(`{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": {
+			"name": "nginx", "namespace": "default",
+			"resourceVersion": "789012",
+			"uid": "f1e2d3c4-b5a6-0987-fedc-ba0987654321"
+		}
+	}`)
+
+	conn := &Connection{
+		ClusterID: "test-cluster",
+		Path:      "/api/v1/namespaces/default/pods",
+		UserID:    "user-1",
+	}
+
+	clientConn := newBenchmarkWSClient(b)
+	lastRV := "789012"
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_ = m.sendIfNewResourceVersion(directMsg, conn, clientConn, &lastRV)
+	}
+}
+
+// benchConnectionKeySink prevents the compiler from optimizing away benchmark work.
+var benchConnectionKeySink string
+
+// BenchmarkCreateConnectionKey measures the allocation overhead of creating
+// connection keys used for map lookups on every WebSocket message routing.
+func BenchmarkCreateConnectionKey(b *testing.B) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	clusterID := "my-production-cluster"
+	path := "/api/v1/namespaces/kube-system/pods"
+	userID := "user-abc123-def456"
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		benchConnectionKeySink = m.createConnectionKey(clusterID, path, userID)
+	}
+}


### PR DESCRIPTION
## Summary
This PR optimizes the two functions in the WebSocket multiplexer, `sendIfNewResourceVersion` and `createConnectionKey`, by replacing reflect-heavy JSON decoding and `fmt.Sprintf` with a typed struct and plain string concatenation. This cuts down per-message allocation overhead on a path that runs on every incoming WebSocket message from every Kubernetes cluster watch.

## Related Issue
Fixes #6292

## Changes
- Replaced `map[string]interface{}` unmarshalling in `sendIfNewResourceVersion` with a minimal typed struct (`resourceVersionExtractor`) that only extracts `metadata.resourceVersion`, so the JSON decoder can skip unknown fields instead of reflect-decoding everything
- Replaced `fmt.Sprintf("%s:%s:%s", ...)` in `createConnectionKey` with direct string concatenation (`clusterID + ":" + path + ":" + userID`), which the Go compiler can fold into a single allocation
- Added `BenchmarkSendIfNewResourceVersion`, `BenchmarkSendIfNewResourceVersion_DirectMetadata`, and `BenchmarkCreateConnectionKey` to `backend/cmd/multiplexer_test.go`, plus a shared test helper
- No behavior change, same logic and same output, just fewer allocations

## Benchmark Results

### `sendIfNewResourceVersion`

| Metric | Before (`map[string]interface{}`) | After (typed struct) | Improvement |
|---|---|---|---|
| Speed | ~5,900 ns/op | ~3,460 ns/op | 41% faster |
| Memory | 3,712 B/op | 472 B/op | 87% less |
| Allocations | 81 allocs/op | 12 allocs/op | 85% fewer |

### `createConnectionKey`

| Metric | Before (`fmt.Sprintf`) | After (string concat) | Improvement |
|---|---|---|---|
| Speed | ~110 ns/op | ~78 ns/op | 30% faster |
| Memory | 80 B/op | 80 B/op | Same |
| Allocations | 1 alloc/op | 1 alloc/op | Same |

## Steps to Test
1. Run the existing tests to confirm nothing broke:
```bash
   go test -run TestSendIfNewResourceVersion -v -count=1 ./cmd/
```
2. Run the new benchmarks:
```bash
   go test -run=^$ -bench=Benchmark -benchmem -count=3 ./cmd/
```
3. Run `go vet ./...` and make sure it's clean

## Screenshots
 
<img width="1041" height="329" alt="Screenshot 2026-06-30 190704" src="https://github.com/user-attachments/assets/af133597-6fba-4d59-8329-3afc980b521d" />

## Notes for the Reviewer
- This only touches the hot path that handles every incoming WS message per cluster watch. Logic and output are unchanged, just how the data gets parsed and the key gets built.
- Allocations per message dropped from 81 to 12 (69 fewer heap allocations). On a cluster with 50 watches pushing 100 events/sec, that eliminates roughly 6,900 unnecessary allocations per second.
- Kept both functions under the 60-line `funlen` limit.