### PR TITLE
docs: keycloak: Fix oidc-extra-scope argument handling

### DIFF
--- a/docs/installation/in-cluster/keycloak/index.md
+++ b/docs/installation/in-cluster/keycloak/index.md
@@ -113,7 +113,8 @@ kubectl config set-credentials keycloak-oidc \
   --exec-arg=--oidc-issuer-url=<YOUR-KEYCLOAK-URL>/realms/<REALM-NAME> \
   --exec-arg=--oidc-client-id=<CLIENT-ID> \
   --exec-arg=--oidc-client-secret=<CLIENT-SECRET> \
-  --exec-arg=--oidc-extra-scope=email,profile
+  --exec-arg=--oidc-extra-scope=email \
+  --exec-arg=--oidc-extra-scope=profile
 ```
 
 4. Link the User to the Cluster: To associate the user with the cluster, create a new context using these commands:


### PR DESCRIPTION
## What this does

Fixes the Keycloak OIDC tutorial's `kubectl config set-credentials` command in step 3.

`--exec-arg` is a pflag `StringSlice`, which splits values on commas. So `--exec-arg=--oidc-extra-scope=email,profile` is parsed as two args (`--oidc-extra-scope=email` and `profile`), and `profile` is passed to `kubelogin get-token` as an unknown command, breaking authentication:

```
error: unknown command "profile" for "kubelogin get-token"
```

Passing each scope as its own `--oidc-extra-scope` arg avoids the comma-splitting and lets the tutorial work as written.



## Test

Documentation-only change; verified the corrected command against the reproduction in the issue.