### PR TITLE
frontend: Settings: Add Storybook stories for settings widgets

### DIFF
--- a/frontend/src/components/App/Settings/DrawerModeSettings.stories.tsx
+++ b/frontend/src/components/App/Settings/DrawerModeSettings.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { Meta, StoryFn } from '@storybook/react';
+import drawerModeReducer from '../../../redux/drawerModeSlice';
+import { TestContext } from '../../../test';
+import DrawerModeSettings from './DrawerModeSettings';
+
+// A store preloaded with a fixed drawer state keeps the snapshot deterministic
+// (the real initial state is read from localStorage).
+function storeWith(isDetailDrawerEnabled: boolean) {
+  return configureStore({
+    reducer: { drawerMode: drawerModeReducer },
+    preloadedState: { drawerMode: { isDetailDrawerEnabled } },
+  });
+}
+
+export default {
+  title: 'Settings/DrawerModeSettings',
+  component: DrawerModeSettings,
+} as Meta<typeof DrawerModeSettings>;
+
+const Template: StoryFn<{ enabled: boolean }> = ({ enabled }) => (
+  <TestContext store={storeWith(enabled)}>
+    <DrawerModeSettings />
+  </TestContext>
+);
+
+export const DrawerEnabled = Template.bind({});
+DrawerEnabled.args = { enabled: true };
+
+export const FullPage = Template.bind({});
+FullPage.args = { enabled: false };

--- a/frontend/src/components/App/Settings/NumRowsInput.stories.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.stories.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Meta, StoryFn } from '@storybook/react';
-import { useEffect } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { TestContext } from '../../../test';
 import NumRowsInput from './NumRowsInput';
 
@@ -26,18 +26,23 @@ const TABLES_ROWS_PER_PAGE_KEY = 'tables_rows_per_page';
 // a fixed value before the child renders and restore it on unmount so the
 // snapshot is deterministic and does not leak into other stories.
 function WithFixedRowsPerPage({ children }: { children: React.ReactNode }) {
-  const previous = localStorage.getItem(TABLES_ROWS_PER_PAGE_KEY);
-  localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, '15');
-  useEffect(
-    () => () => {
-      if (previous === null) {
+  const [ready, setReady] = useState(false);
+  const previous = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    previous.current = localStorage.getItem(TABLES_ROWS_PER_PAGE_KEY);
+    localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, '15');
+    setReady(true);
+    return () => {
+      if (previous.current === null) {
         localStorage.removeItem(TABLES_ROWS_PER_PAGE_KEY);
       } else {
-        localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, previous);
+        localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, previous.current);
       }
-    },
-    [previous]
-  );
+    };
+  }, []);
+  if (!ready) {
+    return null;
+  }
   return <>{children}</>;
 }
 

--- a/frontend/src/components/App/Settings/NumRowsInput.stories.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.stories.tsx
@@ -15,34 +15,34 @@
  */
 
 import { Meta, StoryFn } from '@storybook/react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { TestContext } from '../../../test';
 import NumRowsInput from './NumRowsInput';
 
 const TABLES_ROWS_PER_PAGE_KEY = 'tables_rows_per_page';
 
-// NumRowsInput reads tables_rows_per_page from localStorage on mount, and the
-// storyshot harness does not reset localStorage between stories. Pin the key to
-// a fixed value before the child renders and restore it on unmount so the
-// snapshot is deterministic and does not leak into other stories.
+// NumRowsInput reads tables_rows_per_page from localStorage in a render-phase
+// initializer, and the storyshot harness does not reset localStorage between
+// stories. Pin the key to a fixed value before the child renders and restore it
+// on unmount so the snapshot is deterministic and does not leak into other
+// stories. The ref guard captures the real previous value exactly once, so a
+// double render (StrictMode) doesn't record the mocked value as the original.
 function WithFixedRowsPerPage({ children }: { children: React.ReactNode }) {
-  const [ready, setReady] = useState(false);
-  const previous = useRef<string | null>(null);
-  useLayoutEffect(() => {
+  const previous = useRef<string | null | undefined>(undefined);
+  if (previous.current === undefined) {
     previous.current = localStorage.getItem(TABLES_ROWS_PER_PAGE_KEY);
     localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, '15');
-    setReady(true);
-    return () => {
-      if (previous.current === null) {
+  }
+  useEffect(
+    () => () => {
+      if (previous.current === null || previous.current === undefined) {
         localStorage.removeItem(TABLES_ROWS_PER_PAGE_KEY);
       } else {
         localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, previous.current);
       }
-    };
-  }, []);
-  if (!ready) {
-    return null;
-  }
+    },
+    []
+  );
   return <>{children}</>;
 }
 

