### PR TITLE
frontend: deployment: Fix potential null reference crashes and add tests

### DIFF
--- a/frontend/src/components/workload/extraInfo.test.tsx
+++ b/frontend/src/components/workload/extraInfo.test.tsx
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TFunction } from 'i18next';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import Deployment from '../../lib/k8s/deployment';
+import Job from '../../lib/k8s/job';
+import StatefulSet from '../../lib/k8s/statefulSet';
+import {
+  deploymentExtraInfo,
+  formatDuration,
+  jobExtraInfo,
+  statefulSetExtraInfo,
+} from './extraInfo';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+const mockT = vi.fn((key: string, options?: Record<string, unknown>) => {
+  if (options && options.n !== undefined) {
+    return `${key} (n=${options.n})`;
+  }
+  return key;
+}) as unknown as TFunction;
+
+describe('workload extraInfo', () => {
+  describe('formatDuration', () => {
+    it('returns empty string for negative values', () => {
+      expect(formatDuration(-1)).toBe('');
+      expect(formatDuration(-1000)).toBe('');
+    });
+
+    it('formats seconds correctly', () => {
+      expect(formatDuration(0)).toBe('0s');
+      expect(formatDuration(500)).toBe('0s');
+      expect(formatDuration(1000)).toBe('1s');
+      expect(formatDuration(59000)).toBe('59s');
+    });
+
+    it('formats minutes correctly', () => {
+      expect(formatDuration(60000)).toBe('1m');
+      expect(formatDuration(90000)).toBe('1m 30s');
+      expect(formatDuration(119000)).toBe('1m 59s');
+      expect(formatDuration(120000)).toBe('2m');
+      expect(formatDuration(3599000)).toBe('59m 59s');
+    });
+
+    it('formats hours correctly', () => {
+      expect(formatDuration(3600000)).toBe('1h');
+      expect(formatDuration(5400000)).toBe('1h 30m');
+      expect(formatDuration(7200000)).toBe('2h');
+      expect(formatDuration(86399000)).toBe('23h 59m');
+    });
+
+    it('formats days correctly', () => {
+      expect(formatDuration(86400000)).toBe('1d');
+      expect(formatDuration(129600000)).toBe('1d 12h');
+      expect(formatDuration(172800000)).toBe('2d');
+    });
+  });
+
+  describe('deploymentExtraInfo', () => {
+    it('returns correct rows when all fields are populated', () => {
+      const mockDeployment = {
+        spec: {
+          minReadySeconds: 10,
+          progressDeadlineSeconds: 600,
+          revisionHistoryLimit: 5,
+        },
+      } as unknown as Deployment;
+
+      const info = deploymentExtraInfo(mockDeployment, mockT);
+      expect(info).toHaveLength(3);
+
+      expect(info[0].name).toBe('glossary|Min Ready Seconds');
+      expect(info[0].value).toBe('10s');
+      expect(info[0].hide).toBe(false);
+
+      expect(info[1].name).toBe('glossary|Progress Deadline');
+      expect(info[1].value).toBe('600s');
+      expect(info[1].hide).toBe(false);
+
+      expect(info[2].name).toBe('glossary|Revision History Limit');
+      expect(info[2].value).toBe(5);
+      expect(info[2].hide).toBe(false);
+    });
+
+    it('hides rows when fields are undefined', () => {
+      const mockDeployment = {
+        spec: {},
+      } as unknown as Deployment;
+
+      const info = deploymentExtraInfo(mockDeployment, mockT);
+      expect(info[0].hide).toBe(true);
+      expect(info[1].hide).toBe(true);
+      expect(info[2].hide).toBe(true);
+    });
+
+    it('handles null spec gracefully', () => {
+      const mockDeployment = {} as unknown as Deployment;
+      const info = deploymentExtraInfo(mockDeployment, mockT);
+      expect(info).toHaveLength(3);
+      expect(info[0].hide).toBe(true);
+    });
+  });
+
+  describe('statefulSetExtraInfo', () => {
+    it('returns correct rows when serviceName is present', () => {
+      const mockStatefulSet = {
+        cluster: 'my-cluster',
+        metadata: {
+          namespace: 'my-namespace',
+        },
+        spec: {
+          serviceName: 'my-service',
+          podManagementPolicy: 'OrderedReady',
+        },
+      } as unknown as StatefulSet;
+
+      const info = statefulSetExtraInfo(mockStatefulSet, mockT);
+      expect(info).toHaveLength(2);
+
+      expect(info[0].name).toBe('glossary|Service Name');
+      expect(info[0].hide).toBe(false);
+      // Verify Link component props
+      const linkComponent = info[0].value as React.ReactElement;
+      expect(linkComponent.props.routeName).toBe('service');
+      expect(linkComponent.props.params).toEqual({
+        namespace: 'my-namespace',
+        name: 'my-service',
+      });
+      expect(linkComponent.props.activeCluster).toBe('my-cluster');
+      expect(linkComponent.props.children).toBe('my-service');
+
+      expect(info[1].name).toBe('glossary|Pod Management Policy');
+      expect(info[1].value).toBe('OrderedReady');
+      expect(info[1].hide).toBe(false);
+    });
+
+    it('hides rows when serviceName and podManagementPolicy are missing', () => {
+      const mockStatefulSet = {
+        spec: {},
+      } as unknown as StatefulSet;
+
+      const info = statefulSetExtraInfo(mockStatefulSet, mockT);
+      expect(info[0].hide).toBe(true);
+      expect(info[1].hide).toBe(true);
+    });
+  });
+
+  describe('jobExtraInfo', () => {
+    it('returns correct rows for Job with all status counts and duration', () => {
+      const mockJob = {
+        getDuration: () => 125000,
+        status: {
+          active: 1,
+          ready: 2,
+          succeeded: 3,
+          failed: 4,
+          startTime: '2026-07-02T12:00:00Z',
+          completionTime: '2026-07-02T12:02:05Z',
+          completedIndexes: '0-2',
+        },
+        spec: {
+          completions: 5,
+          parallelism: 2,
+          completionMode: 'Indexed',
+          suspend: false,
+          backoffLimit: 6,
+          activeDeadlineSeconds: 120,
+          ttlSecondsAfterFinished: 60,
+        },
+      } as unknown as Job;
+
+      const info = jobExtraInfo(mockJob, mockT);
+
+      // Verify glossary|Completions
+      const completionsRow = info.find(r => r.name === 'glossary|Completions');
+      expect(completionsRow).toBeDefined();
+      expect(completionsRow!.value).toBe('3/5');
+      expect(completionsRow!.hide).toBe(false);
+
+      // Verify glossary|Parallelism
+      const parallelismRow = info.find(r => r.name === 'glossary|Parallelism');
+      expect(parallelismRow).toBeDefined();
+      expect(parallelismRow!.value).toBe(2);
+      expect(parallelismRow!.hide).toBe(false);
+
+      // Verify glossary|Completion Mode
+      const completionModeRow = info.find(r => r.name === 'glossary|Completion Mode');
+      expect(completionModeRow).toBeDefined();
+      expect(completionModeRow!.value).toBe('Indexed');
+      expect(completionModeRow!.hide).toBe(false);
+
+      // Verify translation|Suspend
+      const suspendRow = info.find(r => r.name === 'translation|Suspend');
+      expect(suspendRow).toBeDefined();
+      expect(suspendRow!.value).toBe('false');
+      expect(suspendRow!.hide).toBe(false);
+
+      // Verify glossary|Backoff Limit
+      const backoffLimitRow = info.find(r => r.name === 'glossary|Backoff Limit');
+      expect(backoffLimitRow).toBeDefined();
+      expect(backoffLimitRow!.value).toBe(6);
+      expect(backoffLimitRow!.hide).toBe(false);
+
+      // Verify glossary|Active Deadline
+      const activeDeadlineRow = info.find(r => r.name === 'glossary|Active Deadline');
+      expect(activeDeadlineRow).toBeDefined();
+      expect(activeDeadlineRow!.value).toBe('120s');
+      expect(activeDeadlineRow!.hide).toBe(false);
+
+      // Verify glossary|TTL After Finished
+      const ttlRow = info.find(r => r.name === 'glossary|TTL After Finished');
+      expect(ttlRow).toBeDefined();
+      expect(ttlRow!.value).toBe('60s');
+      expect(ttlRow!.hide).toBe(false);
+
+      // Verify glossary|Pods Status
+      const podsStatusRow = info.find(r => r.name === 'glossary|Pods Status');
+      expect(podsStatusRow).toBeDefined();
+      expect(podsStatusRow!.value).toContain('translation|Active: {{ n }} (n=1)');
+      expect(podsStatusRow!.value).toContain('translation|Ready: {{ n }} (n=2)');
+      expect(podsStatusRow!.value).toContain('translation|Succeeded: {{ n }} (n=3)');
+      expect(podsStatusRow!.value).toContain('translation|Failed: {{ n }} (n=4)');
+
+      // Verify glossary|Duration
+      const durationRow = info.find(r => r.name === 'glossary|Duration');
+      expect(durationRow).toBeDefined();
+      expect(durationRow!.value).toBe('2m 5s');
+      expect(durationRow!.hide).toBe(false);
+
+      // Verify glossary|Completed Indexes
+      const completedIndexesRow = info.find(r => r.name === 'glossary|Completed Indexes');
+      expect(completedIndexesRow).toBeDefined();
+      expect(completedIndexesRow!.value).toBe('0-2');
+      expect(completedIndexesRow!.hide).toBe(false);
+    });
+
+    it('correctly handles job completions value when completions spec is undefined', () => {
+      const mockJob = {
+        getDuration: () => -1,
+        status: {
+          succeeded: 3,
+        },
+        spec: {},
+      } as unknown as Job;
+
+      const info = jobExtraInfo(mockJob, mockT);
+      const completionsRow = info.find(r => r.name === 'glossary|Completions');
+      expect(completionsRow!.value).toBe('3');
+      expect(completionsRow!.hide).toBe(false);
+    });
+  });
+});

