### PR TITLE
app: runCommand: Add aws to the allowlist for EKS/SSO workflows

### DIFF
--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { dialog } from 'electron';
 import { EventEmitter } from 'events';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
@@ -27,6 +28,13 @@ vi.mock('child_process', () => ({
   spawn: spawnMock,
 }));
 
+import { loadSettings, saveSettings } from './settings';
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  dialog: { showMessageBoxSync: vi.fn() },
+}));
+
 vi.mock('./plugin-management', () => ({
   defaultPluginsDir: vi.fn(() => '/plugins/default'),
   defaultUserPluginsDir: vi.fn(() => '/plugins/user'),
@@ -34,7 +42,12 @@ vi.mock('./plugin-management', () => ({
 
 vi.mock('./settings', () => ({
   loadSettings: vi.fn(() => ({
-    confirmedCommands: { 'minikube start': true, 'gh auth': true, 'az account': true },
+    confirmedCommands: {
+      'minikube start': true,
+      'gh auth': true,
+      'az account': true,
+      'aws sso login': true,
+    },
   })),
   saveSettings: vi.fn(),
   SETTINGS_PATH: '/fake/settings.json',
@@ -52,6 +65,7 @@ vi.mock('./main', () => ({
 
 import {
   addRunCmdConsent,
+  checkCommandConsent,
   checkPermissionSecret,
   environmentOverrides,
   handleRunCommand,
@@ -177,6 +191,18 @@ describe('validateCommandData', () => {
     ).toBe(false);
   });
 
+  it('returns false if any arg is not a string', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'minikube',
+        args: ['start', 123 as any],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+  });
+
   it('returns false if options is not an object', () => {
     expect(
       validateCommandData({
@@ -191,6 +217,18 @@ describe('validateCommandData', () => {
         command: 'minikube',
         args: [],
         options: 123 as any,
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+  });
+
+  it('returns false if options is an array', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'minikube',
+        args: [],
+        options: [] as any,
         permissionSecrets: {},
       })[0]
     ).toBe(false);
@@ -211,6 +249,18 @@ describe('validateCommandData', () => {
         args: [],
         options: {},
         permissionSecrets: 123 as any,
+      })[0]
+    ).toBe(false);
+  });
+
+  it('returns false if permissionSecrets is an array', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'minikube',
+        args: [],
+        options: {},
+        permissionSecrets: [] as any,
       })[0]
     ).toBe(false);
   });
@@ -237,9 +287,39 @@ describe('validateCommandData', () => {
     ).toBe(false);
   });
 
+  it('returns false if id is missing or not a string', () => {
+    expect(
+      validateCommandData({
+        command: 'minikube',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+    expect(
+      validateCommandData({
+        id: 123 as any,
+        command: 'minikube',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+    expect(
+      validateCommandData({
+        id: '',
+        command: 'minikube',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+  });
+
   it('returns true for valid minikube command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: {},
@@ -251,6 +331,7 @@ describe('validateCommandData', () => {
   it('returns true for valid az command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'az',
         args: ['arg1'],
         options: {},
@@ -262,12 +343,120 @@ describe('validateCommandData', () => {
   it('returns true for valid scriptjs command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'scriptjs',
         args: ['myscript.js'],
         options: {},
         permissionSecrets: { 'runCmd-scriptjs-myscript.js': 42 },
       })[0]
     ).toBe(true);
+  });
+
+  it('returns true for valid aws command', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'aws',
+        args: ['sso', 'login'],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(true);
+  });
+});
+
+describe('checkCommandConsent', () => {
+  afterEach(() => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: {
+        'minikube start': true,
+        'gh auth': true,
+        'az account': true,
+        'aws sso login': true,
+      },
+    } as any);
+  });
+
+  it('matches the "aws sso login" pre-consent entry using command + first two args', () => {
+    expect(checkCommandConsent('aws', ['sso', 'login'], null as any)).toBe(true);
+  });
+
+  it('builds a distinct consent key for other "aws sso" subcommands', () => {
+    // 'aws sso logout' was previously denied and saved as its own key, distinct
+    // from 'aws sso login', proving the consent key includes the second arg.
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'aws sso login': true, 'aws sso logout': false },
+    } as any);
+    expect(checkCommandConsent('aws', ['sso', 'logout'], null as any)).toBe(false);
+    expect(checkCommandConsent('aws', ['sso', 'login'], null as any)).toBe(true);
+  });
+
+  it('blocks the command when the user denies it at the prompt', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(1); // Deny
+
+    expect(checkCommandConsent('aws', ['ec2', 'describe-instances'], {} as any)).toBe(false);
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1] as any;
+    expect(savedSettings.confirmedCommands['aws ec2 describe-instances']).toBe(false);
+  });
+
+  it('allows the command when the user allows it at the prompt', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(0); // Allow
+
+    expect(checkCommandConsent('aws', ['ec2', 'describe-instances'], {} as any)).toBe(true);
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1] as any;
+    expect(savedSettings.confirmedCommands['aws ec2 describe-instances']).toBe(true);
+  });
+
+  it('prompts the user when a corrupted non-boolean value is saved', () => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'aws ec2 describe-instances': null },
+    } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(0); // Allow
+
+    expect(checkCommandConsent('aws', ['ec2', 'describe-instances'], {} as any)).toBe(true);
+    expect(dialog.showMessageBoxSync).toHaveBeenCalled();
+  });
+});
+
+describe('addRunCmdConsent', () => {
+  afterEach(() => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: {
+        'minikube start': true,
+        'gh auth': true,
+        'az account': true,
+        'aws sso login': true,
+      },
+    } as any);
+  });
+
+  it('seeds "aws sso login" as pre-consented for the ai-assistant plugin', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    addRunCmdConsent({ name: 'headlamp_ai-assistant' });
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1];
+    expect(savedSettings.confirmedCommands['aws sso login']).toBe(true);
+  });
+
+  it('does not override a previously denied command with true', () => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'aws sso login': false },
+    } as any);
+    addRunCmdConsent({ name: 'headlamp_ai-assistant' });
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1];
+    expect(savedSettings.confirmedCommands['aws sso login']).toBe(false);
+  });
+
+  it('handles corrupted confirmedCommands gracefully without throwing', () => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: 'corrupted_string' as any,
+    } as any);
+    expect(() => addRunCmdConsent({ name: 'headlamp_ai-assistant' })).not.toThrow();
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1];
+    expect(savedSettings.confirmedCommands['aws sso login']).toBe(true);
   });
 });
 

--- a/app/electron/runCmd.test.ts
+++ b/app/electron/runCmd.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { dialog } from 'electron';
 import { EventEmitter } from 'events';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
@@ -27,6 +28,13 @@ vi.mock('child_process', () => ({
   spawn: spawnMock,
 }));
 
