### PR TITLE
frontend: Tabs: Fix defaultindex always initialising at zero

### DIFF
--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
@@ -74,14 +74,14 @@
         </div>
         <div
           aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
           tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -89,7 +89,7 @@
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ClusterParentSelected.stories.storyshot
@@ -77,7 +77,7 @@
           class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
-          tabindex="0"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
@@ -88,7 +88,7 @@
         </div>
         <div
           aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -96,7 +96,7 @@
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -104,7 +104,7 @@
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -112,7 +112,7 @@
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
           tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.ItemWithoutOwnURLSelected.stories.storyshot
@@ -115,7 +115,7 @@
           class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
-          tabindex="0"
+          tabindex="-1"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
@@ -159,7 +159,7 @@
           class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-5-NavigationTabs-tabs-id"
           role="tabpanel"
-          tabindex="0"
+          tabindex="-1"
         />
         <hr
           class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.NetworkPoliciesSelected.stories.storyshot
@@ -116,7 +116,7 @@
         </div>
         <div
           aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -124,7 +124,7 @@
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -132,7 +132,7 @@
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -140,7 +140,7 @@
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -148,7 +148,7 @@
         />
         <div
           aria-labelledby="full-width-tab-4-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-4-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -156,7 +156,7 @@
         />
         <div
           aria-labelledby="full-width-tab-5-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-5-NavigationTabs-tabs-id"
           role="tabpanel"
           tabindex="0"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
@@ -74,14 +74,14 @@
         </div>
         <div
           aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
           tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -89,7 +89,7 @@
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.SettingsParentSelected.stories.storyshot
@@ -77,7 +77,7 @@
           class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
-          tabindex="0"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
@@ -88,7 +88,7 @@
         </div>
         <div
           aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -96,14 +96,14 @@
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
           tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -111,7 +111,7 @@
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsChildSelected.stories.storyshot
@@ -99,7 +99,7 @@
           class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
-          tabindex="0"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
@@ -88,14 +88,14 @@
         </div>
         <div
           aria-labelledby="full-width-tab-0-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
           tabindex="0"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-1-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -103,7 +103,7 @@
         />
         <div
           aria-labelledby="full-width-tab-2-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-2-NavigationTabs-tabs-id"
           role="tabpanel"
@@ -111,7 +111,7 @@
         />
         <div
           aria-labelledby="full-width-tab-3-NavigationTabs-tabs-id"
-          class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           hidden=""
           id="full-width-tabpanel-3-NavigationTabs-tabs-id"
           role="tabpanel"

--- a/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/NavigationTabs.WorkloadsParentSelected.stories.storyshot
@@ -91,7 +91,7 @@
           class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
           id="full-width-tabpanel-0-NavigationTabs-tabs-id"
           role="tabpanel"
-          tabindex="0"
+          tabindex="-1"
         />
         <div
           aria-labelledby="full-width-tab-1-NavigationTabs-tabs-id"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -211,7 +211,7 @@
             class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             id="full-width-tabpanel-0-Editor-tabs-id"
             role="tabpanel"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
               class="MuiBox-root css-10klw3m"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.EditorDialogWithResource.stories.storyshot
@@ -208,7 +208,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-0-Editor-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             id="full-width-tabpanel-0-Editor-tabs-id"
             role="tabpanel"
             tabindex="0"
@@ -223,7 +223,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-1-Editor-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             hidden=""
             id="full-width-tabpanel-1-Editor-tabs-id"
             role="tabpanel"
@@ -245,7 +245,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-2-Editor-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             hidden=""
             id="full-width-tabpanel-2-Editor-tabs-id"
             role="tabpanel"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -247,7 +247,7 @@
             class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             id="full-width-tabpanel-0-Editor-tabs-id"
             role="tabpanel"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
               class="MuiBox-root css-10klw3m"

--- a/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/EditorDialog.ExtraActions.stories.storyshot
@@ -244,7 +244,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-0-Editor-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             id="full-width-tabpanel-0-Editor-tabs-id"
             role="tabpanel"
             tabindex="0"
@@ -259,7 +259,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-1-Editor-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             hidden=""
             id="full-width-tabpanel-1-Editor-tabs-id"
             role="tabpanel"
@@ -281,7 +281,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-2-Editor-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             hidden=""
             id="full-width-tabpanel-2-Editor-tabs-id"
             role="tabpanel"

