### PR TITLE
frontend: common: Add Storybook stories for PhaseLabel

### DIFF
--- a/frontend/src/components/common/PhaseLabel.stories.tsx
+++ b/frontend/src/components/common/PhaseLabel.stories.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { PhaseLabel, PhaseLabelProps } from './PhaseLabel';
+
+export default {
+  title: 'PhaseLabel',
+  component: PhaseLabel,
+} as Meta;
+
+const Template: StoryFn<PhaseLabelProps> = args => <PhaseLabel {...args} />;
+
+// phase === successPhase (default 'Active')
+export const Success = Template.bind({});
+Success.args = {
+  phase: 'Active',
+};
+
+// phase in warningPhases
+export const Warning = Template.bind({});
+Warning.args = {
+  phase: 'Available',
+  successPhase: 'Bound',
+  warningPhases: ['Available'],
+};
+
+// phase matching neither successPhase nor warningPhases
+export const Error = Template.bind({});
+Error.args = {
+  phase: 'Terminating',
+};
+
+// empty phase renders nothing
+export const Empty = Template.bind({});
+Empty.args = {
+  phase: '',
+};

--- a/frontend/src/components/common/PhaseLabel.stories.tsx
+++ b/frontend/src/components/common/PhaseLabel.stories.tsx
@@ -44,8 +44,18 @@ Error.args = {
   phase: 'Terminating',
 };
 
-// empty phase renders nothing
+// empty/undefined/null phase all render nothing
 export const Empty = Template.bind({});
 Empty.args = {
   phase: '',
+};
+
+export const EmptyUndefined = Template.bind({});
+EmptyUndefined.args = {
+  phase: undefined,
+};
+
+export const EmptyNull = Template.bind({});
+EmptyNull.args = {
+  phase: null,
 };

--- a/frontend/src/components/common/__snapshots__/PhaseLabel.Empty.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/PhaseLabel.Empty.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/__snapshots__/PhaseLabel.EmptyNull.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/PhaseLabel.EmptyNull.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/__snapshots__/PhaseLabel.EmptyUndefined.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/PhaseLabel.EmptyUndefined.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/__snapshots__/PhaseLabel.Error.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/PhaseLabel.Error.stories.storyshot
@@ -1,0 +1,9 @@
+<body>
+  <div>
+    <span
+      class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+    >
+      Terminating
+    </span>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/PhaseLabel.Success.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/PhaseLabel.Success.stories.storyshot
@@ -1,0 +1,9 @@
+<body>
+  <div>
+    <span
+      class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+    >
+      Active
+    </span>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/PhaseLabel.Warning.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/PhaseLabel.Warning.stories.storyshot
@@ -1,0 +1,9 @@
+<body>
+  <div>
+    <span
+      class="MuiTypography-root MuiTypography-body1 css-1dablfr-MuiTypography-root"
+    >
+      Available
+    </span>
+  </div>
+</body>


### PR DESCRIPTION
Adds Storybook stories (which double as snapshot tests via `frontend/src/storybook.test.tsx`) for `common/PhaseLabel.tsx`, which previously had neither a unit test nor a story.

Fixes #6368

`PhaseLabel` is pure and props-driven, so the stories need no MSW/Redux. They cover every branch of the colour mapping:

- **Success** — `phase` equals `successPhase` (default `Active`)
- **Warning** — `phase` in `warningPhases`
- **Error** — `phase` matching neither
- **Empty** — empty `phase` renders nothing (documents the null-render contract)

Full storyshot suite passes (607), zero drift.