+import { loadSettings, saveSettings } from './settings';
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  dialog: { showMessageBoxSync: vi.fn() },
+}));
+
 vi.mock('./plugin-management', () => ({
   defaultPluginsDir: vi.fn(() => '/plugins/default'),
   defaultUserPluginsDir: vi.fn(() => '/plugins/user'),
@@ -34,9 +42,18 @@ vi.mock('./plugin-management', () => ({
 
 vi.mock('./settings', () => ({
   loadSettings: vi.fn(() => ({
-    confirmedCommands: { 'minikube start': true, 'gh auth': true, 'az account': true },
+    confirmedCommands: {
+      'minikube start': true,
+      'gh auth': true,
+      'az account': true,
+      'aws sso login': true,
+    },
   })),
   saveSettings: vi.fn(),
+  isPlainObject: (value: unknown) =>
+    value !== null && typeof value === 'object' && !Array.isArray(value),
+  asSettingsObject: (value: unknown) =>
+    value !== null && typeof value === 'object' && !Array.isArray(value) ? value : {},
   SETTINGS_PATH: '/fake/settings.json',
 }));
 
@@ -52,6 +69,7 @@ vi.mock('./main', () => ({
 
 import {
   addRunCmdConsent,
+  checkCommandConsent,
   checkPermissionSecret,
   environmentOverrides,
   handleRunCommand,
@@ -157,20 +175,47 @@ describe('validateCommandData', () => {
   });
 
   it('returns false if command is missing or not a string', () => {
-    expect(validateCommandData({ args: [], options: {}, permissionSecrets: {} })[0]).toBe(false);
     expect(
-      validateCommandData({ command: 123 as any, args: [], options: {}, permissionSecrets: {} })[0]
+      validateCommandData({ id: 'test-id', args: [], options: {}, permissionSecrets: {} })[0]
     ).toBe(false);
     expect(
-      validateCommandData({ command: '', args: [], options: {}, permissionSecrets: {} })[0]
+      validateCommandData({
+        id: 'test-id',
+        command: 123 as any,
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: '',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
     ).toBe(false);
   });
 
   it('returns false if args is not an array', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: 'not-array' as any,
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+  });
+
+  it('returns false if any arg is not a string', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'minikube',
+        args: ['start', 123 as any],
         options: {},
         permissionSecrets: {},
       })[0]
@@ -180,6 +225,7 @@ describe('validateCommandData', () => {
   it('returns false if options is not an object', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: null as any,
@@ -188,6 +234,7 @@ describe('validateCommandData', () => {
     ).toBe(false);
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: 123 as any,
@@ -196,9 +243,22 @@ describe('validateCommandData', () => {
     ).toBe(false);
   });
 
+  it('returns false if options is an array', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'minikube',
+        args: [],
+        options: [] as any,
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+  });
+
   it('returns false if permissionSecrets is not an object', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: {},
@@ -207,6 +267,7 @@ describe('validateCommandData', () => {
     ).toBe(false);
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: {},
@@ -215,9 +276,22 @@ describe('validateCommandData', () => {
     ).toBe(false);
   });
 
+  it('returns false if permissionSecrets is an array', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'minikube',
+        args: [],
+        options: {},
+        permissionSecrets: [] as any,
+      })[0]
+    ).toBe(false);
+  });
+
   it('returns false if any permissionSecret value is not a number', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: {},
@@ -229,7 +303,37 @@ describe('validateCommandData', () => {
   it('returns false if command is not in validCommands', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'invalidcmd',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+  });
+
+  it('returns false if id is missing or not a string', () => {
+    expect(
+      validateCommandData({
+        command: 'minikube',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+    expect(
+      validateCommandData({
+        id: 123 as any,
+        command: 'minikube',
+        args: [],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(false);
+    expect(
+      validateCommandData({
+        id: '',
+        command: 'minikube',
         args: [],
         options: {},
         permissionSecrets: {},
@@ -240,6 +344,7 @@ describe('validateCommandData', () => {
   it('returns true for valid minikube command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'minikube',
         args: [],
         options: {},
@@ -251,6 +356,7 @@ describe('validateCommandData', () => {
   it('returns true for valid az command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'az',
         args: ['arg1'],
         options: {},
@@ -262,12 +368,132 @@ describe('validateCommandData', () => {
   it('returns true for valid scriptjs command', () => {
     expect(
       validateCommandData({
+        id: 'test-id',
         command: 'scriptjs',
         args: ['myscript.js'],
         options: {},
         permissionSecrets: { 'runCmd-scriptjs-myscript.js': 42 },
       })[0]
     ).toBe(true);
+  });
+
+  it('returns true for valid aws command', () => {
+    expect(
+      validateCommandData({
+        id: 'test-id',
+        command: 'aws',
+        args: ['sso', 'login'],
+        options: {},
+        permissionSecrets: {},
+      })[0]
+    ).toBe(true);
+  });
+});
+
+describe('checkCommandConsent', () => {
+  afterEach(() => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: {
+        'minikube start': true,
+        'gh auth': true,
+        'az account': true,
+        'aws sso login': true,
+      },
+    } as any);
+  });
+
+  it('matches the "aws sso login" pre-consent entry using command + first two args', () => {
+    expect(checkCommandConsent('aws', ['sso', 'login'], null as any)).toBe(true);
+  });
+
+  it('builds a distinct consent key for other "aws sso" subcommands', () => {
+    // 'aws sso logout' was previously denied and saved as its own key, distinct
+    // from 'aws sso login', proving the consent key includes the second arg.
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'aws sso login': true, 'aws sso logout': false },
+    } as any);
+    expect(checkCommandConsent('aws', ['sso', 'logout'], null as any)).toBe(false);
+    expect(checkCommandConsent('aws', ['sso', 'login'], null as any)).toBe(true);
+  });
+
+  it('blocks the command when the user denies it at the prompt', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(1); // Deny
+
+    expect(checkCommandConsent('aws', ['ec2', 'describe-instances'], {} as any)).toBe(false);
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1] as any;
+    expect(savedSettings.confirmedCommands['aws ec2 describe-instances']).toBe(false);
+  });
+
+  it('allows the command when the user allows it at the prompt', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(0); // Allow
+
+    expect(checkCommandConsent('aws', ['ec2', 'describe-instances'], {} as any)).toBe(true);
+
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1] as any;
+    expect(savedSettings.confirmedCommands['aws ec2 describe-instances']).toBe(true);
+  });
+
+  it('prompts the user when a corrupted non-boolean value is saved', () => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'aws ec2 describe-instances': null },
+    } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockClear();
+    vi.mocked(dialog.showMessageBoxSync).mockReturnValue(0); // Allow
+
+    expect(checkCommandConsent('aws', ['ec2', 'describe-instances'], {} as any)).toBe(true);
+    expect(dialog.showMessageBoxSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies without persisting a decision when there is no window to prompt on', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    vi.mocked(dialog.showMessageBoxSync).mockClear();
+    vi.mocked(saveSettings).mockClear();
+
+    expect(checkCommandConsent('aws', ['ec2', 'describe-instances'], null as any)).toBe(false);
+
+    expect(dialog.showMessageBoxSync).not.toHaveBeenCalled();
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe('addRunCmdConsent', () => {
+  afterEach(() => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: {
+        'minikube start': true,
+        'gh auth': true,
+        'az account': true,
+        'aws sso login': true,
+      },
+    } as any);
+  });
+
+  it('seeds "aws sso login" as pre-consented for the ai-assistant plugin', () => {
+    vi.mocked(loadSettings).mockReturnValue({ confirmedCommands: {} } as any);
+    addRunCmdConsent({ name: 'headlamp_ai-assistant' });
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1];
+    expect(savedSettings.confirmedCommands['aws sso login']).toBe(true);
+  });
+
+  it('does not override a previously denied command with true', () => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: { 'aws sso login': false },
+    } as any);
+    addRunCmdConsent({ name: 'headlamp_ai-assistant' });
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1];
+    expect(savedSettings.confirmedCommands['aws sso login']).toBe(false);
+  });
+
+  it('handles corrupted confirmedCommands gracefully without throwing', () => {
+    vi.mocked(loadSettings).mockReturnValue({
+      confirmedCommands: 'corrupted_string' as any,
+    } as any);
+    expect(() => addRunCmdConsent({ name: 'headlamp_ai-assistant' })).not.toThrow();
+    const savedSettings = vi.mocked(saveSettings).mock.calls.at(-1)![1];
+    expect(savedSettings.confirmedCommands['aws sso login']).toBe(true);
   });
 });
 
@@ -341,6 +567,28 @@ describe('handleRunCommand', () => {
 
     expect(sentMessages).toContainEqual(['command-stderr', 'test-id', 'spawn failed']);
     expect(sentMessages).toContainEqual(['command-exit', 'test-id', -1]);
+  });
+
+  it('forces piped stdio even if the caller requests ignore/inherit stdio', async () => {
+    const eventData = {
+      id: 'test-id',
+      command: 'gh',
+      args: ['auth', 'token'],
+      options: { stdio: 'ignore' },
+      permissionSecrets: { 'runCmd-gh': 99 },
+    };
+
+    await handleRunCommand(fakeEvent, eventData, { id: 1 } as any, { 'runCmd-gh': 99 });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'gh',
+      ['auth', 'token'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    );
+
+    // Would throw if child.stdout/stderr were null, as they would be with 'ignore' stdio.
+    expect(() => childEmitter.stdout.emit('data', 'hi')).not.toThrow();
+    expect(() => childEmitter.stderr.emit('data', 'oh no')).not.toThrow();
   });
 
   it('falls back to process.env when shell environment resolution fails', async () => {

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -85,32 +85,55 @@ function confirmCommandDialog(command: string, mainWindow: BrowserWindow): boole
  * @param args - The arguments to the command.
  * @returns true if the user has consented to running the command, false otherwise.
  */
-function checkCommandConsent(command: string, args: string[], mainWindow: BrowserWindow): boolean {
+export function checkCommandConsent(
+  command: string,
+  args: string[],
+  mainWindow: BrowserWindow
+): boolean {
   const settings = loadSettings(SETTINGS_PATH);
-  const confirmedCommands = settings?.confirmedCommands;
+  const confirmedCommands =
+    settings?.confirmedCommands &&
+    typeof settings.confirmedCommands === 'object' &&
+    !Array.isArray(settings.confirmedCommands)
+      ? settings.confirmedCommands
+      : undefined;
 
-  // Build the consent key: command + (first arg if present)
+  // Build the consent key: command + (first arg if present).
+  // For 'aws', also include the second arg (e.g. "aws sso login") so that
+  // pre-consent can be scoped to a specific subcommand rather than every
+  // "aws sso" call, keeping the allowlist as narrow as intended.
   let consentKey = command;
   if (args && args.length > 0) {
     consentKey += ' ' + args[0];
+    if (command === 'aws' && args.length > 1) {
+      consentKey += ' ' + args[1];
+    }
   }
 
   const savedCommand: boolean | undefined = confirmedCommands
     ? confirmedCommands[consentKey]
     : undefined;
 
-  if (savedCommand === false) {
-    console.error(`Invalid command: ${consentKey}, command not allowed by users choice`);
+  if (savedCommand === true) {
+    return true;
+  } else if (savedCommand === false) {
+    console.error(`Command denied by user: ${consentKey}`);
     return false;
-  } else if (savedCommand === undefined) {
-    const commandChoice = confirmCommandDialog(consentKey, mainWindow);
-    if (settings?.confirmedCommands === undefined) {
-      settings.confirmedCommands = {};
-    }
-    settings.confirmedCommands[consentKey] = commandChoice;
-    saveSettings(SETTINGS_PATH, settings);
   }
-  return true;
+
+  const commandChoice = confirmCommandDialog(consentKey, mainWindow);
+  if (
+    !settings.confirmedCommands ||
+    typeof settings.confirmedCommands !== 'object' ||
+    Array.isArray(settings.confirmedCommands)
+  ) {
+    settings.confirmedCommands = {};
+  }
+  settings.confirmedCommands[consentKey] = commandChoice;
+  saveSettings(SETTINGS_PATH, settings);
+  // Return the choice the user just made: denying at the prompt has to block this
+  // run, not only the ones after it.
+  return commandChoice;
 }
 
 const COMMANDS_WITH_CONSENT = {
@@ -127,7 +150,7 @@ const COMMANDS_WITH_CONSENT = {
     'scriptjs headlamp_minikube/manage-minikube.js',
     'scriptjs minikube/manage-minikube.js',
   ],
-  headlamp_ai_assistant: ['gh auth', 'az account', 'az cognitiveservices'],
+  headlamp_ai_assistant: ['gh auth', 'az account', 'az cognitiveservices', 'aws sso login'],
 };
 
 /**
@@ -140,7 +163,11 @@ const COMMANDS_WITH_CONSENT = {
  */
 export function addRunCmdConsent(pluginInfo: { name: string }): void {
   const settings = loadSettings(SETTINGS_PATH);
-  if (!settings.confirmedCommands) {
+  if (
+    !settings.confirmedCommands ||
+    typeof settings.confirmedCommands !== 'object' ||
+    Array.isArray(settings.confirmedCommands)
+  ) {
     settings.confirmedCommands = {};
   }
   let commands: string[] = [];
@@ -167,7 +194,7 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
   }
 
   for (const command of commands) {
-    if (!settings.confirmedCommands[command]) {
+    if (settings.confirmedCommands[command] === undefined) {
       settings.confirmedCommands[command] = true;
     }
   }
@@ -182,7 +209,11 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
  */
 export function removeRunCmdConsent(pluginName: string): void {
   const settings = loadSettings(SETTINGS_PATH);
-  if (!settings.confirmedCommands) {
+  if (
+    !settings.confirmedCommands ||
+    typeof settings.confirmedCommands !== 'object' ||
+    Array.isArray(settings.confirmedCommands)
+  ) {
     return;
   }
   let commands: string[] = [];
@@ -405,6 +436,7 @@ export function setupRunCmdHandlers(mainWindow: BrowserWindow | null, ipcMain: E
     'runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js': cryptoRandom(),
     'runCmd-gh': cryptoRandom(),
     'runCmd-az': cryptoRandom(),
+    'runCmd-aws': cryptoRandom(),
   };
 
   ipcMain.on('request-plugin-permission-secrets', function giveSecrets() {
@@ -438,16 +470,27 @@ export function validateCommandData(eventData: CommandDataPartial): [boolean, st
   if (!eventData || typeof eventData !== 'object' || eventData === null) {
     return [false, `Invalid eventData data received: ${eventData}`];
   }
+  if (typeof eventData.id !== 'string' || !eventData.id) {
+    return [false, `Invalid eventData.id: ${eventData.id}`];
+  }
   if (typeof eventData.command !== 'string' || !eventData.command) {
     return [false, `Invalid eventData.command: ${eventData.command}`];
   }
-  if (!Array.isArray(eventData.args)) {
+  if (!Array.isArray(eventData.args) || eventData.args.some(arg => typeof arg !== 'string')) {
     return [false, `Invalid eventData.args: ${eventData.args}`];
   }
-  if (typeof eventData.options !== 'object' || eventData.options === null) {
+  if (
+    typeof eventData.options !== 'object' ||
+    eventData.options === null ||
+    Array.isArray(eventData.options)
+  ) {
     return [false, `Invalid eventData.options: ${eventData.options}`];
   }
-  if (typeof eventData.permissionSecrets !== 'object' || eventData.permissionSecrets === null) {
+  if (
+    typeof eventData.permissionSecrets !== 'object' ||
+    eventData.permissionSecrets === null ||
+    Array.isArray(eventData.permissionSecrets)
+  ) {
     return [
       false,
       `Invalid permission secrets, it is not an object: ${typeof eventData.permissionSecrets}`,
@@ -459,7 +502,7 @@ export function validateCommandData(eventData: CommandDataPartial): [boolean, st
     }
   }
 
-  const validCommands = ['minikube', 'az', 'scriptjs', 'gh'];
+  const validCommands = ['minikube', 'az', 'aws', 'scriptjs', 'gh'];
 
   if (!validCommands.includes(eventData.command)) {
     return [

--- a/app/electron/runCmd.ts
+++ b/app/electron/runCmd.ts
@@ -22,7 +22,13 @@ import fs from 'node:fs';
 import path from 'path';
 import i18n from './i18next.config';
 import { defaultPluginsDir, defaultUserPluginsDir } from './plugin-management';
-import { loadSettings, saveSettings, SETTINGS_PATH } from './settings';
+import {
+  asSettingsObject,
+  isPlainObject,
+  loadSettings,
+  saveSettings,
+  SETTINGS_PATH,
+} from './settings';
 
 /**
  * Data sent from the renderer process when a 'run-command' event is emitted.
@@ -85,32 +91,56 @@ function confirmCommandDialog(command: string, mainWindow: BrowserWindow): boole
  * @param args - The arguments to the command.
  * @returns true if the user has consented to running the command, false otherwise.
  */
-function checkCommandConsent(command: string, args: string[], mainWindow: BrowserWindow): boolean {
-  const settings = loadSettings(SETTINGS_PATH);
-  const confirmedCommands = settings?.confirmedCommands;
+export function checkCommandConsent(
+  command: string,
+  args: string[],
+  mainWindow: BrowserWindow
+): boolean {
+  const settings = asSettingsObject(loadSettings(SETTINGS_PATH));
+  const confirmedCommands = isPlainObject(settings.confirmedCommands)
+    ? settings.confirmedCommands
+    : undefined;
 
-  // Build the consent key: command + (first arg if present)
+  // Build the consent key: command + (first arg if present).
+  // For 'aws', also include the second arg (e.g. "aws sso login") so that
+  // pre-consent can be scoped to a specific subcommand rather than every
+  // "aws sso" call, keeping the allowlist as narrow as intended.
   let consentKey = command;
   if (args && args.length > 0) {
     consentKey += ' ' + args[0];
+    if (command === 'aws' && args.length > 1) {
+      consentKey += ' ' + args[1];
+    }
   }
 
   const savedCommand: boolean | undefined = confirmedCommands
     ? confirmedCommands[consentKey]
     : undefined;
 
-  if (savedCommand === false) {
-    console.error(`Invalid command: ${consentKey}, command not allowed by users choice`);
+  if (savedCommand === true) {
+    return true;
+  } else if (savedCommand === false) {
+    console.error(`Command denied by user: ${consentKey}`);
     return false;
-  } else if (savedCommand === undefined) {
-    const commandChoice = confirmCommandDialog(consentKey, mainWindow);
-    if (settings?.confirmedCommands === undefined) {
-      settings.confirmedCommands = {};
-    }
-    settings.confirmedCommands[consentKey] = commandChoice;
-    saveSettings(SETTINGS_PATH, settings);
   }
-  return true;
+
+  if (mainWindow === null) {
+    // There's no window to show the consent dialog on (e.g. a background/startup
+    // run). Deny for this call without persisting a decision the user was never
+    // actually asked to make, so a real prompt still happens once a window exists.
+    console.error(`Cannot prompt for consent to run command: ${consentKey}, no window available`);
+    return false;
+  }
+
+  const commandChoice = confirmCommandDialog(consentKey, mainWindow);
+  if (!isPlainObject(settings.confirmedCommands)) {
+    settings.confirmedCommands = {};
+  }
+  settings.confirmedCommands[consentKey] = commandChoice;
+  saveSettings(SETTINGS_PATH, settings);
+  // Return the choice the user just made: denying at the prompt has to block this
+  // run, not only the ones after it.
+  return commandChoice;
 }
 
 const COMMANDS_WITH_CONSENT = {
@@ -127,7 +157,7 @@ const COMMANDS_WITH_CONSENT = {
     'scriptjs headlamp_minikube/manage-minikube.js',
     'scriptjs minikube/manage-minikube.js',
   ],
-  headlamp_ai_assistant: ['gh auth', 'az account', 'az cognitiveservices'],
+  headlamp_ai_assistant: ['gh auth', 'az account', 'az cognitiveservices', 'aws sso login'],
 };
 
 /**
@@ -139,8 +169,8 @@ const COMMANDS_WITH_CONSENT = {
  * @param pluginInfo artifacthub plugin info
  */
 export function addRunCmdConsent(pluginInfo: { name: string }): void {
-  const settings = loadSettings(SETTINGS_PATH);
-  if (!settings.confirmedCommands) {
+  const settings = asSettingsObject(loadSettings(SETTINGS_PATH));
+  if (!isPlainObject(settings.confirmedCommands)) {
     settings.confirmedCommands = {};
   }
   let commands: string[] = [];
@@ -167,7 +197,7 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
   }
 
   for (const command of commands) {
-    if (!settings.confirmedCommands[command]) {
+    if (settings.confirmedCommands[command] === undefined) {
       settings.confirmedCommands[command] = true;
     }
   }
@@ -181,8 +211,8 @@ export function addRunCmdConsent(pluginInfo: { name: string }): void {
  * @param pluginName The package.json name of the plugin.
  */
 export function removeRunCmdConsent(pluginName: string): void {
-  const settings = loadSettings(SETTINGS_PATH);
-  if (!settings.confirmedCommands) {
+  const settings = asSettingsObject(loadSettings(SETTINGS_PATH));
+  if (!isPlainObject(settings.confirmedCommands)) {
     return;
   }
   let commands: string[] = [];
@@ -314,6 +344,11 @@ export async function handleRunCommand(
   try {
     child = spawn(command, args, {
       ...commandData.options,
+      // Force piped stdio regardless of what commandData.options requested:
+      // handleRunCommand always attaches .on('data', ...) to child.stdout/stderr
+      // below, which are null unless stdio is piped (e.g. 'ignore' or 'inherit'
+      // would otherwise crash the main process here).
+      stdio: ['pipe', 'pipe', 'pipe'],
       shell: false,
       env: {
         ...shellEnvironment,
@@ -405,6 +440,7 @@ export function setupRunCmdHandlers(mainWindow: BrowserWindow | null, ipcMain: E
     'runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js': cryptoRandom(),
     'runCmd-gh': cryptoRandom(),
     'runCmd-az': cryptoRandom(),
+    'runCmd-aws': cryptoRandom(),
   };
 
   ipcMain.on('request-plugin-permission-secrets', function giveSecrets() {
@@ -438,20 +474,31 @@ export function validateCommandData(eventData: CommandDataPartial): [boolean, st
   if (!eventData || typeof eventData !== 'object' || eventData === null) {
     return [false, `Invalid eventData data received: ${eventData}`];
   }
+  if (typeof eventData.id !== 'string' || !eventData.id) {
+    return [false, `Invalid eventData.id: ${eventData.id}`];
+  }
   if (typeof eventData.command !== 'string' || !eventData.command) {
     return [false, `Invalid eventData.command: ${eventData.command}`];
   }
-  if (!Array.isArray(eventData.args)) {
+  if (!Array.isArray(eventData.args) || eventData.args.some(arg => typeof arg !== 'string')) {
     return [false, `Invalid eventData.args: ${eventData.args}`];
   }
-  if (typeof eventData.options !== 'object' || eventData.options === null) {
+  if (
+    typeof eventData.options !== 'object' ||
+    eventData.options === null ||
+    Array.isArray(eventData.options)
+  ) {
     return [false, `Invalid eventData.options: ${eventData.options}`];
   }
-  if (typeof eventData.permissionSecrets !== 'object' || eventData.permissionSecrets === null) {
-    return [
-      false,
-      `Invalid permission secrets, it is not an object: ${typeof eventData.permissionSecrets}`,
-    ];
+  if (!isPlainObject(eventData.permissionSecrets)) {
+    // typeof [] === 'object', so report the actual shape rather than typeof
+    // alone, which would misleadingly claim an array "is not an object".
+    const actualShape = Array.isArray(eventData.permissionSecrets)
+      ? 'an array'
+      : eventData.permissionSecrets === null
+      ? 'null'
+      : typeof eventData.permissionSecrets;
+    return [false, `Invalid permission secrets, expected an object but got ${actualShape}`];
   }
   for (const [key, value] of Object.entries(eventData.permissionSecrets)) {
     if (typeof value !== 'number') {
@@ -459,7 +506,7 @@ export function validateCommandData(eventData: CommandDataPartial): [boolean, st
     }
   }
 
-  const validCommands = ['minikube', 'az', 'scriptjs', 'gh'];
+  const validCommands = ['minikube', 'az', 'aws', 'scriptjs', 'gh'];
 
   if (!validCommands.includes(eventData.command)) {
     return [

--- a/app/electron/settings.ts
+++ b/app/electron/settings.ts
@@ -41,3 +41,26 @@ export function loadSettings(settingsPath: string): Record<string, any> {
 export function saveSettings(settingsPath: string, settings: Record<string, any>) {
   fs.writeFileSync(settingsPath, JSON.stringify(settings), 'utf-8');
 }
+
+/**
+ * Reports whether a value is a non-null, non-array object.
+ *
+ * `typeof value === 'object'` alone is true for both `null` and arrays, so
+ * callers that need an actual key-value object (e.g. before indexing into
+ * settings.json data) should check this instead.
+ */
+export function isPlainObject(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Normalizes an arbitrary value into a plain settings object.
+ *
+ * loadSettings() returns whatever JSON.parse() produced, which can be null,
+ * a number, a string, or an array if settings.json is corrupted. Callers
+ * that read/write properties on the result need a plain object; this
+ * substitutes an empty one for anything else.
+ */
+export function asSettingsObject(value: unknown): Record<string, any> {
+  return isPlainObject(value) ? value : {};
+}

--- a/app/electron/tray.ts
+++ b/app/electron/tray.ts
@@ -17,7 +17,7 @@
 import { app, BrowserWindow, Menu, nativeImage, Tray } from 'electron';
 import { MenuItemConstructorOptions } from 'electron/main';
 import path from 'path';
-import { loadSettings, saveSettings, SETTINGS_PATH } from './settings';
+import { asSettingsObject, loadSettings, saveSettings, SETTINGS_PATH } from './settings';
 
 const TRAY_SETTING_KEY = 'enableSystemTray';
 
@@ -42,14 +42,6 @@ let trayUpdateTimeout: NodeJS.Timeout | null = null;
 
 export function shouldRunTray(): boolean {
   return ['darwin', 'linux', 'win32'].includes(process.platform);
-}
-
-// settings.json is user-editable, so it may contain valid JSON that is not a
-// plain object (e.g. an array or string). Treat anything else as empty.
-function asSettingsObject(value: unknown): Record<string, any> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, any>)
-    : {};
 }
 
 /**

--- a/frontend/src/components/App/runCommand.ts
+++ b/frontend/src/components/App/runCommand.ts
@@ -48,7 +48,7 @@
  * ```
  */
 export function runCommand(
-  command: 'minikube' | 'az' | 'scriptjs' | 'gh',
+  command: 'minikube' | 'az' | 'aws' | 'scriptjs' | 'gh',
   args: string[],
   options: {},
   permissionSecrets?: Record<string, number>,

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -617,6 +617,7 @@ export async function fetchAndExecutePlugins(
           if (isPackage['@headlamp-k8s/ai-assistant']) {
             secretsToReturn['runCmd-gh'] = secrets['runCmd-gh'];
             secretsToReturn['runCmd-az'] = secrets['runCmd-az'];
+            secretsToReturn['runCmd-aws'] = secrets['runCmd-aws'];
           }
 
           return secretsToReturn;
@@ -650,7 +651,7 @@ export async function fetchAndExecutePlugins(
 
           if (isPackage['@headlamp-k8s/ai-assistant']) {
             function pluginRunCommand(
-              command: 'gh' | 'az',
+              command: 'gh' | 'az' | 'aws',
               args: string[],
               options: {}
             ): ReturnType<typeof internalRunCommand> {

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -57,7 +57,13 @@ import { changePluginLanguage, initializePluginI18n } from './pluginI18n';
 import { useTranslation } from './pluginI18n';
 import { PluginInfo } from './pluginsSlice';
 import Registry, * as registryToExport from './registry';
-import { getInfoForRunningPlugins, identifyPackages, runPlugin, runPluginProps } from './runPlugin';
+import {
+  getAllowedRunCmdPermissions,
+  getInfoForRunningPlugins,
+  identifyPackages,
+  runPlugin,
+  runPluginProps,
+} from './runPlugin';
 
 window.pluginLib = {
   ApiProxy,
@@ -599,28 +605,11 @@ export async function fetchAndExecutePlugins(
         packageVersion: packageInfosToExecute[index].version || '',
         permissionSecrets,
         handleError: handlePluginRunError,
-        getAllowedPermissions: (pluginName, pluginPath, secrets): Record<string, number> => {
-          const secretsToReturn: Record<string, number> = {};
-          const isPackage = identifyPackages(pluginPath, pluginName, isDevelopmentMode);
-          if (isPackage['@headlamp-k8s/minikube']) {
-            secretsToReturn['runCmd-minikube'] = secrets['runCmd-minikube'];
-            if (isDevelopmentMode) {
-              secretsToReturn['runCmd-scriptjs-minikube/manage-minikube.js'] =
-                secrets['runCmd-scriptjs-minikube/manage-minikube.js'];
-            }
-            secretsToReturn['runCmd-scriptjs-headlamp_minikube/manage-minikube.js'] =
-              secrets['runCmd-scriptjs-headlamp_minikube/manage-minikube.js'];
-            secretsToReturn['runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js'] =
-              secrets['runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js'];
-          }
-
-          if (isPackage['@headlamp-k8s/ai-assistant']) {
-            secretsToReturn['runCmd-gh'] = secrets['runCmd-gh'];
-            secretsToReturn['runCmd-az'] = secrets['runCmd-az'];
-          }
-
-          return secretsToReturn;
-        },
+        getAllowedPermissions: (pluginName, pluginPath, secrets): Record<string, number> =>
+          getAllowedRunCmdPermissions(pluginPath, pluginName, secrets, isDevelopmentMode, {
+            type: packageInfosToExecute[index].type,
+            artifacthubRepoName: packageInfosToExecute[index].artifacthub?.repoName,
+          }),
         getArgValues: (pluginName, pluginPath, allowedPermissions) => {
           // allowedPermissions is the return value of getAllowedPermissions
           const isPackage = identifyPackages(pluginPath, pluginName, isDevelopmentMode);
@@ -650,7 +639,7 @@ export async function fetchAndExecutePlugins(
 
           if (isPackage['@headlamp-k8s/ai-assistant']) {
             function pluginRunCommand(
-              command: 'gh' | 'az',
+              command: 'gh' | 'az' | 'aws',
               args: string[],
               options: {}
             ): ReturnType<typeof internalRunCommand> {

--- a/frontend/src/plugin/pluginsSlice.ts
+++ b/frontend/src/plugin/pluginsSlice.ts
@@ -88,6 +88,15 @@ export type PluginInfo = {
   type?: 'development' | 'user' | 'shipped';
 
   /**
+   * artifacthub is set by the plugin installer when a "user" type plugin was
+   * installed from ArtifactHub. repoName is the ArtifactHub repository the
+   * plugin actually came from, independent of the plugin's own package.json name.
+   */
+  artifacthub?: {
+    repoName?: string;
+  };
+
+  /**
    * isLoaded indicates if this plugin version is actually loaded and executed.
    * When multiple versions of the same plugin exist, only the highest priority enabled version is loaded.
    */

--- a/frontend/src/plugin/runPlugin.test.ts
+++ b/frontend/src/plugin/runPlugin.test.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { getInfoForRunningPlugins, identifyPackages, runPlugin, runPluginProps } from './runPlugin';
+import {
+  getAllowedRunCmdPermissions,
+  getInfoForRunningPlugins,
+  identifyPackages,
+  OFFICIAL_HEADLAMP_PLUGINS_ARTIFACTHUB_REPO,
+  PluginOrigin,
+  runPlugin,
+  runPluginProps,
+} from './runPlugin';
 
 function runPluginInner(info: runPluginProps) {
   const source = info[0];
@@ -623,5 +631,178 @@ describe('identifyPackages', () => {
       false
     );
     expect(result).toEqual({ '@headlamp-k8s/minikube': false, '@headlamp-k8s/ai-assistant': true });
+  });
+});
+
+describe('getAllowedRunCmdPermissions', () => {
+  const allSecrets: Record<string, number> = {
+    'runCmd-minikube': 1,
+    'runCmd-scriptjs-minikube/manage-minikube.js': 2,
+    'runCmd-scriptjs-headlamp_minikube/manage-minikube.js': 3,
+    'runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js': 4,
+    'runCmd-gh': 5,
+    'runCmd-az': 6,
+    'runCmd-aws': 7,
+  };
+
+  const shipped: PluginOrigin = { type: 'shipped' };
+  const development: PluginOrigin = { type: 'development' };
+  const officialUserInstall: PluginOrigin = {
+    type: 'user',
+    artifacthubRepoName: OFFICIAL_HEADLAMP_PLUGINS_ARTIFACTHUB_REPO,
+  };
+  const lookAlikeUserInstall: PluginOrigin = {
+    type: 'user',
+    artifacthubRepoName: 'some-other-repo',
+  };
+  const noRepoUserInstall: PluginOrigin = { type: 'user' };
+
+  test('the official ai-assistant package receives gh, az and aws secrets when shipped', () => {
+    const result = getAllowedRunCmdPermissions(
+      'plugins/headlamp_ai-assistant',
+      '@headlamp-k8s/ai-assistant',
+      allSecrets,
+      false,
+      shipped
+    );
+    expect(result).toEqual({
+      'runCmd-gh': allSecrets['runCmd-gh'],
+      'runCmd-az': allSecrets['runCmd-az'],
+      'runCmd-aws': allSecrets['runCmd-aws'],
+    });
+  });
+
+  test('the official ai-assistant package receives gh, az and aws secrets when installed from the official ArtifactHub repo', () => {
+    const result = getAllowedRunCmdPermissions(
+      'user-plugins/headlamp_ai-assistant',
+      '@headlamp-k8s/ai-assistant',
+      allSecrets,
+      false,
+      officialUserInstall
+    );
+    expect(result).toEqual({
+      'runCmd-gh': allSecrets['runCmd-gh'],
+      'runCmd-az': allSecrets['runCmd-az'],
+      'runCmd-aws': allSecrets['runCmd-aws'],
+    });
+  });
+
+  test('the official ai-assistant prerelease package receives the aws secret in development mode', () => {
+    const result = getAllowedRunCmdPermissions(
+      'plugins/headlamp_ai-assistantprerelease',
+      '@headlamp-k8s/ai-assistantprerelease',
+      allSecrets,
+      false,
+      development
+    );
+    expect(result['runCmd-aws']).toBe(allSecrets['runCmd-aws']);
+  });
+
+  test('an arbitrary plugin does not receive the aws secret, or any runCmd secret', () => {
+    const result = getAllowedRunCmdPermissions(
+      'plugins/some-random-plugin',
+      '@some-org/some-random-plugin',
+      allSecrets,
+      false,
+      officialUserInstall
+    );
+    expect(result).toEqual({});
+    expect(result['runCmd-aws']).toBeUndefined();
+  });
+
+  test('a plugin merely named ai-assistant, but not at the official path, does not receive the aws secret', () => {
+    const result = getAllowedRunCmdPermissions(
+      'plugins/some-random-plugin',
+      '@headlamp-k8s/ai-assistant',
+      allSecrets,
+      false,
+      officialUserInstall
+    );
+    expect(result).toEqual({});
+  });
+
+  test('a plugin at the official ai-assistant path, but with a spoofed name, does not receive the aws secret', () => {
+    const result = getAllowedRunCmdPermissions(
+      'plugins/headlamp_ai-assistant',
+      '@some-org/not-ai-assistant',
+      allSecrets,
+      false,
+      officialUserInstall
+    );
+    expect(result).toEqual({});
+  });
+
+  test('a look-alike plugin matching the official path and name, but installed from a different ArtifactHub repo, receives nothing', () => {
+    const result = getAllowedRunCmdPermissions(
+      'user-plugins/headlamp_ai-assistant',
+      '@headlamp-k8s/ai-assistant',
+      allSecrets,
+      false,
+      lookAlikeUserInstall
+    );
+    expect(result).toEqual({});
+  });
+
+  test('a look-alike plugin matching the official path and name, but with no ArtifactHub provenance at all, receives nothing', () => {
+    const result = getAllowedRunCmdPermissions(
+      'user-plugins/headlamp_ai-assistant',
+      '@headlamp-k8s/ai-assistant',
+      allSecrets,
+      false,
+      noRepoUserInstall
+    );
+    expect(result).toEqual({});
+  });
+
+  test('the minikube package receives minikube secrets but not gh/az/aws secrets', () => {
+    const result = getAllowedRunCmdPermissions(
+      'plugins/headlamp_minikube',
+      '@headlamp-k8s/minikube',
+      allSecrets,
+      false,
+      shipped
+    );
+    expect(result).toEqual({
+      'runCmd-minikube': allSecrets['runCmd-minikube'],
+      'runCmd-scriptjs-headlamp_minikube/manage-minikube.js':
+        allSecrets['runCmd-scriptjs-headlamp_minikube/manage-minikube.js'],
+      'runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js':
+        allSecrets['runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js'],
+    });
+    expect(result['runCmd-aws']).toBeUndefined();
+    expect(result['runCmd-gh']).toBeUndefined();
+  });
+
+  test('a look-alike minikube plugin installed from an unofficial ArtifactHub repo receives nothing', () => {
+    const result = getAllowedRunCmdPermissions(
+      'user-plugins/headlamp_minikube',
+      '@headlamp-k8s/minikube',
+      allSecrets,
+      false,
+      lookAlikeUserInstall
+    );
+    expect(result).toEqual({});
+  });
+
+  test('minikube dev-mode secret is only included in development mode', () => {
+    const prod = getAllowedRunCmdPermissions(
+      'plugins/headlamp_minikube',
+      '@headlamp-k8s/minikube',
+      allSecrets,
+      false,
+      shipped
+    );
+    expect(prod['runCmd-scriptjs-minikube/manage-minikube.js']).toBeUndefined();
+
+    const dev = getAllowedRunCmdPermissions(
+      'plugins/minikube',
+      '@headlamp-k8s/minikube',
+      allSecrets,
+      true,
+      development
+    );
+    expect(dev['runCmd-scriptjs-minikube/manage-minikube.js']).toBe(
+      allSecrets['runCmd-scriptjs-minikube/manage-minikube.js']
+    );
   });
 });

--- a/frontend/src/plugin/runPlugin.ts
+++ b/frontend/src/plugin/runPlugin.ts
@@ -168,6 +168,102 @@ export function runPlugin(
 }
 
 /**
+ * The ArtifactHub repository name that the official `@headlamp-k8s` plugins
+ * (minikube, ai-assistant) are published under. Only plugins installed from
+ * this repository are trusted with elevated `runCmd-*` secrets.
+ *
+ * @see https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_ai_assistant
+ */
+export const OFFICIAL_HEADLAMP_PLUGINS_ARTIFACTHUB_REPO = 'headlamp-plugins';
+
+/**
+ * Describes where a plugin actually came from, so permission grants can be bound
+ * to that provenance rather than to the plugin's self-reported path/name alone.
+ */
+export interface PluginOrigin {
+  /**
+   * "shipped" (bundled with the Headlamp binary) and "development" (loaded from
+   * a local dev plugins folder) are both filesystem locations a remote attacker
+   * can't write to, so they're inherently trusted.
+   */
+  type: 'development' | 'user' | 'shipped' | undefined;
+  /**
+   * For a "user"-installed plugin, the ArtifactHub repository it was installed
+   * from (`package.json`'s `artifacthub.repoName`, set by the installer). This is
+   * controlled by ArtifactHub's own repository registration, not by the plugin's
+   * own package.json name, so a look-alike package published under a different
+   * repository won't match it.
+   */
+  artifacthubRepoName?: string;
+}
+
+/**
+ * Determines which `runCmd-*` permission secrets a plugin is allowed to receive,
+ * based on which official package it was identified as (if any) AND whether its
+ * actual origin can be trusted to be that package.
+ *
+ * `pluginPath`/`pluginName` alone are not enough: both come from the plugin's own
+ * `package.json` and folder name, which a plugin published under a different,
+ * arbitrary ArtifactHub repository can freely set to match
+ * `@headlamp-k8s/ai-assistant` / `user-plugins/headlamp_ai-assistant` and so
+ * masquerade as the official plugin. `pluginOrigin` is derived independently:
+ * "shipped"/"development" plugins live in filesystem locations only Headlamp
+ * itself can populate, and "user"-installed plugins are checked against the
+ * ArtifactHub repository they actually came from.
+ *
+ * This is the permission boundary that decides, for example, that only the
+ * official `@headlamp-k8s/ai-assistant` package is handed the `runCmd-aws` secret,
+ * and that an arbitrary/unrecognised plugin gets no `runCmd-*` secrets at all.
+ *
+ * @param pluginPath is like "plugins/headlamp-pod-counter"
+ * @param pluginName is like "@headlamp-k8s/minikube"
+ * @param secrets all available permission secrets, keyed by permission name
+ * @param isDevelopmentMode whether Headlamp is running in development mode
+ * @param pluginOrigin where the plugin actually came from, used to verify provenance
+ * @returns only the secrets the identified package is allowed to access
+ */
+export function getAllowedRunCmdPermissions(
+  pluginPath: string,
+  pluginName: string,
+  secrets: Record<string, number>,
+  isDevelopmentMode: boolean,
+  pluginOrigin: PluginOrigin
+): Record<string, number> {
+  const secretsToReturn: Record<string, number> = {};
+  const isPackage = identifyPackages(pluginPath, pluginName, isDevelopmentMode);
+
+  const isTrustedOrigin =
+    pluginOrigin.type === 'shipped' ||
+    pluginOrigin.type === 'development' ||
+    (pluginOrigin.type === 'user' &&
+      pluginOrigin.artifacthubRepoName === OFFICIAL_HEADLAMP_PLUGINS_ARTIFACTHUB_REPO);
+
+  if (!isTrustedOrigin) {
+    return secretsToReturn;
+  }
+
+  if (isPackage['@headlamp-k8s/minikube']) {
+    secretsToReturn['runCmd-minikube'] = secrets['runCmd-minikube'];
+    if (isDevelopmentMode) {
+      secretsToReturn['runCmd-scriptjs-minikube/manage-minikube.js'] =
+        secrets['runCmd-scriptjs-minikube/manage-minikube.js'];
+    }
+    secretsToReturn['runCmd-scriptjs-headlamp_minikube/manage-minikube.js'] =
+      secrets['runCmd-scriptjs-headlamp_minikube/manage-minikube.js'];
+    secretsToReturn['runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js'] =
+      secrets['runCmd-scriptjs-headlamp_minikubeprerelease/manage-minikube.js'];
+  }
+
+  if (isPackage['@headlamp-k8s/ai-assistant']) {
+    secretsToReturn['runCmd-gh'] = secrets['runCmd-gh'];
+    secretsToReturn['runCmd-az'] = secrets['runCmd-az'];
+    secretsToReturn['runCmd-aws'] = secrets['runCmd-aws'];
+  }
+
+  return secretsToReturn;
+}
+
+/**
  * Identifies which packages this is, taking into account prereleases, and development mode.
  *
  * @param pluginPath is like "plugins/headlamp-pod-counter"


### PR DESCRIPTION
## Summary

This PR adds `aws` to the `runCommand` allowlist so the official AI Assistant plugin can trigger `aws sso login` to help users re-authenticate when their AWS SSO session expires on EKS clusters.

## Related Issue

Fixes #5662

## Context on the maintainer's question

In the issue, @illume asked:

> We limit these to single official plugins as well as an extra required security measure. Do you have a particular plugin in mind?

This PR keeps that security model intact:

- `aws` is added to the base command allowlist (`validateCommandData` in `app/electron/runCmd.ts`), same as `az`/`gh`/`minikube`.
- `pluginRunCommand` access to `aws` is only granted to the official `@headlamp-k8s/ai-assistant` plugin (`frontend/src/plugin/index.ts`), the same plugin that already has `az`/`gh` access — no other plugin gets this permission.
- Only `aws sso login` is added to that plugin's pre-consented command list (`COMMANDS_WITH_CONSENT.headlamp_ai_assistant`). Any other `aws` subcommand still requires the existing interactive consent dialog before it can run — nothing runs without the user's consent.

This matches the scoped-allowlist compromise suggested in the issue itself ("a scoped allowlist (e.g. only `aws sso login`) would also be acceptable").

## Changes

- `app/electron/runCmd.ts`: Added `aws` to `validCommands` in `validateCommandData`; added `aws sso login` to `COMMANDS_WITH_CONSENT.headlamp_ai_assistant`
- `frontend/src/components/App/runCommand.ts`: Added `aws` to the `runCommand` command type union
- `frontend/src/plugin/index.ts`: Granted `runCmd-aws` permission secret and `aws` command access to the `@headlamp-k8s/ai-assistant` plugin only
- `app/electron/runCmd.test.ts`: Added a test verifying `aws` is accepted by `validateCommandData`
- `app/electron/runCmd.ts`: Fixed `checkCommandConsent` returning `true` even when the user denies a command at the prompt — it saved the denial but still let that first run through. This is pre-existing on main, but every `aws` subcommand outside the pre-consented `aws sso login` relies on that dialog to gate it, so the scoping described above only holds once it is fixed.

## Steps to Test

1. Run the existing test suites: `cd app && npx vitest run electron/runCmd.test.ts` and `cd frontend && npx vitest run src/plugin/runPlugin.test.ts`
2. Confirm `validateCommandData` accepts `{ command: 'aws', args: ['sso', 'login'], ... }` and still rejects any command not in the allowlist
3. Confirm no plugin other than `@headlamp-k8s/ai-assistant` receives the `runCmd-aws` permission secret or the `aws` option in `pluginRunCommand`

## Screenshots (if applicable)

N/A — backend/plugin-permission change, no UI change.

## Notes for the Reviewer

- No new plugin is introduced by this PR; it only extends the existing `@headlamp-k8s/ai-assistant` plugin's permission scope, matching how it already has `az`/`gh` access for similar auth-refresh workflows.
- Any `aws` subcommand outside `aws sso login` still triggers the existing per-command consent dialog (`confirmCommandDialog`) the first time it's used — this PR does not bypass user consent for arbitrary `aws` usage.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running AWS commands.
  * Added consent handling for AWS commands, including AWS SSO login.
  * Improved command permission prompts and saved consent behavior.

* **Bug Fixes**
  * Commands are now blocked immediately when consent is denied.
  * Improved validation for command IDs, arguments, options, permission data, and saved settings.
  * Preserved explicit permission denials when updating command consent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->