### PR TITLE
backend: kubeconfig: Pre-allocate slices in contextStore methods

### DIFF
--- a/backend/pkg/kubeconfig/contextStore.go
+++ b/backend/pkg/kubeconfig/contextStore.go
@@ -120,11 +120,9 @@ func (c *contextStore) GetContexts() ([]*Context, error) {
 		return nil, err
 	}
 
-	contexts := make([]*Context, len(contextMap))
-	i := 0
+	contexts := make([]*Context, 0, len(contextMap))
 	for _, ctx := range contextMap {
-		contexts[i] = ctx
-		i++
+		contexts = append(contexts, ctx)
 	}
 
 	return contexts, nil
@@ -137,11 +135,9 @@ func (c *contextStore) GetContextKeys() ([]string, error) {
 		return nil, err
 	}
 
-	keys := make([]string, len(contextMap))
-	i := 0
+	keys := make([]string, 0, len(contextMap))
 	for key := range contextMap {
-		keys[i] = key
-		i++
+		keys = append(keys, key)
 	}
 
 	return keys, nil

--- a/backend/pkg/kubeconfig/contextStore.go
+++ b/backend/pkg/kubeconfig/contextStore.go
@@ -115,15 +115,16 @@ func (c *contextStore) AddContext(headlampContext *Context) error {
 
 // GetContexts returns all contexts in the store.
 func (c *contextStore) GetContexts() ([]*Context, error) {
-	contexts := []*Context{}
-
 	contextMap, err := c.cache.GetAll(context.Background(), nil)
 	if err != nil {
 		return nil, err
 	}
 
+	contexts := make([]*Context, len(contextMap))
+	i := 0
 	for _, ctx := range contextMap {
-		contexts = append(contexts, ctx)
+		contexts[i] = ctx
+		i++
 	}
 
 	return contexts, nil
@@ -131,15 +132,16 @@ func (c *contextStore) GetContexts() ([]*Context, error) {
 
 // GetContextKeys returns all context keys in the store.
 func (c *contextStore) GetContextKeys() ([]string, error) {
-	var keys []string
-
 	contextMap, err := c.cache.GetAll(context.Background(), nil)
 	if err != nil {
 		return nil, err
 	}
 
+	keys := make([]string, len(contextMap))
+	i := 0
 	for key := range contextMap {
-		keys = append(keys, key)
+		keys[i] = key
+		i++
 	}
 
 	return keys, nil

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -1046,3 +1046,46 @@ users:
 		})
 	})
 }
+
+func TestContextAuthType(t *testing.T) {
+	tests := []struct {
+		name     string
+		context  *kubeconfig.Context
+		expected string
+	}{
+		{
+			name: "OIDC configuration present",
+			context: &kubeconfig.Context{
+				OidcConf: &kubeconfig.OidcConfig{},
+			},
+			expected: "oidc",
+		},
+		{
+			name: "AuthProvider present",
+			context: &kubeconfig.Context{
+				AuthInfo: &api.AuthInfo{
+					AuthProvider: &api.AuthProviderConfig{},
+				},
+			},
+			expected: "oidc",
+		},
+		{
+			name: "No auth configuration",
+			context: &kubeconfig.Context{
+				AuthInfo: &api.AuthInfo{},
+			},
+			expected: "",
+		},
+		{
+			name:     "Nil auth info and oidc config",
+			context:  &kubeconfig.Context{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.context.AuthType())
+		})
+	}
+}


### PR DESCRIPTION
**Summary:** Pre-allocate slices in contextStore methods for memory efficiency
**Related Issue:** Fixes #6377 
**Changes:**
- Modified `GetContexts()` in `backend/pkg/kubeconfig/contextStore.go` to pre-allocate the `contexts` slice using `make([]*Context, 0, len(contextMap))`.
- Modified `GetContextKeys()` in `backend/pkg/kubeconfig/contextStore.go` to pre-allocate the `keys` slice using `make([]string, 0, len(contextMap))`.

**Steps to Test:**
1. Run backend tests: `npm run backend:test`
2. Verify all `contextStore` tests continue to pass.

**Notes for the Reviewer:**
A small memory optimization to prevent unnecessary slice growth reallocations. Since the target sizes are exactly known from the map lengths beforehand, this enhances code efficiency and readability with zero side effects.