### PR TITLE
frontend: drawerModeSlice: Fix Redux init crash on localStorage failure

### DIFF
--- a/frontend/src/redux/drawerModeSlice.test.ts
+++ b/frontend/src/redux/drawerModeSlice.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('drawerModeSlice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('defaults to true when localStorage is empty', async () => {
+      const { drawerModeSlice } = await import('./drawerModeSlice');
+      const state = drawerModeSlice.getInitialState();
+      expect(state.isDetailDrawerEnabled).toBe(true);
+    });
+
+    it('initializes to false when localStorage has "false"', async () => {
+      localStorage.setItem('detailDrawerEnabled', 'false');
+      const { drawerModeSlice } = await import('./drawerModeSlice');
+      const state = drawerModeSlice.getInitialState();
+      expect(state.isDetailDrawerEnabled).toBe(false);
+    });
+
+    it('initializes to true and logs warning when localStorage.getItem throws (e.g. SecurityError)', async () => {
+      const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+        throw new Error('SecurityError: The operation is insecure.');
+      });
+
+      const { drawerModeSlice } = await import('./drawerModeSlice');
+      const state = drawerModeSlice.getInitialState();
+
+      expect(state.isDetailDrawerEnabled).toBe(true);
+      expect(spyWarn).toHaveBeenCalledWith(
+        'Failed to get detailDrawerEnabled from localStorage, defaulting to true:',
+        expect.stringContaining('SecurityError: The operation is insecure.')
+      );
+    });
+  });
+
+  describe('setDetailDrawerEnabled', () => {
+    it('updates state and writes to localStorage', async () => {
+      const { drawerModeSlice, setDetailDrawerEnabled } = await import('./drawerModeSlice');
+      let state = drawerModeSlice.getInitialState();
+
+      state = drawerModeSlice.reducer(state, setDetailDrawerEnabled(false));
+
+      expect(state.isDetailDrawerEnabled).toBe(false);
+      expect(localStorage.getItem('detailDrawerEnabled')).toBe('false');
+    });
+
+    it('updates state and logs error when localStorage.setItem throws', async () => {
+      const spyError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('Quota exceeded');
+      });
+
+      const { drawerModeSlice, setDetailDrawerEnabled } = await import('./drawerModeSlice');
+      let state = drawerModeSlice.getInitialState();
+
+      state = drawerModeSlice.reducer(state, setDetailDrawerEnabled(false));
+
+      expect(state.isDetailDrawerEnabled).toBe(false);
+      expect(spyError).toHaveBeenCalledWith(
+        'Failed to set detailDrawerEnabled in localStorage:',
+        expect.stringContaining('Quota exceeded')
+      );
+    });
+  });
+
+  describe('setSelectedResource', () => {
+    it('updates selectedResource in state', async () => {
+      const { drawerModeSlice, setSelectedResource } = await import('./drawerModeSlice');
+      let state = drawerModeSlice.getInitialState();
+      const resource = { kind: 'Pod', metadata: { name: 'test' }, cluster: 'minikube' };
+
+      state = drawerModeSlice.reducer(state, setSelectedResource(resource));
+
+      expect(state.selectedResource).toEqual(resource);
+    });
+  });
+});

--- a/frontend/src/redux/drawerModeSlice.ts
+++ b/frontend/src/redux/drawerModeSlice.ts
@@ -30,7 +30,15 @@ export interface DrawerModeState {
   };
 }
 
-const getLocalDrawerStatus = (key: string) => localStorage.getItem(key) !== 'false';
+const getLocalDrawerStatus = (key: string) => {
+  try {
+    return localStorage.getItem(key) !== 'false';
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.warn(`Failed to get ${key} from localStorage, defaulting to true:`, errorMsg);
+    return true;
+  }
+};
 
 const localStorageName = 'detailDrawerEnabled';
 
@@ -45,7 +53,12 @@ export const drawerModeSlice = createSlice({
   reducers: {
     setDetailDrawerEnabled: (state, action: PayloadAction<boolean>) => {
       state.isDetailDrawerEnabled = action.payload;
-      localStorage.setItem(localStorageName, `${action.payload}`);
+      try {
+        localStorage.setItem(localStorageName, `${action.payload}`);
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.stack ?? error.message : String(error);
+        console.error(`Failed to set ${localStorageName} in localStorage:`, errorMsg);
+      }
     },
     setSelectedResource: (state, action: PayloadAction<DrawerModeState['selectedResource']>) => {
       state.selectedResource = action.payload;


### PR DESCRIPTION


## Summary
This PR adds defensive `try/catch` wrapping around `localStorage` interactions within the `drawerModeSlice`. It mitigates a critical startup crash caused by `localStorage` restrictions.

## Related Issue
Fixes #6311 

## Root Cause
`drawerModeSlice.ts` populates its `initialState` by immediately calling `localStorage.getItem` at module evaluation time. In environments where `localStorage` is completely blocked by the browser (e.g. some iframe embeddings, strict privacy settings), this triggers a synchronous `SecurityError` that crashes the entire Redux initialization and prevents the application UI from loading. Additionally, `setDetailDrawerEnabled` writes to `localStorage` without catching potential `QuotaExceededError` exceptions.

## Changes
- **`frontend/src/redux/drawerModeSlice.ts`:**
  - Wrapped `localStorage.getItem` inside `getLocalDrawerStatus` with `try/catch`. It now correctly type-narrows the error, logs a warning, and falls back to `true` (the default behavior) if access fails.
  - Wrapped `localStorage.setItem` in `setDetailDrawerEnabled` with `try/catch` to gracefully type-narrow, catch, and log write errors.
- **`frontend/src/redux/drawerModeSlice.test.ts`:**
  - Created a new test suite to explicitly test module initialization.
  - Added tests simulating `SecurityError` during initialization to verify it falls back safely.
  - Added tests to verify write errors are caught and logged during updates.
  - Uses `vi.resetModules()` and dynamic `await import` to properly test module-scope `localStorage` access without cache pollution.

## Steps to Test
1. Run `cd frontend && npx vitest run src/redux/drawerModeSlice.test.ts` to verify all 6 tests pass.
2. In Google Chrome, go to `chrome://settings/content/siteData`, select "Don't allow sites to save data on your device", and reload Headlamp.
3. The app should load and render properly (with drawer mode defaulting to true) rather than blank-screening with a `SecurityError` in the console.

## Verification
- [x] Linting and type checking (`npm run frontend:tsc`) pass.
- [x] Pre-commit hooks successfully run.
- [x] Edge cases evaluated for module-scope side effects.
- [x] Error handling type-narrowed (`error instanceof Error`) to satisfy strict automated reviews.
