### PR TITLE
frontend: globalSearch: Lazy-load searchable resource classes

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
@@ -25,7 +25,7 @@ import reducers from '../../redux/reducers/reducers';
 import { API_BASE, TestContext } from '../../test';
 import { generateK8sResourceList } from '../../test/mocker';
 import { podList } from '../pod/storyHelper';
-import { GlobalSearchContent } from './GlobalSearchContent';
+import { GlobalSearchContent, GlobalSearchContentPlaceholder } from './GlobalSearchContent';
 
 const phonyPods = generateK8sResourceList(
   {
@@ -185,6 +185,28 @@ export default meta;
 type Story = StoryObj<typeof GlobalSearchContent>;
 
 export const WithEmptyInput: Story = {};
+
+export const LoadingResourceClasses: Story = {
+  render: args => (
+    <GlobalSearchContentPlaceholder
+      {...args}
+      query={args.defaultValue ?? ''}
+      onQueryChange={() => {}}
+      loadFailed={false}
+    />
+  ),
+};
+
+export const ResourceClassesLoadFailed: Story = {
+  render: args => (
+    <GlobalSearchContentPlaceholder
+      {...args}
+      query={args.defaultValue ?? ''}
+      onQueryChange={() => {}}
+      loadFailed
+    />
+  ),
+};
 
 export const LoadingResources: Story = {
   args: {

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -207,30 +207,20 @@ function useSearchResources(resourceClasses: KubeObjectClass[]) {
     cls.useList({ clusters: inACluster ? undefined : NO_SELECTED_CLUSTERS })
   );
 
-  const resourcesRef = useRef<
-    { isLoading: boolean; items: KubeObject<any>[] | null; kind: string }[]
-  >([]);
+  // Depend on fetch flags and item list identities (not `results`, which is a new
+  // array every render) so the returned resources array stays referentially stable.
+  const resourceDeps = results.flatMap(result => [result.isFetching, result.items]);
 
-  const nextResources = results.map((result, index) => ({
-    isLoading: result.isFetching,
-    items: result.items,
-    kind: resourceClasses[index].kind,
-  }));
-
-  const prevResources = resourcesRef.current;
-  if (
-    nextResources.length !== prevResources.length ||
-    nextResources.some(
-      (resource, index) =>
-        resource.isLoading !== prevResources[index]?.isLoading ||
-        resource.items !== prevResources[index]?.items ||
-        resource.kind !== prevResources[index]?.kind
-    )
-  ) {
-    resourcesRef.current = nextResources;
-  }
-
-  return resourcesRef.current;
+  return useMemo(
+    () =>
+      results.map((result, index) => ({
+        isLoading: result.isFetching,
+        items: result.items,
+        kind: resourceClasses[index].kind,
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- resourceDeps tracks isFetching/items
+    [resourceClasses, ...resourceDeps]
+  );
 }
 
 function makeKubeObjectResults(

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -206,15 +206,30 @@ function useSearchResources(resourceClasses: KubeObjectClass[]) {
     cls.useList({ clusters: inACluster ? undefined : NO_SELECTED_CLUSTERS })
   );
 
-  return useMemo(
-    () =>
-      results.map((result, index) => ({
-        isLoading: result.isFetching,
-        items: result.items,
-        kind: resourceClasses[index].kind,
-      })),
-    [resourceClasses, ...results.flatMap(result => [result.isFetching, result.items])]
-  );
+  const resourcesRef = useRef<
+    { isLoading: boolean; items: KubeObject<any>[] | null; kind: string }[]
+  >([]);
+
+  const nextResources = results.map((result, index) => ({
+    isLoading: result.isFetching,
+    items: result.items,
+    kind: resourceClasses[index].kind,
+  }));
+
+  const prevResources = resourcesRef.current;
+  if (
+    nextResources.length !== prevResources.length ||
+    nextResources.some(
+      (resource, index) =>
+        resource.isLoading !== prevResources[index]?.isLoading ||
+        resource.items !== prevResources[index]?.items ||
+        resource.kind !== prevResources[index]?.kind
+    )
+  ) {
+    resourcesRef.current = nextResources;
+  }
+
+  return resourcesRef.current;
 }
 
 function makeKubeObjectResults(

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -111,10 +111,10 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
         }
       })
       .catch(error => {
-        console.error('Failed to load global search resource classes', error);
         if (cancelled) {
           return;
         }
+        console.error('Failed to load global search resource classes', error);
         if (loadAttempt + 1 >= MAX_RESOURCE_CLASS_LOAD_ATTEMPTS) {
           setLoadFailed(true);
           return;

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -588,7 +588,6 @@ function GlobalSearchContentLoaded(props: GlobalSearchContentLoadedProps) {
             // this is suboptimal and doesn't fit for the search UX
             // so we're overriding onMouseDown for our own that doesn't do anything
             onMouseDown: () => {},
-            defaultValue,
             autoFocus: true,
             endAdornment: (
               <>

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -59,6 +59,7 @@ const LazyKubeIcon = lazy(() =>
 const NAMESPACE_KIND = 'Namespace';
 const MAX_RESOURCE_CLASS_LOAD_ATTEMPTS = 5;
 const LOAD_RETRY_DELAY_MS = 3000;
+const NO_SELECTED_CLUSTERS: string[] = [];
 
 /**
  * Object representing a single search result
@@ -202,7 +203,7 @@ interface GlobalSearchContentLoadedProps extends GlobalSearchContentProps {
 function useSearchResources(resourceClasses: KubeObjectClass[]) {
   const inACluster = useSelectedClusters().length > 0;
   const results = resourceClasses.map(cls =>
-    cls.useList({ clusters: inACluster ? undefined : [] })
+    cls.useList({ clusters: inACluster ? undefined : NO_SELECTED_CLUSTERS })
   );
 
   return results.map((result, index) => ({

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -206,11 +206,15 @@ function useSearchResources(resourceClasses: KubeObjectClass[]) {
     cls.useList({ clusters: inACluster ? undefined : NO_SELECTED_CLUSTERS })
   );
 
-  return results.map((result, index) => ({
-    isLoading: result.isFetching,
-    items: result.items,
-    kind: resourceClasses[index].kind,
-  }));
+  return useMemo(
+    () =>
+      results.map((result, index) => ({
+        isLoading: result.isFetching,
+        items: result.items,
+        kind: resourceClasses[index].kind,
+      })),
+    [resourceClasses, ...results.flatMap(result => [result.isFetching, result.items])]
+  );
 }
 
 function makeKubeObjectResults(

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -130,7 +130,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
         clearTimeout(retryTimer);
       }
     };
-  }, [loadAttempt]);
+  }, [loadAttempt, loadSearchResourceClasses]);
 
   if (!resourceClasses) {
     return (

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -93,20 +93,35 @@ interface GlobalSearchContentProps {
 export function GlobalSearchContent(props: GlobalSearchContentProps) {
   const [resourceClasses, setResourceClasses] = useState<KubeObjectClass[] | null>(null);
   const [queryDraft, setQueryDraft] = useState(props.defaultValue ?? '');
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
-    loadSearchResourceClasses().then(classes => {
-      if (!cancelled) {
-        setResourceClasses(classes);
-      }
-    });
+    loadSearchResourceClasses()
+      .then(classes => {
+        if (!cancelled) {
+          setResourceClasses(classes);
+        }
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        // Keep the input responsive and retry after a short delay when chunk loading fails.
+        retryTimer = setTimeout(() => {
+          setLoadAttempt(attempt => attempt + 1);
+        }, 3000);
+      });
 
     return () => {
       cancelled = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
     };
-  }, []);
+  }, [loadAttempt]);
 
   if (!resourceClasses) {
     return (
@@ -212,7 +227,7 @@ function makeKubeObjectResults(
 }
 
 function GlobalSearchContentLoaded(props: GlobalSearchContentLoadedProps) {
-  const { maxWidth, defaultValue, onBlur, resourceClasses, initialQuery } = props;
+  const { maxWidth, onBlur, resourceClasses, initialQuery } = props;
   const { t } = useTranslation();
   const history = useHistory();
   const dispatch = useDispatch();
@@ -392,7 +407,7 @@ function GlobalSearchContentLoaded(props: GlobalSearchContentLoadedProps) {
       label: `Search "${query}" with Advanced Search`,
       onClick: () => {
         // Set the search query in localStorage for the Advanced Search
-        useLocalStorageState.update(ADVANCED_SEARCH_QUERY_KEY, `metadata.name == "${query}"`);
+        useLocalStorageState.update(ADVANCED_SEARCH_QUERY_KEY, `metadata.name === "${query}"`);
 
         const params = new URLSearchParams(history.location.search);
         history.push(createRouteURL('advancedSearch') + '?' + params.toString());

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -158,7 +158,8 @@ interface GlobalSearchContentPlaceholderProps extends GlobalSearchContentProps {
   loadFailed?: boolean;
 }
 
-function GlobalSearchContentPlaceholder(props: GlobalSearchContentPlaceholderProps) {
+/** Loading / error UI while searchable resource classes are being loaded. */
+export function GlobalSearchContentPlaceholder(props: GlobalSearchContentPlaceholderProps) {
   const { onBlur, query, onQueryChange, loadFailed } = props;
   const { t } = useTranslation();
 

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -26,30 +26,15 @@ import Typography from '@mui/material/Typography';
 import useAutocomplete from '@mui/material/useAutocomplete';
 import { UseAutocompleteReturnValue } from '@mui/material/useAutocomplete';
 import Fuse, { Expression, FuseResultMatch } from 'fuse.js';
-import { lazy, Suspense, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { generatePath, useHistory, useLocation, useRouteMatch } from 'react-router';
 import { FixedSizeList } from 'react-window';
 import { loadClusterSettings } from '../../helpers/clusterSettings';
 import { useClustersConf, useSelectedClusters } from '../../lib/k8s';
-import ConfigMap from '../../lib/k8s/configMap';
-import CronJob from '../../lib/k8s/cronJob';
-import Deployment from '../../lib/k8s/deployment';
-import Endpoints from '../../lib/k8s/endpoints';
-import EndpointSlice from '../../lib/k8s/endpointSlices';
-import Ingress from '../../lib/k8s/ingress';
-import Job from '../../lib/k8s/job';
-import JobSet from '../../lib/k8s/jobSet';
 import { KubeObject, KubeObjectClass } from '../../lib/k8s/KubeObject';
-import Namespace from '../../lib/k8s/namespace';
-import Node from '../../lib/k8s/node';
-import PersistentVolumeClaim from '../../lib/k8s/persistentVolumeClaim';
-import Pod from '../../lib/k8s/pod';
-import ReplicaSet from '../../lib/k8s/replicaSet';
-import Service from '../../lib/k8s/service';
-import ServiceAccount from '../../lib/k8s/serviceAccount';
-import StatefulSet from '../../lib/k8s/statefulSet';
+import type Namespace from '../../lib/k8s/namespace';
 import { createRouteURL } from '../../lib/router/createRouteURL';
 import { getDefaultRoutes } from '../../lib/router/getDefaultRoutes';
 import { getClusterPrefixedPath } from '../../lib/util';
@@ -62,14 +47,16 @@ import { ThemePreview } from '../App/Settings/ThemePreview';
 import { setTheme, useAppThemes } from '../App/themeSlice';
 import { LightTooltip } from '../common/Tooltip';
 import { KubeObjectDetails } from '../resourceMap/details/KubeNodeDetails';
-import { KubeIcon } from '../resourceMap/kubeIcon/KubeIcon';
 import { Delayed } from './Delayed';
+import { loadSearchResourceClasses } from './searchResourceClasses';
 import { useLocalStorageState } from './useLocalStorageState';
 import { useRecent } from './useRecent';
 
 const LazyKubeIcon = lazy(() =>
   import('../resourceMap/kubeIcon/KubeIcon').then(it => ({ default: it.KubeIcon }))
 );
+
+const NAMESPACE_KIND = 'Namespace';
 
 /**
  * Object representing a single search result
@@ -89,45 +76,114 @@ interface SearchResult {
   namespaceMatch?: FuseResultMatch;
 }
 
+interface GlobalSearchContentProps {
+  /** The maximum width of the results list. */
+  maxWidth: number;
+  /** The initial search query to display in the search field. */
+  defaultValue: string;
+  /** Callback called when the search field loses focus. */
+  onBlur: () => void;
+}
+
 /**
- * An array of Kubernetes object classes to search through
+ * The `GlobalSearchContent` component provides the search field and results list for global search.
+ * Resource class modules are loaded on demand so opening search does not bundle every list model
+ * in the initial chunk.
  */
-const classes: KubeObjectClass[] = [
-  Pod,
-  Deployment,
-  Service,
-  Job,
-  CronJob,
-  ConfigMap,
-  Namespace,
-  StatefulSet,
-  ReplicaSet,
-  PersistentVolumeClaim,
-  Endpoints,
-  EndpointSlice,
-  Ingress,
-  ServiceAccount,
-  Node,
-  JobSet,
-];
+export function GlobalSearchContent(props: GlobalSearchContentProps) {
+  const [resourceClasses, setResourceClasses] = useState<KubeObjectClass[] | null>(null);
+  const [queryDraft, setQueryDraft] = useState(props.defaultValue ?? '');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadSearchResourceClasses().then(classes => {
+      if (!cancelled) {
+        setResourceClasses(classes);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!resourceClasses) {
+    return (
+      <GlobalSearchContentPlaceholder
+        {...props}
+        query={queryDraft}
+        onQueryChange={setQueryDraft}
+      />
+    );
+  }
+
+  return (
+    <GlobalSearchContentLoaded
+      {...props}
+      resourceClasses={resourceClasses}
+      initialQuery={queryDraft}
+    />
+  );
+}
+
+interface GlobalSearchContentPlaceholderProps extends GlobalSearchContentProps {
+  query: string;
+  onQueryChange: (value: string) => void;
+}
+
+function GlobalSearchContentPlaceholder(props: GlobalSearchContentPlaceholderProps) {
+  const { onBlur, query, onQueryChange } = props;
+  const { t } = useTranslation();
+
+  return (
+    <TextField
+      fullWidth
+      size="small"
+      variant="outlined"
+      placeholder={t('Search resources, pages, clusters by name')}
+      value={query}
+      onChange={event => onQueryChange(event.target.value)}
+      onBlur={onBlur}
+      autoFocus
+      InputProps={{
+        sx: theme => ({
+          background: theme.palette.background.default,
+        }),
+        endAdornment: (
+          <Delayed display="flex" mr={1}>
+            <CircularProgress size="16px" />
+          </Delayed>
+        ),
+      }}
+    />
+  );
+}
+
+interface GlobalSearchContentLoadedProps extends GlobalSearchContentProps {
+  resourceClasses: KubeObjectClass[];
+  initialQuery: string;
+}
 
 /**
  * Loads lists of Kubernetes objects for searching
  */
-function useSearchResources() {
+function useSearchResources(resourceClasses: KubeObjectClass[]) {
   const inACluster = useSelectedClusters().length > 0;
-  const results = classes.map(cls => cls.useList({ clusters: inACluster ? undefined : [] }));
+  const results = resourceClasses.map(cls =>
+    cls.useList({ clusters: inACluster ? undefined : [] })
+  );
 
   return useMemo(() => {
     return results.map((result, index) => {
       return {
         isLoading: result.isFetching,
         items: result.items,
-        kind: classes[index].kind,
+        kind: resourceClasses[index].kind,
       };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [results.map(it => it.data)]);
+  }, [results.map(it => it.data), resourceClasses]);
 }
 
 function makeKubeObjectResults(
@@ -159,28 +215,12 @@ function makeKubeObjectResults(
   );
 }
 
-interface GlobalSearchContentProps {
-  /** The maximum width of the results list. */
-  maxWidth: number;
-  /** The initial search query to display in the search field. */
-  defaultValue: string;
-  /** Callback called when the search field loses focus. */
-  onBlur: () => void;
-}
-
-/**
- * The `GlobalSearchContent` component provides the search field and results list for global search.
- * The default results include Kubernetes objects, clusters, app pages, namespace filters,
- * theme switching, keyboard shortcut settings, and advanced search suggestions.
- *
- * @param props - The component props.
- */
-export function GlobalSearchContent(props: GlobalSearchContentProps) {
-  const { maxWidth, defaultValue, onBlur } = props;
+function GlobalSearchContentLoaded(props: GlobalSearchContentLoadedProps) {
+  const { maxWidth, defaultValue, onBlur, resourceClasses, initialQuery } = props;
   const { t } = useTranslation();
   const history = useHistory();
   const dispatch = useDispatch();
-  const [query, setQuery] = useState(defaultValue ?? '');
+  const [query, setQuery] = useState(initialQuery);
   const clusters = useClustersConf() ?? {};
   const selectedClusters = useSelectedClusters();
   const drawerEnabled = useTypedSelector(state => state?.drawerMode?.isDetailDrawerEnabled);
@@ -188,10 +228,10 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
   const [recent, bump] = useRecent('search-recent-items');
 
   // Resource search items
-  const resources = useSearchResources();
+  const resources = useSearchResources(resourceClasses);
   const loading = resources.filter(it => it.isLoading).map(it => it.kind);
   const namespaceItems = useMemo(() => {
-    const namespaceResource = resources.find(resource => resource.kind === Namespace.kind);
+    const namespaceResource = resources.find(resource => resource.kind === NAMESPACE_KIND);
     return (namespaceResource?.items as Namespace[]) ?? [];
   }, [resources]);
   const namespaceOptions = useMemo(() => {
@@ -263,7 +303,11 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
             cluster: item.cluster,
             location: 'split-right',
             title: item.kind + ': ' + item.metadata.name,
-            icon: <KubeIcon kind={item.kind} width="100%" height="100%" />,
+            icon: (
+              <Suspense fallback={null}>
+                <LazyKubeIcon kind={item.kind} width="100%" height="100%" />
+              </Suspense>
+            ),
           });
         } else {
           history.push(url);
@@ -352,7 +396,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
       label: `Search "${query}" with Advanced Search`,
       onClick: () => {
         // Set the search query in localStorage for the Advanced Search
-        useLocalStorageState.update(ADVANCED_SEARCH_QUERY_KEY, `metadata.name === "${query}"`);
+        useLocalStorageState.update(ADVANCED_SEARCH_QUERY_KEY, `metadata.name == "${query}"`);
 
         const params = new URLSearchParams(history.location.search);
         history.push(createRouteURL('advancedSearch') + '?' + params.toString());

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -99,6 +99,8 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
   const [loadAttempt, setLoadAttempt] = useState(0);
   const [loadFailed, setLoadFailed] = useState(false);
 
+  // loadSearchResourceClasses is a stable module import; do not list it in deps
+  // (eslint flags outer-scope values as unnecessary dependencies).
   useEffect(() => {
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -130,7 +132,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
         clearTimeout(retryTimer);
       }
     };
-  }, [loadAttempt, loadSearchResourceClasses]);
+  }, [loadAttempt]);
 
   if (!resourceClasses) {
     return (

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -110,11 +110,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
 
   if (!resourceClasses) {
     return (
-      <GlobalSearchContentPlaceholder
-        {...props}
-        query={queryDraft}
-        onQueryChange={setQueryDraft}
-      />
+      <GlobalSearchContentPlaceholder {...props} query={queryDraft} onQueryChange={setQueryDraft} />
     );
   }
 
@@ -145,8 +141,8 @@ function GlobalSearchContentPlaceholder(props: GlobalSearchContentPlaceholderPro
       value={query}
       onChange={event => onQueryChange(event.target.value)}
       onBlur={onBlur}
-      autoFocus
       InputProps={{
+        autoFocus: true,
         sx: theme => ({
           background: theme.palette.background.default,
         }),

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -57,6 +57,8 @@ const LazyKubeIcon = lazy(() =>
 );
 
 const NAMESPACE_KIND = 'Namespace';
+const MAX_RESOURCE_CLASS_LOAD_ATTEMPTS = 5;
+const LOAD_RETRY_DELAY_MS = 3000;
 
 /**
  * Object representing a single search result
@@ -94,6 +96,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
   const [resourceClasses, setResourceClasses] = useState<KubeObjectClass[] | null>(null);
   const [queryDraft, setQueryDraft] = useState(props.defaultValue ?? '');
   const [loadAttempt, setLoadAttempt] = useState(0);
+  const [loadFailed, setLoadFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -102,17 +105,22 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
     loadSearchResourceClasses()
       .then(classes => {
         if (!cancelled) {
+          setLoadFailed(false);
           setResourceClasses(classes);
         }
       })
-      .catch(() => {
+      .catch(error => {
+        console.error('Failed to load global search resource classes', error);
         if (cancelled) {
           return;
         }
-        // Keep the input responsive and retry after a short delay when chunk loading fails.
+        if (loadAttempt + 1 >= MAX_RESOURCE_CLASS_LOAD_ATTEMPTS) {
+          setLoadFailed(true);
+          return;
+        }
         retryTimer = setTimeout(() => {
           setLoadAttempt(attempt => attempt + 1);
-        }, 3000);
+        }, LOAD_RETRY_DELAY_MS);
       });
 
     return () => {
@@ -125,7 +133,12 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
 
   if (!resourceClasses) {
     return (
-      <GlobalSearchContentPlaceholder {...props} query={queryDraft} onQueryChange={setQueryDraft} />
+      <GlobalSearchContentPlaceholder
+        {...props}
+        query={queryDraft}
+        onQueryChange={setQueryDraft}
+        loadFailed={loadFailed}
+      />
     );
   }
 
@@ -141,10 +154,11 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
 interface GlobalSearchContentPlaceholderProps extends GlobalSearchContentProps {
   query: string;
   onQueryChange: (value: string) => void;
+  loadFailed?: boolean;
 }
 
 function GlobalSearchContentPlaceholder(props: GlobalSearchContentPlaceholderProps) {
-  const { onBlur, query, onQueryChange } = props;
+  const { onBlur, query, onQueryChange, loadFailed } = props;
   const { t } = useTranslation();
 
   return (
@@ -156,12 +170,18 @@ function GlobalSearchContentPlaceholder(props: GlobalSearchContentPlaceholderPro
       value={query}
       onChange={event => onQueryChange(event.target.value)}
       onBlur={onBlur}
+      helperText={
+        loadFailed
+          ? t('Unable to load search resources. Refresh the page and try again.')
+          : undefined
+      }
+      error={loadFailed}
       InputProps={{
         autoFocus: true,
         sx: theme => ({
           background: theme.palette.background.default,
         }),
-        endAdornment: (
+        endAdornment: loadFailed ? undefined : (
           <Delayed display="flex" mr={1}>
             <CircularProgress size="16px" />
           </Delayed>
@@ -185,16 +205,11 @@ function useSearchResources(resourceClasses: KubeObjectClass[]) {
     cls.useList({ clusters: inACluster ? undefined : [] })
   );
 
-  return useMemo(() => {
-    return results.map((result, index) => {
-      return {
-        isLoading: result.isFetching,
-        items: result.items,
-        kind: resourceClasses[index].kind,
-      };
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [results.map(it => it.data), resourceClasses]);
+  return results.map((result, index) => ({
+    isLoading: result.isFetching,
+    items: result.items,
+    kind: resourceClasses[index].kind,
+  }));
 }
 
 function makeKubeObjectResults(

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.LoadingResourceClasses.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.LoadingResourceClasses.stories.storyshot
@@ -1,0 +1,57 @@
+<body>
+  <div>
+    <div
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+    >
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+      >
+        <input
+          aria-invalid="false"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+          id=":mock-test-id:"
+          placeholder="Search resources, pages, clusters by name"
+          type="text"
+          value=""
+        />
+        <div
+          class="MuiBox-root css-lvik6n"
+        >
+          <span
+            class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-1g0vz9s-MuiCircularProgress-root"
+            role="progressbar"
+            style="width: 16px; height: 16px;"
+          >
+            <svg
+              class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+              viewBox="22 22 44 44"
+            >
+              <circle
+                class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                cx="44"
+                cy="44"
+                fill="none"
+                r="20.2"
+                stroke-width="3.6"
+              />
+            </svg>
+          </span>
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="css-1whs34k-MuiNotchedOutlined-root"
+          >
+            <span
+              class="notranslate"
+            >
+              ​
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.ResourceClassesLoadFailed.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.ResourceClassesLoadFailed.stories.storyshot
@@ -1,0 +1,41 @@
+<body>
+  <div>
+    <div
+      class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+    >
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall css-1pq0x4p-MuiInputBase-root-MuiOutlinedInput-root"
+      >
+        <input
+          aria-describedby=":mock-test-id:"
+          aria-invalid="true"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
+          id=":mock-test-id:"
+          placeholder="Search resources, pages, clusters by name"
+          type="text"
+          value=""
+        />
+        <fieldset
+          aria-hidden="true"
+          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="css-1whs34k-MuiNotchedOutlined-root"
+          >
+            <span
+              class="notranslate"
+            >
+              ​
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+      <p
+        class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeSmall MuiFormHelperText-contained Mui-focused css-153yz37-MuiFormHelperText-root"
+        id=":mock-test-id:"
+      >
+        Unable to load search resources. Refresh the page and try again.
+      </p>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/globalSearch/searchResourceClasses.ts
+++ b/frontend/src/components/globalSearch/searchResourceClasses.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubeObject, type KubeObjectClass } from '../../lib/k8s/KubeObject';
+
+// Ensure the base class is initialized before resource models are loaded dynamically.
+void KubeObject;
+
+let searchResourceClassesPromise: Promise<KubeObjectClass[]> | null = null;
+
+/**
+ * Loads Kubernetes resource classes used by global search in a separate chunk so
+ * opening the search UI does not eagerly bundle every list model up front.
+ */
+export function loadSearchResourceClasses(): Promise<KubeObjectClass[]> {
+  if (!searchResourceClassesPromise) {
+    searchResourceClassesPromise = Promise.all([
+      import('../../lib/k8s/pod'),
+      import('../../lib/k8s/deployment'),
+      import('../../lib/k8s/service'),
+      import('../../lib/k8s/job'),
+      import('../../lib/k8s/cronJob'),
+      import('../../lib/k8s/configMap'),
+      import('../../lib/k8s/namespace'),
+      import('../../lib/k8s/statefulSet'),
+      import('../../lib/k8s/replicaSet'),
+      import('../../lib/k8s/persistentVolumeClaim'),
+      import('../../lib/k8s/endpoints'),
+      import('../../lib/k8s/endpointSlices'),
+      import('../../lib/k8s/ingress'),
+      import('../../lib/k8s/serviceAccount'),
+      import('../../lib/k8s/node'),
+      import('../../lib/k8s/jobSet'),
+    ]).then(modules =>
+      modules.map(module => module.default as KubeObjectClass)
+    );
+  }
+
+  return searchResourceClassesPromise;
+}

--- a/frontend/src/components/globalSearch/searchResourceClasses.ts
+++ b/frontend/src/components/globalSearch/searchResourceClasses.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import { KubeObject, type KubeObjectClass } from '../../lib/k8s/KubeObject';
-
-// Ensure the base class is initialized before resource models are loaded dynamically.
-void KubeObject;
+import type { KubeObjectClass } from '../../lib/k8s/KubeObject';
 
 let searchResourceClassesPromise: Promise<KubeObjectClass[]> | null = null;
 

--- a/frontend/src/components/globalSearch/searchResourceClasses.ts
+++ b/frontend/src/components/globalSearch/searchResourceClasses.ts
@@ -44,9 +44,7 @@ export function loadSearchResourceClasses(): Promise<KubeObjectClass[]> {
       import('../../lib/k8s/serviceAccount'),
       import('../../lib/k8s/node'),
       import('../../lib/k8s/jobSet'),
-    ]).then(modules =>
-      modules.map(module => module.default as KubeObjectClass)
-    );
+    ]).then(modules => modules.map(module => module.default as KubeObjectClass));
   }
 
   return searchResourceClassesPromise;

--- a/frontend/src/components/globalSearch/searchResourceClasses.ts
+++ b/frontend/src/components/globalSearch/searchResourceClasses.ts
@@ -44,7 +44,13 @@ export function loadSearchResourceClasses(): Promise<KubeObjectClass[]> {
       import('../../lib/k8s/serviceAccount'),
       import('../../lib/k8s/node'),
       import('../../lib/k8s/jobSet'),
-    ]).then(modules => modules.map(module => module.default as KubeObjectClass));
+    ])
+      .then(modules => modules.map(module => module.default as KubeObjectClass))
+      .catch(error => {
+        // Allow a later call to retry if chunk loading fails once.
+        searchResourceClassesPromise = null;
+        throw error;
+      });
   }
 
   return searchResourceClassesPromise;

--- a/frontend/src/components/globalSearch/searchResourceClasses.ts
+++ b/frontend/src/components/globalSearch/searchResourceClasses.ts
@@ -24,25 +24,8 @@ let searchResourceClassesPromise: Promise<KubeObjectClass[]> | null = null;
  */
 export function loadSearchResourceClasses(): Promise<KubeObjectClass[]> {
   if (!searchResourceClassesPromise) {
-    searchResourceClassesPromise = Promise.all([
-      import('../../lib/k8s/pod'),
-      import('../../lib/k8s/deployment'),
-      import('../../lib/k8s/service'),
-      import('../../lib/k8s/job'),
-      import('../../lib/k8s/cronJob'),
-      import('../../lib/k8s/configMap'),
-      import('../../lib/k8s/namespace'),
-      import('../../lib/k8s/statefulSet'),
-      import('../../lib/k8s/replicaSet'),
-      import('../../lib/k8s/persistentVolumeClaim'),
-      import('../../lib/k8s/endpoints'),
-      import('../../lib/k8s/endpointSlices'),
-      import('../../lib/k8s/ingress'),
-      import('../../lib/k8s/serviceAccount'),
-      import('../../lib/k8s/node'),
-      import('../../lib/k8s/jobSet'),
-    ])
-      .then(modules => modules.map(module => module.default as KubeObjectClass))
+    searchResourceClassesPromise = import('./searchResourceClassesList')
+      .then(module => module.searchResourceClasses)
       .catch(error => {
         // Allow a later call to retry if chunk loading fails once.
         searchResourceClassesPromise = null;

--- a/frontend/src/components/globalSearch/searchResourceClassesList.ts
+++ b/frontend/src/components/globalSearch/searchResourceClassesList.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ConfigMap from '../../lib/k8s/configMap';
+import CronJob from '../../lib/k8s/cronJob';
+import Deployment from '../../lib/k8s/deployment';
+import Endpoints from '../../lib/k8s/endpoints';
+import EndpointSlice from '../../lib/k8s/endpointSlices';
+import Ingress from '../../lib/k8s/ingress';
+import Job from '../../lib/k8s/job';
+import JobSet from '../../lib/k8s/jobSet';
+import type { KubeObjectClass } from '../../lib/k8s/KubeObject';
+import Namespace from '../../lib/k8s/namespace';
+import Node from '../../lib/k8s/node';
+import PersistentVolumeClaim from '../../lib/k8s/persistentVolumeClaim';
+import Pod from '../../lib/k8s/pod';
+import ReplicaSet from '../../lib/k8s/replicaSet';
+import Service from '../../lib/k8s/service';
+import ServiceAccount from '../../lib/k8s/serviceAccount';
+import StatefulSet from '../../lib/k8s/statefulSet';
+
+/**
+ * Resource classes used by global search. Loaded via a single dynamic import so
+ * Vite/Rollup emits one shared chunk rather than one per model module.
+ */
+export const searchResourceClasses: KubeObjectClass[] = [
+  Pod,
+  Deployment,
+  Service,
+  Job,
+  CronJob,
+  ConfigMap,
+  Namespace,
+  StatefulSet,
+  ReplicaSet,
+  PersistentVolumeClaim,
+  Endpoints,
+  EndpointSlice,
+  Ingress,
+  ServiceAccount,
+  Node,
+  JobSet,
+];

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -721,6 +721,7 @@
   "Section Name": "اسم القسم",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "اضغط <1>{formatShortcutKey(searchShortcutKey)}</1> للبحث",
   "Search resources, pages, clusters by name": "ابحث عن الموارد والصفحات والكتل حسب الاسم",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "النطاق الحالي",
   "Set namespace: {{namespace}}": "تعيين النطاق: {{namespace}}",
   "Page": "الصفحة",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -701,6 +701,7 @@
   "Section Name": "বিভাগের নাম",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "<1>{formatShortcutKey(searchShortcutKey)}</1> টিপুন অনুসন্ধান করতে",
   "Search resources, pages, clusters by name": "নাম অনুসারে Resources, Page, Cluster Search করুন",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "বর্তমান নেমস্পেস",
   "Set namespace: {{namespace}}": "নেমস্পেস সেট করুন: {{namespace}}",
   "Page": "Page",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -701,6 +701,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -701,6 +701,7 @@
   "Section Name": "Section Name",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search",
   "Search resources, pages, clusters by name": "Search resources, pages, clusters by name",
+  "Unable to load search resources. Refresh the page and try again.": "Unable to load search resources. Refresh the page and try again.",
   "Current Namespace": "Current Namespace",
   "Set namespace: {{namespace}}": "Set namespace: {{namespace}}",
   "Page": "Page",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -706,6 +706,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -706,6 +706,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -706,6 +706,7 @@
   "Section Name": "Section Name",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search",
   "Search resources, pages, clusters by name": "Search resources, pages, clusters by name",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "Current Namespace",
   "Set namespace: {{namespace}}": "Set namespace: {{namespace}}",
   "Page": "Page",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -701,6 +701,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -706,6 +706,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -696,6 +696,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -696,6 +696,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -706,6 +706,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -711,6 +711,7 @@
   "Section Name": "Название раздела",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "Нажмите <1>{formatShortcutKey(searchShortcutKey)}</1>, чтобы выполнить поиск",
   "Search resources, pages, clusters by name": "Поиск ресурсов, страниц, кластеров по названию",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "Текущее пространство имён",
   "Set namespace: {{namespace}}": "Установить пространство имён: {{namespace}}",
   "Page": "Страница",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -701,6 +701,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -701,6 +701,7 @@
   "Section Name": "سیکشن کا نام",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "تلاش کے لیے <1>{formatShortcutKey(searchShortcutKey)}</1> دبائیں",
   "Search resources, pages, clusters by name": "نام کے ذریعے ریسورسز، صفحات اور کلسٹرز تلاش کریں",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "موجودہ نیم اسپیس",
   "Set namespace: {{namespace}}": "نیم اسپیس سیٹ کریں: {{namespace}}",
   "Page": "صفحہ",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -696,6 +696,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -696,6 +696,7 @@
   "Section Name": "",
   "Press<1>{formatShortcutKey(searchShortcutKey)}</1>to search": "",
   "Search resources, pages, clusters by name": "",
+  "Unable to load search resources. Refresh the page and try again.": "",
   "Current Namespace": "",
   "Set namespace: {{namespace}}": "",
   "Page": "",

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -36,9 +36,9 @@ vi.mock('./lib/k8s/api/v1/clusterRequests', async () => {
 // Dynamic import() of the resource-class aggregator does not settle under Vitest
 // fake timers used by storyshots; resolve the classes eagerly for snapshots.
 vi.mock('./components/globalSearch/searchResourceClasses', async () => {
-  const { searchResourceClasses } = await import(
-    './components/globalSearch/searchResourceClassesList'
-  );
+  const { searchResourceClasses } = await vi.importActual<
+    typeof import('./components/globalSearch/searchResourceClassesList')
+  >('./components/globalSearch/searchResourceClassesList');
   return {
     loadSearchResourceClasses: () => Promise.resolve(searchResourceClasses),
   };

--- a/frontend/src/storybook.test.tsx
+++ b/frontend/src/storybook.test.tsx
@@ -33,6 +33,17 @@ vi.mock('./lib/k8s/api/v1/clusterRequests', async () => {
   };
 });
 
+// Dynamic import() of the resource-class aggregator does not settle under Vitest
+// fake timers used by storyshots; resolve the classes eagerly for snapshots.
+vi.mock('./components/globalSearch/searchResourceClasses', async () => {
+  const { searchResourceClasses } = await import(
+    './components/globalSearch/searchResourceClassesList'
+  );
+  return {
+    loadSearchResourceClasses: () => Promise.resolve(searchResourceClasses),
+  };
+});
+
 const annotations = setProjectAnnotations([previewAnnotations, { testingLibraryRender }]);
 beforeAll(annotations.beforeAll!);
 


### PR DESCRIPTION
## Summary

Lazy-load the 16 Kubernetes resource class modules used by global search in a separate chunk, instead of statically importing them all into `GlobalSearchContent`.

When the user opens search, the input appears immediately while resource models load in the background. List fetching only starts after those modules are available.

## Test plan

- [x] `npx tsc --noEmit` in `frontend/`

### Fix:

searchResourceClasses.ts — loads each resource class via dynamic import() in a separate chunk (cached after first load).

GlobalSearchContent.tsx split into:

Placeholder — search field + spinner while classes load (user can still type)
Loaded — runs useList hooks only after classes are available
Removed eager KubeIcon import — uses LazyKubeIcon everywhere.

