### PR TITLE
Stop showing `undefined` for volume expansion in the `StorageClass` list

### DIFF
--- a/frontend/src/components/storage/ClassDetails.stories.tsx
+++ b/frontend/src/components/storage/ClassDetails.stories.tsx
@@ -18,7 +18,7 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { API_BASE, TestContext } from '../../test';
 import Details from './ClassDetails';
-import { BASE_SC } from './storyHelper';
+import { BASE_SC_EXPLICIT_EXPANDABLE } from './storyHelper';
 
 export default {
   title: 'StorageClass/DetailsView',
@@ -27,7 +27,7 @@ export default {
   decorators: [
     Story => {
       return (
-        <TestContext routerMap={{ name: 'my-sc' }}>
+        <TestContext routerMap={{ name: 'storage-class-expandable' }}>
           <Story />
         </TestContext>
       );
@@ -44,8 +44,8 @@ Base.parameters = {
   msw: {
     handlers: {
       story: [
-        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses/my-sc`, () =>
-          HttpResponse.json(BASE_SC)
+        http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses/storage-class-expandable`, () =>
+          HttpResponse.json(BASE_SC_EXPLICIT_EXPANDABLE)
         ),
         http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses`, () => HttpResponse.error()),
       ],

--- a/frontend/src/components/storage/ClassList.stories.tsx
+++ b/frontend/src/components/storage/ClassList.stories.tsx
@@ -18,7 +18,11 @@ import { Meta, StoryFn } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
 import { API_BASE, TestContext } from '../../test';
 import ListView from './ClassList';
-import { BASE_SC } from './storyHelper';
+import {
+  BASE_SC,
+  BASE_SC_EXPLICIT_EXPANDABLE,
+  BASE_SC_EXPLICIT_NON_EXPANDABLE,
+} from './storyHelper';
 
 export default {
   title: 'StorageClass/ListView',
@@ -47,7 +51,7 @@ Items.parameters = {
         http.get(`${API_BASE}/apis/storage.k8s.io/v1/storageclasses`, () =>
           HttpResponse.json({
             kind: 'StorageClassList',
-            items: [BASE_SC],
+            items: [BASE_SC_EXPLICIT_EXPANDABLE, BASE_SC_EXPLICIT_NON_EXPANDABLE, BASE_SC],
             metadata: {},
           })
         ),

--- a/frontend/src/components/storage/ClassList.test.tsx
+++ b/frontend/src/components/storage/ClassList.test.tsx
@@ -92,4 +92,22 @@ describe('ClassList (StorageClass)', () => {
     expect(defaultCol.render({ isDefault: true } as any)).toBe('Yes');
     expect(defaultCol.render({ isDefault: false } as any)).toBeNull();
   });
+
+  it('renders the volume expansion column content only when the field value is explicitly specified', () => {
+    render(
+      <TestContext>
+        <ClassList />
+      </TestContext>
+    );
+
+    const allowVolumeExpansionCol = getColumn('allowVolumeExpansion');
+    expect(allowVolumeExpansionCol.getValue({ allowVolumeExpansion: true } as any)).toBe('true');
+    expect(allowVolumeExpansionCol.render({ allowVolumeExpansion: true } as any)).toBe('Yes');
+    expect(allowVolumeExpansionCol.getValue({ allowVolumeExpansion: false } as any)).toBe('false');
+    expect(allowVolumeExpansionCol.render({ allowVolumeExpansion: false } as any)).toBe('No');
+    expect(allowVolumeExpansionCol.getValue({ allowVolumeExpansion: undefined } as any)).toBe(
+      'false'
+    );
+    expect(allowVolumeExpansionCol.render({ allowVolumeExpansion: undefined } as any)).toBeNull();
+  });
 });

--- a/frontend/src/components/storage/ClassList.tsx
+++ b/frontend/src/components/storage/ClassList.tsx
@@ -60,7 +60,11 @@ export default function ClassList() {
           id: 'allowVolumeExpansion',
           label: t('Allow Volume Expansion'),
           filterVariant: 'checkbox',
-          getValue: storageClass => String(storageClass.allowVolumeExpansion),
+          getValue: storageClass => String(storageClass.allowVolumeExpansion ?? false),
+          render: (storageClass: StorageClass) => {
+            if (storageClass.allowVolumeExpansion === undefined) return null;
+            return storageClass.allowVolumeExpansion ? t('Yes') : t('No');
+          },
         },
         'labels',
         'age',

--- a/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassDetails.Base.stories.storyshot
@@ -47,7 +47,7 @@
                 <h1
                   class="MuiTypography-root MuiTypography-h1 MuiTypography-noWrap css-yeaech-MuiTypography-root"
                 >
-                  StorageClass: my-pvc
+                  StorageClass: storage-class-expandable
                 </h1>
                 <div
                   class="MuiBox-root css-ldp2l3"
@@ -145,7 +145,7 @@
                     <span
                       class="MuiTypography-root MuiTypography-body1 css-e06lsu-MuiTypography-root"
                     >
-                      my-pvc
+                      storage-class-expandable
                     </span>
                   </dd>
                   <dt

--- a/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/ClassList.Items.stories.storyshot
@@ -681,7 +681,7 @@
                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
                   href="/"
                 >
-                  my-pvc
+                  storage-class-expandable
                 </a>
               </td>
               <td
@@ -705,8 +705,194 @@
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-xt8srx-MuiTableCell-root"
               >
-                true
+                Yes
               </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+              >
+                <p
+                  aria-label="2023-04-27T20:31:27.000Z"
+                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  90d
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+              >
+                <button
+                  aria-label="Row Actions"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="css-1ospngb"
+              data-selected="false"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+              >
+                <span
+                  aria-label="Toggle select row"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  <input
+                    aria-label="Toggle select row"
+                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    data-indeterminate="false"
+                    type="checkbox"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="CheckBoxOutlineBlankIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  storage-class-non-expandable
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ilsbxl-MuiTableCell-root"
+              >
+                csi.test
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-12j49la-MuiTableCell-root"
+              />
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-10q82xd-MuiTableCell-root"
+              >
+                Delete
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ade44f-MuiTableCell-root"
+              >
+                WaitForFirstConsumer
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-xt8srx-MuiTableCell-root"
+              >
+                No
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
+              >
+                <p
+                  aria-label="2023-04-27T20:31:27.000Z"
+                  class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  90d
+                </p>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-hq12h3-MuiTableCell-root"
+              >
+                <button
+                  aria-label="Row Actions"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1cxdeyj-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </td>
+            </tr>
+            <tr
+              class="css-1ospngb"
+              data-selected="false"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1nchbpl-MuiTableCell-root"
+              >
+                <span
+                  aria-label="Toggle select row"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-3nlepf-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  data-mui-internal-clone-element="true"
+                >
+                  <input
+                    aria-label="Toggle select row"
+                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    data-indeterminate="false"
+                    type="checkbox"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                    data-testid="CheckBoxOutlineBlankIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1adoll5-MuiTableCell-root"
+              >
+                <a
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-2ugbm1-MuiTypography-root-MuiLink-root"
+                  href="/"
+                >
+                  storage-class
+                </a>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1ilsbxl-MuiTableCell-root"
+              >
+                csi.test
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-12j49la-MuiTableCell-root"
+              />
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-10q82xd-MuiTableCell-root"
+              >
+                Delete
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-ade44f-MuiTableCell-root"
+              >
+                WaitForFirstConsumer
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-xt8srx-MuiTableCell-root"
+              />
               <td
                 class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
               >

--- a/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
+++ b/frontend/src/components/storage/__snapshots__/VolumeList.Items.stories.storyshot
@@ -698,9 +698,7 @@
               />
               <td
                 class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-xt8srx-MuiTableCell-root"
-              >
-                undefined
-              </td>
+              />
               <td
                 class="MuiTableCell-root MuiTableCell-alignRight MuiTableCell-sizeMedium css-14i1ub9-MuiTableCell-root"
               >

--- a/frontend/src/components/storage/storyHelper.ts
+++ b/frontend/src/components/storage/storyHelper.ts
@@ -24,14 +24,33 @@ export const BASE_SC: KubeStorageClass = {
   kind: 'StorageClass',
   metadata: {
     creationTimestamp: '2023-04-27T20:31:27Z',
-    name: 'my-pvc',
+    name: 'storage-class',
     resourceVersion: '1234',
-    uid: 'abc-1234',
+    uid: '1',
   },
   provisioner: 'csi.test',
   reclaimPolicy: 'Delete',
-  allowVolumeExpansion: true,
   volumeBindingMode: 'WaitForFirstConsumer',
+};
+
+export const BASE_SC_EXPLICIT_EXPANDABLE: KubeStorageClass = {
+  ...BASE_SC,
+  metadata: {
+    ...BASE_SC.metadata,
+    uid: '2',
+    name: 'storage-class-expandable',
+  },
+  allowVolumeExpansion: true,
+};
+
+export const BASE_SC_EXPLICIT_NON_EXPANDABLE: KubeStorageClass = {
+  ...BASE_SC,
+  metadata: {
+    ...BASE_SC.metadata,
+    uid: '3',
+    name: 'storage-class-non-expandable',
+  },
+  allowVolumeExpansion: false,
 };
 
 export const BASE_PVC: KubePersistentVolumeClaim = {

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "السماح بتوسيع التخزين",
   "Mount Options": "",
   "Volume Binding Mode": "وضع ربط التخزين",
-  "No": "",
+  "No": "لا",
   "Driver Name": "اسم المشغل",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "هذا المورد فعال فقط مع مشغلات CSI المتوافقة التي تدعم خصائص التخزين القابلة للتعديل.",
   "Claim": "المطالبة",

--- a/frontend/src/i18n/locales/ar/glossary.json
+++ b/frontend/src/i18n/locales/ar/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "السماح بتوسيع التخزين",
   "Mount Options": "",
   "Volume Binding Mode": "وضع ربط التخزين",
+  "No": "",
   "Driver Name": "اسم المشغل",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "هذا المورد فعال فقط مع مشغلات CSI المتوافقة التي تدعم خصائص التخزين القابلة للتعديل.",
   "Claim": "المطالبة",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "ভলিউম এক্সপ্যানশন অনুমতি দিন",
   "Mount Options": "মাউন্ট অপশন",
   "Volume Binding Mode": "ভলিউম বাইন্ডিং Mode",
+  "No": "",
   "Driver Name": "ড্রাইভার নাম",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "এই Resource শুধুমাত্র পরিবর্তনযোগ্য ভলিউম Attribute সমর্থনকারী সামঞ্জস্যপূর্ণ CSI ড্রাইভারের জন্য কার্যকর।",
   "Claim": "দাবি",

--- a/frontend/src/i18n/locales/bn/glossary.json
+++ b/frontend/src/i18n/locales/bn/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "ভলিউম এক্সপ্যানশন অনুমতি দিন",
   "Mount Options": "মাউন্ট অপশন",
   "Volume Binding Mode": "ভলিউম বাইন্ডিং Mode",
-  "No": "",
+  "No": "না",
   "Driver Name": "ড্রাইভার নাম",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "এই Resource শুধুমাত্র পরিবর্তনযোগ্য ভলিউম Attribute সমর্থনকারী সামঞ্জস্যপূর্ণ CSI ড্রাইভারের জন্য কার্যকর।",
   "Claim": "দাবি",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "Volumenerweiterung zulassen",
   "Mount Options": "",
   "Volume Binding Mode": "Bindungsmodus",
-  "No": "",
+  "No": "Nein",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/de/glossary.json
+++ b/frontend/src/i18n/locales/de/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Volumenerweiterung zulassen",
   "Mount Options": "",
   "Volume Binding Mode": "Bindungsmodus",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/en/glossary.json
+++ b/frontend/src/i18n/locales/en/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Allow Volume Expansion",
   "Mount Options": "Mount Options",
   "Volume Binding Mode": "Volume Binding Mode",
+  "No": "No",
   "Driver Name": "Driver Name",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "This resource is only effective for compatible CSI drivers that support mutable volume attributes.",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "Permitir Expansión de Volume",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
-  "No": "",
+  "No": "No",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/es/glossary.json
+++ b/frontend/src/i18n/locales/es/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Permitir Expansión de Volume",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Permettre l'expansion du volume",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
+  "No": "",
   "Driver Name": "Nom du pilote",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/fr/glossary.json
+++ b/frontend/src/i18n/locales/fr/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "Permettre l'expansion du volume",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
-  "No": "",
+  "No": "Non",
   "Driver Name": "Nom du pilote",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "Allow Volume Expansion",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
-  "No": "",
+  "No": "No",
   "Driver Name": "Driver Name",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "This resource is only effective for compatible CSI drivers that support mutable volume attributes.",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/he/glossary.json
+++ b/frontend/src/i18n/locales/he/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Allow Volume Expansion",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
+  "No": "",
   "Driver Name": "Driver Name",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "This resource is only effective for compatible CSI drivers that support mutable volume attributes.",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "वॉल्यूम विस्तार अनुमति",
   "Mount Options": "",
   "Volume Binding Mode": "वॉल्यूम बाइंडिंग मोड",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "क्लेम",

--- a/frontend/src/i18n/locales/hi/glossary.json
+++ b/frontend/src/i18n/locales/hi/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "वॉल्यूम विस्तार अनुमति",
   "Mount Options": "",
   "Volume Binding Mode": "वॉल्यूम बाइंडिंग मोड",
-  "No": "",
+  "No": "नहीं",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "क्लेम",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Consenti Espansione Volume",
   "Mount Options": "",
   "Volume Binding Mode": "Modalità Binding di Volume",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Richiesta",

--- a/frontend/src/i18n/locales/it/glossary.json
+++ b/frontend/src/i18n/locales/it/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "Consenti Espansione Volume",
   "Mount Options": "",
   "Volume Binding Mode": "Modalità Binding di Volume",
-  "No": "",
+  "No": "No",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Richiesta",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "ボリューム拡張の許可",
   "Mount Options": "",
   "Volume Binding Mode": "ボリュームバインディングモード",
-  "No": "",
+  "No": "いいえ",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "要求",

--- a/frontend/src/i18n/locales/ja/glossary.json
+++ b/frontend/src/i18n/locales/ja/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "ボリューム拡張の許可",
   "Mount Options": "",
   "Volume Binding Mode": "ボリュームバインディングモード",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "要求",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "볼륨 확장 허용",
   "Mount Options": "",
   "Volume Binding Mode": "볼륨 바인딩 모드",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "클레임",

--- a/frontend/src/i18n/locales/ko/glossary.json
+++ b/frontend/src/i18n/locales/ko/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "볼륨 확장 허용",
   "Mount Options": "",
   "Volume Binding Mode": "볼륨 바인딩 모드",
-  "No": "",
+  "No": "아니요",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "클레임",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "Permitir Expansão de Volume",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
-  "No": "",
+  "No": "Não",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/pt/glossary.json
+++ b/frontend/src/i18n/locales/pt/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Permitir Expansão de Volume",
   "Mount Options": "",
   "Volume Binding Mode": "Volume Binding Mode",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "Claim",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "Разрешить расширение тома",
   "Mount Options": "",
   "Volume Binding Mode": "Режим привязки тома",
-  "No": "",
+  "No": "Нет",
   "Driver Name": "Имя драйвера",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "Этот ресурс действует только для совместимых CSI-драйверов, поддерживающих изменяемые атрибуты тома.",
   "Claim": "Запрос",

--- a/frontend/src/i18n/locales/ru/glossary.json
+++ b/frontend/src/i18n/locales/ru/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "Разрешить расширение тома",
   "Mount Options": "",
   "Volume Binding Mode": "Режим привязки тома",
+  "No": "",
   "Driver Name": "Имя драйвера",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "Этот ресурс действует только для совместимых CSI-драйверов, поддерживающих изменяемые атрибуты тома.",
   "Claim": "Запрос",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "வால்யூம் விரிவாக்கத்தை அனுமதி",
   "Mount Options": "",
   "Volume Binding Mode": "வால்யூம் பைண்டிங் மோட்",
-  "No": "",
+  "No": "இல்லை",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "கிளெயிம்",

--- a/frontend/src/i18n/locales/ta/glossary.json
+++ b/frontend/src/i18n/locales/ta/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "வால்யூம் விரிவாக்கத்தை அனுமதி",
   "Mount Options": "",
   "Volume Binding Mode": "வால்யூம் பைண்டிங் மோட்",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "கிளெயிம்",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "والیوم توسیع کی اجازت",
   "Mount Options": "",
   "Volume Binding Mode": "والیوم بائنڈنگ موڈ",
-  "No": "",
+  "No": "نہیں",
   "Driver Name": "ڈرائیور کا نام",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "یہ ریسورس صرف ان CSI ڈرائیورز کے لیے مؤثر ہے جو قابلِ ترمیم والیوم خصوصیات کو سپورٹ کرتے ہیں۔",
   "Claim": "کلیم",

--- a/frontend/src/i18n/locales/ur/glossary.json
+++ b/frontend/src/i18n/locales/ur/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "والیوم توسیع کی اجازت",
   "Mount Options": "",
   "Volume Binding Mode": "والیوم بائنڈنگ موڈ",
+  "No": "",
   "Driver Name": "ڈرائیور کا نام",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "یہ ریسورس صرف ان CSI ڈرائیورز کے لیے مؤثر ہے جو قابلِ ترمیم والیوم خصوصیات کو سپورٹ کرتے ہیں۔",
   "Claim": "کلیم",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "允許卷擴充套件",
   "Mount Options": "",
   "Volume Binding Mode": "卷繫結模式",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "宣告",

--- a/frontend/src/i18n/locales/zh-tw/glossary.json
+++ b/frontend/src/i18n/locales/zh-tw/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "允許卷擴充套件",
   "Mount Options": "",
   "Volume Binding Mode": "卷繫結模式",
-  "No": "",
+  "No": "否",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "宣告",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -276,6 +276,7 @@
   "Allow Volume Expansion": "允许卷扩充",
   "Mount Options": "",
   "Volume Binding Mode": "卷绑定模式",
+  "No": "",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "宣告",

--- a/frontend/src/i18n/locales/zh/glossary.json
+++ b/frontend/src/i18n/locales/zh/glossary.json
@@ -276,7 +276,7 @@
   "Allow Volume Expansion": "允许卷扩充",
   "Mount Options": "",
   "Volume Binding Mode": "卷绑定模式",
-  "No": "",
+  "No": "否",
   "Driver Name": "",
   "This resource is only effective for compatible CSI drivers that support mutable volume attributes.": "",
   "Claim": "宣告",


### PR DESCRIPTION
## Summary

The `StorageClass` list view printed the literal string `undefined` in the "Allow Volume Expansion" column when said resource did not set that field. This PR renders a translated "Yes" or "No", only when the field is present, leaving the cell empty otherwise.

## Changes

- `ClassList`: the "Allow Volume Expansion" column now returns `null` when `allowVolumeExpansion` is `undefined`, and renders Yes / No depending on the boolean value. The sort value falls back to `false` for missing fields, so sorting stays stable.
- Stories: the list story now covers three cases (expandable, non-expandable, and a class that leaves the field unset). The details story uses the explicit expandable fixtures: `BASE_SC_EXPLICIT_EXPANDABLE` and `BASE_SC_EXPLICIT_NON_EXPANDABLE`.
- i18n: added the `"No"` glossary key and its translation to all locales. `"Yes"` already existed.

## Steps to Test

1. From `frontend/`, run `npm run storybook`.
2. Open `StorageClass/ListView` -> `Items`.
3. Check the "Allow Volume Expansion" column: `Yes` for the expandable class, `No` for the non-expandable class, and an empty cell for the class that does not set the field.

## Screenshots

<img width="2376" height="740" alt="localhost_6006__path=_story_storageclass-listview--items" src="https://github.com/user-attachments/assets/f54c6c96-3f18-4bd7-aa6f-d5a2567652d7" />

## Notes for the Reviewer

- I used [DeepL](https://deepl.com) for translation. While I don't trust translators to cover nuances in language, I at the very least assume the word "No" would accurately be covered.