### PR TITLE
backend: add OIDC claim mapping for user impersonation

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1182,6 +1182,54 @@ func (c *HeadlampConfig) shouldUseUnsafeServiceAccountTokenForContext(kContext *
 	return c.shouldUseUnsafeServiceAccountToken() && kContext.UsesInClusterServiceAccountToken()
 }
 
+func (c *HeadlampConfig) applyAuthAndImpersonation(r *http.Request, kContext *kubeconfig.Context) {
+	if c.shouldUseUnsafeServiceAccountTokenForContext(kContext) {
+		clearRequestAuthorization(r)
+		return
+	}
+
+	var token string
+	if c.ProxyAuthEnabled && c.ProxyAuthTokenHeader != "" {
+		token = strings.TrimSpace(r.Header.Get(c.ProxyAuthTokenHeader))
+	}
+
+	if token == "" {
+		token, _ = auth.GetTokenFromCookie(r, kContext.Name)
+	}
+
+	if token == "" {
+		return
+	}
+
+	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	if !c.ImpersonationEnabled {
+		return
+	}
+
+	claims, err := auth.ExtractClaims(token)
+	if err != nil {
+		logger.Log(logger.LevelWarn, nil, err, "failed to extract claims for impersonation")
+		return
+	}
+
+	impUser, impGroups, err := auth.EvaluateRules(c.ImpersonationRules, claims)
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "failed to evaluate impersonation rules")
+		return
+	}
+
+	if impUser != "" {
+		r.Header.Set("Impersonate-User", impUser)
+	}
+
+	r.Header.Del("Impersonate-Group")
+
+	for _, group := range impGroups {
+		r.Header.Add("Impersonate-Group", group)
+	}
+}
+
 func tokenFromCookie(r *http.Request, clusterName string) string {
 	if cookieToken, err := auth.GetTokenFromCookie(r, clusterName); err == nil && cookieToken != "" {
 		return cookieToken
@@ -1360,6 +1408,7 @@ func serverHandler(ctx context.Context, config *HeadlampConfig) (http.Handler, e
 	}
 
 	handler = config.OIDCTokenRefreshMiddleware(handler)
+	handler = auth.StripImpersonationHeadersMiddleware(handler)
 
 	// Only validate the Host header when listening on a loopback address.
 	// When bound to a non-loopback address (e.g. behind a reverse proxy),
@@ -1832,23 +1881,7 @@ func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 		// Process WebSocket protocol headers if present
 		processWebSocketProtocolHeader(r)
 
-		if c.shouldUseUnsafeServiceAccountTokenForContext(kContext) {
-			clearRequestAuthorization(r)
-		} else {
-			var token string
-
-			if c.ProxyAuthEnabled && c.ProxyAuthTokenHeader != "" {
-				token = strings.TrimSpace(r.Header.Get(c.ProxyAuthTokenHeader))
-			}
-
-			if token == "" {
-				token, _ = auth.GetTokenFromCookie(r, mux.Vars(r)["clusterName"])
-			}
-
-			if token != "" {
-				r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-			}
-		}
+		c.applyAuthAndImpersonation(r, kContext)
 
 		clearConfiguredProxyTokenHeader(r, c.ProxyAuthTokenHeader)
 

--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cli/browser"
 	"github.com/gorilla/mux"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
@@ -202,6 +203,18 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 
 	multiplexer := NewMultiplexer(kubeConfigStore, conf.InCluster && conf.UnsafeUseServiceAccountToken)
 
+	var impersonationRules []config.MappingRule
+
+	if conf.ImpersonationEnabled {
+		rules, err := auth.ParseRules(conf.ImpersonationRules, conf.ImpersonationRulesFile)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "failed to parse impersonation rules")
+			os.Exit(1)
+		}
+
+		impersonationRules = rules
+	}
+
 	cfg := &headlampconfig.HeadlampConfig{
 		HeadlampCFG:               buildHeadlampCFG(conf, kubeConfigStore),
 		OidcClientID:              conf.OidcClientID,
@@ -222,6 +235,8 @@ func createHeadlampConfig(conf *config.Config) *HeadlampConfig {
 		Multiplexer:               multiplexer,
 		TelemetryConfig:           buildTelemetryConfig(conf),
 		OidcCACert:                loadOidcCACert(conf.OidcCAFile),
+		ImpersonationEnabled:      conf.ImpersonationEnabled,
+		ImpersonationRules:        impersonationRules,
 	}
 
 	cfg.ProxyAuthEnabled = conf.ProxyAuthEnabled

--- a/backend/pkg/auth/impersonation.go
+++ b/backend/pkg/auth/impersonation.go
@@ -1,0 +1,139 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"sigs.k8s.io/yaml"
+)
+
+type TemplateContext struct {
+	Value  interface{}
+	Claims map[string]interface{}
+}
+
+// ExtractClaims extracts the claims from a JWT bearer token.
+func ExtractClaims(token string) (map[string]interface{}, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid token format, expected 3 parts")
+	}
+
+	return DecodeBase64JSON(parts[1])
+}
+
+// ParseRules parses mapping rules from a raw JSON/YAML string or a file path.
+func ParseRules(rulesStr, rulesFile string) ([]config.MappingRule, error) {
+	var (
+		rules   []config.MappingRule
+		rawData []byte
+	)
+
+	switch {
+	case rulesFile != "":
+		data, err := os.ReadFile(rulesFile) //nolint:gosec
+		if err != nil {
+			return nil, fmt.Errorf("reading rules file: %w", err)
+		}
+
+		rawData = data
+	case rulesStr != "":
+		rawData = []byte(rulesStr)
+	default:
+		return nil, nil
+	}
+
+	// Try parsing as JSON first, fallback to YAML
+	if err := json.Unmarshal(rawData, &rules); err == nil {
+		return rules, nil
+	}
+
+	if err := yaml.Unmarshal(rawData, &rules); err != nil {
+		return nil, fmt.Errorf("unmarshaling rules as JSON/YAML: %w", err)
+	}
+
+	return rules, nil
+}
+
+func getRuleValues(rule config.MappingRule, claims map[string]interface{}) ([]interface{}, bool) {
+	if rule.FromClaim == "" {
+		return []interface{}{nil}, true
+	}
+
+	claimVal, exists := claims[rule.FromClaim]
+	if !exists {
+		return nil, false
+	}
+
+	if sliceVal, ok := claimVal.([]interface{}); ok {
+		return sliceVal, true
+	}
+
+	if strSliceVal, ok := claimVal.([]string); ok {
+		values := make([]interface{}, len(strSliceVal))
+		for i, v := range strSliceVal {
+			values[i] = v
+		}
+
+		return values, true
+	}
+
+	return []interface{}{claimVal}, true
+}
+
+// EvaluateRules evaluates identity mapping rules against validated OIDC claims.
+// It returns the impersonated user (must resolve to exactly one) and a list of groups.
+func EvaluateRules(rules []config.MappingRule, claims map[string]interface{}) (string, []string, error) {
+	var (
+		user   string
+		groups []string
+	)
+
+	for _, rule := range rules {
+		values, exists := getRuleValues(rule, claims)
+		if !exists {
+			continue
+		}
+
+		// Compile the Go template
+		tmpl, err := template.New("rule").Parse(rule.Template)
+		if err != nil {
+			return "", nil, fmt.Errorf("parsing template %q failed: %w", rule.Template, err)
+		}
+
+		for _, val := range values {
+			var buf bytes.Buffer
+
+			ctx := TemplateContext{
+				Value:  val,
+				Claims: claims,
+			}
+			if err := tmpl.Execute(&buf, ctx); err != nil {
+				return "", nil, fmt.Errorf("evaluating template failed: %w", err)
+			}
+
+			rendered := buf.String()
+			if rendered == "" {
+				continue
+			}
+
+			switch rule.Target {
+			case "user":
+				if user != "" {
+					return "", nil, fmt.Errorf("multiple mapping rules resolved to Impersonate-User; must resolve to exactly one")
+				}
+
+				user = rendered
+			case "group":
+				groups = append(groups, rendered)
+			}
+		}
+	}
+
+	return user, groups, nil
+}

