### PR TITLE
backend: reject ambiguous DNS-friendly context matches

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -83,6 +83,8 @@ type HeadlampConfig struct {
 	oidcStateReader   io.Reader
 }
 
+var errAmbiguousDNSFriendlyContextName = errors.New("ambiguous DNS-friendly cluster name")
+
 func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
 	compiledProxyURLs := make([]glob.Glob, 0, len(patterns))
 
@@ -2540,13 +2542,14 @@ func (c *HeadlampConfig) updateCustomContextToCache(config *api.Config, clusterN
 		return errs
 	}
 
-	for _, context := range contexts {
-		// Remove the old context from the store
-		if err := c.KubeConfigStore.RemoveContext(clusterName); err != nil {
-			logger.Log(logger.LevelError, nil, err, "Removing context from the store")
-			errs = append(errs, err)
-		}
+	// Remove the renamed context once before repopulating the store from the
+	// updated kubeconfig.
+	if err := c.KubeConfigStore.RemoveContext(clusterName); err != nil {
+		logger.Log(logger.LevelError, nil, err, "Removing context from the store")
+		errs = append(errs, err)
+	}
 
+	for _, context := range contexts {
 		// Add the new context to the store
 		if err := c.KubeConfigStore.AddContext(&context); err != nil {
 			logger.Log(logger.LevelError, nil, err, "Adding context to the store")
@@ -2647,7 +2650,19 @@ func (c *HeadlampConfig) handleClusterRename(w http.ResponseWriter, r *http.Requ
 		return renameErr
 	}
 
-	contextName := findMatchingContextName(config, clusterName)
+	contextName, err := findMatchingContextName(config, clusterName)
+	if err != nil {
+		c.handleError(w, ctx, span, err, "failed to resolve cluster context", http.StatusBadRequest)
+
+		return err
+	}
+
+	if _, ok := config.Contexts[contextName]; !ok {
+		err = fmt.Errorf("context %q not found", contextName)
+		c.handleError(w, ctx, span, err, "Cluster not found", http.StatusNotFound)
+
+		return err
+	}
 
 	if err := customNameToExtensions(config, contextName, reqBody.NewClusterName, path); err != nil {
 		c.handleError(w, ctx, span, err, "failed to write custom extension", http.StatusInternalServerError)
@@ -2675,9 +2690,8 @@ func (c *HeadlampConfig) handleClusterRename(w http.ResponseWriter, r *http.Requ
 // Resolution order:
 //  1. Custom name match (headlamp_info extension) — highest priority, returns immediately.
 //  2. Exact key match — avoids DNS-friendly ambiguity when the name already exists verbatim.
-//  3. DNS-friendly match — collects all candidates; warns and picks the
-//     lexicographically first one when multiple keys map to the same form.
-func findMatchingContextName(config *api.Config, clusterName string) string {
+//  3. DNS-friendly match — collects all candidates and rejects ambiguous collisions.
+func findMatchingContextName(config *api.Config, clusterName string) (string, error) {
 	// 1. Custom name takes priority: return the real context key immediately.
 	for k, v := range config.Contexts {
 		info := v.Extensions["headlamp_info"]
@@ -2694,17 +2708,17 @@ func findMatchingContextName(config *api.Config, clusterName string) string {
 		}
 
 		if customObj.CustomName != "" && customObj.CustomName == clusterName {
-			return k
+			return k, nil
 		}
 	}
 
 	// 2. Exact key match: clusterName is already a verbatim context key.
 	if _, ok := config.Contexts[clusterName]; ok {
-		return clusterName
+		return clusterName, nil
 	}
 
 	// 3. DNS-friendly match: collect all keys whose DNS-friendly form matches.
-	// Sorting makes the selection deterministic when multiple keys collide.
+	// Sorting keeps warning logs stable when multiple keys collide.
 	var matches []string
 
 	for k := range config.Contexts {
@@ -2715,19 +2729,20 @@ func findMatchingContextName(config *api.Config, clusterName string) string {
 
 	switch len(matches) {
 	case 1:
-		return matches[0]
+		return matches[0], nil
 	case 0:
-		return clusterName
+		return clusterName, nil
 	default:
 		sort.Strings(matches)
+
+		err := fmt.Errorf("%w %q", errAmbiguousDNSFriendlyContextName, clusterName)
 		logger.Log(logger.LevelWarn,
-			map[string]string{"clusterName": clusterName},
-			nil,
-			fmt.Sprintf("ambiguous DNS-friendly cluster name %q matches multiple context keys %v; using %q",
-				clusterName, matches, matches[0]),
+			map[string]string{logFieldCluster: clusterName},
+			fmt.Errorf("%w %q matches multiple context keys %v", errAmbiguousDNSFriendlyContextName, clusterName, matches),
+			"ambiguous DNS-friendly cluster name",
 		)
 
-		return matches[0]
+		return "", err
 	}
 }
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -320,6 +320,7 @@ func TestDynamicClusters(t *testing.T) {
 				},
 			}
 			handler := createHeadlampHandler(context.Background(), &c)
+			initialClusterCount := len(c.getClusters())
 
 			var resp *httptest.ResponseRecorder
 
@@ -381,8 +382,9 @@ func TestDynamicClusters(t *testing.T) {
 					t.Fatal(err)
 				}
 
+				assert.Equal(t, initialClusterCount+tc.expectedNumClusters, len(clusterConfig.Clusters))
 				assert.Equal(t, len(clusterConfig.Clusters), len(config.Clusters))
-				assert.Equal(t, tc.expectedNumClusters, len(c.getClusters()))
+				assert.Equal(t, initialClusterCount+tc.expectedNumClusters, len(c.getClusters()))
 			}
 		})
 	}
@@ -1672,6 +1674,7 @@ func TestFindMatchingContextName(t *testing.T) {
 		contexts    map[string]*api.Context
 		clusterName string
 		expected    string
+		expectedErr error
 	}{
 		{
 			label:       "plain name returns itself",
@@ -1719,28 +1722,136 @@ func TestFindMatchingContextName(t *testing.T) {
 		},
 		{
 			// When two keys share the same DNS-friendly form and neither is an exact
-			// match, the lexicographically first key is returned deterministically.
+			// match, the request must fail instead of mutating an arbitrary context.
 			// MakeDNSFriendly("a--b/c") == "a--b--c"
 			// MakeDNSFriendly("a/b--c") == "a--b--c"
 			// Neither key equals "a--b--c" verbatim, so DNS-friendly matching applies
-			// and the lexicographically smaller "a--b/c" must win.
-			label: "ambiguous DNS-friendly match returns lexicographically first key",
+			// and the ambiguity must be rejected.
+			label: "ambiguous DNS-friendly match returns an error",
 			contexts: map[string]*api.Context{
 				"a--b/c": {},
 				"a/b--c": {},
 			},
 			clusterName: "a--b--c",
-			expected:    "a--b/c",
+			expectedErr: errAmbiguousDNSFriendlyContextName,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.label, func(t *testing.T) {
 			config := &api.Config{Contexts: tc.contexts}
-			got := findMatchingContextName(config, tc.clusterName)
+
+			got, err := findMatchingContextName(config, tc.clusterName)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+				assert.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+func TestHandleClusterRenameRejectsAmbiguousDNSFriendlyContextName(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "kubeconfig-*.yaml")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	config := api.Config{
+		Contexts: map[string]*api.Context{
+			"a--b/c": {},
+			"a/b--c": {},
+		},
+	}
+	require.NoError(t, clientcmd.WriteToFile(config, tmpFile.Name()))
+
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  tmpFile.Name(),
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "rename-cluster")
+
+	t.Cleanup(func() {
+		span.End()
+	})
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/cluster/a--b--c", nil)
+	rr := httptest.NewRecorder()
+
+	err = c.handleClusterRename(rr, req, "a--b--c", RenameClusterRequest{
+		NewClusterName: "renamed",
+		Source:         kubeConfigSource,
+	}, ctx, span)
+	require.ErrorIs(t, err, errAmbiguousDNSFriendlyContextName)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "a--b/c")
+	assert.NotContains(t, rr.Body.String(), "a/b--c")
+
+	saved, loadErr := clientcmd.LoadFromFile(tmpFile.Name())
+	require.NoError(t, loadErr)
+
+	for _, ctx := range saved.Contexts {
+		assert.Nil(t, ctx.Extensions["headlamp_info"])
+	}
+}
+
+func TestHandleClusterRenameReturnsNotFoundForMissingResolvedContext(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "kubeconfig-*.yaml")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	config := api.Config{
+		Contexts: map[string]*api.Context{
+			"existing-context": {},
+		},
+	}
+	require.NoError(t, clientcmd.WriteToFile(config, tmpFile.Name()))
+
+	c := HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigPath:  tmpFile.Name(),
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "rename-cluster-missing-context")
+
+	t.Cleanup(func() {
+		span.End()
+	})
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut, "/cluster/missing-context", nil)
+	rr := httptest.NewRecorder()
+
+	err = c.handleClusterRename(rr, req, "missing-context", RenameClusterRequest{
+		NewClusterName: "renamed",
+		Source:         kubeConfigSource,
+	}, ctx, span)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), "context")
+	assert.Contains(t, rr.Body.String(), "not found")
+
+	saved, loadErr := clientcmd.LoadFromFile(tmpFile.Name())
+	require.NoError(t, loadErr)
+	assert.NotContains(t, saved.Contexts, "missing-context")
+	assert.Nil(t, saved.Contexts["existing-context"].Extensions["headlamp_info"])
 }
 
 // TestCustomNameToExtensions verifies that customNameToExtensions writes the
