### PR TITLE
app: electron: Add TLS proxy certificate support

### DIFF
--- a/app/electron/certificates.test.ts
+++ b/app/electron/certificates.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for certificate handling module.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock fs module using vi.hoisted for proper hoisting
+const { mockReadFileSync } = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    readFileSync: mockReadFileSync,
+  };
+});
+
+// Mock the tls module using vi.hoisted for proper hoisting
+const { mockGetCACertificates, mockSetDefaultCACertificates } = vi.hoisted(() => ({
+  mockGetCACertificates: vi.fn(),
+  mockSetDefaultCACertificates: vi.fn(),
+}));
+
+vi.mock('node:tls', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:tls')>();
+  return {
+    ...actual,
+    rootCertificates: ['-----BEGIN CERTIFICATE-----\nmock-node-ca\n-----END CERTIFICATE-----'],
+    getCACertificates: mockGetCACertificates,
+    setDefaultCACertificates: mockSetDefaultCACertificates,
+  };
+});
+
+import { loadCustomCAs, setupCustomCAs, setupSystemCAs } from './certificates';
+
+describe('certificates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCACertificates.mockReset();
+    mockSetDefaultCACertificates.mockReset();
+    mockReadFileSync.mockReset();
+  });
+
+  describe('setupSystemCAs', () => {
+    it('should merge system CAs with Node CAs when enabled', () => {
+      const mockSystemCAs = [
+        '-----BEGIN CERTIFICATE-----\nmock-system-ca\n-----END CERTIFICATE-----',
+      ];
+      const mockNodeCAs = ['-----BEGIN CERTIFICATE-----\nmock-node-ca\n-----END CERTIFICATE-----'];
+      mockGetCACertificates.mockImplementation((type: string) => {
+        if (type === 'system') return mockSystemCAs;
+        if (type === 'default') return mockNodeCAs;
+        return [];
+      });
+
+      setupSystemCAs({ useSystemCAs: true });
+
+      expect(mockGetCACertificates).toHaveBeenCalledWith('system');
+      expect(mockGetCACertificates).toHaveBeenCalledWith('default');
+      expect(mockSetDefaultCACertificates).toHaveBeenCalledWith(
+        expect.arrayContaining([...mockNodeCAs, ...mockSystemCAs])
+      );
+    });
+
+    it('should skip system CA merging when disabled', () => {
+      setupSystemCAs({ useSystemCAs: false });
+
+      expect(mockGetCACertificates).not.toHaveBeenCalled();
+      expect(mockSetDefaultCACertificates).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty system CA list gracefully', () => {
+      mockGetCACertificates.mockReturnValue([]);
+
+      setupSystemCAs({ useSystemCAs: true });
+
+      expect(mockSetDefaultCACertificates).not.toHaveBeenCalled();
+    });
+
+    it('should handle getCACertificates errors gracefully', () => {
+      mockGetCACertificates.mockImplementation(() => {
+        throw new Error('System CA retrieval failed');
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      setupSystemCAs({ useSystemCAs: true });
+
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockSetDefaultCACertificates).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle setDefaultCACertificates errors gracefully', () => {
+      mockGetCACertificates.mockReturnValue([
+        '-----BEGIN CERTIFICATE-----\nmock-system-ca\n-----END CERTIFICATE-----',
+      ]);
+      mockSetDefaultCACertificates.mockImplementationOnce(() => {
+        throw new Error('setDefaultCACertificates failed');
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      setupSystemCAs({ useSystemCAs: true });
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('loadCustomCAs', () => {
+    it('should load custom CA certificates from file', () => {
+      const mockCAContent =
+        '-----BEGIN CERTIFICATE-----\nmock-ca-1\n-----END CERTIFICATE-----\n' +
+        '-----BEGIN CERTIFICATE-----\nmock-ca-2\n-----END CERTIFICATE-----';
+      mockReadFileSync.mockReturnValue(mockCAContent);
+
+      const caCerts = loadCustomCAs('/path/to/ca-bundle.crt');
+
+      expect(caCerts).toHaveLength(2);
+      expect(caCerts[0]).toContain('mock-ca-1');
+      expect(caCerts[1]).toContain('mock-ca-2');
+    });
+
+    it('should handle file read errors gracefully', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('File not found');
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const caCerts = loadCustomCAs('/path/to/nonexistent.crt');
+
+      expect(caCerts).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle empty CA bundle file', () => {
+      mockReadFileSync.mockReturnValue('');
+
+      const caCerts = loadCustomCAs('/path/to/empty.crt');
+
+      expect(caCerts).toEqual([]);
+    });
+  });
+
+  describe('setupCustomCAs', () => {
+    it('should merge custom CAs with existing root certificates', () => {
+      const mockNodeCAs = ['-----BEGIN CERTIFICATE-----\nmock-node-ca\n-----END CERTIFICATE-----'];
+      const mockCAContent =
+        '-----BEGIN CERTIFICATE-----\nmock-custom-ca\n-----END CERTIFICATE-----';
+      mockGetCACertificates.mockImplementation((type: string) => {
+        if (type === 'default') return mockNodeCAs;
+        return [];
+      });
+      mockReadFileSync.mockReturnValue(mockCAContent);
+
+      setupCustomCAs('/path/to/ca-bundle.crt');
+
+      expect(mockSetDefaultCACertificates).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          '-----BEGIN CERTIFICATE-----\nmock-node-ca\n-----END CERTIFICATE-----',
+          '-----BEGIN CERTIFICATE-----\nmock-custom-ca\n-----END CERTIFICATE-----',
+        ])
+      );
+    });
+
+    it('should handle setDefaultCACertificates errors gracefully', () => {
+      mockGetCACertificates.mockReturnValue([
+        '-----BEGIN CERTIFICATE-----\nmock-node-ca\n-----END CERTIFICATE-----',
+      ]);
+      mockReadFileSync.mockReturnValue(
+        '-----BEGIN CERTIFICATE-----\nmock-custom-ca\n-----END CERTIFICATE-----'
+      );
+      mockSetDefaultCACertificates.mockImplementationOnce(() => {
+        throw new Error('setDefaultCACertificates failed');
+      });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      setupCustomCAs('/path/to/ca-bundle.crt');
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should warn when no custom CAs are loaded', () => {
+      mockGetCACertificates.mockReturnValue([
+        '-----BEGIN CERTIFICATE-----\nmock-node-ca\n-----END CERTIFICATE-----',
+      ]);
+      mockReadFileSync.mockReturnValue('');
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      setupCustomCAs('/path/to/empty.crt');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No custom CA certificates loaded')
+      );
+      expect(mockSetDefaultCACertificates).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/app/electron/certificates.ts
+++ b/app/electron/certificates.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Certificate handling for TLS-inspecting proxy support.
+ *
+ * Merges system CA certificates with Node's bundled CA list to support
+ * corporate TLS-inspecting proxies (e.g., Netskope) that use custom root CAs.
+ */
+
+import * as fs from 'node:fs';
+import * as tls from 'node:tls';
+
+/**
+ * Extended TLS interface with system CA support (Node.js 22+)
+ */
+interface TlsWithSystemCA {
+  rootCertificates: string[];
+  getCACertificates?: (type: 'system' | 'default') => string[];
+  setDefaultCACertificates?: (certificates: string[]) => void;
+}
+
+/**
+ * Settings interface for certificate configuration.
+ */
+export interface CertificateSettings {
+  /** Whether to use system CA certificates (default: true) */
+  useSystemCAs?: boolean;
+  /** Optional custom CA bundle path (NODE_EXTRA_CA_CERTS equivalent) */
+  customCAPath?: string;
+}
+
+/**
+ * Merges system CA certificates with Node's bundled CA list.
+ *
+ * This function attempts to retrieve system CA certificates and merge them
+ * with Node's default CA bundle. It includes version checking and graceful
+ * fallback for older Node versions that don't support system CA retrieval.
+ *
+ * @param settings - Optional certificate settings
+ * @returns void - Modifies global TLS configuration
+ */
+export function setupSystemCAs(settings: CertificateSettings = {}): void {
+  const { useSystemCAs = true } = settings;
+
+  // If explicitly disabled, do nothing
+  if (!useSystemCAs) {
+    console.log('System CA certificates disabled by settings');
+    return;
+  }
+
+  const tlsExt = tls as unknown as TlsWithSystemCA;
+  const supportsSystemCA =
+    typeof tlsExt.getCACertificates === 'function' &&
+    typeof tlsExt.setDefaultCACertificates === 'function';
+
+  if (!supportsSystemCA) {
+    console.warn(
+      'System CA trust not supported on this Node version, skipping. ' +
+        'Required functions: getCACertificates and setDefaultCACertificates'
+    );
+    return;
+  }
+
+  const nodeVersion = process.version;
+  const majorVersion = parseInt(nodeVersion.slice(1).split('.')[0], 10);
+
+  if (majorVersion < 22) {
+    console.warn(
+      `Node.js ${nodeVersion} does not support system CA certificates. ` +
+        'System CA merging skipped. Minimum required: Node.js 22.0.0'
+    );
+    return;
+  }
+
+  try {
+    const systemCAs = tlsExt.getCACertificates!('system');
+
+    if (!systemCAs || systemCAs.length === 0) {
+      console.log('No system CA certificates found');
+      return;
+    }
+
+    const nodeCAs = tlsExt.getCACertificates!('default');
+
+    const caSet = new Set([...nodeCAs, ...systemCAs]);
+    const mergedCAs = Array.from(caSet);
+
+    tlsExt.setDefaultCACertificates!(mergedCAs);
+
+    console.log(
+      `Merged ${systemCAs.length} system CA certificates with ${nodeCAs.length} Node certificates ` +
+        `(total: ${mergedCAs.length})`
+    );
+  } catch (error) {
+    console.error('Failed to merge system CA certificates:', error);
+  }
+}
+
+/**
+ * Loads custom CA certificates from a file.
+ *
+ * @param caPath - Path to the custom CA bundle file
+ * @returns Array of CA certificate strings or empty array on error
+ */
+export function loadCustomCAs(caPath: string): string[] {
+  try {
+    const caContent = fs.readFileSync(caPath, 'utf8');
+    // Split by common CA bundle delimiters
+    const caCerts = caContent
+      .split(/-----END CERTIFICATE-----/)
+      .filter(cert => cert.trim().length > 0)
+      .map(cert => cert.trim() + '\n-----END CERTIFICATE-----');
+    return caCerts;
+  } catch (error) {
+    console.error(`Failed to load custom CA certificates from ${caPath}:`, error);
+    return [];
+  }
+}
+
+/**
+ * Sets up custom CA certificates from a file.
+ *
+ * @param caPath - Path to the custom CA bundle file
+ * @returns void - Modifies global TLS configuration
+ */
+export function setupCustomCAs(caPath: string): void {
+  const tlsExt = tls as unknown as TlsWithSystemCA;
+
+  if (typeof tlsExt.setDefaultCACertificates !== 'function') {
+    console.warn('setDefaultCACertificates not available, cannot add custom CA certificates');
+    return;
+  }
+
+  const customCAs = loadCustomCAs(caPath);
+
+  if (customCAs.length === 0) {
+    console.warn(`No custom CA certificates loaded from ${caPath}`);
+    return;
+  }
+
+  try {
+    const currentCAs =
+      typeof tlsExt.getCACertificates === 'function'
+        ? tlsExt.getCACertificates('default')
+        : tlsExt.rootCertificates;
+    const caSet = new Set([...currentCAs, ...customCAs]);
+    const mergedCAs = Array.from(caSet);
+
+    tlsExt.setDefaultCACertificates!(mergedCAs);
+
+    console.log(`Added ${customCAs.length} custom CA certificates (total: ${mergedCAs.length})`);
+  } catch (error) {
+    console.error('Failed to add custom CA certificates:', error);
+  }
+}

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -40,6 +40,7 @@ import path from 'path';
 import url from 'url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import { setupCustomCAs, setupSystemCAs } from './certificates';
 import i18n from './i18next.config';
 import MCPClient from './mcp/MCPClient';
 import {
@@ -52,6 +53,7 @@ import {
   PluginManager,
 } from './plugin-management';
 import { addRunCmdConsent, removeRunCmdConsent, runScript, setupRunCmdHandlers } from './runCmd';
+import { loadSettings, SETTINGS_PATH } from './settings';
 import {
   cleanupHeadlampTray,
   createHeadlampTray,
@@ -83,6 +85,13 @@ if (process.env.HEADLAMP_RUN_SCRIPT) {
 const ENABLE_MCP = process.env.HEADLAMP_MCP_ENABLE !== 'false';
 
 dotenv.config({ path: path.join(process.resourcesPath, '.env') });
+
+const settings = loadSettings(SETTINGS_PATH);
+setupSystemCAs(settings);
+
+if (settings.customCAPath) {
+  setupCustomCAs(settings.customCAPath);
+}
 
 const isDev = !!process.env.ELECTRON_DEV;
 let frontendPath = '';

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -26,7 +26,7 @@ import nock from 'nock';
 import os from 'os';
 import path from 'path';
 import * as tar from 'tar';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { PluginManager } from './plugin-management';
 import { getExtraFiles } from './plugin-management';
 
@@ -499,16 +499,20 @@ describe('getExtraFiles', () => {
   });
 
   it('should allow localhost URLs in test environment', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'test';
-    const annotations = {
-      'headlamp/plugin/extra-files/0/url': 'http://localhost:1234/test.tar.gz',
-      'headlamp/plugin/extra-files/0/checksum': 'sha256:dummy',
-      'headlamp/plugin/extra-files/0/arch': 'linux/x64',
-      'headlamp/plugin/extra-files/0/output/test/output': 'test',
-      'headlamp/plugin/extra-files/0/output/test/input': 'test-linux-amd64',
-    };
-    expect(() => getExtraFiles(annotations)).not.toThrow();
-    process.env.NODE_ENV = '';
+    try {
+      const annotations = {
+        'headlamp/plugin/extra-files/0/url': 'http://localhost:1234/test.tar.gz',
+        'headlamp/plugin/extra-files/0/checksum': 'sha256:dummy',
+        'headlamp/plugin/extra-files/0/arch': 'linux/x64',
+        'headlamp/plugin/extra-files/0/output/test/output': 'test',
+        'headlamp/plugin/extra-files/0/output/test/input': 'test-linux-amd64',
+      };
+      expect(() => getExtraFiles(annotations)).not.toThrow();
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it('should return undefined if no extra-files annotation present', () => {
@@ -518,4 +522,149 @@ describe('getExtraFiles', () => {
     };
     expect(getExtraFiles(annotations)).toBeUndefined();
   });
+});
+
+describe('TLS error detection', () => {
+  it('should detect TLS error when code is on err directly', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'tls-error-direct-code');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'tls-error-direct-code-plugins');
+
+    await createMinimalPluginTarball(testDataDir);
+
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir);
+
+    const pluginURL = 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube';
+
+    const originalFetch = global.fetch;
+    const tlsError = Object.assign(new Error('TLS verification failed'), {
+      code: 'SELF_SIGNED_CERT_IN_CHAIN',
+    });
+    try {
+      global.fetch = vi.fn().mockRejectedValue(tlsError);
+
+      await expect(
+        PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          'TLS certificate verification failed (SELF_SIGNED_CERT_IN_CHAIN).'
+        ),
+        cause: tlsError,
+      });
+    } finally {
+      global.fetch = originalFetch;
+
+      if (fs.existsSync(pluginDestDir)) {
+        fs.rmSync(pluginDestDir, { recursive: true });
+      }
+      if (fs.existsSync(testDataDir)) {
+        fs.rmSync(testDataDir, { recursive: true });
+      }
+    }
+  }, 30000);
+
+  it('should detect TLS error when code is in err.cause', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'tls-error-cause-code');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'tls-error-cause-code-plugins');
+
+    await createMinimalPluginTarball(testDataDir);
+
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir);
+
+    const pluginURL = 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube';
+
+    const originalFetch = global.fetch;
+    try {
+      global.fetch = vi.fn().mockRejectedValue(
+        Object.assign(new Error('TLS verification failed'), {
+          cause: { code: 'CERT_UNTRUSTED' },
+        })
+      );
+
+      await expect(
+        PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toThrow('TLS certificate verification failed (CERT_UNTRUSTED).');
+    } finally {
+      global.fetch = originalFetch;
+
+      if (fs.existsSync(pluginDestDir)) {
+        fs.rmSync(pluginDestDir, { recursive: true });
+      }
+      if (fs.existsSync(testDataDir)) {
+        fs.rmSync(testDataDir, { recursive: true });
+      }
+    }
+  }, 30000);
+
+  it('should throw generic error when no TLS code is present', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'tls-error-no-code');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'tls-error-no-code-plugins');
+
+    await createMinimalPluginTarball(testDataDir);
+
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir);
+
+    const pluginURL = 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube';
+
+    const originalFetch = global.fetch;
+    try {
+      global.fetch = vi.fn().mockRejectedValue(
+        Object.assign(new Error('Network error'), {
+          code: 'ENOTFOUND',
+        })
+      );
+
+      await expect(
+        PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toThrow('Failed to fetch plugin metadata. Please check your network connection.');
+    } finally {
+      global.fetch = originalFetch;
+
+      if (fs.existsSync(pluginDestDir)) {
+        fs.rmSync(pluginDestDir, { recursive: true });
+      }
+      if (fs.existsSync(testDataDir)) {
+        fs.rmSync(testDataDir, { recursive: true });
+      }
+    }
+  }, 30000);
+
+  it('should detect TLS error when the archive download fails', async () => {
+    const testDataDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'tls-error-archive');
+    const pluginDestDir = getUniqueTestDir(PLUGIN_DEST_BASE_DIR, 'tls-error-archive-plugins');
+
+    await createMinimalPluginTarball(testDataDir);
+
+    mockArtifactHubAPIWithoutPlatformSpecific(testDataDir);
+
+    const pluginURL = 'https://artifacthub.io/packages/headlamp/test-repo/headlamp_minikube';
+
+    const originalFetch = global.fetch;
+    try {
+      // Let the metadata fetch through so the failure happens on the archive download.
+      global.fetch = vi.fn((...args: Parameters<typeof fetch>) => {
+        const [url, init] = args;
+        if (url.toString().includes('artifacthub.io')) {
+          return originalFetch(url, init);
+        }
+        return Promise.reject(
+          Object.assign(new Error('TLS verification failed'), {
+            code: 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+          })
+        );
+      });
+
+      await expect(
+        PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, null, null)
+      ).rejects.toThrow('TLS certificate verification failed (UNABLE_TO_GET_ISSUER_CERT_LOCALLY).');
+    } finally {
+      global.fetch = originalFetch;
+
+      if (fs.existsSync(pluginDestDir)) {
+        fs.rmSync(pluginDestDir, { recursive: true });
+      }
+      if (fs.existsSync(testDataDir)) {
+        fs.rmSync(testDataDir, { recursive: true });
+      }
+    }
+  }, 30000);
 });

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -542,14 +542,18 @@ describe('TLS error detection', () => {
     try {
       global.fetch = vi.fn().mockRejectedValue(tlsError);
 
-      await expect(
-        PluginManager.install(pluginURL, pluginDestDir, HEADLAMP_VERSION, null, null)
-      ).rejects.toMatchObject({
-        message: expect.stringContaining(
-          'TLS certificate verification failed (SELF_SIGNED_CERT_IN_CHAIN).'
-        ),
-        cause: tlsError,
-      });
+      const installPromise = PluginManager.install(
+        pluginURL,
+        pluginDestDir,
+        HEADLAMP_VERSION,
+        null,
+        null
+      );
+
+      await expect(installPromise).rejects.toThrow(
+        'TLS certificate verification failed (SELF_SIGNED_CERT_IN_CHAIN).'
+      );
+      await expect(installPromise).rejects.toHaveProperty('cause', tlsError);
     } finally {
       global.fetch = originalFetch;
 

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -42,6 +42,25 @@ import envPaths from './env-paths';
 // }
 
 /**
+ * Extracts TLS error code from an error object.
+ * Checks both err.code directly and err.cause.code for TLS error codes.
+ *
+ * @param err - The error object to extract the code from
+ * @param tlsErrorCodes - Array of TLS error codes to match against
+ * @returns The TLS error code if found, undefined otherwise
+ */
+function extractTlsErrorCode(err: unknown, tlsErrorCodes: string[]): string | undefined {
+  if (!(err instanceof Error)) return undefined;
+  const directCode = 'code' in err ? (err as { code?: string }).code : undefined;
+  const causeCode =
+    err.cause && typeof err.cause === 'object' && 'code' in err.cause
+      ? (err.cause as { code: string }).code
+      : undefined;
+  const code = directCode ?? causeCode;
+  return code && tlsErrorCodes.includes(code) ? code : undefined;
+}
+
+/**
  * `ProgressResp` is an interface for progress response.
  *
  * @interface
@@ -718,6 +737,21 @@ async function downloadAndExtractSingleArchive(
   try {
     archResponse = await fetch(archiveURL, { redirect: 'follow', signal });
   } catch (err) {
+    const tlsErrorCodes = [
+      'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+      'SELF_SIGNED_CERT_IN_CHAIN',
+      'CERT_UNTRUSTED',
+      'CERT_REJECTED',
+    ];
+
+    const tlsCode = extractTlsErrorCode(err, tlsErrorCodes);
+    if (tlsCode) {
+      throw new Error(
+        `TLS certificate verification failed (${tlsCode}). This may be due to a corporate TLS-inspecting proxy. ` +
+          'Ensure the proxy root CA is trusted by your OS certificate store, or configure a custom CA bundle (settings.json: customCAPath).',
+        { cause: err }
+      );
+    }
     throw new Error('Failed to fetch archive. Please check the URL and your network connection.');
   }
 
@@ -944,7 +978,28 @@ async function fetchPluginInfo(
     if (progressCallback) {
       progressCallback({ type: 'info', message: 'Fetching Plugin Metadata' });
     }
-    const response = await fetch(apiURL, { redirect: 'follow', signal });
+    let response;
+    try {
+      response = await fetch(apiURL, { redirect: 'follow', signal });
+    } catch (err) {
+      const tlsErrorCodes = [
+        'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+        'SELF_SIGNED_CERT_IN_CHAIN',
+        'CERT_UNTRUSTED',
+        'CERT_REJECTED',
+      ];
+
+      const tlsCode = extractTlsErrorCode(err, tlsErrorCodes);
+      if (tlsCode) {
+        throw new Error(
+          `TLS certificate verification failed (${tlsCode}). This may be due to a corporate TLS-inspecting proxy. ` +
+            'Ensure the proxy root CA is trusted by your OS certificate store, or configure a custom CA bundle (settings.json: customCAPath).',
+          { cause: err }
+        );
+      }
+      throw new Error('Failed to fetch plugin metadata. Please check your network connection.');
+    }
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -42,6 +42,16 @@ import envPaths from './env-paths';
 // }
 
 /**
+ * TLS certificate error codes that indicate a certificate verification failure.
+ */
+const TLS_ERROR_CODES = [
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'CERT_UNTRUSTED',
+  'CERT_REJECTED',
+];
+
+/**
  * Extracts TLS error code from an error object.
  * Checks both err.code directly and err.cause.code for TLS error codes.
  *
@@ -732,19 +742,12 @@ async function downloadAndExtractSingleArchive(
   }
 
   // await sleep(4000); // comment out for testing
-  let archResponse;
+  let archResponse: Awaited<ReturnType<typeof fetch>>;
 
   try {
     archResponse = await fetch(archiveURL, { redirect: 'follow', signal });
   } catch (err) {
-    const tlsErrorCodes = [
-      'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
-      'SELF_SIGNED_CERT_IN_CHAIN',
-      'CERT_UNTRUSTED',
-      'CERT_REJECTED',
-    ];
-
-    const tlsCode = extractTlsErrorCode(err, tlsErrorCodes);
+    const tlsCode = extractTlsErrorCode(err, TLS_ERROR_CODES);
     if (tlsCode) {
       throw new Error(
         `TLS certificate verification failed (${tlsCode}). This may be due to a corporate TLS-inspecting proxy. ` +
@@ -978,18 +981,11 @@ async function fetchPluginInfo(
     if (progressCallback) {
       progressCallback({ type: 'info', message: 'Fetching Plugin Metadata' });
     }
-    let response;
+    let response: Awaited<ReturnType<typeof fetch>>;
     try {
       response = await fetch(apiURL, { redirect: 'follow', signal });
     } catch (err) {
-      const tlsErrorCodes = [
-        'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
-        'SELF_SIGNED_CERT_IN_CHAIN',
-        'CERT_UNTRUSTED',
-        'CERT_REJECTED',
-      ];
-
-      const tlsCode = extractTlsErrorCode(err, tlsErrorCodes);
+      const tlsCode = extractTlsErrorCode(err, TLS_ERROR_CODES);
       if (tlsCode) {
         throw new Error(
           `TLS certificate verification failed (${tlsCode}). This may be due to a corporate TLS-inspecting proxy. ` +


### PR DESCRIPTION
## Summary
This PR fixes plugin installation failures on Windows (and other platforms) when running behind corporate TLS-inspecting proxies (e.g., Netskope), by making the Electron main process trust OS-level system CA certificates in addition to Node's bundled CA list, and by surfacing clearer error messages when TLS certificate validation fails during plugin installs.

## Related Issue
Fixes #6318

## Changes
- Added `app/electron/certificates.ts` with:
  - `setupSystemCAs()` — merges OS-trusted system CA certificates with Node's default CA bundle using `tls.setDefaultCACertificates()` (the correct API; `tls.rootCertificates` is read-only and cannot be assigned to directly)
  - `setupCustomCAs()` / `loadCustomCAs()` — optional support for a custom CA bundle file, similar to `NODE_EXTRA_CA_CERTS`
  - Function-existence checks (not just a Node version number check) so the code safely no-ops with a warning on Node versions that don't support `getCACertificates`/`setDefaultCACertificates` (requires Node.js 22+)
- Updated `app/electron/main.ts` to run certificate setup at app startup, before any plugin-related network calls happen
- Updated `app/electron/plugin-management.ts` so TLS-certificate-related failures (`UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, `SELF_SIGNED_CERT_IN_CHAIN`, etc.) surface a specific, actionable error message mentioning corporate proxies/TLS inspection, instead of a generic "check your URL and network connection" message
- Added `app/electron/certificates.test.ts` with unit tests covering system CA merging, custom CA loading/merging, and graceful error handling

## Steps to Test
1. Set up a local TLS-inspecting proxy (e.g., `mitmproxy`) with a self-signed root CA, and add that root CA to your OS certificate store
2. Run Headlamp through the proxy without setting any extra environment variables
3. Go to the Plugin Catalog and install any plugin — it should download and install successfully instead of failing with a certificate error
4. Remove the CA from the OS trust store and confirm plugin install now shows a clear, specific error message referencing TLS/certificate issues instead of the old generic "check your network connection" message
5. Run `npm test -- certificates.test.ts` in `app/` — all 11 tests should pass
6. Run the full test suite (`npm test` in `app/`, `go test ./...` in `backend/`) to confirm no regressions

## Notes for the Reviewer
- Requires Node.js 22+ for system CA support; on older Node versions the code logs a warning and continues without system CA merging (same behavior as before this change) — no crash or breaking change for older environments.
- Settings are configurable today via `settings.json` (`useSystemCAs`, default `true`; `customCAPath`, optional) but not yet exposed in the Settings UI — a UI toggle can be a follow-up PR.

