### PR TITLE
frontend: recentClusters: Add try/catch around JSON.parse for localSt…

### DIFF
--- a/frontend/src/helpers/recentClusters.test.ts
+++ b/frontend/src/helpers/recentClusters.test.ts
@@ -27,6 +27,7 @@ function read(): unknown {
 describe('recentClusters', () => {
   beforeEach(() => {
     localStorage.clear();
+    vi.restoreAllMocks();
   });
 
   describe('setRecentCluster', () => {
@@ -75,6 +76,19 @@ describe('recentClusters', () => {
 
       expect(read()).toEqual(['alpha']);
     });
+
+    it('catches and logs errors when localStorage.setItem throws', () => {
+      const spyError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('Quota exceeded');
+      });
+
+      setRecentCluster('alpha');
+      expect(spyError).toHaveBeenCalledWith(
+        `Failed to set ${STORAGE_KEY} in localStorage:`,
+        expect.any(Error)
+      );
+    });
   });
 
   describe('getRecentClusters', () => {
@@ -94,19 +108,42 @@ describe('recentClusters', () => {
       expect(getRecentClusters()).toEqual([]);
     });
 
+    it('returns an empty array when the stored array contains non-string elements', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(['alpha', { name: 'beta' }]));
+
+      expect(getRecentClusters()).toEqual([]);
+    });
+
     it('returns an empty array when the stored value is a JSON null', () => {
       localStorage.setItem(STORAGE_KEY, 'null');
 
       expect(getRecentClusters()).toEqual([]);
     });
 
-    // Documents current behaviour: a corrupted payload surfaces as a parse
-    // error rather than silently falling back to []. A future change could
-    // add defensive recovery; this test should be updated alongside it.
-    it('throws when the stored payload is not valid JSON', () => {
+    // Documents current behaviour: a corrupted payload is caught
+    // and returns an empty array, instead of throwing an error.
+    it('returns an empty array and logs a warning when the stored payload is not valid JSON', () => {
+      const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       localStorage.setItem(STORAGE_KEY, '{not json');
 
-      expect(() => getRecentClusters()).toThrow(SyntaxError);
+      expect(getRecentClusters()).toEqual([]);
+      expect(spyWarn).toHaveBeenCalledWith(
+        `Failed to parse ${STORAGE_KEY} from localStorage, returning empty list:`,
+        expect.any(SyntaxError)
+      );
+    });
+
+    it('returns an empty array and logs a warning when localStorage.getItem throws', () => {
+      const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+        throw new Error('Storage disabled');
+      });
+
+      expect(getRecentClusters()).toEqual([]);
+      expect(spyWarn).toHaveBeenCalledWith(
+        `Failed to read ${STORAGE_KEY} from localStorage, returning empty list:`,
+        expect.any(Error)
+      );
     });
   });
 });

--- a/frontend/src/helpers/recentClusters.ts
+++ b/frontend/src/helpers/recentClusters.ts
@@ -28,18 +28,47 @@ export function setRecentCluster(cluster: string | Cluster) {
   const clusterName = typeof cluster === 'string' ? cluster : cluster.name;
   const currentClusters = recentClusters.filter(name => name !== clusterName);
   const newClusters = [clusterName, ...currentClusters].slice(0, 3);
-  localStorage.setItem(recentClustersStorageKey, JSON.stringify(newClusters));
+  try {
+    localStorage.setItem(recentClustersStorageKey, JSON.stringify(newClusters));
+  } catch (error) {
+    console.error(`Failed to set ${recentClustersStorageKey} in localStorage:`, error);
+  }
 }
 /**
  * @returns the list of recent clusters from localStorage.
  */
-export function getRecentClusters() {
-  const currentClustersStr = localStorage.getItem(recentClustersStorageKey) || '[]';
-  const recentClusters = JSON.parse(currentClustersStr) as string[];
+export function getRecentClusters(): string[] {
+  let currentClustersStr: string | null = null;
 
-  if (!Array.isArray(recentClusters)) {
+  try {
+    currentClustersStr = localStorage.getItem(recentClustersStorageKey);
+  } catch (error) {
+    console.warn(
+      `Failed to read ${recentClustersStorageKey} from localStorage, returning empty list:`,
+      error
+    );
     return [];
   }
 
-  return recentClusters;
+  if (currentClustersStr === null) {
+    return [];
+  }
+
+  let recentClusters: unknown;
+
+  try {
+    recentClusters = JSON.parse(currentClustersStr);
+  } catch (error) {
+    console.warn(
+      `Failed to parse ${recentClustersStorageKey} from localStorage, returning empty list:`,
+      error
+    );
+    return [];
+  }
+
+  if (!Array.isArray(recentClusters) || !recentClusters.every(item => typeof item === 'string')) {
+    return [];
+  }
+
+  return recentClusters as string[];
 }


### PR DESCRIPTION


## Summary
This PR hardens the `recentClusters` helper functions against corrupted `localStorage` data, browser storage exceptions, and type leakage, preventing application startup crashes.

## Related Issue
Fixes #6309 

## Root Cause
`getRecentClusters()` retrieves the `recent_clusters` key from `localStorage` and calls `JSON.parse` without a `try/catch`. If the data is corrupted, a `SyntaxError` is thrown on application startup, crashing the cluster-selection UI before the user can connect. Furthermore, the parsed output was forcefully cast `as string[]` without runtime validation; if the storage contained an array of objects, it would leak incorrect types and crash downstream. Finally, `setRecentCluster()` called `localStorage.setItem` without catching `QuotaExceededError`.

## Changes
- **`frontend/src/helpers/recentClusters.ts`:**
  - Wrapped `JSON.parse` in `getRecentClusters()` with a `try/catch`. On failure, logs a warning and returns `[]`.
  - Added strong runtime type validation (`recentClusters.every(item => typeof item === 'string')`) to prevent non-string elements from leaking past the `as string[]` cast.
  - Wrapped `localStorage.setItem` in `setRecentCluster()` with a `try/catch` to gracefully log errors if the quota is exceeded.
- **`frontend/src/helpers/recentClusters.test.ts`:**
  - Replaced the `toThrow(SyntaxError)` test with one that verifies it correctly catches the error, logs a warning, and returns `[]`.
  - Added a test to ensure it returns `[]` if the stored array contains non-string elements.
  - Added a test to verify `localStorage.setItem` throws are caught and logged.

## Steps to Test
1. Run `cd frontend && npx vitest run src/helpers/recentClusters.test.ts` to verify all 13 tests pass.
2. Open Headlamp, navigate to Local Storage in DevTools, and manually corrupt the `recent_clusters` key (e.g., set it to `{ broken JSON ]` or `[{"unexpected": "object"}]`).
3. Refresh the page. The app should load normally (ignoring the corrupted recent clusters) rather than crashing to a blank screen. 

## Verification
- [x] Linting and type checking (`npm run frontend:tsc`) pass.
- [x] 13/13 tests in `recentClusters.test.ts` pass.
- [x] Diff scope is minimal and targeted.
