### PR TITLE
frontend: secret: add unit tests for details and list views

### DIFF
--- a/frontend/src/components/secret/Details.test.tsx
+++ b/frontend/src/components/secret/Details.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import SecretDetails from './Details';
+import { BASE_SECRET } from './storyHelper';
+
+const { mockDetailsGrid } = vi.hoisted(() => ({
+  mockDetailsGrid: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/secret', () => ({
+  default: { kind: 'Secret' },
+}));
+
+vi.mock('../common/Resource', () => ({
+  DetailsGrid: (props: any) => {
+    mockDetailsGrid(props);
+    return null;
+  },
+  SecretField: () => null,
+}));
+
+describe('SecretDetails', () => {
+  beforeEach(() => {
+    mockDetailsGrid.mockReset();
+  });
+
+  it('passes the Secret resource type and route params to DetailsGrid', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-pvc' }}>
+        <SecretDetails />
+      </TestContext>
+    );
+
+    expect(mockDetailsGrid).toHaveBeenCalled();
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.resourceType.kind).toBe('Secret');
+    expect(props.name).toBe('my-pvc');
+    expect(props.namespace).toBe('default');
+    expect(props.withEvents).toBe(true);
+  });
+
+  it('builds extraInfo from the secret spec', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-pvc' }}>
+        <SecretDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const extraInfo = props.extraInfo(BASE_SECRET);
+
+    const typeInfo = extraInfo.find((info: any) => info.name && info.name.includes('Type'));
+    expect(typeInfo).toBeDefined();
+    expect(typeInfo?.value).toBe('test');
+  });
+
+  it('returns nothing from extraInfo when there is no item', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-pvc' }}>
+        <SecretDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    expect(props.extraInfo(null)).toBeFalsy();
+  });
+
+  it('provides extraSections that renders SecretDataSection', () => {
+    render(
+      <TestContext routerMap={{ namespace: 'default', name: 'my-pvc' }}>
+        <SecretDetails />
+      </TestContext>
+    );
+
+    const props = mockDetailsGrid.mock.calls[0][0];
+    const extraSections = props.extraSections(BASE_SECRET);
+    expect(extraSections).toHaveLength(1);
+    expect(extraSections[0].id).toBe('headlamp.secrets-data');
+    expect(extraSections[0].section).toBeDefined();
+  });
+});

--- a/frontend/src/components/secret/List.test.tsx
+++ b/frontend/src/components/secret/List.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../test';
+import SecretList from './List';
+import { BASE_SECRET } from './storyHelper';
+
+const { mockListView, mockUseList } = vi.hoisted(() => ({
+  mockListView: vi.fn(),
+  mockUseList: vi.fn(),
+}));
+
+vi.mock('../../lib/k8s/secret', () => ({
+  default: {
+    kind: 'Secret',
+    useList: mockUseList,
+    getErrorMessage: (err: any) => err?.message || '',
+  },
+}));
+
+vi.mock('../common/Resource/ResourceListView', () => ({
+  default: (props: any) => {
+    mockListView(props);
+    return null;
+  },
+}));
+
+describe('SecretList', () => {
+  beforeEach(() => {
+    mockListView.mockReset();
+    mockUseList.mockReset();
+    mockUseList.mockReturnValue([[BASE_SECRET], null]);
+  });
+
+  it('renders with the Secret resource class and the expected columns', () => {
+    render(
+      <TestContext>
+        <SecretList />
+      </TestContext>
+    );
+
+    expect(mockListView).toHaveBeenCalled();
+    const props = mockListView.mock.calls[0][0];
+    const columnIds = props.columns.map((c: any) => (typeof c === 'string' ? c : c.id));
+    expect(columnIds).toEqual(['name', 'namespace', 'cluster', 'type', 'data', 'labels', 'age']);
+  });
+
+  it('correctly maps the values for custom columns', () => {
+    render(
+      <TestContext>
+        <SecretList />
+      </TestContext>
+    );
+
+    const props = mockListView.mock.calls[0][0];
+    const typeCol = props.columns.find((c: any) => c?.id === 'type');
+    const dataCol = props.columns.find((c: any) => c?.id === 'data');
+
+    expect(typeCol.getValue(BASE_SECRET)).toBe('test');
+    expect(dataCol.getValue(BASE_SECRET)).toBe(Object.keys(BASE_SECRET.data || {}).length);
+    expect(dataCol.getValue({ ...BASE_SECRET, data: {} })).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds unit tests for the `SecretList` and `SecretDetails` components under the `secret` component family.

## Related Issue

Fixes #6450

## Changes

- Added [Details.test.tsx](file:///Users/rucha/LFX/headlamp/headlamp/frontend/src/components/secret/Details.test.tsx) to test the details view grid, extraInfo fields, and extra sections of the Secret component.
- Added [List.test.tsx](file:///Users/rucha/LFX/headlamp/headlamp/frontend/src/components/secret/List.test.tsx) to test table columns, custom type columns, and the data fields count mapping in the Secret list view.

## Steps to Test

1. Navigate to the `frontend/` directory.
2. Run the vitest test suite for the secret component:
   ```bash
   npm run test -- secret