### PR TITLE
docs: Format Desktop App dependency list in architecture docs

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -182,9 +182,9 @@ For each module we have a test file. For example config.go comes with config_tes
 - Entry point is [app/electron/main.ts](https://github.com/kubernetes-sigs/headlamp/blob/main/app/electron/main.ts)
 
 A few key dependencies:
-**TypeScript**: Language in which the app's code is written.
-**Electron**: Used to create a native desktop application for Headlamp.
-**Yargs**: Used for command line argument processing.
+- **TypeScript**: Language in which the app's code is written.
+- **Electron**: Used to create a native desktop application for Headlamp.
+- **Yargs**: Used for command line argument processing.
 
 ### Plugins
 


### PR DESCRIPTION
## Summary

This PR improves the readability of the **Desktop App** section in the
Architecture documentation by formatting the key dependencies as a
Markdown bullet list.

## Related Issue

Fixes #6372

## Changes

- Updated the Desktop App dependencies section in
  `docs/development/architecture.md`
- Formatted TypeScript, Electron, and Yargs as a bullet list
- Improved documentation readability without changing the content

## Steps to Test

1. Run the documentation locally.
2. Open the **Architecture** documentation page.
3. Navigate to the **Desktop App** section.
4. Verify that the dependencies are displayed as a bullet list.

## Screenshots

**Before**

<img width="891" height="188" alt="Screenshot 2026-07-05 at 4 30 33 PM" src="https://github.com/user-attachments/assets/efb40c91-c376-46ea-8a6d-f2e4f03e6776" />

**After**

<img width="527" height="270" alt="Screenshot 2026-07-05 at 4 32 46 PM" src="https://github.com/user-attachments/assets/4475f6a2-db61-4187-8eac-ed3cbeded985" />


## Notes for the Reviewer

This is a documentation-only change intended to improve readability.
There are no functional changes.