### PR TITLE
backend: handleError: Guard against a nil error

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -1763,6 +1763,13 @@ func (c *HeadlampConfig) dispatchHelmRoute(
 func (c *HeadlampConfig) handleError(w http.ResponseWriter, ctx context.Context,
 	span trace.Span, err error, msg string, status int,
 ) {
+	// Guard against a nil error: some callers pass one on a failure path, and
+	// err.Error() below would then panic and take down the request handler.
+	// Fall back to msg so the client still gets a meaningful response.
+	if err == nil {
+		err = errors.New(msg)
+	}
+
 	logger.Log(logger.LevelError, nil, err, msg)
 	c.TelemetryHandler.RecordError(span, err, msg)
 	c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error.type", msg))

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -1882,6 +1882,31 @@ func TestHandleClusterRename_NameCollision(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TestHandleError_NilError ensures handleError does not panic when a caller
+// passes a nil error. Calling err.Error() on a nil error would otherwise crash
+// the request handler; handleError falls back to the message instead.
+func TestHandleError_NilError(t *testing.T) {
+	c := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG:      &headlampconfig.HeadlampCFG{},
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	ctx, span := otel.Tracer("test").Start(context.Background(), "TestHandleError_NilError")
+
+	defer span.End()
+
+	require.NotPanics(t, func() {
+		c.handleError(w, ctx, span, nil, "something went wrong", http.StatusInternalServerError)
+	})
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "something went wrong")
+}
+
 func TestFileExists(t *testing.T) {
 	// Test for existing file
 	assert.True(t, fileExists("./headlamp_testdata/kubeconfig"),


### PR DESCRIPTION
## What

`handleError` writes the response body with `err.Error()`:

```go
func (c *HeadlampConfig) handleError(w http.ResponseWriter, ctx context.Context,
    span trace.Span, err error, msg string, status int,
) {
    logger.Log(logger.LevelError, nil, err, msg)
    ...
    http.Error(w, err.Error(), status)   // panics if err is nil
}
```

If any of its ~26 callers passes a `nil` error, `err.Error()` dereferences a nil interface and **panics**, taking down the request handler. Callers are supposed to pass a real error, but that is easy to get wrong on a failure path where the actual error lives in a separate variable (#6302 fixed one such caller in the cluster-rename flow).

This makes the sink itself defensive: a `nil` error falls back to `msg`, so the client gets a normal error response instead of a crash. It complements the caller fixes rather than replacing them.

## Why / discussion

This is a small "defense in depth" change, and I would value maintainers' view on the convention: should `handleError` guard `nil` centrally (as here), or should we keep the contract strict at every call site and rely on review/lint to catch nil errors? I lean toward guarding centrally since a mistaken `nil` here means a crash, not a bad log line, but happy to go the other way.

## Testing

Added `TestHandleError_NilError`, which asserts `handleError` does not panic on a nil error and still returns the message. Verified it **panics (fails) without the guard** and passes with it.

```
$ go test ./cmd/ -run TestHandleError_NilError
ok  	github.com/kubernetes-sigs/headlamp/backend/cmd
```

`gofmt`, `go vet`, and `golangci-lint run --new-from-rev=origin/main` are clean.

cc @illume @skoeva

Related to #6302
