### PR TITLE
backend: kubeconfig: derive in-cluster name from kubeadm-config

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -539,7 +539,9 @@ func flagset() *flag.FlagSet {
 func addGeneralFlags(f *flag.FlagSet) {
 	f.Bool("version", false, "Print version information and exit")
 	f.Bool("in-cluster", false, "Set when running from a k8s cluster")
-	f.String("in-cluster-context-name", "main", "Name to use for the in-cluster Kubernetes context")
+	f.String("in-cluster-context-name", "",
+		"Name to use for the in-cluster Kubernetes context. "+
+			"If unset, it is derived from the kube-system/kubeadm-config ConfigMap, falling back to \"main\"")
 	f.Bool("dev", false, "Allow connections from other origins")
 	f.Bool("cache-enabled", false, "K8s cache in backend")
 	f.Bool("no-browser", false, "Disable automatically opening the browser when using embedded frontend")

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -541,7 +541,8 @@ func addGeneralFlags(f *flag.FlagSet) {
 	f.Bool("in-cluster", false, "Set when running from a k8s cluster")
 	f.String("in-cluster-context-name", "",
 		"Name to use for the in-cluster Kubernetes context. "+
-			"If unset, it is derived from the kube-system/kubeadm-config ConfigMap, falling back to \"main\"")
+			"If unset, it is derived from the kube-system/kubeadm-config ConfigMap (treating \"kubernetes\" as unset), "+
+			"falling back to \"main\"")
 	f.Bool("dev", false, "Allow connections from other origins")
 	f.Bool("cache-enabled", false, "K8s cache in backend")
 	f.Bool("no-browser", false, "Disable automatically opening the browser when using embedded frontend")

--- a/backend/pkg/kubeconfig/export_test.go
+++ b/backend/pkg/kubeconfig/export_test.go
@@ -1,12 +1,16 @@
 package kubeconfig
 
-import "net/http"
+import (
+	"net/http"
+)
 
 // This file exports internal functions and types for testing purposes only.
 // These exports are only available during testing and won't be included in production builds.
 
 // BuildUserAgent is exported for testing.
 var BuildUserAgent = buildUserAgent
+
+var DeriveInClusterName = deriveInClusterName
 
 // UserAgentRoundTripper is exported for testing.
 type UserAgentRoundTripper struct {

--- a/backend/pkg/kubeconfig/export_test.go
+++ b/backend/pkg/kubeconfig/export_test.go
@@ -1,8 +1,6 @@
 package kubeconfig
 
-import (
-	"net/http"
-)
+import "net/http"
 
 // This file exports internal functions and types for testing purposes only.
 // These exports are only available during testing and won't be included in production builds.

--- a/backend/pkg/kubeconfig/incluster_name_test.go
+++ b/backend/pkg/kubeconfig/incluster_name_test.go
@@ -62,6 +62,13 @@ func TestDeriveInClusterName(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "kubeadm default clusterName is treated as unset",
+			configMap: kubeadmConfigMap(map[string]string{
+				"ClusterConfiguration": "clusterName: kubernetes\n",
+			}),
+			expectErr: true,
+		},
+		{
 			name: "malformed YAML",
 			configMap: kubeadmConfigMap(map[string]string{
 				"ClusterConfiguration": "clusterName: [unterminated",

--- a/backend/pkg/kubeconfig/incluster_name_test.go
+++ b/backend/pkg/kubeconfig/incluster_name_test.go
@@ -21,63 +21,63 @@ func kubeadmConfigMap(data map[string]string) *corev1.ConfigMap {
 	}
 }
 
-func TestDeriveInClusterName(t *testing.T) {
-	tests := []struct {
-		name      string
-		configMap *corev1.ConfigMap
-		expected  string
-		expectErr bool
-	}{
-		{
-			name: "derives clusterName from ClusterConfiguration",
-			configMap: kubeadmConfigMap(map[string]string{
-				"ClusterConfiguration": "apiVersion: kubeadm.k8s.io/v1beta3\nkind: ClusterConfiguration\nclusterName: my-cluster\n",
-			}),
-			expected: "my-cluster",
-		},
-		{
-			name:      "ConfigMap not found",
-			configMap: nil,
-			expectErr: true,
-		},
-		{
-			name: "missing ClusterConfiguration entry",
-			configMap: kubeadmConfigMap(map[string]string{
-				"other": "value",
-			}),
-			expectErr: true,
-		},
-		{
-			name: "ClusterConfiguration without clusterName",
-			configMap: kubeadmConfigMap(map[string]string{
-				"ClusterConfiguration": "apiVersion: kubeadm.k8s.io/v1beta3\nkind: ClusterConfiguration\n",
-			}),
-			expectErr: true,
-		},
-		{
-			name: "empty clusterName",
-			configMap: kubeadmConfigMap(map[string]string{
-				"ClusterConfiguration": "clusterName: \"   \"\n",
-			}),
-			expectErr: true,
-		},
-		{
-			name: "kubeadm default clusterName is treated as unset",
-			configMap: kubeadmConfigMap(map[string]string{
-				"ClusterConfiguration": "clusterName: kubernetes\n",
-			}),
-			expectErr: true,
-		},
-		{
-			name: "malformed YAML",
-			configMap: kubeadmConfigMap(map[string]string{
-				"ClusterConfiguration": "clusterName: [unterminated",
-			}),
-			expectErr: true,
-		},
-	}
+var deriveInClusterNameTests = []struct {
+	name      string
+	configMap *corev1.ConfigMap
+	expected  string
+	expectErr bool
+}{
+	{
+		name: "derives clusterName from ClusterConfiguration",
+		configMap: kubeadmConfigMap(map[string]string{
+			"ClusterConfiguration": "apiVersion: kubeadm.k8s.io/v1beta3\nkind: ClusterConfiguration\nclusterName: my-cluster\n",
+		}),
+		expected: "my-cluster",
+	},
+	{
+		name:      "ConfigMap not found",
+		configMap: nil,
+		expectErr: true,
+	},
+	{
+		name: "missing ClusterConfiguration entry",
+		configMap: kubeadmConfigMap(map[string]string{
+			"other": "value",
+		}),
+		expectErr: true,
+	},
+	{
+		name: "ClusterConfiguration without clusterName",
+		configMap: kubeadmConfigMap(map[string]string{
+			"ClusterConfiguration": "apiVersion: kubeadm.k8s.io/v1beta3\nkind: ClusterConfiguration\n",
+		}),
+		expectErr: true,
+	},
+	{
+		name: "empty clusterName",
+		configMap: kubeadmConfigMap(map[string]string{
+			"ClusterConfiguration": "clusterName: \"   \"\n",
+		}),
+		expectErr: true,
+	},
+	{
+		name: "kubeadm default clusterName is treated as unset",
+		configMap: kubeadmConfigMap(map[string]string{
+			"ClusterConfiguration": "clusterName: kubernetes\n",
+		}),
+		expectErr: true,
+	},
+	{
+		name: "malformed YAML",
+		configMap: kubeadmConfigMap(map[string]string{
+			"ClusterConfiguration": "clusterName: [unterminated",
+		}),
+		expectErr: true,
+	},
+}
 
-	for _, tt := range tests {
+func TestDeriveInClusterName(t *testing.T) {
+	for _, tt := range deriveInClusterNameTests {
 		t.Run(tt.name, func(t *testing.T) {
 			var clientset *fake.Clientset
 			if tt.configMap != nil {

--- a/backend/pkg/kubeconfig/incluster_name_test.go
+++ b/backend/pkg/kubeconfig/incluster_name_test.go
@@ -1,0 +1,94 @@
+package kubeconfig //nolint:testpackage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func kubeadmConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubeadm-config",
+			Namespace: "kube-system",
+		},
+		Data: data,
+	}
+}
+
+func TestDeriveInClusterName(t *testing.T) {
+	tests := []struct {
+		name      string
+		configMap *corev1.ConfigMap
+		expected  string
+		expectErr bool
+	}{
+		{
+			name: "derives clusterName from ClusterConfiguration",
+			configMap: kubeadmConfigMap(map[string]string{
+				"ClusterConfiguration": "apiVersion: kubeadm.k8s.io/v1beta3\nkind: ClusterConfiguration\nclusterName: my-cluster\n",
+			}),
+			expected: "my-cluster",
+		},
+		{
+			name:      "ConfigMap not found",
+			configMap: nil,
+			expectErr: true,
+		},
+		{
+			name: "missing ClusterConfiguration entry",
+			configMap: kubeadmConfigMap(map[string]string{
+				"other": "value",
+			}),
+			expectErr: true,
+		},
+		{
+			name: "ClusterConfiguration without clusterName",
+			configMap: kubeadmConfigMap(map[string]string{
+				"ClusterConfiguration": "apiVersion: kubeadm.k8s.io/v1beta3\nkind: ClusterConfiguration\n",
+			}),
+			expectErr: true,
+		},
+		{
+			name: "empty clusterName",
+			configMap: kubeadmConfigMap(map[string]string{
+				"ClusterConfiguration": "clusterName: \"   \"\n",
+			}),
+			expectErr: true,
+		},
+		{
+			name: "malformed YAML",
+			configMap: kubeadmConfigMap(map[string]string{
+				"ClusterConfiguration": "clusterName: [unterminated",
+			}),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var clientset *fake.Clientset
+			if tt.configMap != nil {
+				clientset = fake.NewSimpleClientset(tt.configMap)
+			} else {
+				clientset = fake.NewSimpleClientset()
+			}
+
+			name, err := deriveInClusterName(context.Background(), clientset)
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Empty(t, name)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, name)
+		})
+	}
+}

--- a/backend/pkg/kubeconfig/incluster_name_test.go
+++ b/backend/pkg/kubeconfig/incluster_name_test.go
@@ -1,4 +1,4 @@
-package kubeconfig //nolint:testpackage
+package kubeconfig_test
 
 import (
 	"context"
@@ -9,6 +9,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
 )
 
 func kubeadmConfigMap(data map[string]string) *corev1.ConfigMap {
@@ -86,7 +88,7 @@ func TestDeriveInClusterName(t *testing.T) {
 				clientset = fake.NewSimpleClientset()
 			}
 
-			name, err := deriveInClusterName(context.Background(), clientset)
+			name, err := kubeconfig.DeriveInClusterName(context.Background(), clientset)
 			if tt.expectErr {
 				require.Error(t, err)
 				assert.Empty(t, name)

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -1,6 +1,7 @@
 package kubeconfig
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1053,6 +1055,60 @@ func resolveServiceAccountTokenPath(clusterConfig *rest.Config, serviceAccountTo
 	return "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101
 }
 
+// deriveInClusterNameTimeout bounds the kubeadm-config lookup so it cannot block startup.
+const deriveInClusterNameTimeout = 10 * time.Second
+
+// deriveInClusterName reads the cluster name from the kube-system/kubeadm-config
+// ConfigMap, which kubeadm and KiND populate at creation time. It returns an error
+// when the ConfigMap, the ClusterConfiguration key, or the clusterName field is missing.
+func deriveInClusterName(ctx context.Context, clientset kubernetes.Interface) (string, error) {
+	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get(ctx, "kubeadm-config", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	clusterConfiguration, ok := cm.Data["ClusterConfiguration"]
+	if !ok {
+		return "", errors.New("kubeadm-config ConfigMap has no ClusterConfiguration entry")
+	}
+
+	var parsed struct {
+		ClusterName string `yaml:"clusterName"`
+	}
+
+	if err := yaml.Unmarshal([]byte(clusterConfiguration), &parsed); err != nil {
+		return "", fmt.Errorf("parsing kubeadm ClusterConfiguration: %w", err)
+	}
+
+	name := strings.TrimSpace(parsed.ClusterName)
+	if name == "" {
+		return "", errors.New("kubeadm ClusterConfiguration has no clusterName")
+	}
+
+	return name, nil
+}
+
+func deriveInClusterContextName(clusterConfig *rest.Config) string {
+	clientset, err := kubernetes.NewForConfig(clusterConfig)
+	if err != nil {
+		logger.Log(logger.LevelInfo, nil, err, "deriving in-cluster context name: creating clientset")
+
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), deriveInClusterNameTimeout)
+	defer cancel()
+
+	name, err := deriveInClusterName(ctx, clientset)
+	if err != nil {
+		logger.Log(logger.LevelInfo, nil, err, "deriving in-cluster context name from kubeadm-config")
+
+		return ""
+	}
+
+	return name
+}
+
 // GetInClusterContext returns the in-cluster context.
 func GetInClusterContext(
 	contextName string,
@@ -1067,6 +1123,10 @@ func GetInClusterContext(
 	clusterConfig, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
+	}
+
+	if strings.TrimSpace(contextName) == "" {
+		contextName = deriveInClusterContextName(clusterConfig)
 	}
 
 	return newInClusterContextFromConfig(

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -1055,12 +1055,13 @@ func resolveServiceAccountTokenPath(clusterConfig *rest.Config, serviceAccountTo
 	return "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec G101
 }
 
-// deriveInClusterNameTimeout bounds the kubeadm-config lookup so it cannot block startup.
-const deriveInClusterNameTimeout = 10 * time.Second
+// deriveInClusterNameTimeout bounds the kubeadm-config lookup so it cannot block startup indefinitely.
+const deriveInClusterNameTimeout = 2 * time.Second
 
 // deriveInClusterName reads the cluster name from the kube-system/kubeadm-config
 // ConfigMap, which kubeadm and KiND populate at creation time. It returns an error
-// when the ConfigMap, the ClusterConfiguration key, or the clusterName field is missing.
+// when the ConfigMap, the ClusterConfiguration key, or the clusterName field is missing
+// (or when clusterName is kubeadm's default "kubernetes").
 func deriveInClusterName(ctx context.Context, clientset kubernetes.Interface) (string, error) {
 	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get(ctx, "kubeadm-config", metav1.GetOptions{})
 	if err != nil {
@@ -1082,7 +1083,7 @@ func deriveInClusterName(ctx context.Context, clientset kubernetes.Interface) (s
 
 	name := strings.TrimSpace(parsed.ClusterName)
 	if name == "" || strings.EqualFold(name, "kubernetes") {
-		return "", errors.New("kubeadm ClusterConfiguration has no clusterName")
+		return "", errors.New("kubeadm ClusterConfiguration clusterName is empty or default (kubernetes)")
 	}
 
 	return name, nil

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -1081,7 +1081,7 @@ func deriveInClusterName(ctx context.Context, clientset kubernetes.Interface) (s
 	}
 
 	name := strings.TrimSpace(parsed.ClusterName)
-	if name == "" {
+	if name == "" || strings.EqualFold(name, "kubernetes") {
 		return "", errors.New("kubeadm ClusterConfiguration has no clusterName")
 	}
 

--- a/e2e-tests/kubernetes-headlamp-incluster-ci.yaml
+++ b/e2e-tests/kubernetes-headlamp-incluster-ci.yaml
@@ -47,6 +47,7 @@ spec:
         args:
         - "-in-cluster"
         - "-enable-helm"
+        - "-in-cluster-context-name=main"
         ports:
         - name: http
           containerPort: 4466


### PR DESCRIPTION
## Summary

This PR adds automatic derivation of the in-cluster context name by reading the cluster name that kubeadm records at creation time, so operators no longer have to set `--in-cluster-context-name` manually. When the name is left unset, it is derived from the `kube-system/kubeadm-config` ConfigMap; if that lookup fails, it falls back to the existing `"main"` default.

## Related Issue

Fixes #6216

## Changes

- Updated `backend/pkg/config/config.go`: changed the `--in-cluster-context-name` flag default from `"main"` to `""`, and updated its help text to document the derivation + `"main"` fallback.
- Added `deriveInClusterName()` in `backend/pkg/kubeconfig/kubeconfig.go`: reads `kube-system/kubeadm-config`, parses the `ClusterConfiguration` YAML, and returns its `clusterName` field (with explicit errors for a missing ConfigMap/key/empty name).
- Added `deriveInClusterContextName()`: a best-effort wrapper with a 2s timeout that returns `""` on any failure so it can never block startup.
- Updated `GetInClusterContext()`: derives the name when unset; `newInClusterContextFromConfig()` still falls back to `DefaultInClusterContextName` (`"main"`) if derivation yields nothing.
- Added `backend/pkg/kubeconfig/incluster_name_test.go`: unit tests for successful derivation and the missing-ConfigMap, missing-key, empty-name, and malformed-YAML paths.

## Steps to Test

1. Create a cluster that populates `kubeadm-config` (e.g. `kind create cluster` or a kubeadm deployment) and confirm the ConfigMap exists:
   ```bash
   kubectl -n kube-system get cm kubeadm-config -o yaml
   ```
   (note the `clusterName` under `ClusterConfiguration`).

2. Deploy Headlamp in-cluster without setting `--in-cluster-context-name`.

3. Observe that the cluster appears in the UI under its derived name (the `clusterName` value) rather than `main`.

4. Redeploy with `--in-cluster-context-name=my-name` and confirm the explicit value is used unchanged.

5. On a cluster where the ServiceAccount cannot read `kubeadm-config` (or the ConfigMap is absent), confirm Headlamp still starts and falls back to `main` (an info-level log notes the derivation failure).

6. Run the unit tests:
   ```bash
   cd backend
   go test ./pkg/kubeconfig/ ./pkg/config/.
   ```

## Notes for the Reviewer

- Reading `kube-system/kubeadm-config` requires RBAC read on that ConfigMap. The chart's default `clusterRoleName: cluster-admin` covers it out of the box; restricted RBAC setups degrade gracefully to `main`, so no chart change was needed — flag if you'd prefer an explicit RBAC rule added.
- The lookup is intentionally best-effort and time-bounded (2s) so it cannot block or fail startup.
- This is aimed at kubeadm/KiND clusters (the mechanism the issue references). Non-kubeadm in-cluster deployments simply keep the `main` default.