--- a/frontend/src/lib/k8s/deployment.test.ts
+++ b/frontend/src/lib/k8s/deployment.test.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import Deployment from './deployment';
+import ReplicaSet from './replicaSet';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('Deployment class', () => {
+  const mockDeploymentData = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'test-deployment',
+      namespace: 'default',
+      resourceVersion: '42',
+      annotations: {
+        'deployment.kubernetes.io/revision': '3',
+      },
+    },
+    spec: {
+      selector: {
+        matchLabels: { app: 'headlamp', env: 'production' },
+      },
+      template: {
+        spec: {
+          containers: [
+            { name: 'web', image: 'nginx:1.25', imagePullPolicy: 'Always' },
+            { name: 'sidecar', image: 'envoy:v1.28', imagePullPolicy: 'IfNotPresent' },
+          ],
+          nodeName: '',
+        },
+      },
+    },
+    status: {},
+  };
+
+  describe('getBaseObject', () => {
+    it('returns a Deployment with correct kind and apiVersion', () => {
+      const base = Deployment.getBaseObject();
+      expect(base.kind).toBe('Deployment');
+      expect(base.apiVersion).toBe('apps/v1');
+    });
+
+    it('sets namespace to empty string in base object', () => {
+      const base = Deployment.getBaseObject();
+      expect(base.metadata.namespace).toBe('');
+    });
+
+    it('sets metadata labels to app: headlamp', () => {
+      const base = Deployment.getBaseObject();
+      expect(base.metadata.labels).toEqual({ app: 'headlamp' });
+    });
+
+    it('includes a selector with matchLabels in base object', () => {
+      const base = Deployment.getBaseObject();
+      expect(base.spec.selector?.matchLabels).toEqual({ app: 'headlamp' });
+    });
+
+    it('includes one container with empty name and image in base object', () => {
+      const base = Deployment.getBaseObject();
+      const containers = base.spec.template.spec.containers;
+      expect(containers).toHaveLength(1);
+      expect(containers[0].name).toBe('');
+      expect(containers[0].image).toBe('');
+      expect(containers[0].ports).toEqual([{ containerPort: 80 }]);
+    });
+  });
+
+  describe('getContainers', () => {
+    it('returns all containers from spec.template.spec.containers', () => {
+      const deployment = new Deployment(JSON.parse(JSON.stringify(mockDeploymentData)));
+      const containers = deployment.getContainers();
+      expect(containers).toHaveLength(2);
+      expect(containers[0].name).toBe('web');
+      expect(containers[1].name).toBe('sidecar');
+    });
+
+    it('returns empty array when containers are missing', () => {
+      const data = JSON.parse(JSON.stringify(mockDeploymentData));
+      delete data.spec.template.spec.containers;
+      const deployment = new Deployment(data);
+      expect(deployment.getContainers()).toEqual([]);
+    });
+  });
+
+  describe('getMatchLabelsList', () => {
+    it('returns key=value strings for each matchLabel', () => {
+      const deployment = new Deployment(JSON.parse(JSON.stringify(mockDeploymentData)));
+      const labels = deployment.getMatchLabelsList();
+      expect(labels).toContain('app=headlamp');
+      expect(labels).toContain('env=production');
+      expect(labels).toHaveLength(2);
+    });
+
+    it('returns empty array when selector has no matchLabels', () => {
+      const data = JSON.parse(JSON.stringify(mockDeploymentData));
+      delete data.spec.selector.matchLabels;
+      const deployment = new Deployment(data);
+      expect(deployment.getMatchLabelsList()).toEqual([]);
+    });
+
+    it('returns empty array when selector is missing', () => {
+      const data = JSON.parse(JSON.stringify(mockDeploymentData));
+      delete data.spec.selector;
+      const deployment = new Deployment(data);
+      expect(deployment.getMatchLabelsList()).toEqual([]);
+    });
+
+    it('returns empty array when spec is missing entirely', () => {
+      const data = JSON.parse(JSON.stringify(mockDeploymentData));
+      delete data.spec;
+      const deployment = new Deployment(data);
+      expect(deployment.getMatchLabelsList()).toEqual([]);
+    });
+  });
+
+  describe('getCurrentRevision', () => {
+    it('returns the revision annotation value', () => {
+      const deployment = new Deployment(JSON.parse(JSON.stringify(mockDeploymentData)));
+      expect(deployment.getCurrentRevision()).toBe('3');
+    });
+
+    it("returns '0' when the revision annotation is absent", () => {
+      const data = JSON.parse(JSON.stringify(mockDeploymentData));
+      delete data.metadata.annotations;
+      const deployment = new Deployment(data);
+      expect(deployment.getCurrentRevision()).toBe('0');
+    });
+  });
+
+  describe('rollback', () => {
+    it('returns error when target revision is missing spec.template', async () => {
+      const deployment = new Deployment(JSON.parse(JSON.stringify(mockDeploymentData)));
+
+      // Stub getOwnedReplicaSets
+      vi.spyOn(deployment, 'getOwnedReplicaSets').mockResolvedValue([
+        {
+          metadata: {
+            annotations: { 'deployment.kubernetes.io/revision': '3' },
+          },
+          spec: { template: { spec: {} } },
+        } as unknown as ReplicaSet,
+        {
+          metadata: {
+            annotations: { 'deployment.kubernetes.io/revision': '2' },
+          },
+          spec: {}, // Missing template
+        } as unknown as ReplicaSet,
+      ]);
+
+      const result = await deployment.rollback(2);
+      expect(result).toEqual({
+        success: false,
+        message: 'Revision 2 template not found',
+      });
+    });
+
+    it('returns error when target revision template is missing spec', async () => {
+      const deployment = new Deployment(JSON.parse(JSON.stringify(mockDeploymentData)));
+
+      // Stub getOwnedReplicaSets
+      vi.spyOn(deployment, 'getOwnedReplicaSets').mockResolvedValue([
+        {
+          metadata: {
+            annotations: { 'deployment.kubernetes.io/revision': '3' },
+          },
+          spec: { template: { spec: {} } },
+        } as unknown as ReplicaSet,
+        {
+          metadata: {
+            annotations: { 'deployment.kubernetes.io/revision': '2' },
+          },
+          spec: { template: {} }, // Missing template.spec
+        } as unknown as ReplicaSet,
+      ]);
+
+      const result = await deployment.rollback(2);
+      expect(result).toEqual({
+        success: false,
+        message: 'Revision 2 template not found',
+      });
+    });
+  });
+});

