### PR TITLE
frontend: common/ConditionList: Add Storybook stories

### DIFF
--- a/frontend/src/components/common/ConditionList.stories.tsx
+++ b/frontend/src/components/common/ConditionList.stories.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { KubeCondition } from '../../lib/k8s/cluster';
+import { TestContext } from '../../test';
+import { ConditionList, ConditionListProps } from './ConditionList';
+
+export default {
+  title: 'ConditionList',
+  component: ConditionList,
+} as Meta;
+
+// Transition/update times are intentionally omitted: ConditionList renders them via DateLabel
+// (absolute, timezone-dependent), so including them would make the snapshots differ between a
+// local run and CI. lastProbeTime is required by the type but never rendered.
+const CONDITIONS: KubeCondition[] = [
+  {
+    type: 'Ready',
+    status: 'True',
+    lastProbeTime: null,
+    reason: 'PodReady',
+    message: 'Pod is ready',
+  },
+  {
+    type: 'PodScheduled',
+    status: 'False',
+    lastProbeTime: null,
+    reason: 'Unschedulable',
+    message: 'No nodes available',
+  },
+  {
+    type: 'Initialized',
+    status: 'Unknown',
+    lastProbeTime: null,
+  },
+];
+
+const Template: StoryFn<ConditionListProps> = args => (
+  <TestContext>
+    <ConditionList {...args} />
+  </TestContext>
+);
+
+// True -> success, False -> error, anything else -> neutral chip
+export const Default = Template.bind({});
+Default.args = {
+  conditions: CONDITIONS,
+};
+
+// showLastUpdate adds the extra Last Update column
+export const WithLastUpdate = Template.bind({});
+WithLastUpdate.args = {
+  conditions: CONDITIONS,
+  showLastUpdate: true,
+};
+
+// empty/undefined/null conditions all render nothing
+export const Empty = Template.bind({});
+Empty.args = {
+  conditions: [],
+};
+
+export const EmptyUndefined = Template.bind({});
+EmptyUndefined.args = {
+  conditions: undefined,
+};
+
+export const EmptyNull = Template.bind({});
+EmptyNull.args = {
+  conditions: null,
+};

--- a/frontend/src/components/common/__snapshots__/ConditionList.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConditionList.Default.stories.storyshot
@@ -1,0 +1,151 @@
+<body>
+  <div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      class="MuiBox-root css-ty8jgw"
+      role="status"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+      tabindex="0"
+    >
+      <table
+        class="MuiTable-root css-qzmaqi-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Condition
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Status
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Last Transition
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Reason
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+              >
+                Ready
+              </span>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              True
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <p
+                aria-label="Pod is ready"
+                class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                data-mui-internal-clone-element="true"
+              >
+                PodReady
+              </p>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+              >
+                PodScheduled
+              </span>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              False
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <p
+                aria-label="No nodes available"
+                class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                data-mui-internal-clone-element="true"
+              >
+                Unschedulable
+              </p>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+              >
+                Initialized
+              </span>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              Unknown
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/common/__snapshots__/ConditionList.Empty.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConditionList.Empty.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/__snapshots__/ConditionList.EmptyNull.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConditionList.EmptyNull.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/__snapshots__/ConditionList.EmptyUndefined.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConditionList.EmptyUndefined.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>

--- a/frontend/src/components/common/__snapshots__/ConditionList.WithLastUpdate.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/ConditionList.WithLastUpdate.stories.storyshot
@@ -1,0 +1,172 @@
+<body>
+  <div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      class="MuiBox-root css-ty8jgw"
+      role="status"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiTableContainer-root css-onzayo-MuiPaper-root-MuiTableContainer-root"
+      tabindex="0"
+    >
+      <table
+        class="MuiTable-root css-r7i92b-MuiTable-root"
+      >
+        <thead
+          class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        >
+          <tr
+            class="MuiTableRow-root MuiTableRow-head css-13jktim-MuiTableRow-root"
+          >
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Condition
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Status
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Last Transition
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Last Update
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-l4jzay-MuiTableCell-root"
+              scope="col"
+            >
+              Reason
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-1aajmzw-MuiTypography-root"
+              >
+                Ready
+              </span>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              True
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <p
+                aria-label="Pod is ready"
+                class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                data-mui-internal-clone-element="true"
+              >
+                PodReady
+              </p>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-1ge3384-MuiTypography-root"
+              >
+                PodScheduled
+              </span>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              False
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <p
+                aria-label="No nodes available"
+                class="MuiTypography-root MuiTypography-body1 css-1d0cpfm-MuiTypography-root"
+                data-mui-internal-clone-element="true"
+              >
+                Unschedulable
+              </p>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root css-13jktim-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-j24kpb-MuiTypography-root"
+              >
+                Initialized
+              </span>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              Unknown
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-oh2q4q-MuiTableCell-root"
+            >
+              -
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
Closes #6386

`common/ConditionList.tsx` (added in #5968) renders a Kubernetes `.status.conditions` array as a `SimpleTable` of coloured `StatusLabel` chips, but had neither a unit test nor a Storybook story, leaving its status-colour mapping and render output uncovered by the snapshot suite (`frontend/src/storybook.test.tsx`).

This adds `ConditionList.stories.tsx` with five stories:

- **Default** — a populated `conditions` array mixing `True`/`False`/`Unknown` statuses (exercises the `True`→success, `False`→error, else→neutral colour mapping)
- **WithLastUpdate** — same data with `showLastUpdate` to render the extra Last Update column
- **Empty** / **EmptyUndefined** / **EmptyNull** — `[]`/`undefined`/`null` all render nothing (documents the null-render contract)

The hand-written change is small; the rest of the diff is the auto-generated `.storyshot` snapshots.

### Notes
- The stories are pure and props-driven, wrapped in `TestContext` only because `SimpleTable` reads `rowsPerPage` from the Redux store.
- The rendered `lastTransitionTime`/`lastUpdateTime` (via `DateLabel`) format absolute, timezone-dependent time, so the fixtures omit them (leaving the `-` fallback) to keep snapshots stable across local and CI (UTC). Verified stable under `TZ=America/New_York`. Full storyshot suite: 608 passed, zero drift.