### PR TITLE
backend: telemetry: Fix metrics gauge leak and double-count in panic recovery

### DIFF
--- a/backend/pkg/telemetry/metrics.go
+++ b/backend/pkg/telemetry/metrics.go
@@ -132,26 +132,28 @@ func (m *Metrics) RequestCounterMiddleware(next http.Handler) http.Handler {
 		wrapper := newResponseWriter(w)
 
 		defer func() {
+			statusCode := wrapper.statusCode
+
+			// Capture panic before recording metrics so both paths
+			// record exactly once and the gauge always returns to zero.
+			pval := recover()
+			if pval != nil {
+				statusCode = http.StatusInternalServerError
+			}
+
 			attrs := []attribute.KeyValue{
 				attribute.String("http.method", r.Method),
 				attribute.String("http.target", r.URL.Path),
-				attribute.Int("http.status_code", wrapper.statusCode),
-			}
-
-			if rec := recover(); rec != nil {
-				wrapper.statusCode = http.StatusInternalServerError
-				attrs[2] = attribute.Int("http.status_code", http.StatusInternalServerError)
-
-				m.RequestCounter.Add(r.Context(), 1, metric.WithAttributes(attrs...))
-
-				m.ActiveRequestsGauge.Add(r.Context(), -1)
-
-				panic(rec)
+				attribute.Int("http.status_code", statusCode),
 			}
 
 			m.RequestCounter.Add(r.Context(), 1, metric.WithAttributes(attrs...))
 
 			m.ActiveRequestsGauge.Add(r.Context(), -1)
+
+			if pval != nil {
+				panic(pval)
+			}
 		}()
 
 		next.ServeHTTP(wrapper, r)

--- a/backend/pkg/telemetry/metrics_test.go
+++ b/backend/pkg/telemetry/metrics_test.go
@@ -364,11 +364,35 @@ func verifyPanicMetrics(t *testing.T, ctx context.Context, reader *sdkmetric.Man
 }
 
 func verifyRequestCountMetric(t *testing.T, data metricdata.ResourceMetrics) {
-	// Implementation specific to checking request count metric
+	for _, scopeMetric := range data.ScopeMetrics {
+		for _, m := range scopeMetric.Metrics {
+			if m.Name == metricRequestCount {
+				sum := sumDataPoints(m.Data)
+				assert.Equal(t, int64(2), sum,
+					"expected 2 request count increments (one normal + one panic)")
+
+				return
+			}
+		}
+	}
+
+	t.Error("request count metric not found")
 }
 
 func verifyActiveRequestsMetric(t *testing.T, data metricdata.ResourceMetrics) {
-	// Implementation specific to checking active requests metric
+	for _, scopeMetric := range data.ScopeMetrics {
+		for _, m := range scopeMetric.Metrics {
+			if m.Name == metricActiveRequests {
+				lastVal := sumDataPoints(m.Data)
+				assert.Equal(t, int64(0), lastVal,
+					"expected active requests gauge to return to zero after panic recovery")
+
+				return
+			}
+		}
+	}
+
+	t.Error("active requests metric not found")
 }
 
 func sumDataPoints(data metricdata.Aggregation) int64 {


### PR DESCRIPTION
## Summary

Fix a bug in `RequestCounterMiddleware` where panicking requests caused request metrics to be recorded twice and the active requests gauge to be decremented twice.

## Changes

* Restructure the deferred metrics handling to record metrics exactly once.
* Update the response status to `500` when a panic is recovered.
* Re-panic only after all metrics have been recorded.
* Preserve existing behavior for successful and non-panic error requests.

## Result

* `ActiveRequestsGauge` is decremented exactly once per request.
* `RequestCounter` is recorded exactly once, including on panic paths.
* Panic propagation is preserved so `net/http.Server` can perform its normal recovery.

## Testing 

* Relevant Tests passed.


## Note for reviewers

The deferred metrics logic has been restructured so metrics are recorded exactly once before re-panicking, eliminating the double-counting issue while preserving the existing panic propagation behavior.