--- a/frontend/src/lib/k8s/deployment.ts
+++ b/frontend/src/lib/k8s/deployment.ts
@@ -177,8 +177,16 @@ class Deployment extends KubeObject<KubeDeployment> {
       const targetRS = targetEntry.rs;
       const targetRevision = targetEntry.revision;
 
+      const templateSpec = targetRS.spec?.template;
+      if (!templateSpec || !templateSpec.spec) {
+        return {
+          success: false,
+          message: `Revision ${targetRevision} template not found`,
+        };
+      }
+
       const template = JSON.parse(
-        JSON.stringify(targetRS.spec.template)
+        JSON.stringify(templateSpec)
       ) as KubeReplicaSet['spec']['template'];
 
       if (template.metadata?.labels?.['pod-template-hash']) {


### PR DESCRIPTION
## Summary

This PR improves frontend resilience around the `Deployment` Kube model by preventing null/undefined dereferences (notably in `rollback()` and `getMatchLabelsList()`), and adds unit tests to cover common and edge-case behaviors. It also introduces additional workload extraInfo unit tests and updates agent documentation.

## Related Issue

Fixes #6337 

## Changes

- **frontend/src/lib/k8s/deployment.ts**:
  - Hardened `Deployment.rollback()` against ReplicaSets missing `spec.template` (returns a clean failure result instead of crashing).
  - Made `Deployment.getMatchLabelsList()` safe when `spec/selector` are missing.
- **frontend/src/lib/k8s/deployment.test.ts**:
  - Added comprehensive unit tests (15 test cases) covering the `Deployment` model and new edge cases.
- **frontend/src/components/workload/extraInfo.test.tsx**:
  - Added a new test suite for workload extraInfo helpers (`formatDuration`, `deploymentExtraInfo`, `statefulSetExtraInfo`, `jobExtraInfo`).

## Steps to Test

1. Navigate to the frontend directory: `cd frontend`
2. Run the deployment tests: `npm run test -- deployment.test.ts`
3. Verify all 15 tests pass successfully.
4. Run the extraInfo tests: `npm run test -- extraInfo.test.tsx`
5. Verify all tests pass successfully.
6. Start the app locally and test a deployment rollback to ensure no UI crashes occur when templates are missing.
