### PR TITLE
frontend: Fix typo for broken sorting accessor

### DIFF
--- a/frontend/src/components/cronjob/List.tsx
+++ b/frontend/src/components/cronjob/List.tsx
@@ -78,7 +78,7 @@ export default function CronJobList() {
         {
           id: 'lastScheduleTime',
           label: t('Last Schedule'),
-          getValue: cronJob => cronJob.status.lastScheduletime ?? '',
+          getValue: cronJob => cronJob.status.lastScheduleTime ?? '',
           render: cronJob => getLastScheduleTime(cronJob),
         },
         {


### PR DESCRIPTION
## Summary

Fixes a typo in the  getValue  accessor for the Last Schedule column in the CronJob list view. The Kubernetes API field is  lastScheduleTime  (camelCase with a capital  T ), but the accessor was misspelled as  lastScheduletime  (lowercase  t ), which made the column unsortable and unfilterable.


## Related Issue

Fixes #6382