--- a/backend/pkg/auth/impersonation_test.go
+++ b/backend/pkg/auth/impersonation_test.go
@@ -1,0 +1,126 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/auth"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestRules() []config.MappingRule {
+	return []config.MappingRule{
+		{
+			Target:    "user",
+			FromClaim: "sub",
+			Template:  "headlamp:user:{{.Value}}",
+		},
+		{
+			Target:    "group",
+			FromClaim: "groups",
+			Template:  "headlamp:group:{{.Value}}",
+		},
+		{
+			Target:   "group",
+			Template: "headlamp:authenticated",
+		},
+	}
+}
+
+func TestEvaluateRules_Valid(t *testing.T) {
+	rules := getTestRules()
+	claims := map[string]interface{}{
+		"sub":    "12345",
+		"groups": []string{"admin", "dev"},
+	}
+
+	user, groups, err := auth.EvaluateRules(rules, claims)
+	assert.NoError(t, err)
+	assert.Equal(t, "headlamp:user:12345", user)
+	assert.ElementsMatch(t, []string{"headlamp:group:admin", "headlamp:group:dev", "headlamp:authenticated"}, groups)
+}
+
+func TestEvaluateRules_MissingClaim(t *testing.T) {
+	rules := getTestRules()
+	claims := map[string]interface{}{
+		"sub": "12345",
+	}
+
+	user, groups, err := auth.EvaluateRules(rules, claims)
+	assert.NoError(t, err)
+	assert.Equal(t, "headlamp:user:12345", user)
+	assert.ElementsMatch(t, []string{"headlamp:authenticated"}, groups)
+}
+
+func TestEvaluateRules_Nested(t *testing.T) {
+	customRules := []config.MappingRule{
+		{
+			Target:    "user",
+			FromClaim: "sub",
+			Template:  "headlamp:user:{{.Claims.tenant_id}}:{{.Value}}",
+		},
+	}
+
+	claims := map[string]interface{}{
+		"sub":       "12345",
+		"tenant_id": "acme",
+	}
+
+	user, groups, err := auth.EvaluateRules(customRules, claims)
+	assert.NoError(t, err)
+	assert.Equal(t, "headlamp:user:acme:12345", user)
+	assert.Empty(t, groups)
+}
+
+func TestEvaluateRules_MultipleUsers(t *testing.T) {
+	badRules := []config.MappingRule{
+		{
+			Target:    "user",
+			FromClaim: "sub",
+			Template:  "headlamp:user:{{.Value}}",
+		},
+		{
+			Target:    "user",
+			FromClaim: "email",
+			Template:  "headlamp:user:{{.Value}}",
+		},
+	}
+
+	claims := map[string]interface{}{
+		"sub":   "12345",
+		"email": "user@example.com",
+	}
+
+	_, _, err := auth.EvaluateRules(badRules, claims)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple mapping rules resolved to Impersonate-User")
+}
+
+func TestParseRules_JSON(t *testing.T) {
+	jsonStr := `[
+		{"target": "user", "fromClaim": "sub", "template": "user:{{.Value}}"},
+		{"target": "group", "fromClaim": "groups", "template": "group:{{.Value}}"}
+	]`
+	rules, err := auth.ParseRules(jsonStr, "")
+	assert.NoError(t, err)
+	assert.Len(t, rules, 2)
+	assert.Equal(t, "user", rules[0].Target)
+	assert.Equal(t, "sub", rules[0].FromClaim)
+	assert.Equal(t, "user:{{.Value}}", rules[0].Template)
+}
+
+func TestParseRules_YAML(t *testing.T) {
+	yamlStr := `
+- target: user
+  fromClaim: sub
+  template: user:{{.Value}}
+- target: group
+  fromClaim: groups
+  template: group:{{.Value}}
+`
+	rules, err := auth.ParseRules(yamlStr, "")
+	assert.NoError(t, err)
+	assert.Len(t, rules, 2)
+	assert.Equal(t, "group", rules[1].Target)
+	assert.Equal(t, "groups", rules[1].FromClaim)
+}

