### PR TITLE
frontend: use console.error for kubeconfig load failures

### DIFF
--- a/frontend/src/components/cluster/KubeConfigLoader.tsx
+++ b/frontend/src/components/cluster/KubeConfigLoader.tsx
@@ -387,7 +387,7 @@ function KubeConfigLoader() {
             setState(Step.Success);
           })
           .catch(e => {
-            console.debug('Error setting up clusters from kubeconfig:', e);
+            console.error('Error setting up clusters from kubeconfig:', e);
             setError(
               t('translation|Error setting up clusters, please load a valid kubeconfig file')
             );


### PR DESCRIPTION
## Summary

when kubeconfig cluster setup fails, the real error was only logged with `console.debug`. This uses `console.error` so the failure is visible in the console. The UI already shows a generic error message.


## Changes

-  `console.debug`  to   `console.error` in the `setCluster` catch path