### PR TITLE
frontend: Sidebar/VersionButton: Add Storybook stories

### DIFF
--- a/frontend/src/components/Sidebar/VersionButton.stories.tsx
+++ b/frontend/src/components/Sidebar/VersionButton.stories.tsx
@@ -58,14 +58,15 @@ const meta: Meta<typeof VersionButton> = {
       },
     },
   },
-  decorators: [withSidebarOpen(true)],
 };
 
 export default meta;
 
 type Story = StoryObj<typeof VersionButton>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  decorators: [withSidebarOpen(true)],
+};
 
 export const CollapsedSidebar: Story = {
   decorators: [withSidebarOpen(false)],

--- a/frontend/src/components/Sidebar/VersionButton.stories.tsx
+++ b/frontend/src/components/Sidebar/VersionButton.stories.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import { Meta, StoryObj } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import reducers from '../../redux/reducers/reducers';
+import { API_BASE, TestContext } from '../../test';
+import { initialState as sidebarInitialState } from './sidebarSlice';
+import VersionButton from './VersionButton';
+
+// Version served to the real Storybook UI (the snapshot test mocks clusterRequest
+// separately, so this only affects `npm run storybook`). Fixed values keep the
+// version dialog deterministic when viewed there.
+const CLUSTER_VERSION = {
+  gitVersion: 'v1.28.0',
+  gitCommit: '855e7c48de7388eb330da0f8d9d2394ee818fb8d',
+  gitTreeState: 'clean',
+  goVersion: 'go1.20.5',
+  platform: 'linux/amd64',
+};
+
+// The sidebar's default open state depends on window width, so pin it explicitly
+// per story to keep the collapsed/expanded snapshots stable.
+function withSidebarOpen(isSidebarOpen: boolean) {
+  const store = configureStore({
+    reducer: reducers,
+    preloadedState: { sidebar: { ...sidebarInitialState, isSidebarOpen } },
+  });
+  return (Story: React.ComponentType) => (
+    <TestContext store={store}>
+      <Story />
+    </TestContext>
+  );
+}
+
+const meta: Meta<typeof VersionButton> = {
+  title: 'Sidebar/VersionButton',
+  component: VersionButton,
+  parameters: {
+    msw: {
+      handlers: {
+        story: [http.get(`${API_BASE}/version`, () => HttpResponse.json(CLUSTER_VERSION))],
+      },
+    },
+  },
+  decorators: [withSidebarOpen(true)],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof VersionButton>;
+
+export const Default: Story = {};
+
+export const CollapsedSidebar: Story = {
+  decorators: [withSidebarOpen(false)],
+};

--- a/frontend/src/components/Sidebar/__snapshots__/VersionButton.CollapsedSidebar.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/VersionButton.CollapsedSidebar.stories.storyshot
@@ -1,0 +1,29 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-yncjbp"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="MuiBox-root css-1d61ugm"
+        >
+          <div
+            class="MuiBox-root css-0"
+          />
+          <div
+            class="MuiBox-root css-0"
+          >
+            v1.2.3
+          </div>
+        </div>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/VersionButton.Default.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/VersionButton.Default.stories.storyshot
@@ -1,0 +1,29 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-yncjbp"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-disableElevation css-751h87-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <div
+            class="MuiBox-root css-0"
+          />
+          <div
+            class="MuiBox-root css-0"
+          >
+            v1.2.3
+          </div>
+        </div>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
Closes #6447. Part of the umbrella Storybook-stories effort (#931).

Adds `VersionButton.stories.tsx` for the sidebar cluster-version button (`frontend/src/components/Sidebar/VersionButton.tsx`), which previously had no story and so was uncovered by the snapshot suite (`storybook.test.tsx`).

## Stories
- **Default** — expanded sidebar (icon + version shown inline).
- **CollapsedSidebar** — collapsed sidebar (icon + version stacked).

## Notes
- The sidebar's default open state is window-width dependent, so each story pins `sidebar.isSidebarOpen` via a small per-story store (`configureStore({ reducer: reducers, preloadedState: { sidebar: … } })`) to keep the collapsed/expanded snapshots stable.
- The component fetches the version through `useQuery(getVersion)`; the snapshot harness already mocks `clusterRequest('/version')` globally, so the stories need no MSW for the snapshots. An MSW `/version` handler is included in the idiomatic `story` form purely so the version dialog is populated when viewing the component in the real Storybook UI (`npm run storybook`).
- The version dialog (opened by clicking the button) is intentionally not snapshotted: it is internal `open` state that requires a `play` interaction, but this harness only settles the version query *after* `play` runs, so the button isn't present yet during `play`. Exposing an initial-open prop solely for a snapshot wasn't worth the source change; the always-visible button is what the story covers.

Full storyshot suite passes (619), zero drift. `tsc`/`eslint`/`prettier` clean. DCO signed.
