### PR TITLE
tests: fix Request AbortSignal compat for nock on Node.js 24

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -18,6 +18,39 @@
 import '@testing-library/jest-dom/vitest';
 import indexeddb from 'fake-indexeddb';
 
+// nock v14 uses @mswjs/interceptors, which calls `new Request(url, init)` internally when
+// intercepting a fetch. In jsdom v24+, globalThis.Request wraps undici's native Request,
+// whose WebIDL validator requires init.signal to be an instance of undici's own AbortSignal.
+// jsdom installs its own AbortController (via vitest's populateGlobal), so signals created
+// with `new AbortController()` in test code are jsdom AbortSignals that fail that check.
+// This Proxy wraps Request construction: if the call fails with an AbortSignal type error,
+// it retries without the signal so nock can normalise the request. All other behaviour is
+// unchanged. setupFiles run before test-file imports, so this patch is in place before nock
+// patches globalThis.fetch.
+if (typeof Request !== 'undefined') {
+  const OriginalRequest = globalThis.Request;
+  globalThis.Request = new Proxy(OriginalRequest, {
+    construct(target, args, newTarget) {
+      const [input, init] = args as [RequestInfo | URL, RequestInit | undefined];
+      if (init?.signal) {
+        try {
+          return Reflect.construct(target, args, newTarget);
+        } catch (e: unknown) {
+          if (e instanceof TypeError && (e as TypeError).message.includes('AbortSignal')) {
+            return Reflect.construct(
+              target,
+              [input, { ...init, signal: undefined }, ...args.slice(2)],
+              newTarget
+            );
+          }
+          throw e;
+        }
+      }
+      return Reflect.construct(target, args, newTarget);
+    },
+  });
+}
+
 globalThis.indexedDB = indexeddb;
 
 if (typeof TextDecoder === 'undefined' && typeof require !== 'undefined') {


### PR DESCRIPTION
## Summary

This PR fixes the frontend test failures that occur on Node.js v24 due to an incompatibility between `jsdom`, `nock`, and the underlying `Request` implementation.

Under Node.js v24, requests intercepted by `nock` can fail during `Request` construction because the provided `AbortSignal` is not recognized as the expected native implementation. The resulting exception causes the request layer to return an "Unreachable" response, leading to failures across `apiProxy.test.ts`.

This change adds a targeted test-only compatibility layer in `setupTests.ts` so the existing tests execute as intended without modifying production code.

## Related Issue

Fixes #6296

## Changes

- Added a compatibility wrapper around `globalThis.Request` in `frontend/src/setupTests.ts`.
- Preserved normal `Request` behavior by retrying construction only when the specific `AbortSignal` compatibility error occurs.
- Limited the change to the test environment; no production code was modified.

## Steps to Test

1. Use Node.js **v24.14.1**.
2. Run:

   ```bash
   npm run frontend:test
   ```

3. Verify that:
   - All `apiProxy.test.ts` tests pass.
   - The full frontend test suite passes.
   - No production behavior is affected.

## Notes for the Reviewer

### Why the failures occurred

On Node.js v24, `globalThis.Request` (provided by `jsdom` via `undici`) validates that `RequestInit.signal` is an instance of its expected native `AbortSignal`.

During test execution, Vitest replaces `globalThis.AbortController` with jsdom's implementation. As a result, `clusterRequests.ts` creates a jsdom `AbortSignal`.

When `nock` (through `@mswjs/interceptors`) intercepts a `fetch` request, it internally constructs a new `Request` using the provided initialization object. The `Request` constructor rejects the jsdom `AbortSignal` and throws a `TypeError`.

The request layer catches this exception and returns its fallback `502 Unreachable` response, causing the mocked requests to fail before reaching `nock`.

### Why this fix works

The compatibility wrapper attempts normal `Request` construction first.

Only when the specific `AbortSignal` compatibility error is encountered does it retry construction without the `signal`, allowing `nock` to normalize the request successfully.

All other `Request` construction paths continue to behave normally, and the change is confined to the test environment.

### Alternatives considered

Several alternatives were investigated:

- Replacing `globalThis.AbortController` with the native implementation.
- Creating a native `AbortController` via a separate VM context.
- Modifying production request code.

These approaches were rejected because they were either ineffective in the jsdom environment or would have unnecessarily affected production code. A test-only compatibility layer provides the smallest and most targeted solution.

### Testing

Before this change:

- **51/67** tests in `apiProxy.test.ts` failed on Node.js **v24.14.1**.

After this change:

- **67/67** tests in `apiProxy.test.ts` pass.
- The full frontend test suite passes (**140 test files, 1918 tests**).
- No production files were modified.