### PR TITLE
fix: serialize concurrent WebSocket writes to cluster connections to prevent data race

### DIFF
--- a/backend/cmd/multiplexer.go
+++ b/backend/cmd/multiplexer.go
@@ -367,7 +367,9 @@ func (c *Connection) safeClose() {
 		}
 
 		if c.WSConn != nil {
+			c.writeMu.Lock()
 			_ = c.WSConn.Close()
+			c.writeMu.Unlock()
 		}
 	})
 }
@@ -565,7 +567,11 @@ func (m *Multiplexer) monitorConnection(conn *Connection) {
 
 			return
 		case <-heartbeat.C:
-			if err := conn.WSConn.WriteMessage(websocket.PingMessage, nil); err != nil {
+			conn.writeMu.Lock()
+			err := conn.WSConn.WriteMessage(websocket.PingMessage, nil)
+			conn.writeMu.Unlock()
+
+			if err != nil {
 				conn.updateStatus(StateError, fmt.Errorf("heartbeat failed: %w", err))
 
 				if newConn, err := m.reconnect(conn); err != nil {
@@ -585,7 +591,9 @@ func (m *Multiplexer) reconnect(conn *Connection) (*Connection, error) {
 	}
 
 	if conn.WSConn != nil {
+		conn.writeMu.Lock()
 		_ = conn.WSConn.Close()
+		conn.writeMu.Unlock()
 	}
 
 	newConn, err := m.establishClusterConnection(
@@ -855,7 +863,10 @@ func (m *Multiplexer) handleConnectionError(clientConn *WSConnLock, msg Message,
 
 // writeMessageToCluster writes a message to the cluster WebSocket connection.
 func (m *Multiplexer) writeMessageToCluster(conn *Connection, data []byte) error {
+	conn.writeMu.Lock()
 	err := conn.WSConn.WriteMessage(websocket.BinaryMessage, data)
+	conn.writeMu.Unlock()
+
 	if err != nil {
 		conn.updateStatus(StateError, err)
 		logger.Log(

--- a/backend/cmd/multiplexer_test.go
+++ b/backend/cmd/multiplexer_test.go
@@ -1934,3 +1934,114 @@ func BenchmarkCreateConnectionKey(b *testing.B) {
 		benchConnectionKeySink = m.createConnectionKey(clusterID, path, userID)
 	}
 }
+
+// TestConcurrentClusterWrites verifies that concurrent writes to the cluster
+// WebSocket connection are properly serialized by conn.writeMu.
+//
+// Note: This test simulates the heartbeat ping writer; it does not invoke
+// monitorConnection directly (HeartbeatInterval is a const).
+func TestConcurrentClusterWrites(t *testing.T) {
+	m := NewMultiplexer(kubeconfig.NewContextStore(), false)
+
+	// Create a WebSocket pair for the cluster-side connection.
+	clusterConn, clusterServer := createTestWebSocketConnection()
+	defer clusterServer.Close()
+
+	conn := &Connection{
+		ClusterID: "test-cluster",
+		UserID:    "test-user",
+		Path:      "/api/v1/pods",
+		WSConn:    clusterConn.conn,
+		Done:      make(chan struct{}),
+		Status: ConnectionStatus{
+			State:   StateConnected,
+			LastMsg: time.Now(),
+		},
+	}
+
+	drainAndCleanup(t, clusterConn)
+
+	var wg sync.WaitGroup
+
+	// Simulate heartbeat pings (what monitorConnection does).
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < 50; i++ {
+			conn.writeMu.Lock()
+			err := conn.WSConn.WriteMessage(websocket.PingMessage, nil)
+			conn.writeMu.Unlock()
+
+			if err != nil {
+				t.Errorf("ping write failed: %v", err)
+
+				return
+			}
+		}
+	}()
+
+	// Simulate client data forwarding (what writeMessageToCluster does).
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < 50; i++ {
+			if err := m.writeMessageToCluster(conn, []byte(fmt.Sprintf("msg-%d", i))); err != nil {
+				t.Errorf("cluster write failed: %v", err)
+
+				return
+			}
+		}
+	}()
+
+	waitWithTimeout(t, &wg, 5*time.Second, "concurrent cluster writes timed out — possible deadlock")
+}
+
+// waitWithTimeout waits for a WaitGroup to finish within the given timeout,
+// calling t.Fatal with msg if the deadline is exceeded.
+func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, timeout time.Duration, msg string) {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: goroutines completed without deadlock (run with `-race` to check for data races).
+	case <-time.After(timeout):
+		t.Fatal(msg)
+	}
+}
+
+// drainAndCleanup starts a goroutine that drains reads from conn so
+// writes on the other end don't block, and registers a t.Cleanup to
+// close the connection (which also terminates the drain goroutine).
+func drainAndCleanup(t *testing.T, conn *WSConnLock) {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for {
+			_, _, err := conn.conn.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = conn.conn.Close()
+
+		<-done
+	})
+}


### PR DESCRIPTION
## Summary

This PR fixes a data race in the WebSocket multiplexer by serializing concurrent writes to the cluster-side WebSocket connection using the existing `conn.writeMu` mutex.

## Related Issue

Fixes #6008 

## Changes

- Fixed `monitorConnection` to acquire `conn.writeMu` before sending heartbeat pings to the cluster
- Fixed `writeMessageToCluster` to acquire `conn.writeMu` before forwarding client data to the cluster
- Added `TestConcurrentClusterWrites` to verify that concurrent pings and data writes do not race or deadlock

## Steps to Test

1. Run the multiplexer tests: `go test -run "TestConcurrentClusterWrites|TestWriteMessageToCluster|TestMonitorConnection$" -timeout 120s -v ./cmd/...`
2. All three tests should pass
3. On Linux/Mac with a 64-bit GCC available, run with `-race` flag to confirm no data race is detected: `go test -race -run "TestConcurrentClusterWrites" -timeout 120s -v ./cmd/...`

## Notes for the Reviewer

- `gorilla/websocket` explicitly states that concurrent calls to `WriteMessage` on the same `*websocket.Conn` are not safe. Two goroutines (`monitorConnection` for heartbeat pings and `writeMessageToCluster` for forwarding client data) were both writing to `conn.WSConn` without any synchronization. Under load, such as streaming pod logs while a heartbeat fires, this race can cause a panic or corrupt the WebSocket frame stream.
- The `Connection` struct already had `writeMu sync.Mutex` defined for this exact purpose, but it was only used for writes going back to the frontend client, not for writes going to the cluster. This PR completes the intended usage.
- The log error in `TestWriteMessageToCluster` output (`use of closed network connection`) is expected and part of the existing test that intentionally closes the connection to verify error handling.
