### PR TITLE
charts: default ClusterRoleBinding to least-privilege 'view' role

### DIFF
--- a/charts/headlamp/templates/clusterrolebinding.yaml
+++ b/charts/headlamp/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "headlamp.fullname" . }}-admin
+  name: {{ include "headlamp.fullname" . }}
   labels:
     {{- include "headlamp.labels" . | nindent 4 }}
   {{- with .Values.clusterRoleBinding.annotations }}

--- a/charts/headlamp/values.yaml
+++ b/charts/headlamp/values.yaml
@@ -198,9 +198,15 @@ serviceAccount:
 clusterRoleBinding:
   # -- Specified whether a cluster role binding should be created
   create: true
-  # -- Set name of the Cluster Role with limited permissions from you cluster
+  # -- Name of the ClusterRole to bind Headlamp's ServiceAccount to.
+  # Defaults to "view" (read-only, least-privilege) rather than "cluster-admin"
+  # for security. Headlamp relies on the user's own Bearer Token for
+  # authorization against the Kubernetes API in most setups — the pod's own
+  # ServiceAccount typically does not need write/admin access.
+  # Set to "cluster-admin" only if you rely on unsafeUseServiceAccountToken
+  # or another setup where the pod itself must act with elevated permissions.
   # for example - clusterRoleName: user-ro
-  clusterRoleName: cluster-admin
+  clusterRoleName: view
   # -- Annotations to add to the cluster role binding
   annotations: {}
 


### PR DESCRIPTION
Fixes #4435

Previously the Helm chart granted `cluster-admin` to the Headlamp pod's
ServiceAccount by default, and hardcoded an `-admin` suffix on the
ClusterRoleBinding name regardless of the configured `clusterRoleName`.

Changes:
- Default `clusterRoleBinding.clusterRoleName` from `cluster-admin` to `view`
- Remove hardcoded `-admin` suffix from the ClusterRoleBinding name

Verified with `helm template` — confirmed the rendered manifest no longer
has the `-admin` suffix and `roleRef.name` correctly reflects `view`.

Note for reviewers: this changes a default, so existing users relying on
implicit cluster-admin access will need to explicitly set
`clusterRoleName: cluster-admin` after upgrading.