### PR TITLE
frontend: activity: Wrap Close button aria-label with t()

### DIFF
--- a/frontend/src/components/activity/Activity.tsx
+++ b/frontend/src/components/activity/Activity.tsx
@@ -1212,7 +1212,7 @@ export const ActivityBar = React.memo(function ({
               Activity.close(it.id);
             }}
             sx={{ width: '42px', height: '100%', borderRadius: 1, flexShrink: 0 }}
-            aria-label="Close"
+            aria-label={t('Close')}
           >
             <Icon icon="mdi:close" />
           </IconButton>

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "Schließen",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "Cerrar",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "Fermer",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "बंद करें",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "Chiudi",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "閉じる",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "닫기",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "Fechar",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "மூடு",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "關閉",
   "Close All": "",
   "Overview": "",
   "Loading": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -16,7 +16,7 @@
   "Snap Top": "",
   "Snap Bottom": "",
   "Minimize": "",
-  "Close": "",
+  "Close": "关闭",
   "Close All": "",
   "Overview": "",
   "Loading": "",


### PR DESCRIPTION
The 'Close' IconButton in ActivityBar had its aria-label hardcoded as the
English string "Close" while every other aria-label in the same component
(Window, Fullscreen, Snap Left/Right/Top/Bottom, Overview) correctly uses
the t() translation helper.

Wrap it in t('Close') for consistency and to ensure screen readers announce
the label in the user's chosen language.

## Summary

Fixes a missed `t()` wrap on the ActivityBar close button's `aria-label`.
Every other button in the same component was already translated — this one
got skipped.

## Related Issue

Fixes #6350

## Changes

- `Activity.tsx`: `aria-label="Close"` → `aria-label={t('Close')}`
- Added missing `"Close"` translations for 11 locales (de, es, fr, hi, it,
  ja, ko, pt, ta, zh, zh-tw) that previously had empty strings and were
  silently falling back to English

## Steps to Test

1. Switch Headlamp to any non-English language (Settings → General → Language)
2. Open pod logs or a terminal so the ActivityBar appears at the bottom
3. Use a screen reader or inspect the × button in the activity bar —
   the `aria-label` should now reflect the translated string

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- `"Close"` already existed as a key in all locale files but 11 of them
  had empty string values — with `returnEmptyString:false` in the i18next
  config, those fell back to English silently
- ar, bn, ru, ur already had correct translations; he and en were fine as-is