### PR TITLE
frontend: Pod: Fix lexicographical sorting bugs in Restarts and Ready columns

### DIFF
--- a/frontend/src/components/pod/List.tsx
+++ b/frontend/src/components/pod/List.tsx
@@ -301,6 +301,7 @@ export function PodListRenderer(props: PodListProps) {
         'namespace',
         'cluster',
         {
+          id: 'restarts',
           label: t('Restarts'),
           gridTemplate: 'min-content',
           disableFiltering: true,
@@ -313,6 +314,7 @@ export function PodListRenderer(props: PodListProps) {
                 })
               : restarts;
           },
+          sort: (a, b) => a.getDetailedStatus().restarts - b.getDetailedStatus().restarts,
         },
         {
           id: 'ready',
@@ -322,6 +324,15 @@ export function PodListRenderer(props: PodListProps) {
           getValue: pod => {
             const podRow = pod.getDetailedStatus();
             return `${podRow.readyContainers}/${podRow.totalContainers}`;
+          },
+          sort: (a, b) => {
+            const aStatus = a.getDetailedStatus();
+            const bStatus = b.getDetailedStatus();
+            const aRatio =
+              aStatus.totalContainers > 0 ? aStatus.readyContainers / aStatus.totalContainers : 0;
+            const bRatio =
+              bStatus.totalContainers > 0 ? bStatus.readyContainers / bStatus.totalContainers : 0;
+            return aRatio - bRatio;
           },
         },
         {

--- a/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
+++ b/frontend/src/components/pod/__snapshots__/PodList.Items.stories.storyshot
@@ -430,7 +430,7 @@
                 </th>
                 <th
                   aria-sort="none"
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-9s5e2s-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeMedium css-5m78vi-MuiTableCell-root"
                   colspan="1"
                   data-can-sort="true"
                   data-index="-1"
@@ -952,7 +952,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   1 (90d ago)
                 </td>
@@ -1088,7 +1088,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   0
                 </td>
@@ -1242,7 +1242,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   0
                 </td>
@@ -1378,7 +1378,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   337 (90d ago)
                 </td>
@@ -1514,7 +1514,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   0
                 </td>
@@ -1650,7 +1650,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   0
                 </td>
@@ -1786,7 +1786,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   0
                 </td>
@@ -1922,7 +1922,7 @@
                   </a>
                 </td>
                 <td
-                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-1vvmgn4-MuiTableCell-root"
+                  class="MuiTableCell-root MuiTableCell-alignLeft MuiTableCell-sizeMedium css-qi2rnp-MuiTableCell-root"
                 >
                   0
                 </td>


### PR DESCRIPTION
## Summary
This PR fixes sorting in the Pod list for the Restarts and Ready columns. The displayed text stays the same, but the table now sorts using the actual numeric values instead of the formatted strings.

## Related Issue
No related issue. I came across this while working in the area and fixed it directly.

## Changes
- Kept `getValue` for both the Restarts and Ready columns returning the original formatted display string (unchanged), since it's also used for the table's global search/filter — changing it to a numeric value would have broken text search on these columns (e.g. searching "2/2" would no longer match the Ready column).
- Added a custom `sort` comparator for each column via the existing `sort` prop on `ResourceTableColumn`, which compares the real restart count / readiness ratio numerically, independent of the display string.

## Steps to Test
1. Go to Workloads → Pods (using any cluster with a few pods, ideally with different restart counts).
2. Click the Restarts column header to sort in ascending and descending order.
3. Verify the pods are sorted by the actual restart count (for example, `2` comes before `15`) instead of alphabetically.
4. Do the same for the Ready column and confirm the rows are sorted by readiness ratio (for example, `1/2` before `2/2`) rather than by the displayed string.
5. Make sure the values shown in both columns still use the same format as before (for example, `"3 (5m ago)"` and `"2/2"`).
6. Confirm the global search box still matches on values like `"2/2"` for the Ready column.

## Notes for the Reviewer
- This uses the existing `sort` prop already supported by `ResourceTableColumn` — no new pattern introduced.
- `npm run test -- pod` passes (47/47).
- `npm run lint` passes clean.
- The storyshot (`PodList.Items.stories.storyshot`) was regenerated — sort-toggle `aria-label` values are unaffected (since `getValue`'s type is unchanged, MRT's column type inference stays the same as before this PR); the diff is limited to internal snapshot metadata.