### PR TITLE
backend: fail rename when kubeconfig context is missing

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -2595,11 +2595,10 @@ func (c *HeadlampConfig) handleStatelessClusterRename(w http.ResponseWriter, r *
 
 // customNameToExtensions writes the custom name to the Extensions map in the kubeconfig.
 func customNameToExtensions(config *api.Config, contextName, newClusterName, path string) error {
-	var err error
-
 	// Get the context with the given cluster name
 	contextConfig, ok := config.Contexts[contextName]
 	if !ok {
+		err := fmt.Errorf("context %q not found in kubeconfig", contextName)
 		logger.Log(logger.LevelError, map[string]string{logFieldCluster: contextName},
 			err, "getting context from kubeconfig")
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1691,16 +1691,25 @@ func TestFindMatchingContextName(t *testing.T) {
 // contexts that have never had extensions set).
 func TestCustomNameToExtensions(t *testing.T) {
 	cases := []struct {
-		label      string
-		extensions map[string]k8sruntime.Object // nil simulates a fresh context
+		label       string
+		contextName string
+		extensions  map[string]k8sruntime.Object // nil simulates a fresh context
+		wantErr     string
 	}{
 		{
-			label:      "nil Extensions map is initialized before write",
-			extensions: nil,
+			label:       "nil Extensions map is initialized before write",
+			contextName: "my-cluster",
+			extensions:  nil,
 		},
 		{
-			label:      "existing Extensions map is preserved and updated",
-			extensions: map[string]k8sruntime.Object{},
+			label:       "existing Extensions map is preserved and updated",
+			contextName: "my-cluster",
+			extensions:  map[string]k8sruntime.Object{},
+		},
+		{
+			label:       "missing context returns an error",
+			contextName: "missing-cluster",
+			wantErr:     `context "missing-cluster" not found in kubeconfig`,
 		},
 	}
 
@@ -1721,7 +1730,12 @@ func TestCustomNameToExtensions(t *testing.T) {
 			require.NoError(t, clientcmd.WriteToFile(*config, tmpFile.Name()))
 
 			// Must not panic when Extensions is nil.
-			err = customNameToExtensions(config, "my-cluster", "my-custom-name", tmpFile.Name())
+			err = customNameToExtensions(config, tc.contextName, "my-custom-name", tmpFile.Name())
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				return
+			}
+
 			require.NoError(t, err)
 
 			// Reload from disk and verify the custom name was written.
@@ -1818,7 +1832,7 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 				Stateless:      false,
 				Source:         "kubeconfig",
 			},
-			expectedState: http.StatusCreated,
+			expectedState: http.StatusInternalServerError,
 		},
 	}
 
@@ -1827,8 +1841,8 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 	remErr := c.KubeConfigStore.RemoveContext("minikubetest")
 	require.NoError(t, remErr, "Failed to remove context: minikubetest")
 
-	remErrNonDy := c.KubeConfigStore.RemoveContext("minikubetestworkskubeconfig")
-	require.NoError(t, remErrNonDy, "Failed to remove context: minikubetestworkskubeconfig")
+	remErrNonDy := c.KubeConfigStore.RemoveContext("minikubetestnondynamic")
+	require.NoError(t, remErrNonDy, "Failed to remove context: minikubetestnondynamic")
 
 	clusters := c.getClusters()
 	clustersByName := map[string]Cluster{}
@@ -1838,10 +1852,12 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 	}
 
 	// The stateless rename removes the original from the store; the new name is frontend-only.
-	// The kubeconfig rename context was explicitly removed above.
+	// The failed kubeconfig rename left the original context intact, which was removed above.
 	assert.NotContains(t, clustersByName, "minikubetest", "expected stateless cluster to be removed from store")
 	assert.NotContains(t, clustersByName, "minikubetestworkskubeconfig",
-		"expected kubeconfig-renamed cluster to be removed from store")
+		"expected failed kubeconfig rename not to create a new cluster name in the store")
+	assert.NotContains(t, clustersByName, "minikubetestnondynamic",
+		"expected original kubeconfig context to be removed during cleanup")
 	// The clusters added via POST should still be present.
 	assert.Contains(t, clustersByName, minikubeName, "expected minikube cluster to still exist")
 	assert.Contains(t, clustersByName, "docker-desktop", "expected docker-desktop cluster to still exist")


### PR DESCRIPTION
## Summary

This PR makes kubeconfig-backed cluster rename fail explicitly when the target context does not exist, instead of reporting success while leaving state unchanged.

## Related Issue

Fixes #6414

## Changes

- return a concrete error from `customNameToExtensions` when the kubeconfig context lookup misses
- add a regression case to `TestCustomNameToExtensions`
- update `TestRenameCluster` to assert the corrected failure path and unchanged state

## Steps to Test

1. Run `npm run backend:build`.
2. Run `npm run backend:test`.
3. Run `env GOTOOLCHAIN=go1.26.4 npm run backend:lint`.
4. Run `npm run frontend:lint`.
5. Run `npx -y -p node@22 -p npm@11 npm run frontend:test`.
6. Trigger a kubeconfig-backed cluster rename where the request name does not resolve to a real context.
7. Verify the request now fails instead of returning success with no actual rename.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- The backend change is intentionally small and only affects the missing-context failure path.
- Frontend verification was run under Node 22, which matches the repo's supported engine range better than the locally installed Node 26.