--- a/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
@@ -85,7 +85,7 @@
             class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             id="full-width-tabpanel-0-UploadFile/URL-tabs-id"
             role="tabpanel"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
               class="MuiBox-root css-1v3caum"

--- a/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
+++ b/frontend/src/components/common/Resource/__snapshots__/UploadDialog.Default.stories.storyshot
@@ -82,7 +82,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-0-UploadFile/URL-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             id="full-width-tabpanel-0-UploadFile/URL-tabs-id"
             role="tabpanel"
             tabindex="0"
@@ -144,7 +144,7 @@
           </div>
           <div
             aria-labelledby="full-width-tab-1-UploadFile/URL-tabs-id"
-            class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
             hidden=""
             id="full-width-tabpanel-1-UploadFile/URL-tabs-id"
             role="tabpanel"

--- a/frontend/src/components/common/Tabs.test.tsx
+++ b/frontend/src/components/common/Tabs.test.tsx
@@ -15,8 +15,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { TestContext } from '../../test';
 import Tabs, { TabPanel } from './Tabs';
 
@@ -26,65 +25,46 @@ const mockTabs = [
 ];
 
 describe('Tabs', () => {
-  it('renders defaultIndex={1} correctly on initial render (before effects)', () => {
-    // Mock useEffect to prevent it from running, allowing us to inspect the initial render state.
-    const useEffectSpy = vi.spyOn(React, 'useEffect').mockImplementation(() => {});
+  it('renders defaultIndex={1} correctly', () => {
+    render(
+      <TestContext>
+        <Tabs tabs={mockTabs} defaultIndex={1} ariaLabel="Test Tabs" />
+      </TestContext>
+    );
 
-    try {
-      render(
-        <TestContext>
-          <Tabs tabs={mockTabs} defaultIndex={1} ariaLabel="Test Tabs" />
-        </TestContext>
-      );
+    const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+    const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
 
-      const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
-      const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
-
-      expect(panel1).toHaveAttribute('hidden');
-      expect(panel2).not.toHaveAttribute('hidden');
-    } finally {
-      useEffectSpy.mockRestore();
-    }
+    expect(panel1).toHaveAttribute('hidden');
+    expect(panel2).not.toHaveAttribute('hidden');
   });
 
-  it('renders defaultIndex={false} correctly on initial render (before effects)', () => {
-    const useEffectSpy = vi.spyOn(React, 'useEffect').mockImplementation(() => {});
+  it('renders defaultIndex={false} correctly', () => {
+    render(
+      <TestContext>
+        <Tabs tabs={mockTabs} defaultIndex={false} ariaLabel="Test Tabs" />
+      </TestContext>
+    );
 
-    try {
-      render(
-        <TestContext>
-          <Tabs tabs={mockTabs} defaultIndex={false} ariaLabel="Test Tabs" />
-        </TestContext>
-      );
+    const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+    const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
 
-      const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
-      const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
-
-      expect(panel1).toHaveAttribute('hidden');
-      expect(panel2).toHaveAttribute('hidden');
-    } finally {
-      useEffectSpy.mockRestore();
-    }
+    expect(panel1).toHaveAttribute('hidden');
+    expect(panel2).toHaveAttribute('hidden');
   });
 
-  it('renders defaultIndex={null} correctly on initial render (before effects)', () => {
-    const useEffectSpy = vi.spyOn(React, 'useEffect').mockImplementation(() => {});
+  it('renders defaultIndex={null} correctly', () => {
+    render(
+      <TestContext>
+        <Tabs tabs={mockTabs} defaultIndex={null} ariaLabel="Test Tabs" />
+      </TestContext>
+    );
 
-    try {
-      render(
-        <TestContext>
-          <Tabs tabs={mockTabs} defaultIndex={null} ariaLabel="Test Tabs" />
-        </TestContext>
-      );
+    const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+    const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
 
-      const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
-      const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
-
-      expect(panel1).toHaveAttribute('hidden');
-      expect(panel2).toHaveAttribute('hidden');
-    } finally {
-      useEffectSpy.mockRestore();
-    }
+    expect(panel1).toHaveAttribute('hidden');
+    expect(panel2).toHaveAttribute('hidden');
   });
 
   it('handles negative defaultIndex by clamping to 0', () => {

--- a/frontend/src/components/common/Tabs.test.tsx
+++ b/frontend/src/components/common/Tabs.test.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import Tabs, { TabPanel } from './Tabs';
+
+const mockTabs = [
+  { label: 'Tab 1', component: <div data-testid="content-1">Content 1</div> },
+  { label: 'Tab 2', component: <div data-testid="content-2">Content 2</div> },
+];
+
+describe('Tabs', () => {
+  it('renders defaultIndex={1} correctly on initial render (before effects)', () => {
+    // Mock useEffect to prevent it from running, allowing us to inspect the initial render state.
+    const useEffectSpy = vi.spyOn(React, 'useEffect').mockImplementation(() => {});
+
+    try {
+      render(
+        <TestContext>
+          <Tabs tabs={mockTabs} defaultIndex={1} ariaLabel="Test Tabs" />
+        </TestContext>
+      );
+
+      const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+      const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
+
+      expect(panel1).toHaveAttribute('hidden');
+      expect(panel2).not.toHaveAttribute('hidden');
+    } finally {
+      useEffectSpy.mockRestore();
+    }
+  });
+
+  it('renders defaultIndex={false} correctly on initial render (before effects)', () => {
+    const useEffectSpy = vi.spyOn(React, 'useEffect').mockImplementation(() => {});
+
+    try {
+      render(
+        <TestContext>
+          <Tabs tabs={mockTabs} defaultIndex={false} ariaLabel="Test Tabs" />
+        </TestContext>
+      );
+
+      const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+      const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
+
+      expect(panel1).toHaveAttribute('hidden');
+      expect(panel2).toHaveAttribute('hidden');
+    } finally {
+      useEffectSpy.mockRestore();
+    }
+  });
+
+  it('renders defaultIndex={null} correctly on initial render (before effects)', () => {
+    const useEffectSpy = vi.spyOn(React, 'useEffect').mockImplementation(() => {});
+
+    try {
+      render(
+        <TestContext>
+          <Tabs tabs={mockTabs} defaultIndex={null} ariaLabel="Test Tabs" />
+        </TestContext>
+      );
+
+      const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+      const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
+
+      expect(panel1).toHaveAttribute('hidden');
+      expect(panel2).toHaveAttribute('hidden');
+    } finally {
+      useEffectSpy.mockRestore();
+    }
+  });
+
+  it('handles negative defaultIndex by clamping to 0', () => {
+    render(
+      <TestContext>
+        <Tabs tabs={mockTabs} defaultIndex={-1} ariaLabel="Test Tabs" />
+      </TestContext>
+    );
+
+    const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+    const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
+
+    expect(panel1).not.toHaveAttribute('hidden');
+    expect(panel2).toHaveAttribute('hidden');
+  });
+
+  it('handles updates to defaultIndex correctly in effects', () => {
+    const { rerender } = render(
+      <TestContext>
+        <Tabs tabs={mockTabs} defaultIndex={0} ariaLabel="Test Tabs" />
+      </TestContext>
+    );
+
+    const panel1 = screen.getByTestId('content-1').closest('[role="tabpanel"]');
+    const panel2 = screen.getByTestId('content-2').closest('[role="tabpanel"]');
+
+    expect(panel1).not.toHaveAttribute('hidden');
+    expect(panel2).toHaveAttribute('hidden');
+
+    rerender(
+      <TestContext>
+        <Tabs tabs={mockTabs} defaultIndex={1} ariaLabel="Test Tabs" />
+      </TestContext>
+    );
+
+    expect(panel1).toHaveAttribute('hidden');
+    expect(panel2).not.toHaveAttribute('hidden');
+
+    rerender(
+      <TestContext>
+        <Tabs tabs={mockTabs} defaultIndex={false} ariaLabel="Test Tabs" />
+      </TestContext>
+    );
+
+    expect(panel1).toHaveAttribute('hidden');
+    expect(panel2).toHaveAttribute('hidden');
+  });
+
+  it('renders TabPanel correctly using deprecated tabIndex prop for backwards compatibility', () => {
+    render(
+      <TestContext>
+        <TabPanel tabIndex={0} index={0} id="panel-0" labeledBy="tab-0">
+          <div data-testid="panel-content">Content</div>
+        </TabPanel>
+      </TestContext>
+    );
+
+    const panel = screen.getByTestId('panel-content').closest('[role="tabpanel"]');
+    expect(panel).not.toHaveAttribute('hidden');
+  });
+
+  it('renders TabPanel hidden when tabIndex does not match index', () => {
+    render(
+      <TestContext>
+        <TabPanel tabIndex={0} index={1} id="panel-1" labeledBy="tab-1">
+          <div data-testid="panel-content">Content</div>
+        </TabPanel>
+      </TestContext>
+    );
+
+    const panel = screen.getByTestId('panel-content').closest('[role="tabpanel"]');
+    expect(panel).toHaveAttribute('hidden');
+  });
+});

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -65,7 +65,7 @@ export interface TabsProps {
 export default function Tabs(props: TabsProps) {
   const { tabs, tabProps = {}, defaultIndex = 0, onTabChanged = null, ariaLabel } = props;
   const [tabIndex, setTabIndex] = React.useState<TabsProps['defaultIndex']>(
-    defaultIndex && Math.min(defaultIndex as number, 0)
+    Math.max(defaultIndex as number, 0)
   );
 
   /**

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -43,7 +43,7 @@ export interface TabsProps {
     [propName: string]: any;
   };
   /** The index of the initially active tab. Defaults to 0. Set to null or false to disable initial selection. */
-  defaultIndex?: number | null | boolean;
+  defaultIndex?: number | null | false;
   /** Callback invoked when the active tab changes.
    * @param tabIndex - The index of the newly selected tab.
    */
@@ -65,7 +65,7 @@ export interface TabsProps {
 export default function Tabs(props: TabsProps) {
   const { tabs, tabProps = {}, defaultIndex = 0, onTabChanged = null, ariaLabel } = props;
   const [tabIndex, setTabIndex] = React.useState<TabsProps['defaultIndex']>(
-    Math.max(defaultIndex as number, 0)
+    typeof defaultIndex === 'number' ? Math.max(defaultIndex, 0) : false
   );
 
   /**
@@ -83,11 +83,11 @@ export default function Tabs(props: TabsProps) {
   }
 
   React.useEffect(() => {
-    if (defaultIndex === null) {
+    if (typeof defaultIndex === 'number') {
+      setTabIndex(Math.max(defaultIndex, 0));
+    } else {
       setTabIndex(false);
-      return;
     }
-    setTabIndex(defaultIndex);
   }, [defaultIndex]);
 
   const uniqueIdSuffix = useId('tabs-');
@@ -129,7 +129,7 @@ export default function Tabs(props: TabsProps) {
       {tabs.map(({ component }, i) => (
         <TabPanel
           key={i}
-          tabIndex={Number(tabIndex)}
+          activeValue={tabIndex}
           index={i}
           id={`full-width-tabpanel-${i}-${ariaLabel.replace(' ', '')}-${uniqueIdSuffix}`}
           labeledBy={`full-width-tab-${i}-${ariaLabel.replace(' ', '')}-${uniqueIdSuffix}`}
@@ -144,9 +144,11 @@ export default function Tabs(props: TabsProps) {
 /**
  * Props for a single tab panel.
  */
-interface TabPanelProps extends TypographyProps {
+interface TabPanelProps extends Omit<TypographyProps, 'tabIndex'> {
   /** The index of the currently active tab. */
-  tabIndex: number;
+  activeValue?: number | null | false;
+  /** @deprecated Use `activeValue` instead. */
+  tabIndex?: number | null | false;
   /** The index of this tab panel. */
   index: number;
   /** The unique ID for the tab panel, used for accessibility. */
@@ -162,17 +164,19 @@ interface TabPanelProps extends TypographyProps {
  * @returns A container showing the content if this panel is active.
  */
 export function TabPanel(props: TabPanelProps) {
-  const { children, tabIndex, index, id, labeledBy } = props;
+  const { children, activeValue, tabIndex, index, id, labeledBy, sx, ...other } = props;
+  const currentActiveValue = activeValue !== undefined ? activeValue : tabIndex;
 
   return (
     <Typography
       component="div"
       role="tabpanel"
-      hidden={tabIndex !== index}
+      hidden={currentActiveValue !== index}
       id={id}
       aria-labelledby={labeledBy}
       tabIndex={tabIndex === index ? 0 : -1}
-      sx={{ flexGrow: 1, overflow: 'hidden' }}
+      sx={[{ flexGrow: 1, overflow: 'hidden' }, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}
+      {...other}
     >
       {children}
     </Typography>

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -64,7 +64,7 @@ export interface TabsProps {
  */
 export default function Tabs(props: TabsProps) {
   const { tabs, tabProps = {}, defaultIndex = 0, onTabChanged = null, ariaLabel } = props;
-  const [tabIndex, setTabIndex] = React.useState<TabsProps['defaultIndex']>(
+  const [tabIndex, setTabIndex] = React.useState<number | null | false>(
     typeof defaultIndex === 'number' ? Math.max(defaultIndex, 0) : false
   );
 
@@ -144,11 +144,7 @@ export default function Tabs(props: TabsProps) {
 /**
  * Props for a single tab panel.
  */
-interface TabPanelProps extends Omit<TypographyProps, 'tabIndex'> {
-  /** The index of the currently active tab. */
-  activeValue?: number | null | false;
-  /** @deprecated Use `activeValue` instead. */
-  tabIndex?: number | null | false;
+interface TabPanelPropsBase extends Omit<TypographyProps<'div'>, 'tabIndex'> {
   /** The index of this tab panel. */
   index: number;
   /** The unique ID for the tab panel, used for accessibility. */
@@ -156,6 +152,25 @@ interface TabPanelProps extends Omit<TypographyProps, 'tabIndex'> {
   /** The ID of the tab that controls this panel, used for accessibility. */
   labeledBy: string;
 }
+
+/**
+ * Props for a single tab panel. Requires either `activeValue` or `tabIndex` to be provided.
+ */
+export type TabPanelProps = TabPanelPropsBase &
+  (
+    | {
+        /** The index of the currently active tab. */
+        activeValue: number | null | false;
+        /** @deprecated Use `activeValue` instead. */
+        tabIndex?: number | null | false;
+      }
+    | {
+        /** The index of the currently active tab. */
+        activeValue?: number | null | false;
+        /** @deprecated Use `activeValue` instead. */
+        tabIndex: number | null | false;
+      }
+  );
 
 /**
  * Renders a panel for the currently active tab.
@@ -169,6 +184,7 @@ export function TabPanel(props: TabPanelProps) {
 
   return (
     <Typography
+      {...other}
       component="div"
       role="tabpanel"
       hidden={currentActiveValue !== index}
@@ -176,7 +192,6 @@ export function TabPanel(props: TabPanelProps) {
       aria-labelledby={labeledBy}
       tabIndex={tabIndex === index ? 0 : -1}
       sx={[{ flexGrow: 1, overflow: 'hidden' }, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}
-      {...other}
     >
       {children}
     </Typography>

--- a/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
@@ -56,7 +56,7 @@
       class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
       id="full-width-tabpanel-0-BasicTabs-tabs-id"
       role="tabpanel"
-      tabindex="0"
+      tabindex="-1"
     >
       <p>
         tab body 1

--- a/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.BasicTabs.stories.storyshot
@@ -53,7 +53,7 @@
     </div>
     <div
       aria-labelledby="full-width-tab-0-BasicTabs-tabs-id"
-      class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
       id="full-width-tabpanel-0-BasicTabs-tabs-id"
       role="tabpanel"
       tabindex="0"
@@ -64,7 +64,7 @@
     </div>
     <div
       aria-labelledby="full-width-tab-1-BasicTabs-tabs-id"
-      class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
       hidden=""
       id="full-width-tabpanel-1-BasicTabs-tabs-id"
       role="tabpanel"

--- a/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
@@ -53,7 +53,7 @@
     </div>
     <div
       aria-labelledby="full-width-tab-0-StartingTabs-tabs-id"
-      class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
       hidden=""
       id="full-width-tabpanel-0-StartingTabs-tabs-id"
       role="tabpanel"
@@ -65,7 +65,7 @@
     </div>
     <div
       aria-labelledby="full-width-tab-1-StartingTabs-tabs-id"
-      class="MuiTypography-root MuiTypography-body1 css-fth53a-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
       id="full-width-tabpanel-1-StartingTabs-tabs-id"
       role="tabpanel"
       tabindex="0"

--- a/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/Tabs.StartingTab.stories.storyshot
@@ -68,7 +68,7 @@
       class="MuiTypography-root MuiTypography-body1 css-13gio71-MuiTypography-root"
       id="full-width-tabpanel-1-StartingTabs-tabs-id"
       role="tabpanel"
-      tabindex="0"
+      tabindex="-1"
     >
       <p>
         We start on the second tab using defaultIndex=1


### PR DESCRIPTION
## Summary

Math.min(defaultIndex, 0)  was used instead of  Math.max(defaultIndex, 0) , causing the tab to always open at index  0  regardless of the value passed. Replaced with Math.max and removed a faulty  &&  short-circuit.


## Related Issue

Fixes #6409
