### PR TITLE
Docs/fix typos and version requirements

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,7 +70,7 @@ Use **atomic commits** to keep each commit focused on a single change. Follow th
 - Both the title and the body of the commit message should not exceed
   72 characters in length.
   i.e. Please keep the title length under 72
-  characters, and the wrap the body of the message at 72 characters.
+  characters, and wrap the body of the message at 72 characters.
 
 - Commits should be atomic and self-contained. Divide logically separate changes
   to separate commits. This principle is best explained in the Linux Kernel

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -30,11 +30,11 @@ Once built, it can be run in development mode (auto-refresh) using:
 npm run frontend:start
 ```
 
-This command leverages the `create-react-app`'s start script that launches
-a development server for the frontend (by default at `localhost:3000`).
+This command starts the Vite development server for the frontend
+(by default at `localhost:3000`).
 
-We use [react-query](https://tanstack.com/query/latest/docs/framework/react/overview) 
-for network request, if you need the devtools for react-query, you can simply set `REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS=true` in the `.env` file.
+We use [react-query](https://tanstack.com/query/latest/docs/framework/react/overview)
+for network requests. If you need the devtools for react-query, you can simply set `REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS=true` in the `.env` file.
 
 ## Linting
 
@@ -56,7 +56,7 @@ You can run `ci-lint` locally before pushing to catch any react-hooks violations
 
 ## API documentation
 
-API documentation for TypeScript is done with [typedoc](https://typedoc.org/) and [typedoc-plugin-markdown](https://github.com/tgreyuk/typedoc-plugin-markdown), and is configured in tsconfig.json
+API documentation for TypeScript is done with [typedoc](https://typedoc.org/) and [typedoc-plugin-markdown](https://github.com/tgreyuk/typedoc-plugin-markdown), and is configured in tsconfig.json.
 
 ```bash
 npm run docs

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -59,7 +59,7 @@ We test on MacOS, various flavours of Linux, and Windows. Headlamp runs in the b
 
 ## CNCF and Kubernetes Integrations
 
-See these two links up to date lists of plugins which integrate with out cloud native projects:
+See these two links for up-to-date lists of plugins which integrate with our cloud native projects:
 - [Artifact Hub plugin list](https://artifacthub.io/packages/search?kind=21&sort=relevance)
 - [Headlamp plugins repo](https://github.com/headlamp-k8s/plugins/)
 

--- a/docs/tutorials/plugin-development/getting-started/creating-your-first-plugin/index.md
+++ b/docs/tutorials/plugin-development/getting-started/creating-your-first-plugin/index.md
@@ -53,13 +53,13 @@ Before starting, ensure you have:
 
 - ✅ Completed [Tutorial 1: Running Headlamp from Source](../running-from-source/)
 - ✅ Headlamp running locally (or ready to start)
-- ✅ Node.js ≥20.11.1 and npm ≥10.0.0
+- ✅ Node.js ≥22.0.0 and npm ≥11.0.0
 
 Verify your setup:
 
 ```bash
-node --version    # Should be v20.11.1 or higher
-npm --version     # Should be 10.0.0 or higher
+node --version    # Should be v22.0.0 or higher
+npm --version     # Should be 11.0.0 or higher
 ```
 
 **Time to complete:** ~15 minutes

--- a/docs/tutorials/plugin-development/whoami-plugin/index.md
+++ b/docs/tutorials/plugin-development/whoami-plugin/index.md
@@ -46,7 +46,7 @@ Before starting, ensure you have:
 
 - Completed the [Getting Started](../getting-started/) tutorial series (at least Tutorials 1-4)
 - Headlamp running locally with a connected cluster
-- Node.js >= 20.11.1 and npm >= 10.0.0
+- Node.js >= 22.0.0 and npm >= 11.0.0
 - Your cluster running Kubernetes >= 1.28 (for `SelfSubjectReview` API)
 
 **Time to complete:** ~20 minutes


### PR DESCRIPTION
## Summary

This PR fixes minor documentation typos and aligns outdated
prerequisites in plugin tutorials and the frontend guide with the
current project requirements in package.json.

## Related Issue

N/A

## Changes

- Fixed typo in `docs/platforms.md`: "out" → "our"
- Fixed typo in `docs/contributing.md`: "the wrap" → "wrap"
- Updated Node.js/npm prerequisites in plugin tutorials to match
  `package.json` engines (Node >= 22.0.0, npm >= 11.0.0):
  - `docs/tutorials/plugin-development/whoami-plugin/index.md`
  - `docs/tutorials/plugin-development/getting-started/creating-your-first-plugin/index.md`
- Updated `docs/development/frontend.md`:
  - Replaced outdated `create-react-app` reference with Vite
  - Fixed grammar ("network request" → "network requests")
  - Added missing period in the API documentation sentence

## Steps to Test

1. Open each changed file and confirm wording is correct
2. Compare tutorial Node.js/npm versions against `package.json`:
   `"node": ">=22.0.0"` and `"npm": ">=11.0.0"`
3. Confirm `docs/development/frontend.md` matches the current
   frontend dev setup (`npm run frontend:start` uses Vite)

## Screenshots (if applicable)

N/A — documentation-only change.

## Notes for the Reviewer

- Documentation-only PR; no code, tests, or build changes
- Please add the `documentation` label when triaging