### PR TITLE
Reference built-in theme names instead of hard-coding names

### DIFF
--- a/frontend/src/components/App/AppLogo.stories.tsx
+++ b/frontend/src/components/App/AppLogo.stories.tsx
@@ -19,8 +19,9 @@ import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
 import { TestContext } from '../../test';
 import { AppLogo, AppLogoProps } from './AppLogo';
+import { darkTheme, lightTheme } from './defaultAppThemes';
 
-const getMockState = (themeName: 'Light' | 'Dark' = 'Light', loaded = true, logo: any = null) => ({
+const getMockState = (themeName: string = lightTheme.name, loaded = true, logo: any = null) => ({
   plugins: { loaded },
   theme: {
     logo,
@@ -49,7 +50,7 @@ export default {
 } as Meta<typeof AppLogo>;
 
 const Template: StoryFn<AppLogoProps> = args => {
-  const themeName = args.themeName === 'dark' ? 'Dark' : 'Light';
+  const themeName = args.themeName === 'dark' ? darkTheme.name : lightTheme.name;
   const store = configureStore({
     reducer: (state = getMockState(themeName)) => state,
     preloadedState: getMockState(themeName),

--- a/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
@@ -20,13 +20,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../../lib/themes';
 import { PluginInfo } from '../../../plugin/pluginsSlice';
 import { TestContext } from '../../../test';
+import { lightTheme } from '../defaultAppThemes';
 import { PluginSettingsPure } from './PluginSettings';
 
 vi.mock('../../../helpers/isElectron', () => ({
   isElectron: () => true,
 }));
 
-const theme = createMuiTheme({ name: 'Light', base: 'light' });
+const theme = createMuiTheme({ name: lightTheme.name, base: 'light' });
 
 function createPlugins(count: number): PluginInfo[] {
   return Array.from({ length: count }, (_, i) => ({

--- a/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
+++ b/frontend/src/components/App/PluginSettings/PluginSettings.test.tsx
@@ -22,13 +22,14 @@ import { PluginInfo, setPluginSettings } from '../../../plugin/pluginsSlice';
 import { HeadlampEventType } from '../../../redux/headlampEventSlice';
 import store from '../../../redux/stores/store';
 import { recordHeadlampEvents, TestContext } from '../../../test';
+import { lightTheme } from '../defaultAppThemes';
 import PluginSettings, { PluginSettingsPure } from './PluginSettings';
 
 vi.mock('../../../helpers/isElectron', () => ({
   isElectron: () => true,
 }));
 
-const theme = createMuiTheme({ name: 'Light', base: 'light' });
+const theme = createMuiTheme({ name: lightTheme.name, base: 'light' });
 
 function createPlugins(count: number): PluginInfo[] {
   return Array.from({ length: count }, (_, i) => ({

--- a/frontend/src/components/App/themeSlice.test.tsx
+++ b/frontend/src/components/App/themeSlice.test.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { vi } from 'vitest';
 import { AppLogoProps, AppLogoType } from './AppLogo';
+import { darkTheme } from './defaultAppThemes';
 import themeReducer, {
   applyBackendThemeConfig,
   initialState,
@@ -39,7 +40,7 @@ describe('themeSlice', () => {
   });
 
   it('should handle setTheme', () => {
-    const themeName = 'Dark';
+    const themeName = darkTheme.name;
     const actual = themeReducer(initialState, setTheme(themeName));
     expect(actual.name).toEqual(themeName);
   });

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -16,6 +16,10 @@
 
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  darkTheme as builtInDarkTheme,
+  lightTheme as builtInLightTheme,
+} from '../components/App/defaultAppThemes';
 import { AppTheme } from './AppTheme';
 import { createMuiTheme, getThemeName, setTheme, usePrefersColorScheme } from './themes';
 
@@ -67,7 +71,7 @@ describe('themes.ts', () => {
         matchMedia: vi.fn().mockReturnValue({ matches: false }),
       });
 
-      expect(getThemeName()).toBe('Light');
+      expect(getThemeName()).toBe(builtInLightTheme.name);
     });
 
     it('should return dark theme if user prefers dark mode', () => {
@@ -81,7 +85,7 @@ describe('themes.ts', () => {
         })),
       });
 
-      expect(getThemeName()).toBe('Dark');
+      expect(getThemeName()).toBe(builtInDarkTheme.name);
     });
 
     it('should return the theme stored in localStorage', () => {
@@ -284,7 +288,7 @@ describe('themes.ts', () => {
         defaultLightTheme: 'corporate-light',
       };
 
-      expect(getThemeName(backendConfig)).toBe('Dark');
+      expect(getThemeName(backendConfig)).toBe(builtInDarkTheme.name);
     });
 
     it('should handle both default themes with OS preference selection', () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -17,6 +17,7 @@
 import { green, grey, orange, pink, red } from '@mui/material/colors';
 import { createTheme, getContrastRatio, useTheme } from '@mui/material/styles';
 import React from 'react';
+import { darkTheme, lightTheme } from '../components/App/defaultAppThemes';
 import type { AppTheme } from './AppTheme';
 
 export interface HeadlampChartStyles {
@@ -631,7 +632,7 @@ export function getThemeName(backendConfig?: {
 
   // Detect OS preference
   if (typeof window.matchMedia !== 'function') {
-    return backendConfig?.defaultLightTheme || 'Light';
+    return backendConfig?.defaultLightTheme || lightTheme.name;
   }
 
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -645,13 +646,11 @@ export function getThemeName(backendConfig?: {
   }
 
   // Fallback to OS preference
-  if (prefersLight) {
-    return 'Light';
-  } else if (prefersDark) {
-    return 'Dark';
+  if (prefersDark) {
+    return darkTheme.name;
   }
 
-  return 'Light';
+  return lightTheme.name;
 }
 
 export function setTheme(themeName: string) {


### PR DESCRIPTION
## Summary

Refactor the frontend to reference built-in theme names instead of hard-coding them, improving maintainability and consistency.

## Changes

- Updated theme reference logic in the frontend to use built-in theme names.
- Replaced hard-coded theme names in relevant files and tests.

## Notes for the Reviewer

- This change ensures themes align with the system's built-in definitions. Please verify that no hard-coded theme names remain in the updated code.