### PR TITLE
Validate configPath to prevent path traversal in DELETE /cluster/{name}

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2537,6 +2537,25 @@ func (c *HeadlampConfig) handleRemoveKubeConfig(
 	originalName := r.URL.Query().Get("originalName")
 	clusterID := r.URL.Query().Get("clusterID")
 
+	// A missing configPath is a malformed request, not an authorization failure.
+	if configPath == "" {
+		c.handleError(w, ctx, span, errors.New("configPath is required"),
+			"configPath is required", http.StatusBadRequest)
+
+		return
+	}
+
+	validatedPath, err := c.validateKubeConfigPath(configPath)
+	if err != nil {
+		// Log the detailed reason server-side, but return a generic message so
+		// resolved filesystem paths aren't reflected back to the client.
+		logger.Log(logger.LevelError, map[string]string{"cluster": name}, err, "configPath validation failed")
+		c.handleError(w, ctx, span, errors.New("configPath is not allowed"),
+			"configPath is not allowed", http.StatusForbidden)
+
+		return
+	}
+
 	var configName string
 
 	if originalName != "" && clusterID != "" {
@@ -2545,9 +2564,114 @@ func (c *HeadlampConfig) handleRemoveKubeConfig(
 		configName = name
 	}
 
-	if err := kubeconfig.RemoveContextFromFile(configName, configPath); err != nil {
+	if err := kubeconfig.RemoveContextFromFile(configName, validatedPath); err != nil {
 		c.handleError(w, ctx, span, err, "failed to remove cluster from kubeconfig", http.StatusInternalServerError)
 	}
+}
+
+// allowedKubeConfigDirs returns the directories a configPath is permitted to
+// resolve within: Headlamp's own kubeconfigs dir, the directory of each
+// --kubeconfig entry, and ~/.kube.
+func (c *HeadlampConfig) allowedKubeConfigDirs() []string {
+	var allowedDirs []string
+
+	// Headlamp's own kubeconfig persistence directory. Compute the path
+	// directly instead of calling cfg.MakeHeadlampKubeConfigsDir(), which
+	// creates the directory and falls back to the executable's directory on
+	// failure — neither is wanted for a validation-only check.
+	if userConfigDir, err := os.UserConfigDir(); err == nil {
+		headlampDir := filepath.Join(userConfigDir, "Headlamp", "kubeconfigs")
+		if runtime.GOOS == "windows" {
+			headlampDir = filepath.Join(userConfigDir, "Headlamp", "Config", "kubeconfigs")
+		}
+
+		allowedDirs = append(allowedDirs, headlampDir)
+	}
+
+	// KubeConfigPath is a colon-separated (semicolon on Windows) list of
+	// entries. Each is normally a file, so allow its parent directory; but if
+	// an entry is itself a directory, allow that directory rather than widening
+	// the allow-list to its parent.
+	for _, p := range filepath.SplitList(c.KubeConfigPath) {
+		if p == "" {
+			continue
+		}
+
+		if fi, err := os.Stat(p); err == nil && fi.IsDir() {
+			allowedDirs = append(allowedDirs, p)
+		} else {
+			allowedDirs = append(allowedDirs, filepath.Dir(p))
+		}
+	}
+
+	// Default ~/.kube directory.
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		allowedDirs = append(allowedDirs, filepath.Join(homeDir, ".kube"))
+	}
+
+	return allowedDirs
+}
+
+// validateKubeConfigPath checks that the given path resolves within one of the
+// directories Headlamp is allowed to manage kubeconfig files in.
+func (c *HeadlampConfig) validateKubeConfigPath(configPath string) (string, error) {
+	if configPath == "" {
+		return "", errors.New("configPath must not be empty")
+	}
+
+	// Expand leading ~ so that paths like ~/.kube/config are handled correctly.
+	// filepath.Abs does not expand ~. Work on a copy so the original configPath
+	// (the query value) stays unchanged and doesn't leak into error messages.
+	pathToResolve := configPath
+	if strings.HasPrefix(pathToResolve, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand ~: %w", err)
+		}
+
+		pathToResolve = filepath.Join(homeDir, pathToResolve[2:])
+	}
+
+	absPath, err := filepath.Abs(pathToResolve)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve configPath: %w", err)
+	}
+
+	// Resolve symlinks so a symlink inside an allowed dir pointing outside it
+	// cannot bypass the containment check. If the file does not exist yet,
+	// resolve the parent directory instead so that the check still works
+	// consistently on systems where temp/home dirs are themselves symlinks
+	// (e.g. macOS).
+	resolved := absPath
+	if target, err := filepath.EvalSymlinks(resolved); err == nil {
+		resolved = target
+	} else if parentTarget, err := filepath.EvalSymlinks(filepath.Dir(resolved)); err == nil {
+		resolved = filepath.Join(parentTarget, filepath.Base(resolved))
+	}
+
+	for _, dir := range c.allowedKubeConfigDirs() {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+
+		if target, err := filepath.EvalSymlinks(absDir); err == nil {
+			absDir = target
+		}
+
+		// filepath.Rel gives a robust containment check across platforms. A
+		// relative path of "." (the dir itself) or one that doesn't start with
+		// ".." means resolved is inside absDir.
+		rel, err := filepath.Rel(absDir, resolved)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) &&
+			!filepath.IsAbs(rel) {
+			// Return the ~-expanded absolute path so the caller operates on the
+			// same path that was validated (client-go does not expand ~).
+			return absPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("configPath %q is outside allowed directories", configPath)
 }
 
 // Get path of kubeconfig we load headlamp with from source.

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2527,6 +2527,14 @@ func (c *HeadlampConfig) deleteCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate before the store is touched, so a request that is going to be
+	// refused leaves the cluster where it was instead of removing it and then
+	// reporting a 400 or 403.
+	validatedPath, ok := c.validateDeleteKubeConfigRequest(w, r, ctx, span, name)
+	if !ok {
+		return
+	}
+
 	err := c.KubeConfigStore.RemoveContext(name)
 	if err != nil {
 		c.handleError(w, ctx, span, err, "failed to delete cluster", http.StatusInternalServerError)
@@ -2534,38 +2542,86 @@ func (c *HeadlampConfig) deleteCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.handleDeleteCluster(w, r, ctx, span, name)
+	if !c.handleDeleteCluster(w, r, ctx, span, name, validatedPath) {
+		return
+	}
 
 	c.getConfig(w, r)
 }
 
