### PR TITLE
app: main: Terminate zombie headlamp-server process

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -879,9 +879,40 @@ function quitServerProcess() {
   }
 
   serverProcess.stdin.destroy();
-  // @todo: should we try and end the process a bit more gracefully?
-  //       What happens if the kill signal doesn't kill it?
-  serverProcess.kill();
+
+  // Try graceful termination first
+  try {
+    serverProcess.kill('SIGTERM');
+  } catch (err) {
+    console.error('Failed to send SIGTERM to server process:', err);
+  }
+
+  // Fallback to forceful termination if it hasn't quit after a timeout
+  const currentProcess = serverProcess;
+  const fallbackTimeout = setTimeout(() => {
+    // A null exitCode and null signalCode means the process is still running
+    if (currentProcess && currentProcess.exitCode === null && currentProcess.signalCode === null) {
+      console.warn('Server process did not exit gracefully, forcing kill...');
+      try {
+        if (process.platform === 'win32' && currentProcess.pid !== undefined) {
+          killProcess(currentProcess.pid);
+        } else {
+          currentProcess.kill('SIGKILL');
+        }
+      } catch (err) {
+        console.error('Failed to force kill server process:', err);
+      }
+    }
+  }, 5000); // 5 seconds
+
+  const clearFallbackTimeout = () => clearTimeout(fallbackTimeout);
+  currentProcess.once('exit', clearFallbackTimeout);
+  currentProcess.once('close', clearFallbackTimeout);
+
+  // If the process already exited before handlers were attached, clear immediately.
+  if (currentProcess.exitCode !== null || currentProcess.signalCode !== null) {
+    clearFallbackTimeout();
+  }
 
   serverProcess = null;
 }


### PR DESCRIPTION
## Summary
This PR implements graceful shutdown for the backend Go server when the Electron desktop app exits, resolving an explicit codebase TODO. This prevents the server from becoming a zombie process and blocking the port on restart.

## Related Issue
Fixes #6366

## Changes
- Updated `quitServerProcess()` in `app/electron/main.ts`.
- Replaced abrupt `.kill()` with a `SIGTERM` followed by a 5-second `setTimeout`.
- Escalates to `SIGKILL` only if the server fails to shut down gracefully.

## Steps to Test
1. Build and run the desktop app locally (`npm run app:start`).
2. Perform a long-running action or wait for the app to fully initialize.
3. Quit the app via the `File > Quit` menu.
4. Verify in your OS task manager that `headlamp-server` no longer exists.
5. Launch the app again and confirm it starts successfully without a port collision.

## Notes
Tested on Mac; behavior falls back securely to `SIGKILL` if the Go server hangs on exit.

## Local Validations
<img width="1246" height="625" alt="Screenshot 2026-07-05 at 2 21 28 AM" src="https://github.com/user-attachments/assets/a1a74703-fe3f-4f20-810c-f4edb2a4203a" />