--- a/backend/pkg/auth/middleware.go
+++ b/backend/pkg/auth/middleware.go
@@ -266,3 +266,16 @@ func (c *OIDCTokenRefreshConfig) handleOIDCAuthConfigError(
 
 	return false
 }
+
+// StripImpersonationHeadersMiddleware deletes all client-supplied Impersonate- headers.
+func StripImpersonationHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for key := range r.Header {
+			if strings.HasPrefix(strings.ToLower(key), "impersonate-") {
+				r.Header.Del(key)
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/pkg/auth/middleware_test.go
+++ b/backend/pkg/auth/middleware_test.go
@@ -78,3 +78,27 @@ func TestSetTokenFromCookie(t *testing.T) {
 	want := "Bearer " + testToken
 	assert.Equal(t, want, got)
 }
+
+func TestStripImpersonationHeadersMiddleware(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Impersonate-User"))
+		assert.Empty(t, r.Header.Get("Impersonate-Group"))
+		assert.Empty(t, r.Header.Get("impersonate-custom"))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := auth.StripImpersonationHeadersMiddleware(handler)
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Impersonate-User", "some-user")
+	req.Header.Set("Impersonate-Group", "some-group")
+	req.Header.Set("impersonate-custom", "value")
+	req.Header.Set("X-Other-Header", "other-value")
+
+	rec := httptest.NewRecorder()
+	middleware.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "other-value", req.Header.Get("X-Other-Header"))
+}

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -35,6 +35,12 @@ const (
 	DefaultMeUserInfoURL  = ""
 )
 
+type MappingRule struct {
+	Target    string `yaml:"target" json:"target" koanf:"target"`
+	FromClaim string `yaml:"fromClaim" json:"fromClaim" koanf:"fromClaim"`
+	Template  string `yaml:"template" json:"template" koanf:"template"`
+}
+
 type Config struct {
 	Version              bool   `koanf:"version"`
 	InCluster            bool   `koanf:"in-cluster"`
@@ -94,6 +100,10 @@ type Config struct {
 	ProxyAuthTokenHeader         string `koanf:"proxy-auth-token-header"`
 	UnsafeUseServiceAccountToken bool   `koanf:"unsafe-use-service-account-token"`
 	ServiceAccountTokenPath      string `koanf:"service-account-token-path"`
+	// impersonation config
+	ImpersonationEnabled   bool   `koanf:"impersonation-enabled"`
+	ImpersonationRules     string `koanf:"impersonation-rules"`
+	ImpersonationRulesFile string `koanf:"impersonation-rules-file"`
 	// telemetry configs
 	ServiceName        string   `koanf:"service-name"`
 	ServiceVersion     *string  `koanf:"service-version"`
@@ -530,10 +540,17 @@ func flagset() *flag.FlagSet {
 	addGeneralFlags(f)
 	addOIDCFlags(f)
 	addProxyAuthFlags(f)
+	addImpersonationFlags(f)
 	addTelemetryFlags(f)
 	addTLSFlags(f)
 
 	return f
+}
+
+func addImpersonationFlags(f *flag.FlagSet) {
+	f.Bool("impersonation-enabled", false, "Enable Kubernetes-native user/group impersonation")
+	f.String("impersonation-rules", "", "JSON/YAML string of identity mapping rules for impersonation")
+	f.String("impersonation-rules-file", "", "Path to a JSON/YAML file containing identity mapping rules")
 }
 
 func addGeneralFlags(f *flag.FlagSet) {

--- a/backend/pkg/headlampconfig/headlampConfig.go
+++ b/backend/pkg/headlampconfig/headlampConfig.go
@@ -43,6 +43,8 @@ type HeadlampConfig struct {
 	ProxyAuthGroupHeader      string
 	ProxyAuthEmailHeader      string
 	ProxyAuthTokenHeader      string
+	ImpersonationEnabled      bool
+	ImpersonationRules        []config.MappingRule
 	ServerCtx                 context.Context
 }
 


### PR DESCRIPTION
## Summary
This PR adds Kubernetes-native user and group impersonation for multi-cluster environments in Headlamp using the `Impersonate-User` and `Impersonate-Group` headers. It attaches the resulting impersonation headers to outbound proxy and Helm client requests.


## Related Issue

Fixes #6324 

## Changes

- **Backend Configuration**: Added `--impersonation-enabled`, `--impersonation-rules`, and `--impersonation-rules-file` CLI and config options to the server.
- **Translation Engine**: Added a mapping rule processor supporting Go's `text/template` engine to dynamically generate impersonated identities from OIDC token claims (scalars, arrays, and static default groups).
- **Security Middleware**: Added global middleware to strip any incoming client-side `Impersonate-` headers from client requests to prevent privilege escalation.
- **Request Injections**: Integrated resolved impersonated users/groups directly into outbound proxy requests and Helm operations contexts.

## Steps to Test

1. Run Backend Unit Tests
Verify the claim extractor, template engine, and middleware work as expected:
```bash
go test -v ./pkg/auth
go test -v ./cmd
```

## Screenshots (if applicable)


## Notes for the Reviewer

- [e.g., This touches the i18n layer, so please check language consistency.]