-// handleDeleteCluster handles the deletion of a cluster.
+// handleDeleteCluster handles the deletion of a cluster. validatedPath is the
+// kubeconfig to remove the cluster from, empty when the request did not ask for
+// that. It reports whether the caller may go on to write the success response:
+// an error response has already been written when it returns false.
 func (c *HeadlampConfig) handleDeleteCluster(
 	w http.ResponseWriter,
 	r *http.Request,
 	ctx context.Context,
 	span trace.Span,
 	name string,
-) {
-	removeKubeConfig := r.URL.Query().Get("removeKubeConfig") == "true"
-	if removeKubeConfig {
-		c.handleRemoveKubeConfig(w, r, ctx, span, name)
-		return
+	validatedPath string,
+) bool {
+	if validatedPath != "" {
+		return c.handleRemoveKubeConfig(w, r, ctx, span, name, validatedPath)
 	}
 
 	logger.Log(logger.LevelInfo, map[string]string{logFieldCluster: name, "proxy": name},
 		nil, "removed cluster successfully")
+
+	return true
 }
 
-// handleRemoveKubeConfig removes the cluster from the kubeconfig file.
+// validateDeleteKubeConfigRequest checks the configPath of a delete request that
+// also removes the cluster from its kubeconfig. It returns the validated path,
+// empty when the request does not ask for the kubeconfig to be touched, and
+// false when it has written an error response and the request must stop.
+func (c *HeadlampConfig) validateDeleteKubeConfigRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	ctx context.Context,
+	span trace.Span,
+	name string,
+) (string, bool) {
+	if r.URL.Query().Get("removeKubeConfig") != "true" {
+		return "", true
+	}
+
+	configPath := r.URL.Query().Get("configPath")
+
+	// A missing configPath is a malformed request, not an authorization failure.
+	if configPath == "" {
+		c.handleError(w, ctx, span, errors.New("configPath is required"),
+			"configPath is required", http.StatusBadRequest)
+
+		return "", false
+	}
+
+	validatedPath, err := c.validateKubeConfigPath(configPath)
+	if err != nil {
+		// Log the detailed reason server-side, but return a generic message so
+		// resolved filesystem paths aren't reflected back to the client.
+		logger.Log(logger.LevelError, map[string]string{"cluster": name}, err, "configPath validation failed")
+		c.handleError(w, ctx, span, errors.New("configPath is not allowed"),
+			"configPath is not allowed", http.StatusForbidden)
+
+		return "", false
+	}
+
+	return validatedPath, true
+}
+
+// handleRemoveKubeConfig removes the cluster from the kubeconfig file at
+// validatedPath, which validateDeleteKubeConfigRequest has already checked. It
+// reports whether the removal succeeded; on failure it has written the error
+// response itself.
 func (c *HeadlampConfig) handleRemoveKubeConfig(
 	w http.ResponseWriter,
 	r *http.Request,
 	ctx context.Context,
 	span trace.Span,
 	name string,
-) {
-	configPath := r.URL.Query().Get("configPath")
+	validatedPath string,
+) bool {
 	originalName := r.URL.Query().Get("originalName")
 	clusterID := r.URL.Query().Get("clusterID")
 
@@ -2577,9 +2633,141 @@ func (c *HeadlampConfig) handleRemoveKubeConfig(
 		configName = name
 	}
 
-	if err := kubeconfig.RemoveContextFromFile(configName, configPath); err != nil {
+	if err := kubeconfig.RemoveContextFromFile(configName, validatedPath); err != nil {
 		c.handleError(w, ctx, span, err, "failed to remove cluster from kubeconfig", http.StatusInternalServerError)
+
+		return false
 	}
+
+	return true
+}
+
+// allowedKubeConfigDirs returns the directories a configPath is permitted to
+// resolve within: Headlamp's own kubeconfigs dir, the directory of each
+// --kubeconfig entry, and ~/.kube.
+func (c *HeadlampConfig) allowedKubeConfigDirs() []string {
+	var allowedDirs []string
+
+	// Headlamp's own kubeconfig persistence directory, which is where dynamic
+	// clusters are written. --kubeconfig-dir moves it, and then the platform
+	// default is not used at all, so only one of the two is allowed. Compute
+	// the default directly instead of calling cfg.MakeKubeConfigsDir(), which
+	// creates the directory and falls back to the executable's directory on
+	// failure — neither is wanted for a validation-only check.
+	if c.KubeConfigDir != "" {
+		allowedDirs = append(allowedDirs, c.KubeConfigDir)
+	} else if userConfigDir, err := os.UserConfigDir(); err == nil {
+		headlampDir := filepath.Join(userConfigDir, "Headlamp", "kubeconfigs")
+		if runtime.GOOS == "windows" {
+			headlampDir = filepath.Join(userConfigDir, "Headlamp", "Config", "kubeconfigs")
+		}
+
+		allowedDirs = append(allowedDirs, headlampDir)
+	}
+
+	// KubeConfigPath is a colon-separated (semicolon on Windows) list of
+	// entries. Each is normally a file, so allow its parent directory; but if
+	// an entry is itself a directory, allow that directory rather than widening
+	// the allow-list to its parent.
+	for _, p := range filepath.SplitList(c.KubeConfigPath) {
+		if p == "" {
+			continue
+		}
+
+		// An entry that cannot be stat'ed is skipped rather than assumed to be
+		// a file: allowing the parent of a directory entry that happens to be
+		// missing would widen the allow-list on a guess. Nothing can be removed
+		// from a kubeconfig that isn't there anyway.
+		fi, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+
+		if fi.IsDir() {
+			allowedDirs = append(allowedDirs, p)
+
+			continue
+		}
+
+		// Resolve the entry before taking its parent, so a configured kubeconfig
+		// that is itself a symlink stays usable: a request for it is checked
+		// against the resolved path, which lives in the target's directory
+		// rather than the link's.
+		if resolved, err := filepath.EvalSymlinks(p); err == nil {
+			p = resolved
+		}
+
+		allowedDirs = append(allowedDirs, filepath.Dir(p))
+	}
+
+	// Default ~/.kube directory.
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		allowedDirs = append(allowedDirs, filepath.Join(homeDir, ".kube"))
+	}
+
+	return allowedDirs
+}
+
+// validateKubeConfigPath checks that the given path resolves within one of the
+// directories Headlamp is allowed to manage kubeconfig files in.
+func (c *HeadlampConfig) validateKubeConfigPath(configPath string) (string, error) {
+	if configPath == "" {
+		return "", errors.New("configPath must not be empty")
+	}
+
+	// Expand leading ~ so that paths like ~/.kube/config are handled correctly.
+	// filepath.Abs does not expand ~. Work on a copy so the original configPath
+	// (the query value) stays unchanged and doesn't leak into error messages.
+	pathToResolve := configPath
+	if strings.HasPrefix(pathToResolve, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand ~: %w", err)
+		}
+
+		pathToResolve = filepath.Join(homeDir, pathToResolve[2:])
+	}
+
+	absPath, err := filepath.Abs(pathToResolve)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve configPath: %w", err)
+	}
+
+	// Resolve symlinks so a symlink inside an allowed dir pointing outside it
+	// cannot bypass the containment check. If the file does not exist yet,
+	// resolve the parent directory instead so that the check still works
+	// consistently on systems where temp/home dirs are themselves symlinks
+	// (e.g. macOS).
+	resolved := absPath
+	if target, err := filepath.EvalSymlinks(resolved); err == nil {
+		resolved = target
+	} else if parentTarget, err := filepath.EvalSymlinks(filepath.Dir(resolved)); err == nil {
+		resolved = filepath.Join(parentTarget, filepath.Base(resolved))
+	}
+
+	for _, dir := range c.allowedKubeConfigDirs() {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+
+		if target, err := filepath.EvalSymlinks(absDir); err == nil {
+			absDir = target
+		}
+
+		// filepath.Rel gives a robust containment check across platforms. A
+		// relative path of "." (the dir itself) or one that doesn't start with
+		// ".." means resolved is inside absDir.
+		rel, err := filepath.Rel(absDir, resolved)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) &&
+			!filepath.IsAbs(rel) {
+			// Return the ~-expanded absolute path so the caller operates on the
+			// same path that was validated (client-go does not expand ~).
+			return absPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("configPath %q is outside allowed directories", configPath)
 }
 
 // Get path of kubeconfig we load headlamp with from source.

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -3999,3 +3999,77 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func TestValidateKubeConfigPath(t *testing.T) { //nolint:funlen // test scaffolding.
+	t.Parallel()
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	// A temp dir that acts as a custom kubeconfig directory.
+	customDir := t.TempDir()
+	customKubeConfig := filepath.Join(customDir, "config")
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  customKubeConfig,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "empty path is rejected",
+			path:    "",
+			wantErr: true,
+		},
+		{
+			name:    "path traversal to /etc/passwd is rejected",
+			path:    "../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "absolute path outside allowed dirs is rejected",
+			path:    filepath.Join(t.TempDir(), "evil-kubeconfig"),
+			wantErr: true,
+		},
+		{
+			name:    "path within ~/.kube is allowed",
+			path:    filepath.Join(homeDir, ".kube", "config"),
+			wantErr: false,
+		},
+		{
+			name:    "path within custom kubeconfig dir is allowed",
+			path:    customKubeConfig,
+			wantErr: false,
+		},
+		{
+			name:    "tilde path within ~/.kube is allowed",
+			path:    "~/.kube/config",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := c.validateKubeConfigPath(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				// The returned path must be usable directly by client-go: an
+				// absolute path with any leading ~ already expanded.
+				assert.True(t, filepath.IsAbs(got), "returned path should be absolute")
+				assert.False(t, strings.HasPrefix(got, "~"), "returned path should have ~ expanded")
+			}
+		})
+	}
+}

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4584,3 +4584,378 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func TestValidateKubeConfigPath(t *testing.T) { //nolint:funlen // test scaffolding.
+	t.Parallel()
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	// A temp dir that acts as a custom kubeconfig directory. The file has to
+	// exist: an entry that cannot be stat'ed is not allow-listed, since its
+	// type is unknown.
+	customDir := t.TempDir()
+	customKubeConfig := filepath.Join(customDir, "config")
+	require.NoError(t, os.WriteFile(customKubeConfig, []byte("kubeconfig"), 0o600))
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  customKubeConfig,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "empty path is rejected",
+			path:    "",
+			wantErr: true,
+		},
+		{
+			name:    "path traversal to /etc/passwd is rejected",
+			path:    "../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "absolute path outside allowed dirs is rejected",
+			path:    filepath.Join(t.TempDir(), "evil-kubeconfig"),
+			wantErr: true,
+		},
+		{
+			name:    "path within ~/.kube is allowed",
+			path:    filepath.Join(homeDir, ".kube", "config"),
+			wantErr: false,
+		},
+		{
+			name:    "path within custom kubeconfig dir is allowed",
+			path:    customKubeConfig,
+			wantErr: false,
+		},
+		{
+			name:    "tilde path within ~/.kube is allowed",
+			path:    "~/.kube/config",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := c.validateKubeConfigPath(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				// The returned path must be usable directly by client-go: an
+				// absolute path with any leading ~ already expanded.
+				assert.True(t, filepath.IsAbs(got), "returned path should be absolute")
+				assert.False(t, strings.HasPrefix(got, "~"), "returned path should have ~ expanded")
+			}
+		})
+	}
+}
+
+func TestValidateKubeConfigPathRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks needs elevated privileges on Windows")
+	}
+
+	// customDir is allowed, the symlink inside it points outside.
+	customDir := t.TempDir()
+	customKubeConfig := filepath.Join(customDir, "config")
+	require.NoError(t, os.WriteFile(customKubeConfig, []byte("kubeconfig"), 0o600))
+
+	outsideFile := filepath.Join(t.TempDir(), "outside-kubeconfig")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("outside"), 0o600))
+
+	escapingLink := filepath.Join(customDir, "escaping-link")
+	require.NoError(t, os.Symlink(outsideFile, escapingLink))
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  customKubeConfig,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+
+	_, err := c.validateKubeConfigPath(escapingLink)
+	assert.Error(t, err, "a symlink pointing outside the allowed dirs must be rejected")
+}
+
+// Dynamic clusters are persisted under --kubeconfig-dir when it is set, so a
+// request to delete one names a path in that directory and has to be allowed.
+func TestValidateKubeConfigPathAllowsConfiguredKubeConfigDir(t *testing.T) {
+	t.Parallel()
+
+	kubeConfigDir := t.TempDir()
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigDir:   kubeConfigDir,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+
+	got, err := c.validateKubeConfigPath(filepath.Join(kubeConfigDir, "config"))
+	require.NoError(t, err, "the configured kubeconfig persistence dir must be allowed")
+	assert.True(t, filepath.IsAbs(got))
+}
+
+// A --kubeconfig entry that cannot be stat'ed says nothing about whether it is
+// a file or a directory, so its parent must not be allow-listed: an entry meant
+// as a directory, such as /etc/kubeconfigs, would otherwise open up /etc.
+func TestValidateKubeConfigPathIgnoresUnstatableEntries(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+
+	sibling := filepath.Join(parent, "victim")
+	require.NoError(t, os.WriteFile(sibling, []byte("victim"), 0o600))
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  filepath.Join(parent, "missing-kubeconfigs"),
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+
+	_, err := c.validateKubeConfigPath(sibling)
+	assert.Error(t, err, "a missing entry must not allow-list its parent directory")
+}
+
+// A configured kubeconfig that is a symlink is checked against the path it
+// resolves to, so the target's directory is what has to be allowed. Otherwise
+// Headlamp rejects the very file it was pointed at.
+func TestValidateKubeConfigPathAllowsSymlinkedConfiguredKubeConfig(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks needs elevated privileges on Windows")
+	}
+
+	targetDir := t.TempDir()
+	targetConfig := filepath.Join(targetDir, "config")
+	require.NoError(t, os.WriteFile(targetConfig, []byte("kubeconfig"), 0o600))
+
+	link := filepath.Join(t.TempDir(), "config-link")
+	require.NoError(t, os.Symlink(targetConfig, link))
+
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  link,
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+		},
+	}
+
+	got, err := c.validateKubeConfigPath(link)
+	require.NoError(t, err, "the configured kubeconfig must stay usable when it is a symlink")
+	assert.True(t, filepath.IsAbs(got))
+}
+
+// A refused delete must change nothing: the validation runs before the cluster
+// is taken out of the store, and its failure stops the request instead of
+// letting the success response be written after the error body.
+func TestDeleteClusterRefusedRequestHasNoEffect(t *testing.T) { //nolint:funlen // test scaffolding.
+	const validToken = "valid-token-for-test"
+
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", validToken)
+
+	kubeConfigPath, err := filepath.Abs("./headlamp_testdata/kubeconfig")
+	require.NoError(t, err)
+
+	outsideFile := filepath.Join(t.TempDir(), "victim")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("not a kubeconfig"), 0o600))
+
+	refusals := []struct {
+		name       string
+		query      string
+		wantStatus int
+	}{
+		{
+			name:       "configPath outside the allowed dirs",
+			query:      "removeKubeConfig=true&configPath=" + url.QueryEscape(outsideFile),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "missing configPath",
+			query:      "removeKubeConfig=true",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range refusals {
+		t.Run(tc.name, func(t *testing.T) {
+			store := kubeconfig.NewContextStore()
+			require.NoError(t, kubeconfig.LoadAndStoreKubeConfigs(store, kubeConfigPath, kubeconfig.KubeConfig, nil))
+
+			_, err := store.GetContext(minikubeName)
+			require.NoError(t, err, "the cluster should be in the store before the request")
+
+			handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
+				HeadlampConfig: &headlampconfig.HeadlampConfig{
+					HeadlampCFG: &headlampconfig.HeadlampCFG{
+						UseInCluster:          false,
+						KubeConfigPath:        kubeConfigPath,
+						EnableDynamicClusters: true,
+						PluginDir:             t.TempDir(),
+						UserPluginDir:         t.TempDir(),
+						KubeConfigStore:       store,
+					},
+					Cache:            cache.New[interface{}](),
+					TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+					TelemetryHandler: &telemetry.RequestHandler{},
+				},
+			})
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+				"/cluster/"+minikubeName+"?"+tc.query, nil)
+			req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", validToken)
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.wantStatus, rr.Code)
+
+			_, err = store.GetContext(minikubeName)
+			assert.NoError(t, err, "a refused delete must leave the cluster in the store")
+
+			assert.NotContains(t, rr.Body.String(), "isDynamicClusterEnabled",
+				"the config response must not be written after the error")
+		})
+	}
+}
+
+// TestDeleteClusterValidatesConfigPath exercises the route rather than the
+// validator, so dropping the check from handleRemoveKubeConfig, or using the
+// unvalidated configPath for the file operation, fails here.
+func TestDeleteClusterValidatesConfigPath(t *testing.T) { //nolint:funlen // test scaffolding.
+	const validToken = "valid-token-for-test"
+
+	t.Setenv("HEADLAMP_BACKEND_TOKEN", validToken)
+
+	kubeConfigBytes, err := os.ReadFile("./headlamp_testdata/kubeconfig")
+	require.NoError(t, err)
+
+	// Point the home directory at a temp dir so ~/.kube is one of the allowed
+	// dirs without touching the real one. os.UserHomeDir() reads HOME on unix
+	// and USERPROFILE on Windows.
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("USERPROFILE", tempHome)
+
+	homeKubeDir := filepath.Join(tempHome, ".kube")
+	require.NoError(t, os.Mkdir(homeKubeDir, 0o750))
+
+	homeConfig := filepath.Join(homeKubeDir, "config")
+	require.NoError(t, os.WriteFile(homeConfig, kubeConfigBytes, 0o600)) //nolint:gosec
+
+	// The kubeconfig Headlamp is allowed to manage, plus a file outside every
+	// allowed directory, which is what an attacker would aim at.
+	allowedDir := t.TempDir()
+	allowedConfig := filepath.Join(allowedDir, "config")
+	require.NoError(t, os.WriteFile(allowedConfig, kubeConfigBytes, 0o600)) //nolint:gosec
+
+	const outsideContents = "not a kubeconfig"
+
+	outsideFile := filepath.Join(t.TempDir(), "victim")
+	require.NoError(t, os.WriteFile(outsideFile, []byte(outsideContents), 0o600))
+
+	workDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	relOutsideFile, err := filepath.Rel(workDir, outsideFile)
+	require.NoError(t, err)
+
+	newHandler := func(t *testing.T) http.Handler {
+		t.Helper()
+
+		return createHeadlampHandler(context.Background(), &HeadlampConfig{
+			HeadlampConfig: &headlampconfig.HeadlampConfig{
+				HeadlampCFG: &headlampconfig.HeadlampCFG{
+					UseInCluster:          false,
+					KubeConfigPath:        allowedConfig,
+					EnableDynamicClusters: true,
+					PluginDir:             t.TempDir(),
+					UserPluginDir:         t.TempDir(),
+					KubeConfigStore:       kubeconfig.NewContextStore(),
+				},
+				Cache:            cache.New[interface{}](),
+				TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+				TelemetryHandler: &telemetry.RequestHandler{},
+			},
+		})
+	}
+
+	deleteCluster := func(t *testing.T, handler http.Handler, configPath string) *httptest.ResponseRecorder {
+		t.Helper()
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+			"/cluster/"+minikubeName+"?removeKubeConfig=true&configPath="+url.QueryEscape(configPath), nil)
+		req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", validToken)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		return rr
+	}
+
+	outsidePaths := []struct {
+		name       string
+		configPath string
+	}{
+		{name: "absolute path outside allowed dirs", configPath: outsideFile},
+		{name: "relative path traversal", configPath: relOutsideFile},
+	}
+
+	for _, tc := range outsidePaths {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := deleteCluster(t, newHandler(t), tc.configPath)
+
+			assert.Equal(t, http.StatusForbidden, rr.Code)
+
+			contents, err := os.ReadFile(outsideFile) //nolint:gosec
+			require.NoError(t, err)
+			assert.Equal(t, outsideContents, string(contents), "the target file must be untouched")
+		})
+	}
+
+	allowedPaths := []struct {
+		name       string
+		configPath string
+		file       string
+	}{
+		{name: "allowed configPath removes the context", configPath: allowedConfig, file: allowedConfig},
+		// A ~ path only works if the handler operates on the expanded path the
+		// validator returned, since client-go does not expand ~ itself.
+		{name: "tilde configPath removes the context", configPath: "~/.kube/config", file: homeConfig},
+	}
+
+	for _, tc := range allowedPaths {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := deleteCluster(t, newHandler(t), tc.configPath)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+
+			config, err := clientcmd.LoadFromFile(tc.file)
+			require.NoError(t, err)
+			assert.NotContains(t, config.Contexts, minikubeName)
+		})
+	}
+}


