### PR TITLE
frontend: Show exit code when termination signal is absent

### DIFF
--- a/frontend/src/lib/k8s/pod.test.ts
+++ b/frontend/src/lib/k8s/pod.test.ts
@@ -96,6 +96,21 @@ describe('Pod class', () => {
     expect(() => pod.getDetailedStatus()).not.toThrow();
   });
 
+  it('returns ExitCode when a container terminated with empty reason and no signal', () => {
+    const data = JSON.parse(JSON.stringify(mockPodData));
+    data.status.containerStatuses = [
+      {
+        name: 'container-1',
+        ready: false,
+        restartCount: 0,
+        state: { terminated: { exitCode: 1, reason: '' } },
+      },
+    ];
+    const pod = new Pod(data);
+    const status = pod.getDetailedStatus();
+    expect(status.reason).toBe('ExitCode:1');
+  });
+
   describe('getHealth', () => {
     const makePod = (status: any, metadata: any = {}) =>
       new Pod({

--- a/frontend/src/lib/k8s/pod.ts
+++ b/frontend/src/lib/k8s/pod.ts
@@ -499,7 +499,7 @@ class Pod extends KubeObject<KubePod> {
           reason = container.state.terminated.reason;
           message = container.state.terminated.message || '';
         } else if (container.state.terminated?.reason === '') {
-          if (container.state.terminated.signal !== 0) {
+          if (container.state.terminated.signal) {
             reason = `Signal:${container.state.terminated.signal}`;
           } else {
             reason = `ExitCode:${container.state.terminated.exitCode}`;


### PR DESCRIPTION
## Summary

Fixes a bug where `Pod.getDetailedStatus()` returns `"Signal:undefined"` instead of `"ExitCode:<N>"` when a container terminates with an empty reason and no signal.

## Changes

- **pod.ts**: Changed the signal check from `!== 0` to a truthiness check so both `undefined` (absent) and `0` correctly route to the exit code branch.
- **pod.test.ts**: Added a regression test asserting that a terminated container with an empty reason, exit code `1`, and no signal produces `reason === "ExitCode:1"`.

## Steps to Test

1. Run:
   ```bash
   npm run frontend:test -- --run src/lib/k8s/pod.test.ts
   ```
2. Verify all tests pass, including the new regression test.
3. Alternatively, create a `Pod` with a container whose state is:
   ```ts
   {
     terminated: {
       exitCode: 1,
       reason: '',
       // no signal field
     }
   }
   ```
4. Call `getDetailedStatus()` and verify `status.reason` is `"ExitCode:1"` instead of `"Signal:undefined"`.

## Screenshots (if applicable)

N/A

## Notes for the Reviewer

- This is a focused logic fix. Previously, `undefined !== 0` evaluated to `true`, causing the code to produce `"Signal:undefined"`. The updated condition correctly falls back to the exit code when the signal is absent or `0`.
- The accompanying regression test follows the existing `pod.test.ts` pattern and requires no additional mocking or DOM setup.