### PR TITLE
frontend: oidcauth: Fix Safari OIDC login stuck due to ITP storage event suppression

### DIFF
--- a/frontend/src/components/oidcauth/OauthPopup.test.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.test.tsx
@@ -64,7 +64,7 @@ describe('OauthPopup', () => {
     expect(popupWindow.close).toHaveBeenCalled();
   });
 
-  it('removes the storage listener when the popup closes without completing auth', () => {
+  it('removes the storage listener when the popup closes without completing auth', async () => {
     const popupListeners: Record<string, () => void> = {};
     const popupWindow = {
       addEventListener: vi.fn((eventName: string, listener: () => void) => {
@@ -74,6 +74,7 @@ describe('OauthPopup', () => {
       close: vi.fn(),
     } as unknown as Window;
 
+    vi.useFakeTimers();
     vi.spyOn(window, 'open').mockReturnValue(popupWindow);
     const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
     const onClose = vi.fn();
@@ -94,8 +95,13 @@ describe('OauthPopup', () => {
 
     popupListeners.beforeunload?.();
 
+    // beforeUnloadListener defers via setTimeout(..., 0) — flush it
+    await vi.runAllTimersAsync();
+
     expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
     expect(onClose).toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 
   it('closes the popup and removes listeners when auth completes', () => {
@@ -137,5 +143,104 @@ describe('OauthPopup', () => {
       popupListeners.beforeunload
     );
     expect(popupWindow.close).toHaveBeenCalled();
+  });
+
+  it('completes auth when beforeunload fires after localStorage is set (Safari ITP)', async () => {
+    // Safari suppresses the cross-window storage event due to ITP, so the
+    // parent relies on beforeunload + a deferred localStorage check.
+    const popupListeners: Record<string, () => void> = {};
+    const popupWindow = {
+      addEventListener: vi.fn((eventName: string, listener: () => void) => {
+        popupListeners[eventName] = listener;
+      }),
+      removeEventListener: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+    vi.useFakeTimers();
+
+    const onCode = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={onCode}
+        onClose={onClose}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+    // Simulate: popup sets localStorage, then beforeunload fires
+    localStorage.setItem(AUTH_STATUS_KEY, 'success');
+    popupListeners.beforeunload?.();
+
+    // Flush the setTimeout(..., 0) inside beforeUnloadListener
+    await vi.runAllTimersAsync();
+
+    expect(onCode).toHaveBeenCalledWith('success');
+    expect(localStorage.getItem(AUTH_STATUS_KEY)).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it('completes auth when interval detects closed popup with localStorage set (Safari ITP)', () => {
+    // Safari may not fire beforeunload reliably either; the interval is the
+    // last-resort check and must read localStorage when the popup is closed.
+    let isClosed = false;
+    const popupWindow = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      close: vi.fn(),
+      get closed() {
+        return isClosed;
+      },
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+
+    // Capture the interval callback so we can invoke it directly
+    let intervalCallback: (() => void) | null = null;
+    vi.spyOn(window, 'setInterval').mockImplementation((fn: TimerHandler) => {
+      intervalCallback = fn as () => void;
+      return 0 as unknown as ReturnType<typeof setInterval>;
+    });
+
+    const onCode = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={onCode}
+        onClose={onClose}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+    expect(intervalCallback).not.toBeNull();
+
+    // Simulate: popup sets localStorage then closes
+    localStorage.setItem(AUTH_STATUS_KEY, 'success');
+    isClosed = true;
+
+    // Trigger the interval callback manually
+    intervalCallback!();
+
+    expect(onCode).toHaveBeenCalledWith('success');
+    expect(localStorage.getItem(AUTH_STATUS_KEY)).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -41,10 +41,16 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
   const externalWindowRef = React.useRef<Window | null>(null);
   const storageListenerRef = React.useRef<(() => void) | null>(null);
   const beforeUnloadListenerRef = React.useRef<(() => void) | null>(null);
+  const intervalRef = React.useRef<number | null>(null);
 
   const cleanupPopup = React.useCallback(
     (closeWindow = false) => {
       const popupWindow = externalWindowRef.current;
+
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
 
       if (storageListenerRef.current) {
         window.removeEventListener('storage', storageListenerRef.current);
@@ -106,14 +112,65 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
     storageListenerRef.current = storageListener;
     window.addEventListener('storage', storageListener);
 
+    intervalRef.current = window.setInterval(() => {
+      if (externalWindowRef.current?.closed) {
+        // Check localStorage before treating the close as a cancellation.
+        // In Safari the storage event is unreliable, so the interval is the
+        // primary detection mechanism and must read localStorage here too.
+        try {
+          const authStatus = localStorage.getItem(AUTH_STATUS_KEY);
+          if (authStatus) {
+            onCode(authStatus);
+            localStorage.removeItem(AUTH_STATUS_KEY);
+            cleanupPopup(true);
+            return;
+          }
+        } catch (e) {
+          console.error('Error occurred while closing auth window', e);
+        }
+        cleanupPopup();
+        if (!!props.onClose) {
+          props.onClose();
+        }
+        return;
+      }
+
+      try {
+        const authStatus = localStorage.getItem(AUTH_STATUS_KEY);
+        if (authStatus) {
+          onCode(authStatus);
+          localStorage.removeItem(AUTH_STATUS_KEY);
+          cleanupPopup(true);
+        }
+      } catch (e) {
+        // ignore
+      }
+    }, 500);
+
     if (externalWindowRef.current) {
       try {
         const beforeUnloadListener = () => {
-          cleanupPopup();
-          externalWindowRef.current = null;
-          if (!!props.onClose) {
-            props.onClose();
-          }
+          // Safari fires beforeunload before the popup's useEffect has committed
+          // the localStorage write, and also suppresses the cross-window storage
+          // event due to ITP. Defer by one task so localStorage is readable.
+          setTimeout(() => {
+            try {
+              const authStatus = localStorage.getItem(AUTH_STATUS_KEY);
+              if (authStatus) {
+                onCode(authStatus);
+                localStorage.removeItem(AUTH_STATUS_KEY);
+                cleanupPopup(true);
+                return;
+              }
+            } catch (e) {
+              console.error('Error occurred while closing auth window', e);
+            }
+            cleanupPopup();
+            externalWindowRef.current = null;
+            if (!!props.onClose) {
+              props.onClose();
+            }
+          }, 0);
         };
 
         externalWindowRef.current.addEventListener('beforeunload', beforeUnloadListener, false);


### PR DESCRIPTION
Safari's ITP suppresses cross-window storage events, causing the OIDC popup auth flow to get stuck. The beforeUnloadListener and the setInterval closed-window branch both called onClose() without checking localStorage first.

Fix both paths to read AUTH_STATUS_KEY from localStorage before treating the popup close as a cancellation. Use setTimeout(..., 0) in beforeUnloadListener to ensure the popup's useEffect has committed the write.

## Summary

This PR fixes a bug where in-cluster OIDC login gets stuck when using the Safari browser. Safari's Intelligent Tracking Prevention (ITP) suppresses the cross-window storage events that the main window relies on. The fallback mechanisms (beforeunload and window polling) were incorrectly treating the popup closing as a login cancellation without first checking if the auth token was successfully written to localStorage.

## Related Issue

Fixes #6353

## Changes

- Updated `OauthPopup.tsx` `beforeUnloadListener` to defer checking `localStorage` (via `setTimeout(..., 0)`) before triggering cancellation.
- Updated `OauthPopup.tsx` `setInterval` closed-window fallback to read `localStorage` for completed auth before triggering `onClose()`.
- Added two new Safari-specific test cases in `OauthPopup.test.tsx` to cover the ITP fallback scenarios.
- Updated an existing test in `OauthPopup.test.tsx` to correctly handle the now-asynchronous `beforeUnloadListener`.

## Steps to Test

1. Deploy Headlamp in in-cluster mode with OIDC authentication configured.
2. Open Headlamp using the Safari browser.
3. Click on "Sign in" to open the OIDC auth popup.
4. Complete the authentication flow in the popup.
5. Observe that the popup closes and the main window successfully redirects and logs you in, rather than getting stuck waiting.

## Screenshots (if applicable)
*(N/A - underlying logic fix)*

## Notes for the Reviewer

- The `setTimeout(..., 0)` used in `beforeUnloadListener` is a workaround for a timing issue specific to Safari where `beforeunload` can fire before the popup window's React `useEffect` commits the `localStorage` write. Deferring the check to the next event loop tick ensures the data is readable.
