### PR TITLE
frontend : lib : fix decimal CPU quantity formatting in normalizeUnit

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -344,6 +344,14 @@ describe('normalizeUnit', () => {
     it('shows plural cores', () => {
       expect(normalizeUnit('cpu', '2')).toBe('2 cores');
     });
+
+    it('shows singular core from decimal', () => {
+      expect(normalizeUnit('cpu', '1.0')).toBe('1 core');
+    });
+
+    it('shows plural cores from decimal', () => {
+      expect(normalizeUnit('cpu', '2.0')).toBe('2 cores');
+    });
   });
 });
 

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -527,7 +527,7 @@ export function normalizeUnit(resourceType: string, quantity: string) {
     case 'cpu':
       normalizedQuantity = quantity?.endsWith('m')
         ? `${Number(quantity.substring(0, quantity.length - 1)) / 1000}`
-        : `${quantity}`;
+        : `${(quantity ?? '').replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '')}`;
       if (normalizedQuantity === '1') {
         normalizedQuantity = normalizedQuantity + ' ' + 'core';
       } else {


### PR DESCRIPTION
## Summary
This PR fixes a formatting bug in `normalizeUnit` where CPU quantities passed as decimal strings (e.g. `"2.0"`) were displayed as `"2.0 cores"` instead of `"2 cores"`, the current change trims trailing decimal zeros via regex replacement.

## Related Issue
Fixes #6443

## Changes
- Fixed fallback branch in `normalizeUnit` (`frontend/src/lib/util.ts`) to strip trailing decimal zeros using a regex replacement, normalizing decimal strings like `"2.0"` to whole numbers before appending the unit label.

## Steps to Test
1. Call `normalizeUnit('cpu', '2.0')` in a local test script or unit test.
2. Observe the return value is now `"2 cores"` instead of `"2.0 cores"`.
3. Verify existing cases are unaffected: `"1000m"` → `"1 core"`, `"1"` → `"1 core"`, `"2000m"` → `"2 cores"`.

## Screenshots (if applicable)
N/A this is a pure logic fix with no UI changes.

## Notes for the Reviewer
- The change is a single line fix in the CPU case of `normalizeUnit`.
- `"2000"` (no suffix) is not a valid Kubernetes CPU input, so no handling was added for that case.