### PR TITLE
perf(k8cache): Reduce allocations in cache store hot path

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -325,7 +325,7 @@ func cacheMiddlewareHandler(c *HeadlampConfig, next http.Handler, w http.Respons
 
 	next.ServeHTTP(rcw, r)
 
-	if err := k8cache.StoreK8sResponseInCache(k8sResponseCache, r.URL, rcw, r, key); err != nil {
+	if err := k8cache.StoreK8sResponseInCache(k8sResponseCache, r.URL, rcw, key); err != nil {
 		// Response was already written to client via rcw; just log the cache storage error
 		logger.Log(logger.LevelError, nil, err, "failed to store response in cache")
 	}

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -480,7 +480,7 @@ func ServeFromCacheOrForwardToK8s(k8scache cache.Cache[string], isAllowed bool, 
 
 	next.ServeHTTP(rcw, r)
 
-	err := StoreK8sResponseInCache(k8scache, r.URL, rcw, r, key)
+	err := StoreK8sResponseInCache(k8scache, r.URL, rcw, key)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "error while storing in the cache")
 		return

--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -92,7 +92,7 @@ func HandleNonGETCacheInvalidation(k8scache cache.Cache[string], w http.Response
 	freshRcw := NewResponseCapture(rr)
 	next.ServeHTTP(freshRcw, freshReq)
 
-	if err := StoreK8sResponseInCache(k8scache, freshReq.URL, freshRcw, freshReq, key); err != nil {
+	if err := StoreK8sResponseInCache(k8scache, freshReq.URL, freshRcw, key); err != nil {
 		return err
 	}
 

--- a/backend/pkg/k8cache/cacheStore.go
+++ b/backend/pkg/k8cache/cacheStore.go
@@ -193,13 +193,10 @@ func unescapeCacheKeySegment(s string) string {
 // namespace stripping in cache invalidation) must stay consistent with this
 // encoding to avoid the two sides silently drifting out of sync.
 func buildCacheKey(apiGroup, kind, namespace, contextID string) string {
-	return fmt.Sprintf(
-		"%s+%s+%s+%s",
-		escapeCacheKeySegment(apiGroup),
-		escapeCacheKeySegment(kind),
-		escapeCacheKeySegment(namespace),
-		escapeCacheKeySegment(contextID),
-	)
+	return escapeCacheKeySegment(apiGroup) + "+" +
+		escapeCacheKeySegment(kind) + "+" +
+		escapeCacheKeySegment(namespace) + "+" +
+		escapeCacheKeySegment(contextID)
 }
 
 // GenerateKey function helps to generate a unique key based on the request from the client
@@ -286,7 +283,6 @@ func LoadFromCache(k8scache cache.Cache[string], isAllowed bool,
 func StoreK8sResponseInCache(k8scache cache.Cache[string],
 	url *url.URL,
 	rcw *ResponseCapture,
-	r *http.Request,
 	key string,
 ) error {
 	if rcw.StatusCode >= 500 {
@@ -303,7 +299,15 @@ func StoreK8sResponseInCache(k8scache cache.Cache[string],
 	}
 
 	headersToCache := FilterHeaderForCache(capturedHeaders, encoding)
+
 	if !strings.Contains(url.Path, "selfsubjectrulesreviews") {
+		// Check the decompressed body for Kubernetes error status before
+		// marshalling the full CachedResponseData. This avoids allocating
+		// the JSON envelope for responses that will be discarded anyway.
+		if strings.Contains(dcmpBody, "Failure") {
+			return nil
+		}
+
 		cachedData := CachedResponseData{
 			StatusCode: rcw.StatusCode,
 			Headers:    headersToCache,
@@ -315,13 +319,11 @@ func StoreK8sResponseInCache(k8scache cache.Cache[string],
 			return err
 		}
 
-		if !strings.Contains(string(jsonBytes), "Failure") {
-			if err = k8scache.SetWithTTL(context.Background(), key, string(jsonBytes), 10*time.Minute); err != nil {
-				return err
-			}
-
-			logger.Log(logger.LevelInfo, nil, nil, "k8s resource was stored with the key "+redactCacheKey(key))
+		if err = k8scache.SetWithTTL(context.Background(), key, string(jsonBytes), 10*time.Minute); err != nil {
+			return err
 		}
+
+		logger.Log(logger.LevelInfo, nil, nil, "k8s resource was stored with the key "+redactCacheKey(key))
 	}
 
 	return nil

--- a/backend/pkg/k8cache/cacheStore_bench_test.go
+++ b/backend/pkg/k8cache/cacheStore_bench_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package k8cache_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	k8cache "github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
+)
+
+// BenchmarkStoreK8sResponseInCache measures the allocation overhead of storing
+// a typical Kubernetes API response in the cache. This exercises the JSON
+// marshalling, Failure detection, and cache-write path.
+func BenchmarkStoreK8sResponseInCache(b *testing.B) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/api/v1/pods"}
+
+	// Simulate a realistic pod list response body.
+	podListBody := `{"kind":"PodList","apiVersion":"v1",` +
+		`"metadata":{"resourceVersion":"54321"},"items":[` +
+		`{"metadata":{"name":"nginx-1","namespace":"default"}},` +
+		`{"metadata":{"name":"nginx-2","namespace":"default"}},` +
+		`{"metadata":{"name":"nginx-3","namespace":"default"}}` +
+		`]}`
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+
+		rw := httptest.NewRecorder()
+		rcw := k8cache.NewResponseCapture(rw)
+
+		rcw.WriteHeader(http.StatusOK)
+		_, _ = rcw.Write([]byte(podListBody))
+
+		b.StartTimer()
+
+		if err := k8cache.StoreK8sResponseInCache(
+			mockCache, targetURL, rcw, "bench-key",
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkStoreK8sResponseInCache_FailureSkip measures the early-exit
+// path when the response body contains a Kubernetes error status with
+// "Failure". After the optimization, this path skips json.Marshal.
+func BenchmarkStoreK8sResponseInCache_FailureSkip(b *testing.B) {
+	mockCache := NewMockCache()
+	targetURL := &url.URL{Path: "/api/v1/pods"}
+
+	failureBody := `{"kind":"Status","apiVersion":"v1",` +
+		`"status":"Failure","message":"Forbidden",` +
+		`"reason":"Forbidden","code":403}`
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+
+		rw := httptest.NewRecorder()
+		rcw := k8cache.NewResponseCapture(rw)
+
+		rcw.WriteHeader(http.StatusForbidden)
+		_, _ = rcw.Write([]byte(failureBody))
+
+		b.StartTimer()
+
+		if err := k8cache.StoreK8sResponseInCache(
+			mockCache, targetURL, rcw, "failure-bench-key",
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// benchBuildCacheKeySink prevents the compiler from optimizing
+// away benchmark work.
+var benchBuildCacheKeySink string
+
+// BenchmarkGenerateKey measures the allocation overhead of generating
+// cache keys from URL paths and context IDs.
+func BenchmarkGenerateKey(b *testing.B) {
+	targetURL := &url.URL{
+		Path: "/clusters/kind-kind/apis/apps/v1/namespaces/default/deployments",
+	}
+	contextID := "my-production-cluster"
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	var err error
+
+	for i := 0; i < b.N; i++ {
+		benchBuildCacheKeySink, err = k8cache.GenerateKey(
+			targetURL, contextID,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/backend/pkg/k8cache/cacheStore_test.go
+++ b/backend/pkg/k8cache/cacheStore_test.go
@@ -662,9 +662,8 @@ func TestStoreK8sResponseInCache(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			rw := httptest.NewRecorder()
 			rcw := k8cache.NewResponseCapture(rw)
-			r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.urlObj.Path, nil)
 			newCache := NewMockCache()
-			err := k8cache.StoreK8sResponseInCache(newCache, tc.urlObj, rcw, r, tc.key)
+			err := k8cache.StoreK8sResponseInCache(newCache, tc.urlObj, rcw, tc.key)
 			assert.NoError(t, err)
 		})
 	}
@@ -865,11 +864,7 @@ func TestStoreK8sResponseInCache_SkipSelfSubjectRulesReview(t *testing.T) {
 	rw := httptest.NewRecorder()
 	rcw := k8cache.NewResponseCapture(rw)
 
-	r := httptest.NewRequestWithContext(
-		context.Background(), http.MethodGet, targetURL.Path, nil,
-	)
-
-	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "skip-key")
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, "skip-key")
 	assert.NoError(t, err)
 
 	// Key must NOT have been written to the cache.
@@ -897,11 +892,7 @@ func TestStoreK8sResponseInCache_GzipBody(t *testing.T) {
 	rcw.WriteHeader(http.StatusOK)
 	_, _ = rcw.Write(buf.Bytes())
 
-	r := httptest.NewRequestWithContext(
-		context.Background(), http.MethodGet, targetURL.Path, nil,
-	)
-
-	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "gzip-key")
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, "gzip-key")
 	assert.NoError(t, err)
 
 	// The stored value must exist and must NOT contain the Content-Encoding header.
@@ -926,11 +917,7 @@ func TestStoreK8sResponseInCache_FailureBodyNotCached(t *testing.T) {
 	rcw.WriteHeader(http.StatusForbidden)
 	_, _ = rcw.Write([]byte(failureBody))
 
-	r := httptest.NewRequestWithContext(
-		context.Background(), http.MethodGet, targetURL.Path, nil,
-	)
-
-	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "failure-key")
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, "failure-key")
 	assert.NoError(t, err)
 
 	// Key must NOT have been written to the cache.
@@ -980,11 +967,7 @@ func TestStoreK8sResponseInCache_5xxResponseShouldNotBeCached(t *testing.T) {
 	rcw.WriteHeader(http.StatusBadGateway)
 	_, _ = rcw.Write([]byte(`<html><body>Bad Gateway</body></html>`))
 
-	r := httptest.NewRequestWithContext(
-		context.Background(), http.MethodGet, targetURL.Path, nil,
-	)
-
-	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, r, "infra-error-key")
+	err := k8cache.StoreK8sResponseInCache(mockCache, targetURL, rcw, "infra-error-key")
 	assert.NoError(t, err)
 
 	// Key must NOT be in cache — infrastructure errors should not be cached


### PR DESCRIPTION
## Summary

This PR cuts down memory allocations in the k8cache package by catching error statuses earlier, swapping fmt.Sprintf for plain string concatenation, and doing some minor cleanup.

## Related Issue

Fixes #6419 

## Changes

- Refactored StoreK8sResponseInCache to check for "Failure" before calling json.Marshal.
- Refactored buildCacheKey to use string concatenation to build the key.
- Removed the unused *http.Request parameter from StoreK8sResponseInCache and updated its callers.
- Added benchmarks for StoreK8sResponseInCache and GenerateKey.

## Steps to Test

1. Run `npm run backend:test` to make sure the unit tests still pass.
2. Run `cd backend && go test -bench=Benchmark -benchmem ./pkg/k8cache/` to see the allocation drops.
3. Start Headlamp locally and navigate around to verify caching behaves normally.

## Screenshots (if applicable)
Before:

<img width="920" height="163" alt="Screenshot 2026-07-08 002819" src="https://github.com/user-attachments/assets/be1a55b9-03a3-454c-a312-e3bed7ff518f" />

After:

<img width="904" height="158" alt="image" src="https://github.com/user-attachments/assets/05dd0a87-1059-492a-af7e-09a39c28748e" />

## Notes for the Reviewer

- FailureSkip path is ~2.1x faster (1145 -> 544 ns/op) with 34% fewer bytes allocated (1137 -> 752 B/op) and 3 fewer allocs.
- GenerateKey is ~1.6x faster (674 -> 420 ns/op) with 16% fewer bytes (400 -> 336 B/op) and 4 fewer allocs.
