### PR TITLE
frontend: hpa: Fix incorrect check and break statement

### DIFF
--- a/frontend/src/lib/k8s/hpa.test.ts
+++ b/frontend/src/lib/k8s/hpa.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import App from '../../App';
+import HPA from './hpa';
+
+// cyclic imports fix
+// eslint-disable-next-line no-unused-vars
+const _dont_delete_me = App;
+
+describe('HPA class', () => {
+  const mockHpaData = {
+    apiVersion: 'autoscaling/v2',
+    kind: 'HorizontalPodAutoscaler',
+    metadata: {
+      name: 'test-hpa',
+      namespace: 'default',
+      resourceVersion: '123',
+    },
+    spec: {
+      maxReplicas: 10,
+      minReplicas: 1,
+      scaleTargetRef: {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        name: 'test-deployment',
+      },
+      metrics: [
+        {
+          type: 'Resource',
+          resource: {
+            name: 'cpu',
+            target: {
+              type: 'Utilization',
+              averageUtilization: 0,
+            },
+          },
+        },
+      ],
+    },
+    status: {
+      currentReplicas: 1,
+      desiredReplicas: 1,
+      lastScaleTime: '2020-01-01T00:00:00Z',
+      conditions: [],
+      currentMetrics: [
+        {
+          type: 'Resource',
+          resource: {
+            name: 'cpu',
+            current: {
+              averageUtilization: 0,
+              averageValue: '0m',
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  it('correctly handles averageUtilization of 0 in metrics', () => {
+    const data = JSON.parse(JSON.stringify(mockHpaData));
+    const hpa = new HPA(data);
+    const mockT = (key: string) => {
+      if (key.includes('translation|')) {
+        return key.replace('translation|', '');
+      }
+      return key;
+    };
+    const metrics = hpa.metrics(mockT);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0].value).toBe('0% (0m)/0%');
+    expect(metrics[0].shortValue).toBe('0% /0%');
+  });
+});

--- a/frontend/src/lib/k8s/hpa.ts
+++ b/frontend/src/lib/k8s/hpa.ts
@@ -67,7 +67,7 @@ function metricTargetValue(target: MetricTarget): string {
   switch (target.type) {
     case 'Utilization':
       if (target.averageUtilization !== null && target.averageUtilization !== undefined) {
-        return `${target.averageUtilization.toString()}%`;
+        return `${target.averageUtilization}%`;
       }
       return '';
     case 'AverageValue':

--- a/frontend/src/lib/k8s/hpa.ts
+++ b/frontend/src/lib/k8s/hpa.ts
@@ -66,11 +66,10 @@ interface MetricTarget {
 function metricTargetValue(target: MetricTarget): string {
   switch (target.type) {
     case 'Utilization':
-      if (target.averageUtilization) {
+      if (target.averageUtilization !== null && target.averageUtilization !== undefined) {
         return `${target.averageUtilization.toString()}%`;
       }
       return '';
-      break;
     case 'AverageValue':
       return `${target.averageValue}`;
     case 'Value':


### PR DESCRIPTION
## Summary

This PR adds/fixes [feature/bug] by [brief description of what the change does].

## Related Issue

Fixes #6411 

## Changes

Two bugs fixed in  metricTargetValue()  in  frontend/src/lib/k8s/hpa.ts :
- Bug:  if (target.averageUtilization)  used a truthiness check, so a metric with  averageUtilization == 0  would silently render as  ''  instead of  '0%' .
Fix: Changed to  if (target.averageUtilization != null)  to correctly handle the zero case.
- Bug:  break  after  return ''  was unreachable dead code inside a  switch  case.
Fix: Removed the dead  break .

Files changed:  frontend/src/lib/k8s/hpa.ts

