### PR TITLE
frontend: Fix MULTI_HOME_ENABLED always being true regardless of env var

### DIFF
--- a/frontend/src/components/App/Home/clusterStatus.test.ts
+++ b/frontend/src/components/App/Home/clusterStatus.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../../../lib/k8s/api/v2/ApiError';
 import { canSelectCluster, getClusterStatus, getClusterStatusLabel } from './clusterStatus';
 
@@ -52,5 +52,40 @@ describe('getClusterStatusLabel', () => {
     expect(getClusterStatusLabel(t, new ApiError('Bad Gateway', { status: 502 }))).toBe(
       'translation|Unavailable'
     );
+  });
+});
+
+describe('MULTI_HOME_ENABLED', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  it('defaults to true when REACT_APP_MULTI_HOME_ENABLED is an empty string', async () => {
+    try {
+      vi.stubEnv('REACT_APP_MULTI_HOME_ENABLED', '');
+      const { MULTI_HOME_ENABLED } = await vi.importActual('./config');
+      expect(MULTI_HOME_ENABLED).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('is false when REACT_APP_MULTI_HOME_ENABLED is set to "false"', async () => {
+    try {
+      vi.stubEnv('REACT_APP_MULTI_HOME_ENABLED', 'false');
+      const { MULTI_HOME_ENABLED } = await vi.importActual('./config');
+      expect(MULTI_HOME_ENABLED).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('is true when REACT_APP_MULTI_HOME_ENABLED is set to "true"', async () => {
+    try {
+      vi.stubEnv('REACT_APP_MULTI_HOME_ENABLED', 'true');
+      const { MULTI_HOME_ENABLED } = await vi.importActual('./config');
+      expect(MULTI_HOME_ENABLED).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/frontend/src/components/App/Home/config.ts
+++ b/frontend/src/components/App/Home/config.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-/** Allow selecting multiple clusters on home page. */
-export const MULTI_HOME_ENABLED = import.meta.env.REACT_APP_MULTI_HOME_ENABLED === 'true' || true;
+/**
+ * Allow selecting multiple clusters on home page.
+ *
+ * Enabled by default. Set `REACT_APP_MULTI_HOME_ENABLED=false` to disable.
+ */
+export const MULTI_HOME_ENABLED = import.meta.env.REACT_APP_MULTI_HOME_ENABLED !== 'false';
 
 /** Show recent clusters on the home page */
 export const ENABLE_RECENT_CLUSTERS = import.meta.env.REACT_APP_ENABLE_RECENT_CLUSTERS === 'true';


### PR DESCRIPTION
## Summary

Fix `MULTI_HOME_ENABLED` so it correctly respects the
`REACT_APP_MULTI_HOME_ENABLED` environment variable.

## Problem

`MULTI_HOME_ENABLED` was always evaluated as `true` because of the
`|| true` fallback. This meant that setting
`REACT_APP_MULTI_HOME_ENABLED=false` had no effect, and the Multi Home
feature could not be disabled through the environment variable.

## Fix

Remove the `|| true` fallback so `MULTI_HOME_ENABLED` is determined
solely by the value of `REACT_APP_MULTI_HOME_ENABLED`, allowing the
feature to be enabled or disabled as intended.