### PR TITLE
backend: renameCluster: Return errors on collision and cache failure

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2741,10 +2741,12 @@ func (c *HeadlampConfig) handleClusterRename(w http.ResponseWriter, r *http.Requ
 	isUnique := CheckUniqueName(config.Contexts, clusterName, reqBody.NewClusterName)
 	if !isUnique {
 		http.Error(w, "custom name already in use", http.StatusBadRequest)
-		logger.Log(logger.LevelError, map[string]string{logFieldCluster: clusterName},
-			err, "cluster name already exists in the kubeconfig")
 
-		return err
+		renameErr := errors.New("cluster name already in use")
+		logger.Log(logger.LevelError, map[string]string{logFieldCluster: clusterName},
+			renameErr, "cluster name already exists in the kubeconfig")
+
+		return renameErr
 	}
 
 	contextName := findMatchingContextName(config, clusterName)
@@ -2755,8 +2757,10 @@ func (c *HeadlampConfig) handleClusterRename(w http.ResponseWriter, r *http.Requ
 	}
 
 	if errs := c.updateCustomContextToCache(config, clusterName); len(errs) > 0 {
-		c.handleError(w, ctx, span, err, "failed to update context to cache", http.StatusInternalServerError)
-		return errors.New("failed to update context cache")
+		cacheErr := errors.Join(errs...)
+		c.handleError(w, ctx, span, cacheErr, "failed to update context to cache", http.StatusInternalServerError)
+
+		return cacheErr
 	}
 
 	w.WriteHeader(http.StatusCreated)

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1847,6 +1847,40 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 	assert.Contains(t, clustersByName, "docker-desktop", "expected docker-desktop cluster to still exist")
 }
 
+// TestHandleClusterRename_NameCollision covers the name-collision branch of
+// handleClusterRename. It must return a non-nil error so the caller does not
+// record a failed rename as a success (it previously returned nil).
+func TestHandleClusterRename_NameCollision(t *testing.T) {
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				UseInCluster:          false,
+				KubeConfigPath:        "./headlamp_testdata/kubeconfig",
+				EnableDynamicClusters: true,
+				KubeConfigStore:       kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/cluster/minikube/rename", nil)
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "TestHandleClusterRename_NameCollision")
+	defer span.End()
+
+	// Rename "minikube" to "docker-desktop", which already exists in the kubeconfig.
+	err := c.handleClusterRename(w, r, "minikube", RenameClusterRequest{
+		NewClusterName: "docker-desktop",
+		Source:         "kubeconfig",
+	}, ctx, span)
+
+	require.Error(t, err, "a name collision must return a non-nil error")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestFileExists(t *testing.T) {
 	// Test for existing file
 	assert.True(t, fileExists("./headlamp_testdata/kubeconfig"),


### PR DESCRIPTION
## What

`handleClusterRename` (backend) had two failure paths that were reported as success:

- On a **duplicate cluster name** it writes a 400, but then returns the outer `err`, which is `nil` at that point. So `renameCluster` falls through and records the failed rename as a success (it logs "Completed renameCluster request" and records success metrics/duration).
- On an **`updateCustomContextToCache` failure** it passes that same `nil` `err` to `handleError`, which does `http.Error(w, err.Error(), ...)` and **panics** on the nil dereference. The real errors in `errs` were also discarded.

This returns a real error in both cases: a non-nil error for the name collision, and `errors.Join(errs...)` for the cache failure (which also surfaces the actual cause instead of a generic message).

## Why

A name collision was silently logged and measured as a successful rename, and a cache-update failure crashed the request handler via a nil-pointer panic.

## Testing

- Added `TestHandleClusterRename_NameCollision`, which asserts the collision path returns a non-nil error and a 400. Confirmed it **fails without the fix** ("An error is expected but got nil") and passes with it.
- Existing `TestRenameCluster` still passes; `gofmt` and `go vet` are clean.

```
$ go test ./cmd/ -run 'TestRenameCluster|TestHandleClusterRename_NameCollision'
ok  	github.com/kubernetes-sigs/headlamp/backend/cmd
```

cc @illume
