### PR TITLE
docs: Add missing JSDoc comments to API endpoints

### DIFF
--- a/frontend/src/lib/k8s/api/v1/drainNode.ts
+++ b/frontend/src/lib/k8s/api/v1/drainNode.ts
@@ -57,7 +57,7 @@ export function drainNode(cluster: string, nodeName: string) {
  * Represents the current status of a node drain operation.
  */
 interface DrainNodeStatus {
-  /** The unique identifier representing the drain operation. */
+  /** Status of the drain operation (e.g., 'success' or an 'error: ...' message). */
   id: string;
   /** The name of the cluster where the node is being drained. */
   cluster: string;

--- a/frontend/src/lib/k8s/api/v1/drainNode.ts
+++ b/frontend/src/lib/k8s/api/v1/drainNode.ts
@@ -53,10 +53,13 @@ export function drainNode(cluster: string, nodeName: string) {
   });
 }
 
-// @todo: needs documenting.
-
+/**
+ * Represents the current status of a node drain operation.
+ */
 interface DrainNodeStatus {
-  id: string; //@todo: what is this and what is it for?
+  /** The unique identifier representing the drain operation. */
+  id: string;
+  /** The name of the cluster where the node is being drained. */
   cluster: string;
 }
 
@@ -70,7 +73,7 @@ interface DrainNodeStatus {
  * @param cluster - The cluster to get the status of the drain node process for.
  * @param nodeName - The node name to get the status of the drain node process for.
  *
- * @returns - The response from the API. @todo: what response?
+ * @returns A promise that resolves to the current status of the drain node process.
  * @throws {Error} if the request fails
  * @throws {Error} if the response is not ok
  */

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -116,7 +116,7 @@ export function streamResult<T extends KubeObjectInterface>(
  * @param errCb - The callback function to execute when an error occurs.
  * @param queryParams - The query parameters to include in the API request.
  *
- * @returns A function to cancel the stream.
+ * @returns A promise that resolves to a function which can be called to cancel the stream.
  */
 export function streamResults<T extends KubeObjectInterface>(
   url: string,
@@ -400,11 +400,15 @@ export async function connectStream<T>(
   });
 }
 
-// @todo: needs documenting.
-
+/**
+ * Configuration options for establishing a stream.
+ */
 interface StreamParams {
+  /** The name of the cluster to connect to. */
   cluster?: string;
+  /** Whether the stream is expected to receive JSON data. */
   isJson?: boolean;
+  /** Additional WebSocket protocols to use when connecting. */
   additionalProtocols?: string[];
 }
 

--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -128,7 +128,10 @@ export function streamResults<T extends KubeObjectInterface>(
   return streamResultsForCluster(url, { cb, errCb, cluster }, queryParams);
 }
 
-// @todo: this interface needs documenting.
+/**
+ * Configuration options for establishing a stream to a cluster.
+ * Groups the cluster name along with the callbacks used to process incoming data and errors.
+ */
 
 export interface StreamResultsParams {
   cb: StreamResultsCb;
@@ -136,7 +139,14 @@ export interface StreamResultsParams {
   cluster?: string;
 }
 
-// @todo: needs documenting
+/**
+ * Establishes a stream to the Kubernetes API for a specific cluster.
+ *
+ * @param url - The Kubernetes API endpoint to stream from.
+ * @param params - The callback functions and cluster information.
+ * @param queryParams - Optional query parameters to append to the request.
+ * @returns A promise that resolves to a function which can be called to cancel the stream.
+ */
 
 export function streamResultsForCluster(
   url: string,


### PR DESCRIPTION
## Summary

This PR adds missing JSDoc comments to the frontend API layer, replacing old `@todo` placeholders with proper documentation to improve developer experience.

## Related Issue


## Changes

- **Updated** `drainNode.ts`: Added JSDoc blocks for the `DrainNodeStatus` interface and documented the return promise for the `drainNodeStatus` function.
- **Updated** `streamingApi.ts`: Added JSDoc blocks clarifying the internal configuration structure of `StreamResultsParams` and the behavior of the `streamResultsForCluster` streaming function.
- **Fixed** various `// @todo: needs documenting` comments scattered throughout the API files.

## Steps to Test
1. Open `frontend/src/lib/k8s/api/v1/drainNode.ts` and `frontend/src/lib/k8s/api/v1/streamingApi.ts` in an IDE 
2. Hover over the `DrainNodeStatus` type or the `StreamResultsParams` interface.
3. Observe that the tooltip successfully renders the new JSDoc descriptions.

## Screenshots (if applicable)


## Notes for the Reviewer
- These are simple cleanup tasks targeting `@todo` comments left by previous developers. No logic changes were made, only JSDoc additions to improve code readability and editor tooling support.
