### PR TITLE
pluginsManager: Sidecar container missing liveness probe and resource…

### DIFF
--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -478,8 +478,21 @@ spec:
             {{- with .Values.pluginsManager.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.pluginsManager.livenessProbe }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pgrep -f pluginctl || pgrep -f node
+            initialDelaySeconds: {{ .Values.pluginsManager.livenessProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.pluginsManager.livenessProbe.periodSeconds | default 30 }}
+            timeoutSeconds: {{ .Values.pluginsManager.livenessProbe.timeoutSeconds | default 1 }}
+            successThreshold: 1
+            failureThreshold: {{ .Values.pluginsManager.livenessProbe.failureThreshold | default 3 }}
+          {{- end }}
           resources:
-            {{- toYaml .Values.pluginsManager.resources | nindent 12 }}
+            {{- toYaml (.Values.pluginsManager.resources | default dict) | nindent 12 }}
           securityContext:
             {{- if .Values.pluginsManager.securityContext }}
               {{- toYaml .Values.pluginsManager.securityContext | nindent 12 }}

--- a/charts/headlamp/templates/deployment.yaml
+++ b/charts/headlamp/templates/deployment.yaml
@@ -484,7 +484,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - pgrep -f pluginctl || pgrep -f node
+                - pgrep node >/dev/null
             initialDelaySeconds: {{ .Values.pluginsManager.livenessProbe.initialDelaySeconds | default 30 }}
             periodSeconds: {{ .Values.pluginsManager.livenessProbe.periodSeconds | default 30 }}
             timeoutSeconds: {{ .Values.pluginsManager.livenessProbe.timeoutSeconds | default 1 }}

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-inherit.yaml
@@ -183,8 +183,24 @@ spec:
               mountPath: /config
             - name: headlamp-plugins-tmp
               mountPath: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pgrep -f pluginctl || pgrep -f node
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
-            null
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           securityContext:
             privileged: false
             readOnlyRootFilesystem: true

--- a/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
+++ b/charts/headlamp/tests/expected_templates/readonly-root-filesystem-plugins-only.yaml
@@ -181,8 +181,24 @@ spec:
               mountPath: /config
             - name: headlamp-plugins-tmp
               mountPath: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pgrep -f pluginctl || pgrep -f node
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
-            null
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           securityContext:
             readOnlyRootFilesystem: true
       volumes:

--- a/charts/headlamp/tests/expected_templates/security-context.yaml
+++ b/charts/headlamp/tests/expected_templates/security-context.yaml
@@ -193,8 +193,24 @@ spec:
               mountPath: /config
             - name: headlamp-plugins-tmp
               mountPath: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pgrep -f pluginctl || pgrep -f node
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           resources:
-            null
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -469,14 +469,23 @@ pluginsManager:
   # env:
   # - name: HTTPS_PROXY
   #   value: "proxy.example.com:8080"
-  # -- Specify resrouces
-  # resources:
-  #   requests:
-  #     cpu: "500m"
-  #     memory: "2048Mi"
-  #   limits:
-  #     cpu: "1000m"
-  #     memory: "4096Mi"
+  # -- CPU/Memory resource requests/limits for the plugin manager sidecar container.
+  # Provides Burstable QoS by default. Set to null (~) to remove all constraints.
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+  # -- Liveness probe configuration for the plugin manager sidecar container.
+  # Set to null (~) to disable the liveness probe entirely.
+  # Note: successThreshold is always 1 (Kubernetes requires this for liveness probes).
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 1
+    failureThreshold: 3
   # If omitted, the plugin manager will inherit the global securityContext.
   # When readOnlyRootFilesystem: true is active (set here or inherited), the
   # chart automatically adds a writable emptyDir volume named


### PR DESCRIPTION

## Summary

This PR fixes the `headlamp-plugin` sidecar container (used by `pluginsManager`) by adding a configurable liveness probe and default resource requests/limits, making it consistent with the main `headlamp` container which already has both configured.

## Related Issue

Fixes #6380 

## Changes

- Added `pluginsManager.livenessProbe` block in `charts/headlamp/values.yaml` with  sensible defaults (`initialDelaySeconds: 30`, `periodSeconds: 30`,   `failureThreshold: 3`)
- Added `pluginsManager.resources` block in `charts/headlamp/values.yaml` with   default requests (`cpu: 100m`, `memory: 256Mi`) and limits (`cpu: 500m`,  `memory: 1Gi`)
- Updated `charts/headlamp/templates/deployment.yaml` to wire up   `pluginsManager.resources` via `toYaml` on the `headlamp-plugin` container
- Updated `charts/headlamp/templates/deployment.yaml` to add an `exec`-based  liveness probe (`pgrep -f pluginctl || pgrep -f node`) on the `headlamp-plugin` container with timing pulled from `pluginsManager.livenessProbe` values
- No changes made to the main `headlamp` container spec or any unrelated files


## Steps to Test

1. Deploy Headlamp locally via Helm with `pluginsManager` enabled:

```yaml
pluginsManager:
  enabled: true
  configContent: |
    plugins:
      - name: flux
        source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_flux
        version: 0.5.0
```

```bash
helm install headlamp ./charts/headlamp \
  --namespace headlamp \
  --create-namespace \
  -f values.yaml
```

2. Wait for the pod to reach `2/2 Running`:

```bash
kubectl get pods -n headlamp -w
```

3. Describe the pod and inspect the `headlamp-plugin` container section:

```bash
kubectl describe pod -n headlamp \
  $(kubectl get pods -n headlamp -o jsonpath='{.items[0].metadata.name}')
```

4. Verify the following are now present on the `headlamp-plugin` container:
Limits:
cpu:     500m
memory:  1Gi
Requests:
cpu:     100m
memory:  256Mi
Liveness:  exec [/bin/sh -c pgrep -f pluginctl || pgrep -f node]
delay=30s timeout=1s period=30s #success=1 #failure=3

5. Confirm QoS class has been upgraded:

```bash
kubectl describe pod -n headlamp \
  $(kubectl get pods -n headlamp -o jsonpath='{.items[0].metadata.name}') \
  | grep "QoS Class"
# Expected: QoS Class: Burstable
```

6. Simulate a sidecar crash and verify Kubernetes now restarts it automatically:

```bash
kubectl exec -n headlamp \
  $(kubectl get pods -n headlamp -o jsonpath='{.items[0].metadata.name}') \
  -c headlamp-plugin -- /bin/sh -c "pkill -f node"

kubectl get pods -n headlamp -w
# Expected: RESTARTS counter increments for the pod
```

## Notes for the Reviewer

- Only `charts/headlamp/values.yaml` and `charts/headlamp/templates/deployment.yaml`
  are modified — no frontend, backend, or unrelated chart files are touched
- The liveness probe and resources are fully configurable via `values.yaml` — operators
  can override defaults by setting `pluginsManager.livenessProbe` and
  `pluginsManager.resources` in their own values file, consistent with how the main
  container's `probes` and `resources` work
- The fix was verified locally on minikube v1.35.1 / Headlamp v0.43.0 / Ubuntu 24.04
- Related: #3999 (sidecar CrashLoopBackOff) — the liveness probe ensures Kubernetes
  can now automatically recover the sidecar if it crashes instead of silently leaving
  plugins in a broken state

Replace #ISSUE_NUMBER with the actual issue number you get after filing the issue on GitHub.