### PR TITLE
frontend: pod: Remove unreachable duplicate condition

### DIFF
--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -375,14 +375,6 @@ class Pod extends KubeObject<KubePod> {
       return this.detailedStatusCache.details;
     }
 
-    // We cache this data to avoid going through all this logic when nothing has changed
-    if (
-      !!this.detailedStatusCache.details &&
-      this.detailedStatusCache.resourceVersion === this.jsonData.metadata.resourceVersion
-    ) {
-      return this.detailedStatusCache.details;
-    }
-
     let restarts = 0;
     let restartableInitContainerRestarts = 0;
     let readyContainers = 0;


### PR DESCRIPTION
## Summary

Remove the duplicate unreachable cache-hit check in getDetailedStatus(). The second guard was identical to the first and could never be executed because the function would already have returned. This change removes dead code without altering functionality, improving readability and maintainability

## Related Issue

Fixes #6404

