### PR TITLE
backend: kubeconfig: Add unit test for Context AuthType method

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -1046,3 +1046,46 @@ users:
 		})
 	})
 }
+
+func TestContextAuthType(t *testing.T) {
+	tests := []struct {
+		name     string
+		context  *kubeconfig.Context
+		expected string
+	}{
+		{
+			name: "OIDC configuration present",
+			context: &kubeconfig.Context{
+				OidcConf: &kubeconfig.OidcConfig{},
+			},
+			expected: "oidc",
+		},
+		{
+			name: "AuthProvider present",
+			context: &kubeconfig.Context{
+				AuthInfo: &api.AuthInfo{
+					AuthProvider: &api.AuthProviderConfig{},
+				},
+			},
+			expected: "oidc",
+		},
+		{
+			name: "No auth configuration",
+			context: &kubeconfig.Context{
+				AuthInfo: &api.AuthInfo{},
+			},
+			expected: "",
+		},
+		{
+			name:     "Nil auth info and oidc config",
+			context:  &kubeconfig.Context{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.context.AuthType())
+		})
+	}
+}


### PR DESCRIPTION
**Summary:** Add unit test for Context AuthType method
**Related Issue:** Fixes #6376
**Changes:**
- Added `TestContextAuthType` in `backend/pkg/kubeconfig/kubeconfig_test.go` to cover the `AuthType()` method on the `Context` struct.

**Steps to Test:**
1. Run backend tests: `npm run backend:test`
2. Verify that the new test passes and coverage increases for `backend/pkg/kubeconfig/kubeconfig.go`.

**Notes for the Reviewer:**
This is an isolated, backward-compatible addition to the test suite to increase coverage for OIDC and empty auth type detection. No production code was modified.