### PR TITLE
helm: Default oidc.externalSecret.hasScopes to legacy behavior (include -oidc-scopes)

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -354,7 +354,7 @@ spec:
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            {{- if $oidc.externalSecret.hasScopes }}
+            {{- if ne $oidc.externalSecret.hasScopes false }}
             - "-oidc-scopes=$(OIDC_SCOPES)"
             {{- end }}
             {{- if or (ne $oidc.callbackURL "") (ne $callbackURL "") }}

--- a/charts/headlamp/tests/expected_templates/oidc-external-secret-no-scopes.yaml
+++ b/charts/headlamp/tests/expected_templates/oidc-external-secret-no-scopes.yaml
@@ -110,7 +110,6 @@ spec:
             - "-oidc-client-id=$(OIDC_CLIENT_ID)"
             - "-oidc-client-secret=$(OIDC_CLIENT_SECRET)"
             - "-oidc-idp-issuer-url=$(OIDC_ISSUER_URL)"
-            - "-oidc-scopes=$(OIDC_SCOPES)"
           ports:
             - name: http
               containerPort: 4466

--- a/charts/headlamp/tests/test_cases/oidc-external-secret-no-scopes.yaml
+++ b/charts/headlamp/tests/test_cases/oidc-external-secret-no-scopes.yaml
@@ -1,0 +1,11 @@
+# This is a test case for OIDC external secret without an OIDC_SCOPES key.
+# Setting hasScopes to false explicitly opts out of the -oidc-scopes argument,
+# for external secrets that do not contain an OIDC_SCOPES key.
+config:
+  oidc:
+    secret:
+      create: false
+    externalSecret:
+      enabled: true
+      name: oidc
+      hasScopes: false

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -112,10 +112,11 @@ config:
     externalSecret:
       enabled: false
       name: ""
-      # -- Set to true if your external secret contains an OIDC_SCOPES key.
-      # When false (default), the -oidc-scopes argument is omitted so that
-      # a missing key does not produce an empty or unresolved argument.
-      hasScopes: false
+      # -- Set to false if your external secret does NOT contain an OIDC_SCOPES
+      # key, to omit the -oidc-scopes argument and avoid an empty or unresolved
+      # argument. Defaults to unset (treated as true / -oidc-scopes included)
+      # to preserve behavior for existing external-secret based OIDC setups
+      # created before this option was introduced.
 
     # -- URL to fetch additional user info for the /me endpoint.
     # For oauth2proxy /oauth2/userinfo can be used. Empty and it will not be used.


### PR DESCRIPTION
## Summary

The 0.43.0 chart introduced `config.oidc.externalSecret.hasScopes`, defaulting to `false`, to gate whether the `-oidc-scopes` argument is passed to the backend when using an externally managed OIDC secret.

Prior to this option existing, `-oidc-scopes` was always passed unconditionally in this code path. Because the new default is `false`, any existing externalSecret-based OIDC deployment upgrading from <=0.42.0 **without** adding the new `hasScopes: true` value silently stops passing its configured scopes to the backend on upgrade to 0.43.0.

For providers/resources that require a resource-scoped access token (e.g. Entra ID/Azure AD validating an AKS-audience access token via `-oidc-use-access-token` with `-oidc-validator-client-id`/`-oidc-validator-idp-issuer-url`), losing the configured scope means the backend requests/receives a token for the wrong audience, breaking the OIDC login flow with errors such as `failed to verify id token signature` even though the externalSecret still contains a valid `OIDC_SCOPES` key.

We hit this directly: upgrading our Flux-managed Headlamp release from chart 0.42.0 to 0.43.0 broke Entra ID login in production with no configuration changes on our side. I verified this is not a go-oidc / golang.org/x/oauth2 library regression by reproducing the exact production code path (`oidc.NewProvider` + `InsecureIssuerURLContext` + `Verifier.Verify`) standalone against a real captured Azure AD token using the pinned 0.43.0 dependency versions (go-oidc v3.18.0) — verification succeeds when the correct scope/audience is used. Rolling back to chart 0.42.0 immediately restored login; re-rendering the chart confirmed `-oidc-scopes` is silently omitted with our (pre-existing) values on 0.43.0.

## Changes

- `charts/headlamp/values.yaml`: remove the hardcoded `hasScopes: false` default so the value is unset unless the user configures it.
- `charts/headlamp/templates/deployment.yaml`: include `-oidc-scopes` unless `hasScopes` is explicitly set to `false`.
- `charts/headlamp/tests`: update the `oidc-external-secret` expected output to include `-oidc-scopes`, and add a new `oidc-external-secret-no-scopes` test case covering the explicit opt-out.

## Testing

Ran the full chart test suite (`charts/headlamp/tests/test.sh`) against `main` — all cases pass, including the two touched/added by this change.

## Related

Fixes a backward-compatibility regression introduced alongside the `hasScopes` option (part of the 0.43.0 milestone service-account-token / OIDC work).