### PR TITLE
frontend: backend: docs: Fix OIDC token rejection loop

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -437,6 +438,31 @@ func (c *Context) SetupProxy() error {
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(URL)
+
+	// For OIDC clusters, log a hint upon receiving a 401 from the API server (StatusUnauthorized),
+	// as it can indicate the API server does not trust the same OIDC provider as Headlamp.
+	if c.AuthType() == "oidc" {
+		// Log at most once per proxy to avoid flooding the logs on repeated 401s.
+		var warnOnce sync.Once
+
+		proxy.ModifyResponse = func(resp *http.Response) error {
+			authHeader := ""
+			if resp.Request != nil {
+				authHeader = resp.Request.Header.Get("Authorization")
+			}
+
+			if resp.StatusCode == http.StatusUnauthorized && strings.HasPrefix(authHeader, "Bearer ") {
+				warnOnce.Do(func() {
+					logger.Log(logger.LevelWarn, map[string]string{"context": c.Name}, nil,
+						"API server rejected the forwarded bearer token (401); the token may be "+
+							"expired/invalid, or the API server may not trust the same OIDC issuer "+
+							"and client-id as Headlamp")
+				})
+			}
+
+			return nil
+		}
+	}
 
 	restConf, err := c.RESTConfig()
 	if err == nil {

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -438,6 +439,31 @@ func (c *Context) SetupProxy() error {
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(URL)
+
+	// For OIDC clusters, log a hint upon receiving a 401 from the API server (StatusUnauthorized),
+	// as it can indicate the API server does not trust the same OIDC provider as Headlamp.
+	if c.AuthType() == "oidc" {
+		// Log at most once per proxy to avoid flooding the logs on repeated 401s.
+		var warnOnce sync.Once
+
+		proxy.ModifyResponse = func(resp *http.Response) error {
+			authHeader := ""
+			if resp.Request != nil {
+				authHeader = resp.Request.Header.Get("Authorization")
+			}
+
+			if resp.StatusCode == http.StatusUnauthorized && strings.HasPrefix(authHeader, "Bearer ") {
+				warnOnce.Do(func() {
+					logger.Log(logger.LevelWarn, map[string]string{"context": c.Name}, nil,
+						"API server rejected the forwarded bearer token (401); the token may be "+
+							"expired/invalid, or the API server may not trust the same OIDC issuer "+
+							"and client-id as Headlamp")
+				})
+			}
+
+			return nil
+		}
+	}
 
 	restConf, err := c.RESTConfig()
 	if err == nil {

--- a/backend/pkg/kubeconfig/kubeconfig_test.go
+++ b/backend/pkg/kubeconfig/kubeconfig_test.go
@@ -9,10 +9,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -405,6 +407,48 @@ func TestContext(t *testing.T) {
 	t.Logf("Proxy request Response: %s", rr.Body.String())
 	assert.Contains(t, rr.Body.String(), "major")
 	assert.Contains(t, rr.Body.String(), "minor")
+}
+
+// Check that a hint is logged when an OIDC cluster returns a 401.
+func TestSetupProxyOIDCTokenRejectionWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		oidc     bool
+		status   int
+		wantWarn bool
+	}{
+		{"oidc 401 warns", true, http.StatusUnauthorized, true},
+		{"oidc 200 is silent", true, http.StatusOK, false},
+		{"non-oidc 401 is silent", false, http.StatusUnauthorized, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warned := false
+
+			original := logger.SetLogFunc(func(_ uint, _ map[string]string, _ interface{}, msg string) {
+				warned = warned || strings.Contains(msg, "rejected the forwarded bearer token")
+			})
+			defer logger.SetLogFunc(original)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer server.Close()
+
+			ctx := &kubeconfig.Context{Name: "oidc-test-context", Cluster: &api.Cluster{Server: server.URL}}
+			if tt.oidc {
+				ctx.OidcConf = &kubeconfig.OidcConfig{ClientID: "test-client-id", IdpIssuerURL: "https://oidc.example.com"}
+			}
+
+			request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api", nil)
+			require.NoError(t, err)
+			request.Header.Set("Authorization", "Bearer test-token")
+
+			require.NoError(t, ctx.ProxyRequest(httptest.NewRecorder(), request))
+			assert.Equal(t, tt.wantWarn, warned)
+		})
+	}
 }
 
 func TestLoadContextsFromBase64String(t *testing.T) {

--- a/docs/installation/in-cluster/oidc.md
+++ b/docs/installation/in-cluster/oidc.md
@@ -114,3 +114,11 @@ then you have to:
 - Set `-oidc-scopes` if needed, e.g. `-oidc-scopes=profile,email,groups`
 
 **Note** If you already have another static client configured for Kubernetes for the [apiserver's OIDC](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server) (OpenID Connect) configuration, use a **single static client ID** i.e `-oidc-client-id` for both Dex and Headlamp. Additionally, the **redirectURIs** need to be specified for each client.
+
+### Troubleshooting: OIDC sign-in succeeds but the cluster rejects your token
+
+If you can sign in via OIDC but are returned to the "Sign in" screen with a message that the cluster rejected your token (and cannot load cluster resources), the cluster's **API server** is most likely not configured to trust the same OIDC provider as Headlamp. Headlamp only forwards the token to the API server, and the API server is what accepts or rejects it, so it must be OIDC-aware with a matching issuer, client ID, and audience.
+
+Make sure the API server is configured for the same OIDC provider (via its `--oidc-issuer-url` / `--oidc-client-id` flags or the equivalent [structured authentication configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server)), so that `--oidc-issuer-url` matches Headlamp's `-oidc-idp-issuer-url` and `--oidc-client-id` matches Headlamp's `-oidc-client-id`.
+
+Managed control planes (e.g. AKS, EKS, GKE) may not accept arbitrary OIDC flags on the API server. If that is the case, use the provider's managed identity/OIDC integration instead. When the API server rejects the token, Headlamp logs a warning containing `API server rejected the forwarded bearer token (401)`.

--- a/e2e-tests/tests/oidcTokenRejection.spec.ts
+++ b/e2e-tests/tests/oidcTokenRejection.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const CLUSTER_NAME = 'test';
+const AUTH_PROBE_URL = `**/clusters/${CLUSTER_NAME}/apis/authorization.k8s.io/v1/selfsubjectrulesreviews`;
+
+/**
+ * Model the point where the identity provider accepted the sign-in, but the
+ * Kubernetes API rejects the returned token. Headlamp should remember that the
+ * OIDC callback completed, return to the login dialog after the 403 auth probe,
+ * and explain the cluster-side rejection instead of starting another login loop.
+ */
+test('shows an error when the API server rejects an OIDC token', async ({ page }) => {
+  let authProbeCount = 0;
+
+  await page.route('**/config', route =>
+    route.fulfill({
+      json: {
+        clusters: [{ name: CLUSTER_NAME, auth_type: 'oidc' }],
+      },
+    })
+  );
+  await page.route('**/plugins', route => route.fulfill({ json: [] }));
+
+  await page.route(AUTH_PROBE_URL, async route => {
+    authProbeCount++;
+    await route.fulfill({
+      status: 403,
+      contentType: 'application/json',
+      json: {
+        apiVersion: 'v1',
+        kind: 'Status',
+        status: 'Failure',
+        message: 'The API server rejected the OIDC token',
+        reason: 'Forbidden',
+        code: 403,
+      },
+    });
+  });
+
+  // The popup is a separate same-origin page because the parent OauthPopup
+  // listens for the browser storage event emitted by the callback window.
+  await page.context().route(/\/oidc\?.*/, route =>
+    route.fulfill({
+      contentType: 'text/html',
+      body: '<!doctype html><title>OIDC callback</title>',
+    })
+  );
+
+  await page.goto('/');
+  await page.evaluate(clusterName => {
+    window.history.pushState({}, '', `/c/${clusterName}/login`);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, CLUSTER_NAME);
+  await expect(page.getByRole('heading', { level: 1, name: 'Authentication' })).toBeVisible();
+
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.getByRole('button', { name: 'Sign In' }).click(),
+  ]);
+  await popup.waitForLoadState();
+  await expect(popup).toHaveTitle('OIDC callback');
+  await popup.evaluate(() => localStorage.setItem('auth_status', 'success'));
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        clusterName => sessionStorage.getItem(`oidc-login-attempted.${clusterName}`),
+        CLUSTER_NAME
+      )
+    )
+    .toBe('true');
+  await expect(page).toHaveURL(new RegExp(`/c/${CLUSTER_NAME}/login$`));
+  await expect(
+    page.getByText(
+      /The cluster did not accept your sign-in\. Its API server may not trust this OIDC provider/
+    )
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Use A Token' })).toBeVisible();
+  await expect.poll(() => popup.isClosed()).toBe(true);
+  // A single probe confirms the 403 was handled without retrying auth in a loop.
+  expect(authProbeCount).toBe(1);
+});

--- a/frontend/src/components/App/RouteSwitcher.tsx
+++ b/frontend/src/components/App/RouteSwitcher.tsx
@@ -180,6 +180,18 @@ function AuthRoute(props: AuthRouteProps) {
   const authError = query.error as any;
   const isExplicitAuthError = [401, 403].includes(authError?.status);
 
+  // Once the cluster successfully accepts the token, clear the flag that marked
+  // previous OIDC sign-in as rejected by the API server. See Issue #2848
+  React.useEffect(() => {
+    if (cluster && clusters?.[cluster]?.auth_type === 'oidc' && query.isSuccess) {
+      try {
+        sessionStorage.removeItem(`oidc-login-attempted.${cluster}`);
+      } catch {
+        // sessionStorage unavailable (e.g. private browsing with strict settings).
+      }
+    }
+  }, [cluster, clusters, query.isSuccess]);
+
   let redirectRoute: string;
 
   if (!currentCluster) {

--- a/frontend/src/components/authchooser/AuthChooser.stories.tsx
+++ b/frontend/src/components/authchooser/AuthChooser.stories.tsx
@@ -74,6 +74,14 @@ AuthTypeoidc.args = {
   title: 'Sign in with OpenID Connect',
 };
 
+export const AuthTypeoidcTokenRejected = Template.bind({});
+AuthTypeoidcTokenRejected.args = {
+  ...argFixture,
+  clusterAuthType: 'oidc',
+  oidcTokenRejected: true,
+  title: 'Authentication',
+};
+
 export const AnError = Template.bind({});
 AnError.args = {
   ...argFixture,

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidcTokenRejected.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.AuthTypeoidcTokenRejected.stories.storyshot
@@ -91,7 +91,7 @@
                     style="font-size: 1.25rem; font-weight: 500; line-height: 1.6;"
                     tabindex="-1"
                   >
-                    Sign in with OpenID Connect
+                    Authentication
                   </h1>
                 </div>
               </div>
@@ -99,6 +99,19 @@
             <div
               class="MuiBox-root css-dvxtzn"
             >
+              <div
+                class="MuiBox-root css-1c5ij41"
+              >
+                <div
+                  class="MuiBox-root css-19midj6"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-18lkse1-MuiTypography-root"
+                  >
+                    The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.
+                  </p>
+                </div>
+              </div>
               <div
                 class="MuiBox-root css-1c5ij41"
               >

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.BasicAuthChooser.stories.storyshot
@@ -97,7 +97,7 @@
               </div>
             </h2>
             <div
-              class="MuiBox-root css-0"
+              class="MuiBox-root css-dvxtzn"
             >
               <div
                 class="MuiBox-root css-1c5ij41"

--- a/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
+++ b/frontend/src/components/authchooser/__snapshots__/AuthChooser.HaveClusters.stories.storyshot
@@ -97,7 +97,7 @@
               </div>
             </h2>
             <div
-              class="MuiBox-root css-0"
+              class="MuiBox-root css-dvxtzn"
             >
               <div
                 class="MuiBox-root css-1c5ij41"

--- a/frontend/src/components/authchooser/index.tsx
+++ b/frontend/src/components/authchooser/index.tsx
@@ -73,6 +73,17 @@ function AuthChooser({ children }: AuthChooserProps) {
     clusterAuthType = clusters[clusterName].auth_type;
   }
 
+  // Whether the last OIDC sign-in was rejected by the cluster's API server.
+  // Set in handleOidcAuth, & cleared once auth succeeds in AuthRoute. See Issue #2848.
+  let oidcTokenRejected = false;
+  if (clusterAuthType === 'oidc' && clusterName) {
+    try {
+      oidcTokenRejected = sessionStorage.getItem(`oidc-login-attempted.${clusterName}`) === 'true';
+    } catch {
+      // sessionStorage unavailable (e.g. private browsing with strict settings).
+    }
+  }
+
   const numClusters = Object.keys(clusters || {}).length;
 
   function runTestAuthAgain() {
@@ -206,9 +217,17 @@ function AuthChooser({ children }: AuthChooserProps) {
       error={error}
       oauthUrl={`${getAppUrl()}oidc?dt=${Date()}&cluster=${getCluster()}`}
       clusterAuthType={clusterAuthType}
+      oidcTokenRejected={oidcTokenRejected}
       handleTryAgain={runTestAuthAgain}
       handleOidcAuth={() => {
-        queryClient.invalidateQueries({ queryKey: ['clusterMe', clusterName], exact: true });
+        if (clusterName) {
+          try {
+            sessionStorage.setItem(`oidc-login-attempted.${clusterName}`, 'true');
+          } catch {
+            // sessionStorage unavailable (e.g. private browsing with strict settings).
+          }
+          queryClient.invalidateQueries({ queryKey: ['clusterMe', clusterName], exact: true });
+        }
         history.replace(from);
       }}
       handleBackButtonPress={() => {
@@ -239,6 +258,7 @@ export interface PureAuthChooserProps {
   error: Error | null;
   oauthUrl: string;
   clusterAuthType: string;
+  oidcTokenRejected?: boolean;
   handleOidcAuth: () => void;
   handleTokenAuth: () => void;
   handleTryAgain: () => void;
@@ -254,6 +274,7 @@ export function PureAuthChooser({
   error,
   oauthUrl,
   clusterAuthType,
+  oidcTokenRejected,
   handleOidcAuth,
   handleTokenAuth,
   handleTryAgain,
@@ -282,7 +303,16 @@ export function PureAuthChooser({
             {title}
           </DialogTitle>
           {!error ? (
-            <Box>
+            <Box display="flex" flexDirection="column" alignItems="center">
+              {clusterAuthType === 'oidc' && oidcTokenRejected ? (
+                <Box m={2}>
+                  <Empty>
+                    {t(
+                      'The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.'
+                    )}
+                  </Empty>
+                </Box>
+              ) : null}
               {clusterAuthType === 'oidc' ? (
                 <Box m={2}>
                   <OauthPopup

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "جارٍ الحصول على معلومات المصادقة: {{ clusterName }}",
   "Getting auth info": "جارٍ الحصول على معلومات المصادقة",
   "Testing auth": "جارٍ اختبار المصادقة",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "مصادقة كتلة Headlamp",
   "Sign In": "تسجيل الدخول",
   "Use A Token": "استخدام رمز",

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "جارٍ الحصول على معلومات المصادقة: {{ clusterName }}",
   "Getting auth info": "جارٍ الحصول على معلومات المصادقة",
   "Testing auth": "جارٍ اختبار المصادقة",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "مصادقة كتلة Headlamp",
   "Sign In": "تسجيل الدخول",
   "Use A Token": "استخدام رمز",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "প্রমাণ তথ্য পাচ্ছেন: {{ clusterName }}",
   "Getting auth info": "প্রমাণ তথ্য পাচ্ছেন",
   "Testing auth": "পরীক্ষা প্রমাণ",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "হেডল্যাম্প Cluster Authentication",
   "Sign In": "সাইন ইন",
   "Use A Token": "একটি Token ব্যবহার করুন",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "প্রমাণ তথ্য পাচ্ছেন: {{ clusterName }}",
   "Getting auth info": "প্রমাণ তথ্য পাচ্ছেন",
   "Testing auth": "পরীক্ষা প্রমাণ",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "হেডল্যাম্প Cluster Authentication",
   "Sign In": "সাইন ইন",
   "Use A Token": "একটি Token ব্যবহার করুন",

--- a/frontend/src/i18n/locales/cs/translation.json
+++ b/frontend/src/i18n/locales/cs/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Získávají se informace o ověřování: {{ clusterName }}",
   "Getting auth info": "Získávají se informace o ověřování.",
   "Testing auth": "Testování ověřování",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Ověřování clusteru Headlamp",
   "Sign In": "Přihlásit se",
   "Use A Token": "Použít token",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Rufe Authentifizierungsinformationen für {{ clusterName }} ab",
   "Getting auth info": "Rufe Authentifizierungsinformationen ab",
   "Testing auth": "Prüfe Authentifizierungsinformationen",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp Cluster-Authentifizierung",
   "Sign In": "Anmelden",
   "Use A Token": "Token verwenden",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "Getting auth info: {{ clusterName }}",
   "Getting auth info": "Getting auth info",
   "Testing auth": "Testing auth",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.",
   "Headlamp Cluster Authentication": "Headlamp Cluster Authentication",
   "Sign In": "Sign In",
   "Use A Token": "Use A Token",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Getting auth info: {{ clusterName }}",
   "Getting auth info": "Getting auth info",
   "Testing auth": "Testing auth",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.",
   "Headlamp Cluster Authentication": "Headlamp Cluster Authentication",
   "Sign In": "Sign In",
   "Use A Token": "Use A Token",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Obteniendo información de autenticación: {{ clusterName }}",
   "Getting auth info": "Obteniendo información de autenticación",
   "Testing auth": "Comprobando autenticación",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Autenticación de cluster Headlamp",
   "Sign In": "Iniciar sesión",
   "Use A Token": "Use un token",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Obtenir des informations d'authentification : {{ clusterName }}",
   "Getting auth info": "Obtenir des informations d'authentification",
   "Testing auth": "Test d'authentification",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Authentification du cluster HeadLamp",
   "Sign In": "Se connecter",
   "Use A Token": "Utiliser un jeton",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "Getting auth info: {{ clusterName }}",
   "Getting auth info": "Getting auth info",
   "Testing auth": "Testing auth",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp Cluster Authentication",
   "Sign In": "Sign In",
   "Use A Token": "Use A Token",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Getting auth info: {{ clusterName }}",
   "Getting auth info": "Getting auth info",
   "Testing auth": "Testing auth",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp Cluster Authentication",
   "Sign In": "Sign In",
   "Use A Token": "Use A Token",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/hu/translation.json
+++ b/frontend/src/i18n/locales/hu/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Hitelesítési adatok beolvasása: {{ clusterName }}",
   "Getting auth info": "Hitelesítési adatok lekérése",
   "Testing auth": "Hitelesítés tesztelése",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp fürthitelesítés",
   "Sign In": "Bejelentkezés",
   "Use A Token": "Token használata",

--- a/frontend/src/i18n/locales/id/translation.json
+++ b/frontend/src/i18n/locales/id/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Mendapatkan info autentikasi: {{ clusterName }}",
   "Getting auth info": "Mendapatkan info autentikasi",
   "Testing auth": "Menguji autentikasi",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Autentikasi Kluster Headlamp",
   "Sign In": "Masuk",
   "Use A Token": "Gunakan token",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Recuperando le informazioni di autenticazione: {{ clusterName }}",
   "Getting auth info": "Recuperando le informazioni di autenticazione",
   "Testing auth": "Test di autenticazione",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Autenticazione del Cluster Headlamp",
   "Sign In": "Accedi",
   "Use A Token": "Usa Un Token",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "認証情報を取得中: {{ clusterName }}",
   "Getting auth info": "認証情報を取得中",
   "Testing auth": "認証をテスト中",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp クラスター認証",
   "Sign In": "サインイン",
   "Use A Token": "トークンを使用する",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "{{ clusterName }} 클러스터의 인증 정보 가져오는 중",
   "Getting auth info": "인증 정보 가져오는 중",
   "Testing auth": "인증 테스트 중",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp 클러스터 인증",
   "Sign In": "로그인",
   "Use A Token": "토큰 사용",

--- a/frontend/src/i18n/locales/nl/translation.json
+++ b/frontend/src/i18n/locales/nl/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Verificatiegegevens ophalen: {{ clusterName }}",
   "Getting auth info": "Verificatiegegevens ophalen",
   "Testing auth": "Verificatie testen...",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp-clusterverificatie",
   "Sign In": "Aanmelden",
   "Use A Token": "Een token gebruiken",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Uzyskiwanie informacji o uwierzytelnieniach: {{ clusterName }}",
   "Getting auth info": "Uzyskiwanie informacji o uwierzytelnianiu",
   "Testing auth": "Testowanie uwierzytelniania",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Uwierzytelnianie klastra usługi Headlamp",
   "Sign In": "Zaloguj się",
   "Use A Token": "Używanie tokenu",

--- a/frontend/src/i18n/locales/pt-br/translation.json
+++ b/frontend/src/i18n/locales/pt-br/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "A obter informação de autentição: {{ clusterName }}",
   "Getting auth info": "A obter informação de autentição",
   "Testing auth": "A testar autenticação",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Autenticação em Cluster Headlamp",
   "Sign In": "Autenticar",
   "Use A Token": "Use um token",

--- a/frontend/src/i18n/locales/pt-pt/translation.json
+++ b/frontend/src/i18n/locales/pt-pt/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "Получение информации для авторизации: {{ clusterName }}",
   "Getting auth info": "Получение информации для авторизации",
   "Testing auth": "Тестирование авторизации",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Аутентификация кластера Headlamp",
   "Sign In": "Войти",
   "Use A Token": "Использовать токен",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Получение информации для авторизации: {{ clusterName }}",
   "Getting auth info": "Получение информации для авторизации",
   "Testing auth": "Тестирование авторизации",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Аутентификация кластера Headlamp",
   "Sign In": "Войти",
   "Use A Token": "Использовать токен",

--- a/frontend/src/i18n/locales/sv/translation.json
+++ b/frontend/src/i18n/locales/sv/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Hämtar autentiseringsinformation: {{ clusterName }}",
   "Getting auth info": "Hämtar autentiseringsinformation",
   "Testing auth": "Testar autentisering",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp-klusterautentisering",
   "Sign In": "Logga in",
   "Use A Token": "Använd en token",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "அங்கீகாரத் தகவல் பெறுகிறது: {{ clusterName }}",
   "Getting auth info": "அங்கீகாரத் தகவல் பெறுகிறது",
   "Testing auth": "அங்கீகாரத்தைச் சோதிக்கிறது",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "ஹெட்லேம்ப் க்ளஸ்டர் அங்கீகாரம்",
   "Sign In": "உள்நுழை",
   "Use A Token": "ஒரு டோக்கன் பயன்படுத்து",

--- a/frontend/src/i18n/locales/tr/translation.json
+++ b/frontend/src/i18n/locales/tr/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "Kimlik doğrulama bilgileri alınıyor: {{ clusterName }}",
   "Getting auth info": "Kimlik doğrulama bilgileri alınıyor",
   "Testing auth": "Kimlik doğrulaması test ediliyor",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp Kümesi Kimlik Doğrulaması",
   "Sign In": "Oturum Aç",
   "Use A Token": "Bir Belirteç Kullan",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "{{ clusterName }} کی تصدیقی معلومات حاصل کی جا رہی ہیں",
   "Getting auth info": "تصدیقی معلومات حاصل کی جا رہی ہیں",
   "Testing auth": "تصدیق کی جانچ کی جا رہی ہے",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "ہیڈلیمپ کلسٹر تصدیق",
   "Sign In": "سائن ان کریں",
   "Use A Token": "ٹوکن استعمال کریں",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "{{ clusterName }} کی تصدیقی معلومات حاصل کی جا رہی ہیں",
   "Getting auth info": "تصدیقی معلومات حاصل کی جا رہی ہیں",
   "Testing auth": "تصدیق کی جانچ کی جا رہی ہے",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "ہیڈلیمپ کلسٹر تصدیق",
   "Sign In": "سائن ان کریں",
   "Use A Token": "ٹوکن استعمال کریں",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "獲取身份驗證訊息：{{ clusterName }}",
   "Getting auth info": "獲取身份驗證訊息",
   "Testing auth": "測試身份驗證",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp 叢集身份驗證",
   "Sign In": "登入",
   "Use A Token": "使用令牌",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -214,6 +214,7 @@
   "Getting auth info: {{ clusterName }}": "",
   "Getting auth info": "",
   "Testing auth": "",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "",
   "Sign In": "",
   "Use A Token": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -226,6 +226,7 @@
   "Getting auth info: {{ clusterName }}": "获取身份验证信息：{{ clusterName }}",
   "Getting auth info": "获取身份验证信息",
   "Testing auth": "测试身份验证",
+  "The cluster did not accept your sign-in. Its API server may not trust this OIDC provider (issuer, client ID, or audience), or your token may be expired or lack the required permissions. Please check the cluster API server OIDC configuration.": "",
   "Headlamp Cluster Authentication": "Headlamp 集群身份验证",
   "Sign In": "登入",
   "Use A Token": "使用令牌",


### PR DESCRIPTION
## Summary

For in-cluster OIDC clusters, if the Kubernetes API server does not trust the same OIDC provider as Headlamp, it rejects the forwarded token with a 401. Headlamp previously would react by redirecting to the login screen on every action, producing an endless loop for users without surfacing error or constructive feedback information. 

This PR surfaces to the user why sign-in failed in the UI and logs a corresponding hint in the headlamp server logs. 

### Context: 

Currently, Headlamp handles forwarding the OIDC token to the API server. In instances where the API server is unaware / misconfigured for the forwarded OIDC token, we return a 401. The issue is that this is universally treated as a 'needs login', which leads to the redirect, so a successful authentication would still bounce right back.

## Related Issue

Fixes: #2848
- #2848 

## Changes

-  Frontend: After a rejected OIDC sign-in, the user stays on the login screen but this time with a clear message instead of invisible redirect loop. All options remain available for re-interaction once settings are configured. Flag is set on initial sign-in completion & then cleared if authentication succeeds.

- Backend: Added a warning informational message on 401 responses from the API server for OIDC clusters. 

- Docs: Added troubleshooting section  in  `docs/installation/in-cluster/oidc.md` for failed Sign-in case. 

- Translation files updated to include new OIDC feedback message

- Story book snapshots updated for new slight style changes.

## Steps to Test

1. Deploy Headlamp in-cluster with OIDC pointed at a provider on a cluster who's API server **does not** trust that provider. (For example: Auth0 on unconfigured AKS or GKE cluster)
2. Sign in via OIDC.
3. Observe if you correctly see the 'cluster rejected your token' message & sign-in screen is preserved. 
4. Observe if you see relevant 401 log in headlamp deployment logs. (`API server rejected the OIDC token (401)...`)

## Screenshots (if applicable)

### Failed OIDC Sign-in feedback message:

<img width="70%" height="auto" alt="Screenshot 2026-07-07 200712" src="https://github.com/user-attachments/assets/2c0f70ed-9d0e-474f-b1b9-e7596d802750" />

## Notes for the Reviewer

- `oidcTokenRejected` property addition shouldn't effect storybooks where omitted, as it's optional.
- The storybook snapshot changes are regernerated snapshots from the style change we did in `AuthChooser` to align things properly.