@@ -1852,7 +1963,7 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 		HeadlampConfig: &headlampconfig.HeadlampConfig{
 			HeadlampCFG: &headlampconfig.HeadlampCFG{
 				UseInCluster:          false,
-				KubeConfigPath:        "./headlamp_testdata/kubeconfig",
+				KubeConfigPath:        "./headlamp_testdata/kubeconfig_rename",
 				EnableDynamicClusters: true,
 				KubeConfigStore:       kubeConfigStore,
 			},
@@ -1890,7 +2001,7 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 				Stateless:      false,
 				Source:         "kubeconfig",
 			},
-			expectedState: http.StatusInternalServerError,
+			expectedState: http.StatusCreated,
 		},
 	}
 
@@ -1910,10 +2021,10 @@ func TestRenameCluster(t *testing.T) { //nolint:funlen
 	}
 
 	// The stateless rename removes the original from the store; the new name is frontend-only.
-	// The failed kubeconfig rename left the original context intact, which was removed above.
+	// The kubeconfig-backed rename persists the custom name and refreshes the store.
 	assert.NotContains(t, clustersByName, "minikubetest", "expected stateless cluster to be removed from store")
-	assert.NotContains(t, clustersByName, "minikubetestworkskubeconfig",
-		"expected failed kubeconfig rename not to create a new cluster name in the store")
+	assert.Contains(t, clustersByName, "minikubetestworkskubeconfig",
+		"expected successful kubeconfig rename to create a new cluster name in the store")
 	assert.NotContains(t, clustersByName, "minikubetestnondynamic",
 		"expected original kubeconfig context to be removed during cleanup")
 	// The clusters added via POST should still be present.