--- a/frontend/src/components/App/Settings/NumRowsInput.stories.tsx
+++ b/frontend/src/components/App/Settings/NumRowsInput.stories.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { useEffect } from 'react';
+import { TestContext } from '../../../test';
+import NumRowsInput from './NumRowsInput';
+
+const TABLES_ROWS_PER_PAGE_KEY = 'tables_rows_per_page';
+
+// NumRowsInput reads tables_rows_per_page from localStorage on mount, and the
+// storyshot harness does not reset localStorage between stories. Pin the key to
+// a fixed value before the child renders and restore it on unmount so the
+// snapshot is deterministic and does not leak into other stories.
+function WithFixedRowsPerPage({ children }: { children: React.ReactNode }) {
+  const previous = localStorage.getItem(TABLES_ROWS_PER_PAGE_KEY);
+  localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, '15');
+  useEffect(
+    () => () => {
+      if (previous === null) {
+        localStorage.removeItem(TABLES_ROWS_PER_PAGE_KEY);
+      } else {
+        localStorage.setItem(TABLES_ROWS_PER_PAGE_KEY, previous);
+      }
+    },
+    [previous]
+  );
+  return <>{children}</>;
+}
+
+export default {
+  title: 'Settings/NumRowsInput',
+  component: NumRowsInput,
+  decorators: [
+    Story => (
+      <TestContext>
+        <WithFixedRowsPerPage>
+          <Story />
+        </WithFixedRowsPerPage>
+      </TestContext>
+    ),
+  ],
+} as Meta<typeof NumRowsInput>;
+
+const Template: StoryFn<typeof NumRowsInput> = args => <NumRowsInput {...args} />;
+
+export const Default = Template.bind({});
+Default.args = { defaultValue: [15, 25, 50] };

--- a/frontend/src/components/App/Settings/SettingsButton.stories.tsx
+++ b/frontend/src/components/App/Settings/SettingsButton.stories.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { useEffect } from 'react';
+import { TestContext } from '../../../test';
+import SettingsButton from './SettingsButton';
+
+// SettingsButton reads the active cluster from window.location (getCluster) and
+// renders nothing when there is none. Point the URL at a cluster for the story,
+// restoring it afterwards so other stories are unaffected.
+function WithCluster({ children }: { children: React.ReactNode }) {
+  const previous = window.location.pathname;
+  window.history.replaceState({}, '', '/c/mock-cluster/settings');
+  useEffect(() => () => window.history.replaceState({}, '', previous), [previous]);
+  return <>{children}</>;
+}
+
+export default {
+  title: 'Settings/SettingsButton',
+  component: SettingsButton,
+  decorators: [
+    Story => (
+      <TestContext>
+        <WithCluster>
+          <Story />
+        </WithCluster>
+      </TestContext>
+    ),
+  ],
+} as Meta<typeof SettingsButton>;
+
+const Template: StoryFn<typeof SettingsButton> = args => <SettingsButton {...args} />;
+
+export const Default = Template.bind({});

--- a/frontend/src/components/App/Settings/SettingsButton.stories.tsx
+++ b/frontend/src/components/App/Settings/SettingsButton.stories.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Meta, StoryFn } from '@storybook/react';
-import { useEffect } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { TestContext } from '../../../test';
 import SettingsButton from './SettingsButton';
 
