### PR TITLE
frontend: globalSearch: Fix namespace query flooding search results

### DIFF
--- a/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.stories.tsx
@@ -38,6 +38,15 @@ const phonyPods = generateK8sResourceList(
   { instantiateAs: Pod }
 );
 
+const kubeSystemPods = phonyPods.map((pod, i) => ({
+  ...pod.jsonData,
+  metadata: {
+    ...pod.jsonData.metadata,
+    name: i === 0 ? 'coredns' : pod.jsonData.metadata.name,
+    namespace: 'kube-system',
+  },
+}));
+
 const sampleCluster: Cluster = {
   name: 'sample-cluster',
   auth_type: '',
@@ -201,5 +210,38 @@ export const LoadingResources: Story = {
 export const FoundSomeResults: Story = {
   args: {
     defaultValue: 'pod',
+  },
+};
+
+export const BareNamespaceQuery: Story = {
+  args: {
+    defaultValue: 'kube-system',
+  },
+  parameters: {
+    msw: {
+      handlers: {
+        pod: [
+          http.get(`${sampleClusterApiBase}/api/v1/pods`, () =>
+            HttpResponse.json(makeKubeList('v1', 'Pod', kubeSystemPods))
+          ),
+        ],
+      },
+    },
+  },
+};
+export const CombinedNamespaceQuery: Story = {
+  args: {
+    defaultValue: 'coredns kube-system',
+  },
+  parameters: {
+    msw: {
+      handlers: {
+        pod: [
+          http.get(`${sampleClusterApiBase}/api/v1/pods`, () =>
+            HttpResponse.json(makeKubeList('v1', 'Pod', kubeSystemPods))
+          ),
+        ],
+      },
+    },
   },
 };

--- a/frontend/src/components/globalSearch/GlobalSearchContent.tsx
+++ b/frontend/src/components/globalSearch/GlobalSearchContent.tsx
@@ -80,6 +80,7 @@ interface SearchResult {
   icon?: JSX.Element;
   subLabel?: string;
   namespace?: string;
+  kind?: string;
   k8sLabels?: string[];
   onClick: () => void;
   labelMatch?: FuseResultMatch;
@@ -150,6 +151,7 @@ function makeKubeObjectResults(
             <LazyKubeIcon kind={item.kind} width="24px" height="24px" />
           </Suspense>
         ),
+        kind: item.kind,
         namespace: item.metadata.namespace,
         subLabel: item.metadata.namespace ? `${item.kind} • ${item.metadata.namespace}` : item.kind,
         onClick: () => onClick(item),
@@ -201,14 +203,20 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
     );
 
     const options: SearchResult[] = [];
+    const addedOptionIds = new Set<string>();
 
     const addOption = (namespaceValue: string) => {
-      if (!namespaceValue) {
+      if (!namespaceValue || /\s/.test(namespaceValue)) {
         return;
       }
+      const id = `set-namespace-${namespaceValue}`;
+      if (addedOptionIds.has(id)) {
+        return;
+      }
+      addedOptionIds.add(id);
 
       options.push({
-        id: `set-namespace-${namespaceValue}`,
+        id,
         subLabel: t('translation|Current Namespace'),
         label: t('translation|Set namespace: {{namespace}}', { namespace: namespaceValue }),
         icon: (
@@ -395,6 +403,7 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
           'label',
           'k8sLabels',
           'namespace',
+          'kind',
           // We also want to search by subLabel sometimes
           // For example 'default namespace' (there are a lot of objects with 'default' name)
           // But it shouldn't be main field so it has half the weight (1/2)
@@ -407,37 +416,62 @@ export function GlobalSearchContent(props: GlobalSearchContentProps) {
   );
 
   const results: SearchResult[] = useMemo(() => {
-    if (!query) return [];
-    return fuse
-      .search(
-        {
-          // Construct logical query https://www.fusejs.io/api/query.html
-          // Improves search for space separated terms
-          $and: query
-            .split(' ')
-            .filter(Boolean)
-            .map(it => ({
-              $or: [
-                { label: it },
-                // Only search labels if there's an "=" character in the query
-                it.includes('=') ? { k8sLabels: it } : undefined,
-                { subLabel: it },
-                { namespace: it },
-              ].filter(Boolean) as Expression[],
-            })),
-        },
-        { limit: 100 }
-      )
-      .map(
-        ({ item, matches }) =>
-          ({
-            ...item,
-            labelMatch: matches?.find(it => it.key === 'label'),
-            subLabelMatch: matches?.find(it => it.key === 'subLabel'),
-            k8sLabelsMatch: matches?.find(it => it.key === 'k8sLabels'),
-            namespaceMatch: matches?.find(it => it.key === 'namespace'),
-          } satisfies SearchResult)
-      );
+    if (!query.trim()) return [];
+    return (
+      fuse
+        .search(
+          {
+            // Construct logical query https://www.fusejs.io/api/query.html
+            // Improves search for space separated terms
+            $and: (() => {
+              const terms = query.split(' ').filter(Boolean);
+              return terms.map(it => ({
+                $or: [
+                  { label: it },
+                  it.includes('=') ? { k8sLabels: it } : undefined,
+                  { kind: it },
+                  { subLabel: it },
+                  // Only match on namespace when combined with another term
+                  // (e.g. "coredns kube-system"). Bare single-term matches that
+                  // only hit via subLabel or namespace are filtered out below,
+                  // since subLabel embeds the namespace as display text (e.g.
+                  // "Pod • kube-system") which would otherwise flood every
+                  // resource in a namespace.
+                  terms.length > 1 ? { namespace: it } : undefined,
+                ].filter(Boolean) as Expression[],
+              }));
+            })(),
+          },
+          { limit: 100 }
+        )
+
+        // For a bare single-term query on a namespaced resource, drop
+        // results that only matched via subLabel or namespace — that's
+        // namespace text leaking through (e.g. "Pod • kube-system" contains
+        // "kube-system"), which would otherwise flood every resource in a
+        // namespace. Non-namespaced entries (Theme, Settings, Cluster, Page)
+        // never hit this path, since they have no namespace field and rely
+        // on subLabel as their only searchable text.
+        .filter(({ item, matches }) => {
+          const terms = query.split(' ').filter(Boolean);
+          if (terms.length > 1) return true;
+          if (!item.namespace) return true;
+          return (
+            matches?.some(m => m.key === 'label' || m.key === 'kind' || m.key === 'k8sLabels') ??
+            false
+          );
+        })
+        .map(
+          ({ item, matches }) =>
+            ({
+              ...item,
+              labelMatch: matches?.find(it => it.key === 'label'),
+              subLabelMatch: matches?.find(it => it.key === 'subLabel'),
+              k8sLabelsMatch: matches?.find(it => it.key === 'k8sLabels'),
+              namespaceMatch: matches?.find(it => it.key === 'namespace'),
+            } satisfies SearchResult)
+        )
+    );
   }, [query, fuse]);
 
   const recentItems = useMemo(() => {

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.BareNamespaceQuery.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.BareNamespaceQuery.stories.storyshot
@@ -1,0 +1,272 @@
+<body>
+  <div>
+    <div
+      aria-owns=":mock-test-id:"
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-controls=":mock-test-id:"
+          aria-expanded="true"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-activedescendant=":mock-test-id:"
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value="kube-system"
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1oql5kp-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-5vmmeo-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    >
+      <div
+        style="position: relative; height: 100px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
+      >
+        <div
+          style="height: 100px; width: 100%;"
+        >
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6 Mui-focused"
+            data-option-index="0"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 0px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Advanced Search (Beta)
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Se
+                </span>
+                arch "
+                <span
+                  style="font-weight: bold;"
+                >
+                  kube-system
+                </span>
+                " with Advanced Search
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="1"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 50px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-wjpmq5"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="ns.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="23.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <rect
+                      height="6.6900792"
+                      id="rect8790"
+                      style="opacity: 1; fill: none; fill-opacity: 1; fill-rule: nonzero; stroke: currentcolor; stroke-width: 0.40000001; stroke-linecap: butt; stroke-linejoin: round; stroke-miterlimit: 10; stroke-dasharray: 0.80000001, 0.4; stroke-dashoffset: 3.44000006; stroke-opacity: 1;"
+                      width="7.6735892"
+                      x="6.1734986"
+                      y="6.5793304"
+                    />
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Current Namespace
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Set
+                </span>
+                 na
+                <span
+                  style="font-weight: bold;"
+                >
+                  mes
+                </span>
+                pac
+                <span
+                  style="font-weight: bold;"
+                >
+                  e
+                </span>
+                : 
+                <span
+                  style="font-weight: bold;"
+                >
+                  kube-system
+                </span>
+              </div>
+            </div>
+          </li>
+        </div>
+      </div>
+    </ul>
+  </div>
+</body>

--- a/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.CombinedNamespaceQuery.stories.storyshot
+++ b/frontend/src/components/globalSearch/__snapshots__/GlobalSearchContent.CombinedNamespaceQuery.stories.storyshot
@@ -1,0 +1,286 @@
+<body>
+  <div>
+    <div
+      aria-owns=":mock-test-id:"
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          aria-activedescendant=""
+          aria-autocomplete="list"
+          aria-controls=":mock-test-id:"
+          aria-expanded="true"
+          autocapitalize="none"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-1qswgw4-MuiInputBase-root-MuiOutlinedInput-root"
+          role="combobox"
+          spellcheck="false"
+        >
+          <input
+            aria-activedescendant=":mock-test-id:"
+            aria-invalid="false"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-19qh8xo-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":mock-test-id:"
+            placeholder="Search resources, pages, clusters by name"
+            type="text"
+            value="coredns kube-system"
+          />
+          <button
+            aria-label="Clear"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1oql5kp-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1whs34k-MuiNotchedOutlined-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiPopper-root css-5vmmeo-MuiPopper-root"
+    data-popper-escaped=""
+    data-popper-placement="bottom"
+    data-popper-reference-hidden=""
+    role="tooltip"
+    style="position: absolute; top: 0px; left: 0px; margin: 0px; right: auto; bottom: auto; transform: translate(0px, 0px);"
+  >
+    <ul
+      aria-labelledby=":mock-test-id:"
+      class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-atm94b-MuiPaper-root"
+      id=":mock-test-id:"
+      role="listbox"
+    >
+      <div
+        style="position: relative; height: 100px; width: 100%; overflow: auto; -webkit-overflow-scrolling: touch; will-change: transform; direction: ltr;"
+      >
+        <div
+          style="height: 100px; width: 100%;"
+        >
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="0"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 0px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            >
+              <div
+                class="MuiBox-root css-72qomf"
+              >
+                <svg
+                  height="17.500378mm"
+                  id="svg13826"
+                  inkscape:version="0.91 r13725"
+                  sodipodi:docname="pod.svg"
+                  style="scale: 1.1; width: 100%; height: 100%;"
+                  viewBox="0 0 18.035334 17.500378"
+                  width="18.035334mm"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:cc="http://creativecommons.org/ns#"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                  xmlns:svg="http://www.w3.org/2000/svg"
+                >
+                  <defs
+                    id="defs13820"
+                  />
+                  <sodipodi:namedview
+                    bordercolor="#666666"
+                    borderopacity="1"
+                    fit-margin-bottom="0"
+                    fit-margin-left="0"
+                    fit-margin-right="0"
+                    fit-margin-top="0"
+                    id="base"
+                    inkscape:current-layer="layer1"
+                    inkscape:cx="-2.090004"
+                    inkscape:cy="33.752239"
+                    inkscape:document-units="mm"
+                    inkscape:pageopacity="0"
+                    inkscape:pageshadow="2"
+                    inkscape:window-height="775"
+                    inkscape:window-maximized="1"
+                    inkscape:window-width="1440"
+                    inkscape:window-x="0"
+                    inkscape:window-y="1"
+                    inkscape:zoom="8"
+                    pagecolor="currentcolor"
+                    showgrid="false"
+                  />
+                  <metadata
+                    id="metadata13823"
+                  >
+                    <rdf:rdf>
+                      <cc:work
+                        rdf:about=""
+                      >
+                        <dc:format>
+                          image/svg+xml
+                        </dc:format>
+                        <dc:type
+                          rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                        />
+                        <dc:title />
+                      </cc:work>
+                    </rdf:rdf>
+                  </metadata>
+                  <g
+                    id="layer1"
+                    inkscape:groupmode="layer"
+                    inkscape:label="Calque 1"
+                    transform="translate(-0.99262638,-1.174181)"
+                  >
+                    <g
+                      id="g70"
+                      transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                    >
+                      <path
+                        d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                        id="path3055"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-filename="new.png"
+                        inkscape:export-xdpi="250.55"
+                        inkscape:export-ydpi="250.55"
+                        style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                      />
+                      <path
+                        d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                        id="path3054-2-9"
+                        inkscape:connector-curvature="0"
+                        style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                      />
+                    </g>
+                    <g
+                      id="g3341"
+                      transform="translate(0.12766661,0.35147801)"
+                    >
+                      <path
+                        d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                        id="path910"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                        id="path912"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                      <path
+                        d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                        id="path914"
+                        inkscape:connector-curvature="0"
+                        inkscape:export-xdpi="376.57999"
+                        inkscape:export-ydpi="376.57999"
+                        style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Pod • 
+                <span
+                  style="font-weight: bold;"
+                >
+                  kube-system
+                </span>
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  coredns
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            aria-disabled="false"
+            aria-selected="false"
+            class="MuiBox-root css-iuk3p6"
+            data-option-index="1"
+            id=":mock-test-id:"
+            role="option"
+            style="position: absolute; left: 0px; top: 50px; height: 50px; width: 100%;"
+            tabindex="-1"
+          >
+            <div
+              class="MuiBox-root css-hj9wmn"
+            />
+            <div
+              class="MuiBox-root css-kznbd2"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-caption css-q1d4hg-MuiTypography-root"
+              >
+                Advanced Search (Beta)
+              </span>
+              <div
+                class="MuiBox-root css-72rvq0"
+              >
+                <span
+                  style="font-weight: bold;"
+                >
+                  Se
+                </span>
+                a
+                <span
+                  style="font-weight: bold;"
+                >
+                  rc
+                </span>
+                h "
+                <span
+                  style="font-weight: bold;"
+                >
+                  coredns
+                </span>
+                 kube-system" with Advanced Search
+              </div>
+            </div>
+          </li>
+        </div>
+      </div>
+    </ul>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

This PR fixes the regression introduced in #6356 where searching for a namespace by itself (for example, `kube-system`) returned every resource in that namespace instead of primarily showing the **"Set namespace"** shortcut. It also fixes a case where that shortcut could appear twice.

---

## Related Issue

No linked issue. The regression was reported on #6356 by @sniok and discussed with @illume in Slack.

---

## Changes

- ✅ Added a dedicated `kind` field to search results and now match on that directly instead of `subLabel`. Since `subLabel` includes the namespace as display text, matching against it caused bare namespace queries to return every resource in that namespace.
- ✅ Restricted namespace matching to **multi-term queries** (for example, `coredns kube-system`). Single-term searches now behave like they did before #6356 and only match through `label`, `kind`, or `k8sLabels`.
- ✅ Restored `subLabel` to the Fuse query and `keys` configuration. Removing it made non-Kubernetes entries like **Theme**, **Settings**, **Cluster**, and **Page** undiscoverable because `subLabel` is their only searchable text.
- ✅ Added a post-search filter so, for **single-term queries** on namespaced resources, results that matched *only* through `subLabel` or `namespace` are filtered out. This keeps the flooding fix while preserving discoverability for non-namespaced entries.
- ✅ Added the missing `kind` field to the `SearchResult` type for better type safety.
- ✅ Replaced the repeated `options.some()` lookup with a `Set`-based lookup when building namespace shortcuts, avoiding the previous O(n²) pattern.
- ✅ Fixed a duplicate case where the **"Set namespace"** shortcut could appear twice if the typed query matched both the raw input and a known namespace.
- ✅ Added two Storybook stories — `BareNamespaceQuery` and `CombinedNamespaceQuery` — along with generated snapshots covering both bare-namespace and combined-namespace searches, so this regression now has automated coverage.
- ✅ Changed the single-term post-filter fallback from `?? true` to `?? false`, so items are only kept on an explicit `label`/`kind`/`k8sLabels` match instead of silently bypassing the flooding protection if match data is ever missing.

---

## Steps to Test

1. Search for a namespace by itself (for example, `kube-system`). You should see **only one** **"Set namespace: kube-system"** shortcut, not a list of every resource in that namespace.
2. Search for a resource name together with a namespace (for example, `coredns kube-system`). The expected pod and related resources should still be returned.
3. Search for a resource kind by itself (for example, `pod`). Matching resources should still be returned across all namespaces.

---

## Notes for the Reviewer

- 💬 Discussed the approach with René and Oleksandr on Slack. The consensus was that global search is meant for finding a specific resource, not browsing everything inside a namespace. Restricting namespace matching to multi-term queries preserves that behavior while keeping the new search capability.
- 🔍 Verified manually against a real Minikube cluster using all three scenarios above, in addition to the new automated Storybook coverage.
- 📸 Updated the existing `GlobalSearchContent` Storybook snapshots and added two new stories to cover the new filtering and match-highlighting behavior.

### Review follow-ups addressed

- 💡 Copilot caught a real regression where removing `subLabel` from the search made non-Kubernetes entries like **Theme**, **Settings**, **Cluster**, and **Page** impossible to find.
- ✅ Restored `subLabel` to the query and added a targeted post-search filter that only excludes `subLabel`/`namespace`-only matches for items that actually have a `namespace`. This keeps the flooding fix without affecting the other search entries.
- ✅ Addressed the remaining review comments by:
  - Adding the missing `kind` field to the `SearchResult` type.
  - Replacing the repeated `options.some()` lookup with a `Set`-based lookup.
  - Changing the post-filter fallback to default to **excluding** rather than **including** when match data is missing.