### PR TITLE
frontend: AlertNotification: reset health-check backoff on recovery

### DIFF
--- a/frontend/src/components/common/AlertNotification.test.tsx
+++ b/frontend/src/components/common/AlertNotification.test.tsx
@@ -25,9 +25,13 @@ vi.mock('../../lib/cluster', async importOriginal => ({
 }));
 
 describe('PureAlertNotification', () => {
-  // The suite-wide config only fakes setTimeout/clearTimeout, so opt setInterval
+  // The suite-wide config fakes Date + setTimeout/clearTimeout; opt setInterval/clearInterval
   // (the health-check poller) in as well for these timing assertions.
-  beforeEach(() => vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] }));
+  beforeEach(() =>
+    vi.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
+    })
+  );
   afterEach(() => vi.useRealTimers());
 
   // A failed check backs the poll interval off from 5s to 10s. Once a check

--- a/frontend/src/components/common/AlertNotification.test.tsx
+++ b/frontend/src/components/common/AlertNotification.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import { PureAlertNotification } from './AlertNotification';
+
+vi.mock('../../lib/cluster', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/cluster')>()),
+  getCluster: () => 'test-cluster',
+}));
+
+describe('PureAlertNotification', () => {
+  // The suite-wide config only fakes setTimeout/clearTimeout, so opt setInterval
+  // (the health-check poller) in as well for these timing assertions.
+  beforeEach(() => vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] }));
+  afterEach(() => vi.useRealTimers());
+
+  // A failed check backs the poll interval off from 5s to 10s. Once a check
+  // succeeds the interval must return to 5s; otherwise it stays elevated for
+  // the rest of the session and the banner lingers after recovery (issue #6445).
+  it('resets the poll interval back to the base cadence after a recovery', async () => {
+    // First check fails (→ next interval 10s), the rest succeed.
+    const checkerFunction = vi.fn().mockRejectedValueOnce(new Error('down')).mockResolvedValue({});
+
+    await act(async () => {
+      render(
+        <TestContext>
+          <PureAlertNotification checkerFunction={checkerFunction} />
+        </TestContext>
+      );
+    });
+
+    // t=5s: first tick fails, backoff bumps the next interval to 10s.
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+    expect(checkerFunction).toHaveBeenCalledTimes(1);
+
+    // t=15s: second tick (10s later) succeeds and should reset the backoff to 5s.
+    await act(async () => await vi.advanceTimersByTimeAsync(10000));
+    expect(checkerFunction).toHaveBeenCalledTimes(2);
+
+    // t=20s: with the reset, the next tick fires 5s later. Without the reset the
+    // interval would still be 10s and this advance would see no new call.
+    await act(async () => await vi.advanceTimersByTimeAsync(5000));
+    expect(checkerFunction).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/components/common/AlertNotification.test.tsx
+++ b/frontend/src/components/common/AlertNotification.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, render } from '@testing-library/react';
+import { act, cleanup, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestContext } from '../../test';
 import { PureAlertNotification } from './AlertNotification';
@@ -32,7 +32,12 @@ describe('PureAlertNotification', () => {
       toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
     })
   );
-  afterEach(() => vi.useRealTimers());
+  // Unmount before restoring real timers so the effect's clearInterval runs
+  // against the same fake implementation that created the interval.
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
 
   // A failed check backs the poll interval off from 5s to 10s. Once a check
   // succeeds the interval must return to 5s; otherwise it stays elevated for

--- a/frontend/src/components/common/AlertNotification.tsx
+++ b/frontend/src/components/common/AlertNotification.tsx
@@ -81,6 +81,10 @@ export function PureAlertNotification({ checkerFunction }: PureAlertNotification
       checkerFunction()
         .then(() => {
           setError(false);
+          // Reset the backoff so polling returns to the normal cadence once the
+          // cluster recovers; otherwise the interval stays elevated for the rest
+          // of the session and the banner lingers after connectivity is restored.
+          setNetworkStatusCheckTimeFactor(0);
         })
         .catch(err => {
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Fixes #6445.

## Problem

`AlertNotification` polls cluster health on an interval of `(networkStatusCheckTimeFactor + 1) * 5000ms`. Every failed check increments `networkStatusCheckTimeFactor`, and the effect re-registers the interval with the longer delay, so the interval backs off 5s → 10s → 15s → … linearly and unbounded.

The factor is reset **only** by the manual "Try Again" button. The automatic success path just calls `setError(false)` and never resets it. So after a transient outage:

- the error/offline banner lingers for up to the grown interval after the cluster is reachable again (the next automatic check that would clear it is that far away), and
- polling stays slow for the rest of the session, delaying detection of the next outage. A longer/repeated outage pushes the interval to several minutes.

## Fix

Reset `networkStatusCheckTimeFactor` to `0` in the success path so polling returns to the normal 5s cadence once a check succeeds. Resetting to `0` when it is already `0` is a no-op (no interval churn); it only re-arms the interval when the factor was elevated.

## Test

Added `AlertNotification.test.tsx`, which drives the poll interval with fake timers and asserts the cadence returns to 5s after a failure → recovery. It fails without the fix (the third check does not fire at t=20s) and passes with it. Note the suite-wide `fakeTimers.toFake` only covers `setTimeout`/`clearTimeout`, so the test opts `setInterval`/`clearInterval` in explicitly.
