### PR TITLE
headlamp-plugin: config: remove deprecated baseUrl and moduleResolution=node10

### DIFF
--- a/plugins/headlamp-plugin/config/plugins-tsconfig.json
+++ b/plugins/headlamp-plugin/config/plugins-tsconfig.json
@@ -3,39 +3,38 @@
     "target": "es2017",
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
-    "moduleResolution": "node",
-    "baseUrl": "../../../../",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "allowJs": true,
     "checkJs": true,
     "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals", "lodash"],
     "paths": {
       "@iconify/react": [
-        "node_modules/@kinvolk/headlamp-plugin/node_modules/@iconify/react/src/icon.js"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/node_modules/@iconify/react/src/icon.js"
       ],
       "@kinvolk/headlamp-plugin/lib/Crd": [
-        "node_modules/@kinvolk/headlamp-plugin/lib/lib/crd.d.ts"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/lib/crd.d.ts"
       ],
       "@kinvolk/headlamp-plugin/lib/K8s/*": [
-        "node_modules/@kinvolk/headlamp-plugin/lib/lib/k8s/*/index.d.ts",
-        "node_modules/@kinvolk/headlamp-plugin/lib/lib/k8s/*.d.ts"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/lib/k8s/*/index.d.ts",
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/lib/k8s/*.d.ts"
       ],
       "@kinvolk/headlamp-plugin/lib/*": [
-        "node_modules/@kinvolk/headlamp-plugin/lib/lib/*/index.d.ts",
-        "node_modules/@kinvolk/headlamp-plugin/lib/lib/*.d.ts"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/lib/*/index.d.ts",
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/lib/*.d.ts"
       ],
       "@kinvolk/headlamp-plugin/lib/ApiProxy": [
-        "node_modules/@kinvolk/headlamp-plugin/lib/lib/k8s/apiProxy.d.ts"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/lib/k8s/apiProxy.d.ts"
       ],
       "@kinvolk/headlamp-plugin/lib/Utils": [
-        "node_modules/@kinvolk/headlamp-plugin/lib/lib/util.d.ts"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/lib/util.d.ts"
       ],
       "@kinvolk/headlamp-plugin/lib/CommonComponents": [
-        "node_modules/@kinvolk/headlamp-plugin/lib/components/common/index.d.ts"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/components/common/index.d.ts"
       ],
       "@kinvolk/headlamp-plugin/lib/CommonComponents/*": [
-        "node_modules/@kinvolk/headlamp-plugin/lib/components/common/*/index.d.ts",
-        "node_modules/@kinvolk/headlamp-plugin/lib/components/common/*.d.ts"
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/components/common/*/index.d.ts",
+        "../../../../node_modules/@kinvolk/headlamp-plugin/lib/components/common/*.d.ts"
       ]
     },
     "rootDirs": ["node_modules/@kinvolk/headlamp-plugin/"],


### PR DESCRIPTION
## Summary
This PR removes the two deprecated TypeScript compiler options flagged in `plugins-tsconfig.json`. `baseUrl` is removed and its value is prepended directly onto every `paths` entry instead (paths without `baseUrl` resolve relative to the tsconfig file itself as of TypeScript 6.0). `moduleResolution` changes from `"node"` (node10) to `"bundler"`, since plugins are bundled via Vite and never run directly under Node. Both options stop functioning entirely in TypeScript 7.0, so this keeps plugin builds working past that migration.

## Related Issue
Fixes #6433

## Changes
- Removed `baseUrl: "../../../../"` from `plugins/headlamp-plugin/config/plugins-tsconfig.json`
- Prepended `../../../../` directly to every string in every `paths` array so each entry still resolves to the same location it did before, now relative to the tsconfig file itself instead of via `baseUrl`
- Changed `moduleResolution` from `"node"` to `"bundler"`
- `rootDirs` and `include` were already relative to the tsconfig file and needed no changes

## Steps to Test
1. From `plugins/examples/pod-counter` (or any generated plugin), run `npm install`
2. Run `npx tsc --noEmit -p tsconfig.json` against the original `plugins-tsconfig.json`, with TypeScript 6.0+ this shows `TS5101` and `TS5107` deprecation errors
3. Apply this PR's change and rerun the same command, both errors are gone and all existing `paths` aliases (`@kinvolk/headlamp-plugin/lib/*`, `@iconify/react`, etc.) still resolve correctly
4. Run `npm run build` on the plugin to confirm the Vite bundle still compiles and produces `dist/main.js`

## Screenshots
Terminal output comparing the original config against the fixed config on TypeScript 6.0.3, isolated to the two deprecation codes from the issue:
<img width="1535" height="414" alt="Screenshot from 2026-07-09 09-40-12" src="https://github.com/user-attachments/assets/661d8b26-70c7-4e9d-9225-129fb63ba036" />


## Notes for the Reviewer
TypeScript 5.6.2, the version pinned in `package.json`, does not emit these deprecation diagnostics at all, they only appear on TypeScript 6.0+. That's likely why this only showed up in-editor for @sniok rather than in local `tsc` runs. Verified against TypeScript 6.0.3 directly to reproduce and confirm the fix.

I also found `plugins/headlamp-plugin/tsconfig.json` (the config that builds the `headlamp-plugin` package itself, separate from this one) still has `moduleResolution: "node"` too, but no `baseUrl`. Left that out of scope here since the issue is specifically about the plugin-facing config.