### PR TITLE
backend: serviceproxy: Use context.Background() instead of context.TODO() in tests

### DIFF
--- a/backend/pkg/serviceproxy/service_test.go
+++ b/backend/pkg/serviceproxy/service_test.go
@@ -28,7 +28,7 @@ func TestGetServiceInternal(t *testing.T) {
 		},
 	}
 
-	_, err := cs.CoreV1().Services("default").Create(context.TODO(), service, metav1.CreateOptions{})
+	_, err := cs.CoreV1().Services("default").Create(context.Background(), service, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("Failed to create test service: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestGetServiceExternal(t *testing.T) {
 		},
 	}
 
-	_, err := cs.CoreV1().Services("default").Create(context.TODO(), service, metav1.CreateOptions{})
+	_, err := cs.CoreV1().Services("default").Create(context.Background(), service, metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("Failed to create test service: %v", err)
 	}


### PR DESCRIPTION
## Summary

Replace `context.TODO()` with `context.Background()` in the service proxy tests.

`context.TODO()` is intended as a temporary placeholder when the appropriate context is not yet known. Since test code always has a valid root context, `context.Background()` is the appropriate choice. This aligns with Go best practices.

## Changes

- `backend/pkg/serviceproxy/service_test.go`
  - Replaced 2 occurrences of `context.TODO()` with `context.Background()`
- No functional changes; this is a test code cleanup for consistency with Go conventions.