### PR DESCRIPTION
The configPath query parameter was passed directly to RemoveContextFromFile()
without any validation, allowing an attacker with a valid backend token to
read and overwrite arbitrary files on the server via path traversal.

Add validateKubeConfigPath() which resolves the path to an absolute path
and checks it falls within one of the directories Headlamp is allowed to
manage: the Headlamp kubeconfigs dir, the --kubeconfig flag dir, or ~/.kube/.

Fixes #6385

## Summary

The `configPath` query param in `DELETE /cluster/{name}` was taken straight
from the URL and handed to `RemoveContextFromFile()` which reads the file
and writes it back. No check that it actually points somewhere safe. This
adds a validation step that rejects any path outside the directories
Headlamp is supposed to manage.

## Related Issue

Fixes #6385

## Changes

- `backend/cmd/headlamp.go`: added `validateKubeConfigPath()` and called it
  at the start of `handleRemoveKubeConfig()` before the path is used

## Steps to Test

1. Start Headlamp with a cluster loaded
2. Send `DELETE /cluster/test?removeKubeConfig=true&configPath=../../etc/passwd`
   with a valid `X-HEADLAMP_BACKEND-TOKEN` header
3. Should get `403 Forbidden` — file is not touched
4. Send the same request with a valid path like `~/.kube/config` — should
   work as normal

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- Allowed dirs: Headlamp's kubeconfigs dir, `--kubeconfig` flag dir, and
  `~/.kube/`. If paths from the `KUBECONFIG` env var should also be in
  scope, happy to add that.