### PR TITLE
frontend: multiplexer: Reconnect after unexpected disconnect

### DIFF
--- a/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.test.ts
@@ -91,6 +91,11 @@ describe('WebSocket Multiplexer', () => {
     WebSocketManager.activeSubscriptions.clear();
     WebSocketManager.pendingUnsubscribes.forEach(clearTimeout);
     WebSocketManager.pendingUnsubscribes.clear();
+    if (WebSocketManager.reconnectTimer) {
+      clearTimeout(WebSocketManager.reconnectTimer);
+    }
+    WebSocketManager.reconnectTimer = null;
+    WebSocketManager.reconnectAttempts = 0;
   });
 
   describe('WebSocketManager', () => {
@@ -571,6 +576,132 @@ describe('WebSocket Multiplexer', () => {
       expect(WebSocketManager.isReconnecting).toBe(false);
 
       newServer.close();
+    });
+
+    it('should automatically reconnect and resubscribe after a close, with no manual connect() call', async () => {
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
+
+      // Establish the first connection with real timers.
+      await WebSocketManager.subscribe(clusterName, path, query, onMessage);
+      await mockServer.connected;
+      await mockServer.nextMessage; // Skip initial subscription
+
+      mockServer.close();
+      expect(WebSocketManager.isReconnecting).toBe(true);
+      expect(WebSocketManager.reconnectTimer).not.toBeNull();
+
+      // mock-socket only allows one server per URL, so create the replacement after closing the old one.
+      const newServer = new WS(`${BASE_WS_URL}${MULTIPLEXER_ENDPOINT}`);
+
+      // Real timers throughout: this is an end-to-end check that a real reconnect
+      // handshake happens with no manual connect() call, so there's a genuine ~1s
+      // wait here. Exact backoff timing is verified separately, under fake timers,
+      // by the "back off exponentially" test below (which mocks connect()).
+      await newServer.connected;
+
+      const resubMsg = JSON.parse((await newServer.nextMessage) as string);
+      expect(resubMsg).toEqual({
+        clusterId: clusterName,
+        path,
+        query,
+        userId,
+        type: 'REQUEST',
+      });
+
+      expect(WebSocketManager.isReconnecting).toBe(false);
+      expect(WebSocketManager.reconnectAttempts).toBe(0);
+      expect(WebSocketManager.reconnectTimer).toBeNull();
+
+      WebSocketManager.activeSubscriptions.clear();
+      newServer.close();
+    });
+
+    it('should back off exponentially between reconnect attempts, capped at 30s', async () => {
+      vi.useFakeTimers();
+
+      try {
+        // Seed the expected reconnect state before calling scheduleReconnect() directly.
+        WebSocketManager.activeSubscriptions.set('backoff-test-key', {
+          clusterId: clusterName,
+          path: '/api/v1/pods',
+          query: '',
+        });
+
+        // Verify backoff behaviorally: connect() shouldn't fire before the expected delay, only after.
+        const connectSpy = vi.spyOn(WebSocketManager, 'connect').mockResolvedValue({} as WebSocket);
+
+        const clearPending = () => {
+          if (WebSocketManager.reconnectTimer) {
+            clearTimeout(WebSocketManager.reconnectTimer);
+          }
+          WebSocketManager.reconnectTimer = null;
+          WebSocketManager.reconnectAttempts = 0;
+          connectSpy.mockClear();
+        };
+
+        WebSocketManager.reconnectAttempts = 0;
+        WebSocketManager.scheduleReconnect();
+        await vi.advanceTimersByTimeAsync(1000 - 1);
+        expect(connectSpy).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(connectSpy).toHaveBeenCalledTimes(1);
+        clearPending();
+
+        WebSocketManager.reconnectAttempts = 3;
+        WebSocketManager.scheduleReconnect();
+        await vi.advanceTimersByTimeAsync(8000 - 1);
+        expect(connectSpy).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(connectSpy).toHaveBeenCalledTimes(1);
+        clearPending();
+
+        // 2 ** 10 * 1000 would be far beyond the 30s cap.
+        WebSocketManager.reconnectAttempts = 10;
+        WebSocketManager.scheduleReconnect();
+        await vi.advanceTimersByTimeAsync(30000 - 1);
+        expect(connectSpy).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(connectSpy).toHaveBeenCalledTimes(1);
+        clearPending();
+      } finally {
+        vi.useRealTimers();
+        WebSocketManager.activeSubscriptions.clear();
+        WebSocketManager.reconnectAttempts = 0;
+        vi.restoreAllMocks();
+      }
+    });
+
+    it('should cancel a pending reconnect once the last active subscription is removed', async () => {
+      const path = '/api/v1/pods';
+      const query = 'watch=true';
+
+      // Real timers here - the mock server handshake needs real async timing.
+      const cleanup = await WebSocketManager.subscribe(clusterName, path, query, onMessage);
+      await mockServer.connected;
+      await mockServer.nextMessage; // Skip initial subscription
+
+      vi.useFakeTimers();
+      try {
+        // Call handleWebSocketClose() directly instead of mockServer.close() - the mock
+        // server's close event isn't reliably observable once fake timers are active.
+        WebSocketManager.handleWebSocketClose();
+        expect(WebSocketManager.reconnectTimer).not.toBeNull();
+
+        cleanup();
+        // Let the unsubscribe debounce (100ms) run.
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(WebSocketManager.activeSubscriptions.size).toBe(0);
+        expect(WebSocketManager.reconnectTimer).toBeNull();
+        expect(WebSocketManager.isReconnecting).toBe(false);
+        const connectSpy = vi.spyOn(WebSocketManager, 'connect').mockResolvedValue({} as WebSocket);
+        // Advance well past what would have been the next backoff attempt.
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(connectSpy).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should handle WebSocket close event', async () => {

--- a/frontend/src/lib/k8s/api/v2/multiplexer.ts
+++ b/frontend/src/lib/k8s/api/v2/multiplexer.ts
@@ -34,6 +34,12 @@ export const WebSocketManager = {
   /** Flag to track if we're reconnecting after a disconnect */
   isReconnecting: false,
 
+  /** Number of consecutive automatic reconnect attempts made since the last successful open */
+  reconnectAttempts: 0,
+
+  /** Timer handle for the pending automatic reconnect attempt, if any */
+  reconnectTimer: null as ReturnType<typeof setTimeout> | null,
+
   /** Map of message handlers for each subscription path */
   listeners: new Map<string, Set<(data: any) => void>>(),
 
@@ -80,6 +86,12 @@ export const WebSocketManager = {
    * @returns Promise resolving to WebSocket connection
    */
   async connect(): Promise<WebSocket> {
+    // An explicit connect (e.g. a new subscriber) supersedes any pending automatic reconnect.
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
     // Return existing connection if available
     if (this.socketMultiplexer?.readyState === WebSocket.OPEN) {
       return this.socketMultiplexer;
@@ -116,6 +128,7 @@ export const WebSocketManager = {
       socket.onopen = () => {
         this.socketMultiplexer = socket;
         this.connecting = false;
+        this.reconnectAttempts = 0;
 
         // Only resubscribe if we're reconnecting after a disconnect
         if (this.isReconnecting) {
@@ -271,6 +284,14 @@ export const WebSocketManager = {
               };
               this.socketMultiplexer.send(JSON.stringify(closeMsg));
             }
+
+            // Nothing left to reconnect for - cancel any pending automatic reconnect.
+            if (this.activeSubscriptions.size === 0 && this.reconnectTimer) {
+              clearTimeout(this.reconnectTimer);
+              this.reconnectTimer = null;
+              this.reconnectAttempts = 0;
+              this.isReconnecting = false;
+            }
           }
           this.pendingUnsubscribes.delete(key);
         }, 100); // 100ms debounce
@@ -292,16 +313,54 @@ export const WebSocketManager = {
   },
 
   /**
-   * Handles WebSocket connection close event
-   * Sets up state for potential reconnection
+   * Handles WebSocket connection close event.
+   * Schedules an automatic reconnect (with backoff) if there are still active
+   * subscriptions that need the connection.
    */
   handleWebSocketClose(): void {
     this.socketMultiplexer = null;
     this.connecting = false;
     this.completedPaths.clear();
 
-    // Only log reconnecting if we have active subscriptions
     this.isReconnecting = this.activeSubscriptions.size > 0;
+
+    if (this.isReconnecting) {
+      this.scheduleReconnect();
+    } else {
+      this.reconnectAttempts = 0;
+    }
+  },
+
+  /**
+   * Schedules an automatic reconnect attempt with exponential backoff
+   * (starting at 1s, capped at 30s). No-op if a reconnect is already scheduled.
+   *
+   * Intended to be called from handleWebSocketClose(), so reconnect scheduling has a single
+   * source of truth. A failed attempt below re-fires onclose (WebSockets often emit close
+   * even for failed handshakes), which schedules the next attempt from there - the catch here
+   * must not call scheduleReconnect() itself.
+   */
+  scheduleReconnect(): void {
+    if (this.reconnectTimer) {
+      return;
+    }
+
+    const delay = Math.min(1000 * 2 ** this.reconnectAttempts, 30000);
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      // Subscriptions may have been removed while we were waiting to reconnect.
+      if (this.activeSubscriptions.size === 0) {
+        this.reconnectAttempts = 0;
+        this.isReconnecting = false;
+        return;
+      }
+      this.reconnectAttempts += 1;
+
+      this.connect().catch(err => {
+        console.error('WebSocketManager: reconnect attempt failed', err);
+      });
+    }, delay);
   },
 
   /**


### PR DESCRIPTION
## Summary

This PR adds automatic reconnect support to the v2 WebSocket multiplexer after unexpected connection loss.

Previously, if the multiplexer socket closed while there were still active subscriptions (for example after a backend restart or a temporary network interruption), the connection remained closed until a new subscription was created. This change adds automatic reconnect with exponential backoff and reuses the existing resubscribe logic once the connection is restored.

## Related Issue

Fixes #6358 

## Changes

- Added automatic reconnect with exponential backoff to `WebSocketManager`
- Reset reconnect state after a successful connection
- Cancel pending reconnect attempts when the last active subscription is removed
- Added tests covering:
  - automatic reconnect after socket close
  - reconnect backoff behavior
  - automatic resubscription after reconnect
  - cancelling reconnect when all subscriptions are removed

## Steps to Test

1. Open a resource list (for example, Pods).
2. Verify live updates are working.
3. Restart the backend or temporarily interrupt the connection.
4. Restore the backend or network.
5. Verify the multiplexer reconnects automatically and the existing watch resumes without refreshing the page.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The reconnect logic is intentionally scoped to `WebSocketManager`; no changes were made to `useWebSocket`, `useKubeObjectList`, or the UI layer.
- Existing resubscription behavior is reused after a successful reconnect.