### PR TITLE
frontend: GlobalSearch: Support namespace-based matching and display

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -79,11 +79,13 @@ interface SearchResult {
   label: string;
   icon?: JSX.Element;
   subLabel?: string;
+  namespace?: string;
   k8sLabels?: string[];
   onClick: () => void;
   labelMatch?: FuseResultMatch;
   subLabelMatch?: FuseResultMatch;
   k8sLabelsMatch?: FuseResultMatch;
+  namespaceMatch?: FuseResultMatch;
 }
 
 /**
@@ -148,7 +150,8 @@ function makeKubeObjectResults(
             <LazyKubeIcon kind={item.kind} width="24px" height="24px" />
           </Suspense>
         ),
-        subLabel: item.kind,
+        namespace: item.metadata.namespace,
+        subLabel: item.metadata.namespace ? `${item.kind} • ${item.metadata.namespace}` : item.kind,
         onClick: () => onClick(item),
       })) ?? []
   );
@@ -391,6 +394,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
         keys: [
           'label',
           'k8sLabels',
+          'namespace',
           // We also want to search by subLabel sometimes
           // For example 'default namespace' (there are a lot of objects with 'default' name)
           // But it shouldn't be main field so it has half the weight (1/2)
@@ -418,6 +422,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
                 // Only search labels if there's an "=" character in the query
                 it.includes('=') ? { k8sLabels: it } : undefined,
                 { subLabel: it },
+                { namespace: it },
               ].filter(Boolean) as Expression[],
             })),
         },
@@ -430,6 +435,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
             labelMatch: matches?.find(it => it.key === 'label'),
             subLabelMatch: matches?.find(it => it.key === 'subLabel'),
             k8sLabelsMatch: matches?.find(it => it.key === 'k8sLabels'),
+            namespaceMatch: matches?.find(it => it.key === 'namespace'),
           } satisfies SearchResult)
       );
   }, [query, fuse]);

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.FoundSomeResults.stories.storyshot
@@ -221,6 +221,7 @@
                 >
                   Pod
                 </span>
+                 • default
               </span>
               <div
                 class="MuiBox-root css-72rvq0"
@@ -379,6 +380,7 @@
                 >
                   Pod
                 </span>
+                 • default
               </span>
               <div
                 class="MuiBox-root css-72rvq0"
@@ -537,6 +539,7 @@
                 >
                   Pod
                 </span>
+                 • default
               </span>
               <div
                 class="MuiBox-root css-72rvq0"
@@ -695,6 +698,7 @@
                 >
                   Pod
                 </span>
+                 • default
               </span>
               <div
                 class="MuiBox-root css-72rvq0"
@@ -853,6 +857,7 @@
                 >
                   Pod
                 </span>
+                 • default
               </span>
               <div
                 class="MuiBox-root css-72rvq0"


### PR DESCRIPTION
## Summary

This PR adds namespace support to the global search. Namespaced resources can now be searched by namespace, and the namespace is shown alongside the resource kind in the results, making it much easier to tell apart resources with the same name.

---

## Related Issue

No related issue. I came across this while working in the area and fixed it directly.

---

## Changes

- ✅ Added a `namespace` field to the `SearchResult` type.
- ✅ Updated `makeKubeObjectResults` to include the resource namespace in the `subLabel` for namespaced resources (for example, `Pod - kube-system`). Cluster-scoped resources are unchanged.
- ✅ Added a `{ namespace: it }` clause to the extended Fuse query's per-term `$or` list, so namespace terms are actually searched. Since this code uses Fuse's extended `$and`/`$or` query syntax, only the fields listed in each query term are considered—the top-level `keys` config doesn't apply here.
- ✅ Added a `namespaceMatch` field to keep things consistent with the existing match fields (`labelMatch`, `subLabelMatch`, and `k8sLabelsMatch`).

---

## Steps to Test

1. Open the global search bar in a cluster with multiple namespaces.
2. Search for a namespace name (for example, `kube-system`) and verify resources from that namespace appear.
3. Search using both a resource name and namespace (for example, `core-dns kube-system`) and confirm it returns the expected result.
4. Verify that resources with the same name in different namespaces (for example, two pods named `web`) are now easy to distinguish in the results.
5. Confirm cluster-scoped resources (such as Nodes) still appear as before without a namespace suffix.

---

## Notes for the Reviewer

- ℹ️ No new search UI was introduced. `subLabel` is still a single string, so the existing `HighlightText` logic continues to highlight `label`, `subLabel`, and `k8sLabels` matches as before.
- ℹ️ One small limitation: matches found only through the new `namespace` field aren't highlighted yet. `namespaceMatch` returns offsets for the raw namespace string, which don't line up with the combined `subLabel` text. Searching and filtering work correctly; only the visual highlighting for that case would need a small follow-up.
- 📸 Updated `GlobalSearchContent.FoundSomeResults.stories.storyshot` to reflect the new `subLabel` format and the new `namespaceMatch` field.
- ✅ `npx vitest run src/storybook.test.tsx -t "GlobalSearchContent"` passes (`2 passed`).
- ✅ `npm run lint` passes clean.