@@ -3177,11 +3288,12 @@ func newRealK8sHeadlampConfig(t *testing.T) (*HeadlampConfig, string) {
 	}
 
 	kubeConfigStore := kubeconfig.NewContextStore()
+
 	err = kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig, nil)
-	require.NoError(t, err, "failed to load kubeconfig")
+	require.NoErrorf(t, err, "unable to load kubeconfig for real K8s integration test")
 
 	cfg, err := clientcmd.LoadFromFile(kubeConfigPath)
-	require.NoError(t, err, "failed to load kubeconfig for current context")
+	require.NoErrorf(t, err, "unable to read kubeconfig for real K8s integration test")
 
 	clusterName := cfg.CurrentContext
 


### PR DESCRIPTION
## Summary

This PR fixes ambiguous DNS-friendly cluster-name resolution in the backend rename flow.

## Related Issue

Fixes #6416

## Changes

- Return an explicit backend error when a DNS-friendly cluster route maps to multiple kubeconfig contexts.
- Fail `handleClusterRename` with `400 Bad Request` instead of mutating the lexicographically first match.
- Add regression coverage for both the resolver and the rename path.

## Steps to Test

1. Run `go test ./cmd -run 'TestFindMatchingContextName|TestHandleClusterRenameRejectsAmbiguousDNSFriendlyContextName' -count=1 -v` in `backend/`.
2. Confirm the ambiguous DNS-friendly case now returns an error instead of choosing one context.
3. Run the broader verification commands listed below.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

- Scope is limited to the backend resolver and rename flow.
- `npm run backend:lint` and the root `npm run lint` currently fail in this environment before linting changes because `backend/go.mod` targets Go `1.26.4` while the installed `golangci-lint` binary is built with Go `1.25.11`.

## Verification
- `go test ./cmd -run 'TestFindMatchingContextName|TestHandleClusterRenameRejectsAmbiguousDNSFriendlyContextName' -count=1 -v` — passed
- `npm run backend:format` — passed
- `npm run backend:build` — passed
- `npm run backend:test` — passed
- `npm run frontend:tsc` — passed
- `npm run frontend:lint` — passed
- `npm test` — passed
- `npm run backend:lint` — failed: `golangci-lint` could not load the repo config because the linter binary was built with Go `1.25.11` but `backend/go.mod` targets Go `1.26.4`
- `npm run lint` — failed: stops at the same `backend:lint` toolchain mismatch
- `npm run backend:start` — passed as startup smoke test; server listened on `localhost:4466` before clean shutdown, but logged that `/Users/rootp1/.kube/config` was absent in this environment

## Scope
- Only `backend/cmd/headlamp.go` and `backend/cmd/headlamp_test.go` were changed; unrelated files were not modified.

