### PR TITLE
frontend: Improve user feedback for failed operations

### DIFF
--- a/frontend/src/components/common/Resource/DeleteButton.tsx
+++ b/frontend/src/components/common/Resource/DeleteButton.tsx
@@ -17,6 +17,7 @@
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
+import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -51,6 +52,7 @@ export default function DeleteButton(props: DeleteButtonProps) {
   const [forceDelete, setForceDelete] = React.useState(false);
   const location = useLocation();
   const { t } = useTranslation(['translation']);
+  const { enqueueSnackbar } = useSnackbar();
   const dispatchDeleteEvent = useEventCallback(HeadlampEventType.DELETE_RESOURCE);
 
   const deleteFunc = React.useCallback(
@@ -96,6 +98,12 @@ export default function DeleteButton(props: DeleteButtonProps) {
       authVerb="delete"
       onError={(err: Error) => {
         console.error(`Error while getting authorization for delete button in ${item}:`, err);
+        enqueueSnackbar(
+          t('Failed to check delete authorization for {{ itemName }}.', {
+            itemName: item?.metadata?.name,
+          }),
+          { variant: 'error' }
+        );
       }}
     >
       <ActionButton

--- a/frontend/src/components/node/NodeShellTerminal.tsx
+++ b/frontend/src/components/node/NodeShellTerminal.tsx
@@ -122,7 +122,7 @@ async function shell(item: Node, onExec: StreamResultsCb) {
     await apply(kubePod);
   } catch (e) {
     console.error('Error:DebugNode: creating pod', e);
-    return {};
+    throw e;
   }
   const tty = true;
   const stdin = true;

--- a/frontend/src/i18n/locales/ar/translation.json
+++ b/frontend/src/i18n/locales/ar/translation.json
@@ -347,6 +347,7 @@
   "Deleting item {{ itemName }}…": "جارٍ حذف العنصر {{ itemName }}…",
   "Deleted item {{ itemName }}.": "تم حذف العنصر {{ itemName }}",
   "Error deleting item {{ itemName }}.": "حدث خطأ أثناء حذف العنصر {{ itemName }}",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "إخلاء",
   "Evict Pod": "إخلاء الـ Pod",
   "Delete item": "حذف العنصر",

--- a/frontend/src/i18n/locales/bn/translation.json
+++ b/frontend/src/i18n/locales/bn/translation.json
@@ -339,6 +339,7 @@
   "Deleting item {{ itemName }}…": "Item Delete করা {{ itemName }}…",
   "Deleted item {{ itemName }}.": "Delete করা item {{ itemName }}।",
   "Error deleting item {{ itemName }}.": "Item Delete করা Error {{ itemName }}।",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "Evict",
   "Evict Pod": "Evict Pod",
   "Delete item": "item Delete করুন",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -339,6 +339,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -339,6 +339,7 @@
   "Deleting item {{ itemName }}…": "Deleting item {{ itemName }}…",
   "Deleted item {{ itemName }}.": "Deleted item {{ itemName }}.",
   "Error deleting item {{ itemName }}.": "Error deleting item {{ itemName }}.",
+  "Failed to check delete authorization for {{ itemName }}.": "Failed to check delete authorization for {{ itemName }}.",
   "Evict": "Evict",
   "Evict Pod": "Evict Pod",
   "Delete item": "Delete item",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -341,6 +341,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -341,6 +341,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/he/translation.json
+++ b/frontend/src/i18n/locales/he/translation.json
@@ -341,6 +341,7 @@
   "Deleting item {{ itemName }}…": "Deleting item {{ itemName }}…",
   "Deleted item {{ itemName }}.": "Deleted item {{ itemName }}.",
   "Error deleting item {{ itemName }}.": "Error deleting item {{ itemName }}.",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "Evict",
   "Evict Pod": "Evict Pod",
   "Delete item": "Delete item",

--- a/frontend/src/i18n/locales/hi/translation.json
+++ b/frontend/src/i18n/locales/hi/translation.json
@@ -339,6 +339,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -341,6 +341,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -337,6 +337,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -337,6 +337,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/pt/translation.json
+++ b/frontend/src/i18n/locales/pt/translation.json
@@ -341,6 +341,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/ru/translation.json
+++ b/frontend/src/i18n/locales/ru/translation.json
@@ -343,6 +343,7 @@
   "Deleting item {{ itemName }}…": "Удаление элемента {{ itemName }}…",
   "Deleted item {{ itemName }}.": "Удалён элемент {{ itemName }}.",
   "Error deleting item {{ itemName }}.": "Ошибка удаления элемента {{ itemName }}.",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "Исключить",
   "Evict Pod": "Исключить Pod",
   "Delete item": "Удалить элемент",

--- a/frontend/src/i18n/locales/ta/translation.json
+++ b/frontend/src/i18n/locales/ta/translation.json
@@ -339,6 +339,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/ur/translation.json
+++ b/frontend/src/i18n/locales/ur/translation.json
@@ -339,6 +339,7 @@
   "Deleting item {{ itemName }}…": "{{ itemName }} حذف کیا جا رہا ہے…",
   "Deleted item {{ itemName }}.": "{{ itemName }} حذف کر دیا گیا",
   "Error deleting item {{ itemName }}.": "{{ itemName }} حذف کرنے میں خرابی",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "خارج کریں",
   "Evict Pod": "پوڈ خارج کریں",
   "Delete item": "آئٹم حذف کریں",

--- a/frontend/src/i18n/locales/zh-tw/translation.json
+++ b/frontend/src/i18n/locales/zh-tw/translation.json
@@ -337,6 +337,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -337,6 +337,7 @@
   "Deleting item {{ itemName }}…": "",
   "Deleted item {{ itemName }}.": "",
   "Error deleting item {{ itemName }}.": "",
+  "Failed to check delete authorization for {{ itemName }}.": "",
   "Evict": "",
   "Evict Pod": "",
   "Delete item": "",


### PR DESCRIPTION
## Summary

This PR improves user feedback by surfacing errors that were previously swallowed or only logged to the console.

## Changes

- Re-throw debug pod creation errors so the terminal displays the existing connection failure message instead of remaining blank.
- Show an error snackbar when the delete authorization check fails.

## Steps to Test

1. Attempt to open a node shell when debug pod creation fails.
2. Verify the terminal displays the connection failure message instead of a blank screen.
3. Attempt to delete a resource without the required permissions.
4. Verify an error snackbar is displayed.

## Notes for the Reviewer

- The `NodeShellTerminal` change propagates the error to the existing `onConnectionFailed` handler instead of swallowing it.
- The `DeleteButton` change follows the existing snackbar notification pattern used throughout the frontend.
- `PluginSettingsDetails` was intentionally left unchanged because plugin deletion failures are already surfaced through the existing `clusterAction` notification flow.