### PR TITLE
backend: reject colliding custom context names

### DIFF
--- a/backend/pkg/kubeconfig/contextStore.go
+++ b/backend/pkg/kubeconfig/contextStore.go
@@ -3,6 +3,8 @@ package kubeconfig
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -78,39 +80,193 @@ func (c *contextStore) notifyListeners() {
 
 // AddContext adds a context to the store.
 func (c *contextStore) AddContext(headlampContext *Context) error {
-	name := headlampContext.Name
+	if headlampContext == nil {
+		return errors.New("context cannot be nil")
+	}
 
-	if headlampContext.KubeContext != nil && headlampContext.KubeContext.Extensions["headlamp_info"] != nil {
-		info := headlampContext.KubeContext.Extensions["headlamp_info"]
-		// Convert the runtime.Unknown object to a byte slice
-		unknownBytes, err := json.Marshal(info)
-		if err != nil {
-			return err
+	name, err := effectiveContextName(headlampContext)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+
+	existingContext, err := c.cache.Get(context.Background(), name)
+
+	if err == nil && !isSameLogicalContext(existingContext, headlampContext, name) {
+		c.mu.Unlock()
+
+		return ContextError{
+			ContextName: name,
+			Reason:      "duplicate effective context name",
 		}
+	}
 
-		// Now, decode the byte slice into your desired struct
-		var customObj CustomObject
+	if err != nil && err != cache.ErrNotFound {
+		c.mu.Unlock()
 
-		err = json.Unmarshal(unknownBytes, &customObj)
-		if err != nil {
-			return err
-		}
-
-		// If the custom name is set, use it as the context name
-		if customObj.CustomName != "" {
-			name = customObj.CustomName
-		}
+		return err
 	}
 
 	// Keep the stored context identifier consistent with the cache key.
 	headlampContext.Name = name
 
-	err := c.cache.Set(context.Background(), name, headlampContext)
-	if err == nil {
-		c.notifyListeners()
+	err = c.cache.Set(context.Background(), name, headlampContext)
+	c.mu.Unlock()
+
+	if err != nil {
+		return err
 	}
 
+	c.notifyListeners()
+
 	return err
+}
+
+func effectiveContextName(headlampContext *Context) (string, error) {
+	if headlampContext == nil {
+		return "", nil
+	}
+
+	name := headlampContext.Name
+
+	if headlampContext.KubeContext == nil || headlampContext.KubeContext.Extensions["headlamp_info"] == nil {
+		return name, nil
+	}
+
+	info := headlampContext.KubeContext.Extensions["headlamp_info"]
+
+	if typedInfo, ok := info.(*CustomObject); ok {
+		if typedInfo != nil && typedInfo.CustomName != "" {
+			return typedInfo.CustomName, nil
+		}
+
+		return name, nil
+	}
+
+	unknownBytes, err := json.Marshal(info)
+	if err != nil {
+		return "", err
+	}
+
+	var customObj CustomObject
+
+	if err := json.Unmarshal(unknownBytes, &customObj); err != nil {
+		return "", err
+	}
+
+	if customObj.CustomName != "" {
+		name = customObj.CustomName
+
+		return name, nil
+	}
+
+	return name, nil
+}
+
+func isSameLogicalContext(existingContext, newContext *Context, newContextName string) bool {
+	if existingContext == nil || newContext == nil {
+		return existingContext == newContext
+	}
+
+	if existingContext.ClusterID != "" && newContext.ClusterID != "" && existingContext.ClusterID == newContext.ClusterID {
+		return true
+	}
+
+	if isDynamicManualUpdate(existingContext, newContext, newContextName) {
+		return true
+	}
+
+	if isDynamicReloadOfKubeConfigContext(existingContext, newContext) {
+		return true
+	}
+
+	return fallbackContextIdentity(existingContext) == fallbackContextIdentity(newContext)
+}
+
+func isDynamicManualUpdate(existingContext, newContext *Context, newContextName string) bool {
+	if existingContext.Source != DynamicCluster ||
+		newContext.Source != DynamicCluster ||
+		existingContext.ClusterID != "" ||
+		newContext.ClusterID != "" ||
+		existingContext.Name != newContextName {
+		return false
+	}
+
+	existingServer := ""
+	if existingContext.Cluster != nil {
+		existingServer = existingContext.Cluster.Server
+	}
+
+	newServer := ""
+	if newContext.Cluster != nil {
+		newServer = newContext.Cluster.Server
+	}
+
+	// Only treat this as a manual update of the same dynamic context when the
+	// cluster target it points to also matches. Otherwise two different dynamic
+	// clusters that happen to share a name would be silently merged instead of
+	// being rejected as a collision.
+	return existingServer == newServer
+}
+
+func isDynamicReloadOfKubeConfigContext(existingContext, newContext *Context) bool {
+	return existingContext.Source == KubeConfig &&
+		newContext.Source == DynamicCluster &&
+		newContext.ClusterID == "" &&
+		sameKubeContextTarget(existingContext, newContext)
+}
+
+func sameKubeContextTarget(existingContext, newContext *Context) bool {
+	if existingContext.KubeContext == nil || newContext.KubeContext == nil {
+		return false
+	}
+
+	existingServer := ""
+	if existingContext.Cluster != nil {
+		existingServer = existingContext.Cluster.Server
+	}
+
+	newServer := ""
+	if newContext.Cluster != nil {
+		newServer = newContext.Cluster.Server
+	}
+
+	return existingServer == newServer &&
+		existingContext.KubeContext.Cluster == newContext.KubeContext.Cluster &&
+		existingContext.KubeContext.AuthInfo == newContext.KubeContext.AuthInfo &&
+		existingContext.KubeContext.Namespace == newContext.KubeContext.Namespace
+}
+
+func fallbackContextIdentity(headlampContext *Context) string {
+	clusterServer := ""
+	if headlampContext.Cluster != nil {
+		clusterServer = headlampContext.Cluster.Server
+	}
+
+	kubeCluster := ""
+	kubeAuthInfo := ""
+	kubeNamespace := ""
+
+	if headlampContext.KubeContext != nil {
+		kubeCluster = headlampContext.KubeContext.Cluster
+		kubeAuthInfo = headlampContext.KubeContext.AuthInfo
+		kubeNamespace = headlampContext.KubeContext.Namespace
+	}
+
+	// Each field is rendered with %q so that any literal "|" or quote characters
+	// within a field are escaped rather than being treated as a delimiter. This
+	// keeps the resulting identity unambiguous even if a path or name contains
+	// the separator character.
+	return fmt.Sprintf(
+		"fallback:%d|%q|%q|%q|%q|%q",
+		headlampContext.Source,
+		headlampContext.KubeConfigPath,
+		clusterServer,
+		kubeCluster,
+		kubeAuthInfo,
+		kubeNamespace,
+	)
 }
 
 // GetContexts returns all contexts in the store.
@@ -157,28 +313,47 @@ func (c *contextStore) GetContext(name string) (*Context, error) {
 
 // RemoveContext removes a context from the store.
 func (c *contextStore) RemoveContext(name string) error {
+	c.mu.Lock()
+
 	err := c.cache.Delete(context.Background(), name)
-	if err == nil {
-		c.notifyListeners()
+	c.mu.Unlock()
+
+	if err != nil {
+		return err
 	}
+
+	c.notifyListeners()
 
 	return err
 }
 
 // AddContextWithKeyAndTTL adds a context to the store with a ttl.
 func (c *contextStore) AddContextWithKeyAndTTL(headlampContext *Context, key string, ttl time.Duration) error {
+	if headlampContext == nil {
+		return errors.New("context cannot be nil")
+	}
+
 	// Keep the stored context identifier consistent with the cache key.
 	headlampContext.Name = key
 
+	c.mu.Lock()
+
 	err := c.cache.SetWithTTL(context.Background(), key, headlampContext, ttl)
-	if err == nil {
-		c.notifyListeners()
+	c.mu.Unlock()
+
+	if err != nil {
+		return err
 	}
+
+	c.notifyListeners()
 
 	return err
 }
 
 // UpdateTTL updates the ttl of a context.
 func (c *contextStore) UpdateTTL(key string, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	return c.cache.UpdateTTL(context.Background(), key, ttl)
 }

--- a/backend/pkg/kubeconfig/contextStore.go
+++ b/backend/pkg/kubeconfig/contextStore.go
@@ -3,6 +3,8 @@ package kubeconfig
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -78,39 +80,219 @@ func (c *contextStore) notifyListeners() {
 
 // AddContext adds a context to the store.
 func (c *contextStore) AddContext(headlampContext *Context) error {
-	name := headlampContext.Name
+	if headlampContext == nil {
+		return errors.New("context cannot be nil")
+	}
 
-	if headlampContext.KubeContext != nil && headlampContext.KubeContext.Extensions["headlamp_info"] != nil {
-		info := headlampContext.KubeContext.Extensions["headlamp_info"]
-		// Convert the runtime.Unknown object to a byte slice
-		unknownBytes, err := json.Marshal(info)
-		if err != nil {
-			return err
+	name, err := effectiveContextName(headlampContext)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+
+	existingContext, err := c.cache.Get(context.Background(), name)
+
+	if err == nil && !isSameLogicalContext(existingContext, headlampContext, name) {
+		c.mu.Unlock()
+
+		return ContextError{
+			ContextName: name,
+			Reason:      "duplicate effective context name",
 		}
+	}
 
-		// Now, decode the byte slice into your desired struct
-		var customObj CustomObject
+	if err != nil && err != cache.ErrNotFound {
+		c.mu.Unlock()
 
-		err = json.Unmarshal(unknownBytes, &customObj)
-		if err != nil {
-			return err
-		}
-
-		// If the custom name is set, use it as the context name
-		if customObj.CustomName != "" {
-			name = customObj.CustomName
-		}
+		return err
 	}
 
 	// Keep the stored context identifier consistent with the cache key.
 	headlampContext.Name = name
 
-	err := c.cache.Set(context.Background(), name, headlampContext)
-	if err == nil {
-		c.notifyListeners()
+	err = c.cache.Set(context.Background(), name, headlampContext)
+	c.mu.Unlock()
+
+	if err != nil {
+		return err
 	}
 
+	c.notifyListeners()
+
 	return err
+}
+
+func effectiveContextName(headlampContext *Context) (string, error) {
+	if headlampContext == nil {
+		return "", errors.New("context cannot be nil")
+	}
+
+	name := headlampContext.Name
+
+	if headlampContext.KubeContext == nil || headlampContext.KubeContext.Extensions["headlamp_info"] == nil {
+		return name, nil
+	}
+
+	info := headlampContext.KubeContext.Extensions["headlamp_info"]
+
+	if typedInfo, ok := info.(*CustomObject); ok {
+		if typedInfo != nil && typedInfo.CustomName != "" {
+			return typedInfo.CustomName, nil
+		}
+
+		return name, nil
+	}
+
+	unknownBytes, err := json.Marshal(info)
+	if err != nil {
+		return "", err
+	}
+
+	var customObj CustomObject
+
+	if err := json.Unmarshal(unknownBytes, &customObj); err != nil {
+		return "", err
+	}
+
+	if customObj.CustomName != "" {
+		name = customObj.CustomName
+	}
+
+	return name, nil
+}
+
+func isSameLogicalContext(existingContext, newContext *Context, newContextName string) bool {
+	if existingContext == nil || newContext == nil {
+		return existingContext == newContext
+	}
+
+	if existingContext.ClusterID != "" && newContext.ClusterID != "" && existingContext.ClusterID == newContext.ClusterID {
+		return true
+	}
+
+	if isDynamicManualUpdate(existingContext, newContext, newContextName) {
+		return true
+	}
+
+	if isDynamicReloadOfKubeConfigContext(existingContext, newContext) {
+		return true
+	}
+
+	return fallbackContextIdentity(existingContext) == fallbackContextIdentity(newContext)
+}
+
+func isDynamicManualUpdate(existingContext, newContext *Context, newContextName string) bool {
+	if existingContext.Source != DynamicCluster ||
+		newContext.Source != DynamicCluster ||
+		existingContext.ClusterID != "" ||
+		newContext.ClusterID != "" ||
+		existingContext.Name != newContextName {
+		return false
+	}
+
+	if !hasCustomContextName(existingContext) && !hasCustomContextName(newContext) {
+		return true
+	}
+
+	existingServer := ""
+	if existingContext.Cluster != nil {
+		existingServer = existingContext.Cluster.Server
+	}
+
+	newServer := ""
+	if newContext.Cluster != nil {
+		newServer = newContext.Cluster.Server
+	}
+
+	return existingServer == newServer
+}
+
+func hasCustomContextName(headlampContext *Context) bool {
+	if headlampContext == nil || headlampContext.KubeContext == nil {
+		return false
+	}
+
+	info := headlampContext.KubeContext.Extensions["headlamp_info"]
+	if info == nil {
+		return false
+	}
+
+	if typedInfo, ok := info.(*CustomObject); ok {
+		return typedInfo != nil && typedInfo.CustomName != ""
+	}
+
+	unknownBytes, err := json.Marshal(info)
+	if err != nil {
+		return false
+	}
+
+	var customObj CustomObject
+
+	if err := json.Unmarshal(unknownBytes, &customObj); err != nil {
+		return false
+	}
+
+	return customObj.CustomName != ""
+}
+
+func isDynamicReloadOfKubeConfigContext(existingContext, newContext *Context) bool {
+	return existingContext.Source == KubeConfig &&
+		newContext.Source == DynamicCluster &&
+		newContext.ClusterID == "" &&
+		sameKubeContextTarget(existingContext, newContext)
+}
+
+func sameKubeContextTarget(existingContext, newContext *Context) bool {
+	if existingContext.KubeContext == nil || newContext.KubeContext == nil {
+		return false
+	}
+
+	existingServer := ""
+	if existingContext.Cluster != nil {
+		existingServer = existingContext.Cluster.Server
+	}
+
+	newServer := ""
+	if newContext.Cluster != nil {
+		newServer = newContext.Cluster.Server
+	}
+
+	return existingServer == newServer &&
+		existingContext.KubeContext.Cluster == newContext.KubeContext.Cluster &&
+		existingContext.KubeContext.AuthInfo == newContext.KubeContext.AuthInfo &&
+		existingContext.KubeContext.Namespace == newContext.KubeContext.Namespace
+}
+
+func fallbackContextIdentity(headlampContext *Context) string {
+	clusterServer := ""
+	if headlampContext.Cluster != nil {
+		clusterServer = headlampContext.Cluster.Server
+	}
+
+	kubeCluster := ""
+	kubeAuthInfo := ""
+	kubeNamespace := ""
+
+	if headlampContext.KubeContext != nil {
+		kubeCluster = headlampContext.KubeContext.Cluster
+		kubeAuthInfo = headlampContext.KubeContext.AuthInfo
+		kubeNamespace = headlampContext.KubeContext.Namespace
+	}
+
+	// Each field is rendered with %q so that any literal "|" or quote characters
+	// within a field are escaped rather than being treated as a delimiter. This
+	// keeps the resulting identity unambiguous even if a path or name contains
+	// the separator character.
+	return fmt.Sprintf(
+		"fallback:%d|%q|%q|%q|%q|%q",
+		headlampContext.Source,
+		headlampContext.KubeConfigPath,
+		clusterServer,
+		kubeCluster,
+		kubeAuthInfo,
+		kubeNamespace,
+	)
 }
 
 // GetContexts returns all contexts in the store.
@@ -157,28 +339,47 @@ func (c *contextStore) GetContext(name string) (*Context, error) {
 
 // RemoveContext removes a context from the store.
 func (c *contextStore) RemoveContext(name string) error {
+	c.mu.Lock()
+
 	err := c.cache.Delete(context.Background(), name)
-	if err == nil {
-		c.notifyListeners()
+	c.mu.Unlock()
+
+	if err != nil {
+		return err
 	}
+
+	c.notifyListeners()
 
 	return err
 }
 
 // AddContextWithKeyAndTTL adds a context to the store with a ttl.
 func (c *contextStore) AddContextWithKeyAndTTL(headlampContext *Context, key string, ttl time.Duration) error {
+	if headlampContext == nil {
+		return errors.New("context cannot be nil")
+	}
+
 	// Keep the stored context identifier consistent with the cache key.
 	headlampContext.Name = key
 
+	c.mu.Lock()
+
 	err := c.cache.SetWithTTL(context.Background(), key, headlampContext, ttl)
-	if err == nil {
-		c.notifyListeners()
+	c.mu.Unlock()
+
+	if err != nil {
+		return err
 	}
+
+	c.notifyListeners()
 
 	return err
 }
 
 // UpdateTTL updates the ttl of a context.
 func (c *contextStore) UpdateTTL(key string, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	return c.cache.UpdateTTL(context.Background(), key, ttl)
 }

--- a/backend/pkg/kubeconfig/contextStore_test.go
+++ b/backend/pkg/kubeconfig/contextStore_test.go
@@ -1,6 +1,7 @@
 package kubeconfig_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -166,4 +167,360 @@ func TestAddContextWithHeadlampInfo(t *testing.T) {
 	_, err = store.GetContext("original-name")
 	require.Error(t, err)
 	require.Equal(t, cache.ErrNotFound, err)
+}
+
+func TestAddContextRejectsDuplicateEffectiveName(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	firstInfo := kubeconfig.CustomObject{CustomName: customName}
+	secondInfo := kubeconfig.CustomObject{CustomName: customName}
+
+	firstContext := &kubeconfig.Context{
+		Name:      "cluster-a",
+		ClusterID: "/tmp/config-a+cluster-a",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &firstInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-a.example"},
+	}
+
+	secondContext := &kubeconfig.Context{
+		Name:      "cluster-b",
+		ClusterID: "/tmp/config-b+cluster-b",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-b",
+			AuthInfo: "user-b",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &secondInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-b.example"},
+	}
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, firstContext.ClusterID, storedContext.ClusterID)
+
+	contexts, err := store.GetContexts()
+	require.NoError(t, err)
+	require.Len(t, contexts, 1)
+}
+
+func TestAddContextRejectsDuplicateNonCustomEffectiveName(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	firstContext := &kubeconfig.Context{
+		Name:      "shared-context-name",
+		ClusterID: "/tmp/config-a+shared-context-name",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-a.example"},
+	}
+
+	secondContext := &kubeconfig.Context{
+		Name:      "shared-context-name",
+		ClusterID: "/tmp/config-b+shared-context-name",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-b",
+			AuthInfo: "user-b",
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-b.example"},
+	}
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext("shared-context-name")
+	require.NoError(t, err)
+	require.Equal(t, firstContext.ClusterID, storedContext.ClusterID)
+}
+
+func TestAddContextAllowsUpdatingSameLogicalContext(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	customInfo := kubeconfig.CustomObject{CustomName: customName}
+
+	originalContext := &kubeconfig.Context{
+		Name:      "cluster-a",
+		ClusterID: "/tmp/config-a+cluster-a",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &customInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-a.example"},
+	}
+
+	updatedContext := &kubeconfig.Context{
+		Name:      "cluster-a",
+		ClusterID: originalContext.ClusterID,
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &customInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://updated-cluster-a.example"},
+	}
+
+	require.NoError(t, store.AddContext(originalContext))
+	require.NoError(t, store.AddContext(updatedContext))
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "https://updated-cluster-a.example", storedContext.Cluster.Server)
+}
+
+func TestAddContextRejectsNilContext(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	err := store.AddContext(nil)
+	require.EqualError(t, err, "context cannot be nil")
+}
+
+func TestAddContextWithKeyAndTTLRejectsNilContext(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	err := store.AddContextWithKeyAndTTL(nil, "nil-context", time.Second)
+	require.EqualError(t, err, "context cannot be nil")
+}
+
+func TestAddContextRejectsConcurrentDuplicateEffectiveName(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	firstContext, secondContext := newConcurrentCollisionContexts(customName)
+
+	errs := addContextsConcurrently(store, firstContext, secondContext)
+
+	successCount := 0
+	duplicateErrCount := 0
+
+	for _, err := range errs {
+		if err == nil {
+			successCount++
+
+			continue
+		}
+
+		require.ErrorContains(t, err, "duplicate effective context name")
+
+		duplicateErrCount++
+	}
+
+	require.Equal(t, 1, successCount)
+	require.Equal(t, 1, duplicateErrCount)
+
+	contexts, err := store.GetContexts()
+	require.NoError(t, err)
+	require.Len(t, contexts, 1)
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Contains(t, []string{firstContext.ClusterID, secondContext.ClusterID}, storedContext.ClusterID)
+}
+
+func TestAddContextRejectsDuplicateEffectiveNameWithoutClusterIDWhenNamespaceDiffers(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	firstContext := newCustomNamedContext(
+		"cluster-a",
+		"",
+		customName,
+		"https://cluster-a.example",
+		"user-a",
+	)
+	firstContext.KubeContext.Namespace = "namespace-a"
+
+	secondContext := newCustomNamedContext(
+		"cluster-a",
+		"",
+		customName,
+		"https://cluster-a.example",
+		"user-a",
+	)
+	secondContext.KubeContext.Namespace = "namespace-b"
+	firstContext.Source = kubeconfig.KubeConfig
+	secondContext.Source = kubeconfig.KubeConfig
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "namespace-a", storedContext.KubeContext.Namespace)
+}
+
+func TestAddContextRejectsDynamicClustersWithSameNameDifferentServer(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-dynamic-name"
+
+	firstContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-a.example", "user-a")
+	firstContext.Source = kubeconfig.DynamicCluster
+
+	secondContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-b.example", "user-b")
+	secondContext.Source = kubeconfig.DynamicCluster
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "https://cluster-a.example", storedContext.Cluster.Server)
+}
+
+func TestAddContextAllowsUpdatingManualDynamicClusterWithSameNameDifferentServer(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	firstContext := &kubeconfig.Context{
+		Name:   "manual-cluster",
+		Source: kubeconfig.DynamicCluster,
+		KubeContext: &api.Context{
+			Cluster:  "manual-cluster",
+			AuthInfo: "user-a",
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-a.example"},
+	}
+
+	updatedContext := &kubeconfig.Context{
+		Name:   "manual-cluster",
+		Source: kubeconfig.DynamicCluster,
+		KubeContext: &api.Context{
+			Cluster:  "manual-cluster",
+			AuthInfo: "user-b",
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-b.example"},
+	}
+
+	require.NoError(t, store.AddContext(firstContext))
+	require.NoError(t, store.AddContext(updatedContext))
+
+	storedContext, err := store.GetContext("manual-cluster")
+	require.NoError(t, err)
+	require.Equal(t, "https://cluster-b.example", storedContext.Cluster.Server)
+	require.Equal(t, "user-b", storedContext.KubeContext.AuthInfo)
+}
+
+func TestAddContextAllowsUpdatingSameDynamicClusterSameServer(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-dynamic-name"
+
+	firstContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-a.example", "user-a")
+	firstContext.Source = kubeconfig.DynamicCluster
+
+	updatedContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-a.example", "user-b")
+	updatedContext.Source = kubeconfig.DynamicCluster
+
+	require.NoError(t, store.AddContext(firstContext))
+	require.NoError(t, store.AddContext(updatedContext))
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "user-b", storedContext.KubeContext.AuthInfo)
+}
+
+func newConcurrentCollisionContexts(customName string) (*kubeconfig.Context, *kubeconfig.Context) {
+	firstContext := newCustomNamedContext(
+		"cluster-a",
+		"/tmp/config-a+cluster-a",
+		customName,
+		"https://cluster-a.example",
+		"user-a",
+	)
+	secondContext := newCustomNamedContext(
+		"cluster-b",
+		"/tmp/config-b+cluster-b",
+		customName,
+		"https://cluster-b.example",
+		"user-b",
+	)
+
+	return firstContext, secondContext
+}
+
+func addContextsConcurrently(
+	store kubeconfig.ContextStore, firstContext *kubeconfig.Context, secondContext *kubeconfig.Context,
+) []error {
+	var wg sync.WaitGroup
+
+	errs := make(chan error, 2)
+	start := make(chan struct{})
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		<-start
+
+		errs <- store.AddContext(firstContext)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		<-start
+
+		errs <- store.AddContext(secondContext)
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	results := make([]error, 0, 2)
+
+	for err := range errs {
+		results = append(results, err)
+	}
+
+	return results
+}
+
+func newCustomNamedContext(
+	name string, clusterID string, customName string, server string, authInfo string,
+) *kubeconfig.Context {
+	customInfo := kubeconfig.CustomObject{CustomName: customName}
+
+	return &kubeconfig.Context{
+		Name:      name,
+		ClusterID: clusterID,
+		KubeContext: &api.Context{
+			Cluster:  name,
+			AuthInfo: authInfo,
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &customInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: server},
+	}
 }

--- a/backend/pkg/kubeconfig/contextStore_test.go
+++ b/backend/pkg/kubeconfig/contextStore_test.go
@@ -1,6 +1,7 @@
 package kubeconfig_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -166,4 +167,320 @@ func TestAddContextWithHeadlampInfo(t *testing.T) {
 	_, err = store.GetContext("original-name")
 	require.Error(t, err)
 	require.Equal(t, cache.ErrNotFound, err)
+}
+
+func TestAddContextRejectsDuplicateEffectiveName(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	firstInfo := kubeconfig.CustomObject{CustomName: customName}
+	secondInfo := kubeconfig.CustomObject{CustomName: customName}
+
+	firstContext := &kubeconfig.Context{
+		Name:      "cluster-a",
+		ClusterID: "/tmp/config-a+cluster-a",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &firstInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-a.example"},
+	}
+
+	secondContext := &kubeconfig.Context{
+		Name:      "cluster-b",
+		ClusterID: "/tmp/config-b+cluster-b",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-b",
+			AuthInfo: "user-b",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &secondInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-b.example"},
+	}
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, firstContext.ClusterID, storedContext.ClusterID)
+
+	contexts, err := store.GetContexts()
+	require.NoError(t, err)
+	require.Len(t, contexts, 1)
+}
+
+func TestAddContextRejectsDuplicateNonCustomEffectiveName(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	firstContext := &kubeconfig.Context{
+		Name:      "shared-context-name",
+		ClusterID: "/tmp/config-a+shared-context-name",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-a.example"},
+	}
+
+	secondContext := &kubeconfig.Context{
+		Name:      "shared-context-name",
+		ClusterID: "/tmp/config-b+shared-context-name",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-b",
+			AuthInfo: "user-b",
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-b.example"},
+	}
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext("shared-context-name")
+	require.NoError(t, err)
+	require.Equal(t, firstContext.ClusterID, storedContext.ClusterID)
+}
+
+func TestAddContextAllowsUpdatingSameLogicalContext(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	customInfo := kubeconfig.CustomObject{CustomName: customName}
+
+	originalContext := &kubeconfig.Context{
+		Name:      "cluster-a",
+		ClusterID: "/tmp/config-a+cluster-a",
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &customInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://cluster-a.example"},
+	}
+
+	updatedContext := &kubeconfig.Context{
+		Name:      "cluster-a",
+		ClusterID: originalContext.ClusterID,
+		KubeContext: &api.Context{
+			Cluster:  "cluster-a",
+			AuthInfo: "user-a",
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &customInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: "https://updated-cluster-a.example"},
+	}
+
+	require.NoError(t, store.AddContext(originalContext))
+	require.NoError(t, store.AddContext(updatedContext))
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "https://updated-cluster-a.example", storedContext.Cluster.Server)
+}
+
+func TestAddContextRejectsNilContext(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	err := store.AddContext(nil)
+	require.EqualError(t, err, "context cannot be nil")
+}
+
+func TestAddContextWithKeyAndTTLRejectsNilContext(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	err := store.AddContextWithKeyAndTTL(nil, "nil-context", time.Second)
+	require.EqualError(t, err, "context cannot be nil")
+}
+
+func TestAddContextRejectsConcurrentDuplicateEffectiveName(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	firstContext, secondContext := newConcurrentCollisionContexts(customName)
+
+	errs := addContextsConcurrently(store, firstContext, secondContext)
+
+	successCount := 0
+	duplicateErrCount := 0
+
+	for _, err := range errs {
+		if err == nil {
+			successCount++
+
+			continue
+		}
+
+		require.ErrorContains(t, err, "duplicate effective context name")
+
+		duplicateErrCount++
+	}
+
+	require.Equal(t, 1, successCount)
+	require.Equal(t, 1, duplicateErrCount)
+
+	contexts, err := store.GetContexts()
+	require.NoError(t, err)
+	require.Len(t, contexts, 1)
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Contains(t, []string{firstContext.ClusterID, secondContext.ClusterID}, storedContext.ClusterID)
+}
+
+func TestAddContextRejectsDuplicateEffectiveNameWithoutClusterIDWhenNamespaceDiffers(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-custom-name"
+	firstContext := newCustomNamedContext(
+		"cluster-a",
+		"",
+		customName,
+		"https://cluster-a.example",
+		"user-a",
+	)
+	firstContext.KubeContext.Namespace = "namespace-a"
+
+	secondContext := newCustomNamedContext(
+		"cluster-a",
+		"",
+		customName,
+		"https://cluster-a.example",
+		"user-a",
+	)
+	secondContext.KubeContext.Namespace = "namespace-b"
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "namespace-a", storedContext.KubeContext.Namespace)
+}
+
+func TestAddContextRejectsDynamicClustersWithSameNameDifferentServer(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-dynamic-name"
+
+	firstContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-a.example", "user-a")
+	firstContext.Source = kubeconfig.DynamicCluster
+
+	secondContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-b.example", "user-b")
+	secondContext.Source = kubeconfig.DynamicCluster
+
+	require.NoError(t, store.AddContext(firstContext))
+
+	err := store.AddContext(secondContext)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate effective context name")
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "https://cluster-a.example", storedContext.Cluster.Server)
+}
+
+func TestAddContextAllowsUpdatingSameDynamicClusterSameServer(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+
+	customName := "shared-dynamic-name"
+
+	firstContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-a.example", "user-a")
+	firstContext.Source = kubeconfig.DynamicCluster
+
+	updatedContext := newCustomNamedContext("dyn-a", "", customName, "https://cluster-a.example", "user-b")
+	updatedContext.Source = kubeconfig.DynamicCluster
+
+	require.NoError(t, store.AddContext(firstContext))
+	require.NoError(t, store.AddContext(updatedContext))
+
+	storedContext, err := store.GetContext(customName)
+	require.NoError(t, err)
+	require.Equal(t, "user-b", storedContext.KubeContext.AuthInfo)
+}
+
+func newConcurrentCollisionContexts(customName string) (*kubeconfig.Context, *kubeconfig.Context) {
+	firstContext := newCustomNamedContext(
+		"cluster-a",
+		"/tmp/config-a+cluster-a",
+		customName,
+		"https://cluster-a.example",
+		"user-a",
+	)
+	secondContext := newCustomNamedContext(
+		"cluster-b",
+		"/tmp/config-b+cluster-b",
+		customName,
+		"https://cluster-b.example",
+		"user-b",
+	)
+
+	return firstContext, secondContext
+}
+
+func addContextsConcurrently(
+	store kubeconfig.ContextStore, firstContext *kubeconfig.Context, secondContext *kubeconfig.Context,
+) []error {
+	var wg sync.WaitGroup
+
+	errs := make(chan error, 2)
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		errs <- store.AddContext(firstContext)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		errs <- store.AddContext(secondContext)
+	}()
+
+	wg.Wait()
+	close(errs)
+
+	results := make([]error, 0, 2)
+
+	for err := range errs {
+		results = append(results, err)
+	}
+
+	return results
+}
+
+func newCustomNamedContext(
+	name string, clusterID string, customName string, server string, authInfo string,
+) *kubeconfig.Context {
+	customInfo := kubeconfig.CustomObject{CustomName: customName}
+
+	return &kubeconfig.Context{
+		Name:      name,
+		ClusterID: clusterID,
+		KubeContext: &api.Context{
+			Cluster:  name,
+			AuthInfo: authInfo,
+			Extensions: map[string]runtime.Object{
+				"headlamp_info": &customInfo,
+			},
+		},
+		Cluster: &api.Cluster{Server: server},
+	}
 }


### PR DESCRIPTION
## Summary
- reject `ContextStore` collisions when different contexts resolve to the same effective context name
- keep re-adding the same logical context working for rename and refresh flows
- add backend regression coverage for custom-name collisions, non-custom collisions, and same-context updates

## Linked Issue
Fixes #6427

## What Changed
- added an effective-name helper in `backend/pkg/kubeconfig/contextStore.go`
- reject colliding inserts for duplicate effective names, including plain `Context.Name` collisions
- compare logical context identity so safe updates still overwrite the same stored context
- preserve existing dynamic manual replacement and dynamic kubeconfig reload flows
- added focused `contextStore` tests for collision rejection and same-context updates

## Verification
- `cd backend && go test ./pkg/kubeconfig/... -count=1` — passed
- `tmp=$(mktemp -d) && gomod=$(go env GOMODCACHE) && gocache=$(go env GOCACHE) && cd backend && HOME="$tmp" XDG_CONFIG_HOME="$tmp/.config" GOMODCACHE="$gomod" GOCACHE="$gocache" HEADLAMP_RUN_INTEGRATION_TESTS=true go test ./cmd -run 'TestDynamicClusters/override|TestRenameCluster' -count=1` — passed
- `cache=$(mktemp -d) && cd backend && GOLANGCI_LINT_CACHE="$cache" ./tools/golangci-lint run ./pkg/kubeconfig/...` — passed
- `cache=$(mktemp -d) && cd backend && GOLANGCI_LINT_CACHE="$cache" ./tools/golangci-lint run` — passed
- `gomod=$(go env GOMODCACHE) && gocache=$(go env GOCACHE) && tmp=$(mktemp -d) && cd backend && HOME="$tmp" XDG_CONFIG_HOME="$tmp/.config" GOMODCACHE="$gomod" GOCACHE="$gocache" HEADLAMP_RUN_INTEGRATION_TESTS=true go test ./...` — not a valid local full-suite analogue with isolated home; `backend/cmd` passed, then helm and portforward tests failed because the isolated home lacks the normal kubeconfig test setup

## Scope
- Only `backend/pkg/kubeconfig/contextStore.go` and `backend/pkg/kubeconfig/contextStore_test.go` were changed.