@@ -23,9 +23,21 @@ import SettingsButton from './SettingsButton';
 // renders nothing when there is none. Point the URL at a cluster for the story,
 // restoring it afterwards so other stories are unaffected.
 function WithCluster({ children }: { children: React.ReactNode }) {
-  const previous = window.location.pathname;
-  window.history.replaceState({}, '', '/c/mock-cluster/settings');
-  useEffect(() => () => window.history.replaceState({}, '', previous), [previous]);
+  const [ready, setReady] = useState(false);
+  const previous = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    previous.current = window.location.pathname;
+    window.history.replaceState({}, '', '/c/mock-cluster/settings');
+    setReady(true);
+    return () => {
+      if (previous.current !== null) {
+        window.history.replaceState({}, '', previous.current);
+      }
+    };
+  }, []);
+  if (!ready) {
+    return null;
+  }
   return <>{children}</>;
 }
 

--- a/frontend/src/components/App/Settings/SettingsButton.stories.tsx
+++ b/frontend/src/components/App/Settings/SettingsButton.stories.tsx
@@ -15,29 +15,29 @@
  */
 
 import { Meta, StoryFn } from '@storybook/react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { TestContext } from '../../../test';
 import SettingsButton from './SettingsButton';
 
-// SettingsButton reads the active cluster from window.location (getCluster) and
-// renders nothing when there is none. Point the URL at a cluster for the story,
-// restoring it afterwards so other stories are unaffected.
+// SettingsButton reads the active cluster from window.location (getCluster) in
+// render and renders nothing when there is none. Point the URL at a cluster
+// before the child renders, restoring it on unmount so other stories are
+// unaffected. The ref guard captures the real previous path exactly once, so a
+// double render (StrictMode) doesn't record the mocked path as the original.
 function WithCluster({ children }: { children: React.ReactNode }) {
-  const [ready, setReady] = useState(false);
-  const previous = useRef<string | null>(null);
-  useLayoutEffect(() => {
+  const previous = useRef<string | undefined>(undefined);
+  if (previous.current === undefined) {
     previous.current = window.location.pathname;
     window.history.replaceState({}, '', '/c/mock-cluster/settings');
-    setReady(true);
-    return () => {
-      if (previous.current !== null) {
+  }
+  useEffect(
+    () => () => {
+      if (previous.current !== undefined) {
         window.history.replaceState({}, '', previous.current);
       }
-    };
-  }, []);
-  if (!ready) {
-    return null;
-  }
+    },
+    []
+  );
   return <>{children}</>;
 }
 

--- a/frontend/src/components/App/Settings/ThemePreview.stories.tsx
+++ b/frontend/src/components/App/Settings/ThemePreview.stories.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { darkTheme, lightTheme } from '../defaultAppThemes';
+import { ThemePreview } from './ThemePreview';
+
+export default {
+  title: 'Settings/ThemePreview',
+  component: ThemePreview,
+} as Meta<typeof ThemePreview>;
+
+const Template: StoryFn<typeof ThemePreview> = args => <ThemePreview {...args} />;
+
+export const Light = Template.bind({});
+Light.args = { theme: lightTheme, size: 110 };
+
+export const Dark = Template.bind({});
+Dark.args = { theme: darkTheme, size: 110 };

--- a/frontend/src/components/App/Settings/__snapshots__/DrawerModeSettings.DrawerEnabled.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/DrawerModeSettings.DrawerEnabled.stories.storyshot
@@ -1,0 +1,64 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-k008qs"
+    >
+      <button
+        aria-pressed="true"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-17o2rvr-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="MuiBox-root css-q5uj3p"
+        >
+          <div
+            class="MuiBox-root css-10tc75p"
+          />
+          <div
+            class="MuiBox-root css-1tuh5dl"
+          />
+          <div
+            class="MuiBox-root css-1wsar2n"
+          >
+            <div
+              class="MuiBox-root css-flohcj"
+            />
+          </div>
+        </div>
+        Window
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        aria-pressed="false"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gl7zuq-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="MuiBox-root css-q5uj3p"
+        >
+          <div
+            class="MuiBox-root css-10tc75p"
+          />
+          <div
+            class="MuiBox-root css-1tuh5dl"
+          />
+          <div
+            class="MuiBox-root css-b95qjn"
+          >
+            <div
+              class="MuiBox-root css-y7640i"
+            />
+          </div>
+        </div>
+        Full page
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/DrawerModeSettings.FullPage.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/DrawerModeSettings.FullPage.stories.storyshot
@@ -1,0 +1,64 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-k008qs"
+    >
+      <button
+        aria-pressed="false"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-gl7zuq-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="MuiBox-root css-q5uj3p"
+        >
+          <div
+            class="MuiBox-root css-10tc75p"
+          />
+          <div
+            class="MuiBox-root css-1tuh5dl"
+          />
+          <div
+            class="MuiBox-root css-1wsar2n"
+          >
+            <div
+              class="MuiBox-root css-flohcj"
+            />
+          </div>
+        </div>
+        Window
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+      <button
+        aria-pressed="true"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation css-17o2rvr-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="MuiBox-root css-q5uj3p"
+        >
+          <div
+            class="MuiBox-root css-10tc75p"
+          />
+          <div
+            class="MuiBox-root css-1tuh5dl"
+          />
+          <div
+            class="MuiBox-root css-b95qjn"
+          >
+            <div
+              class="MuiBox-root css-y7640i"
+            />
+          </div>
+        </div>
+        Full page
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/NumRowsInput.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/NumRowsInput.Default.stories.storyshot
@@ -1,0 +1,55 @@
+<body>
+  <div>
+    <div
+      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+    >
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-uwmwwo-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        style="width: 100px;"
+      >
+        <div
+          aria-controls=":mock-test-id:"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-oswssk-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          role="combobox"
+          tabindex="0"
+        >
+          15
+        </div>
+        <input
+          aria-hidden="true"
+          aria-invalid="false"
+          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          tabindex="-1"
+          value="15"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          data-testid="ArrowDropDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+        <fieldset
+          aria-hidden="true"
+          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="css-1whs34k-MuiNotchedOutlined-root"
+          >
+            <span
+              class="notranslate"
+            >
+              ​
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/SettingsButton.Default.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/SettingsButton.Default.stories.storyshot
@@ -1,0 +1,15 @@
+<body>
+  <div>
+    <button
+      aria-label="Settings"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-1jcv3fz-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/ThemePreview.Dark.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ThemePreview.Dark.stories.storyshot
@@ -1,0 +1,26 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-1giqewv"
+    >
+      <div
+        class="MuiBox-root css-ni9bm1"
+      />
+      <div
+        class="MuiBox-root css-1z0uf79"
+      />
+      <div
+        class="MuiBox-root css-3dcp9m"
+      />
+      <div
+        class="MuiBox-root css-1coq5wc"
+      />
+      <div
+        class="MuiBox-root css-ew82rx"
+      />
+      <div
+        class="MuiBox-root css-1ep3rs4"
+      />
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/App/Settings/__snapshots__/ThemePreview.Light.stories.storyshot
+++ b/frontend/src/components/App/Settings/__snapshots__/ThemePreview.Light.stories.storyshot
@@ -1,0 +1,26 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-h3uu27"
+    >
+      <div
+        class="MuiBox-root css-1f1uc6a"
+      />
+      <div
+        class="MuiBox-root css-1z0uf79"
+      />
+      <div
+        class="MuiBox-root css-5zxu0k"
+      />
+      <div
+        class="MuiBox-root css-1oxk0si"
+      />
+      <div
+        class="MuiBox-root css-jkymop"
+      />
+      <div
+        class="MuiBox-root css-n01h7b"
+      />
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## What this does

Adds Storybook stories (which double as snapshot tests via `frontend/src/storybook.test.tsx`) for four presentational widgets under `frontend/src/components/App/Settings/` that had no coverage, closing a gap in an otherwise well-storied area.

Components covered:
- `ThemePreview` — `Light` and `Dark` stories (props-driven, no store).
- `NumRowsInput` — `Default` story, wrapped in `TestContext` for redux/i18n.
- `DrawerModeSettings` — `DrawerEnabled` and `FullPage` stories, each with a store preloaded to a fixed drawer state so the snapshot is deterministic (real initial state comes from localStorage).
- `SettingsButton` — `Default` story. The button reads the active cluster from the URL and renders nothing without one, so the decorator points `window.location` at a cluster and restores it on unmount (verified the full storyshot suite has zero drift, so this does not leak into other stories).

No new translation keys. The bulk of the diff is generated `.storyshot` snapshots.

Closes #6305

## Test

`cd frontend && CI=true npx vitest run src/storybook.test.tsx` — 609 stories pass, zero drift. Lint and prettier clean.