### PR TITLE
backend: kubeconfig: Log proxy transport errors and fix OIDC transport

### DIFF
--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -437,9 +437,29 @@ func (c *Context) SetupProxy() error {
 	proxy := httputil.NewSingleHostReverseProxy(URL)
 
 	restConf, err := c.RESTConfig()
-	if err == nil {
+	if err != nil {
+		// Keep the proxy working through the default transport, but make the
+		// failure visible instead of silently dropping the kubeconfig's
+		// credentials.
+		logger.Log(logger.LevelError, map[string]string{"context": c.Name},
+			err, "couldn't get REST config for proxy transport, proxying without kubeconfig credentials")
+	} else {
+		// client-go no longer ships the in-tree "oidc" auth provider, so
+		// building a transport fails when a legacy auth-provider: oidc is set.
+		// Headlamp injects the OIDC token itself, so drop only that provider and
+		// keep the TLS settings. Other auth-providers are left intact so their
+		// authentication isn't silently removed.
+		if restConf.AuthProvider != nil && restConf.AuthProvider.Name == "oidc" {
+			confCopy := *restConf
+			confCopy.AuthProvider = nil
+			restConf = &confCopy
+		}
+
 		roundTripper, err := makeTransportFor(restConf)
-		if err == nil {
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{"context": c.Name},
+				err, "couldn't create proxy transport, proxying without kubeconfig credentials")
+		} else {
 			// Wrap the round tripper to add Headlamp User-Agent
 			proxy.Transport = &userAgentRoundTripper{
 				base:      roundTripper,

--- a/backend/pkg/kubeconfig/kubeconfig.go
+++ b/backend/pkg/kubeconfig/kubeconfig.go
@@ -57,6 +57,9 @@ func buildUserAgent() string {
 // DefaultInClusterContextName is the default name used for the in-cluster context.
 const DefaultInClusterContextName = "main"
 
+// logFieldContext is the structured-log field name for context names.
+const logFieldContext = "context"
+
 const (
 	KubeConfig = 1 << iota
 	DynamicCluster
@@ -454,7 +457,7 @@ func (c *Context) SetupProxy() error {
 
 			if resp.StatusCode == http.StatusUnauthorized && strings.HasPrefix(authHeader, "Bearer ") {
 				warnOnce.Do(func() {
-					logger.Log(logger.LevelWarn, map[string]string{"context": c.Name}, nil,
+					logger.Log(logger.LevelWarn, map[string]string{logFieldContext: c.Name}, nil,
 						"API server rejected the forwarded bearer token (401); the token may be "+
 							"expired/invalid, or the API server may not trust the same OIDC issuer "+
 							"and client-id as Headlamp")
@@ -466,9 +469,29 @@ func (c *Context) SetupProxy() error {
 	}
 
 	restConf, err := c.RESTConfig()
-	if err == nil {
+	if err != nil {
+		// Keep the proxy working through the default transport, but make the
+		// failure visible instead of silently dropping the kubeconfig's
+		// credentials.
+		logger.Log(logger.LevelError, map[string]string{logFieldContext: c.Name},
+			err, "couldn't get REST config for proxy transport, proxying without kubeconfig credentials")
+	} else {
+		// client-go no longer ships the in-tree "oidc" auth provider, so
+		// building a transport fails when a legacy auth-provider: oidc is set.
+		// Headlamp injects the OIDC token itself, so drop only that provider and
+		// keep the TLS settings. Other auth-providers are left intact so their
+		// authentication isn't silently removed.
+		if restConf.AuthProvider != nil && restConf.AuthProvider.Name == "oidc" {
+			confCopy := *restConf
+			confCopy.AuthProvider = nil
+			restConf = &confCopy
+		}
+
 		roundTripper, err := makeTransportFor(restConf)
-		if err == nil {
+		if err != nil {
+			logger.Log(logger.LevelError, map[string]string{logFieldContext: c.Name},
+				err, "couldn't create proxy transport, proxying without kubeconfig credentials")
+		} else {
 			// Wrap the round tripper to add Headlamp User-Agent
 			proxy.Transport = &userAgentRoundTripper{
 				base:      roundTripper,
@@ -479,7 +502,7 @@ func (c *Context) SetupProxy() error {
 
 	c.proxy = proxy
 
-	logger.Log(logger.LevelInfo, map[string]string{"context": c.Name, "clusterURL": c.Cluster.Server},
+	logger.Log(logger.LevelInfo, map[string]string{logFieldContext: c.Name, "clusterURL": c.Cluster.Server},
 		nil, "Proxy setup")
 
 	return nil

--- a/backend/pkg/kubeconfig/setupproxy_test.go
+++ b/backend/pkg/kubeconfig/setupproxy_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig //nolint:testpackage // tests inspect the unexported proxy transport.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// minimal valid self-signed CA certificate so transport creation succeeds.
+const testCACert = `-----BEGIN CERTIFICATE-----
+MIIC/jCCAeagAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
+cm5ldGVzMB4XDTIyMDgyNjExMDQ1M1oXDTMyMDgyMzExMDQ1M1owFTETMBEGA1UE
+AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANy7
+/dDC1WL7MsRXevgkTAy3pVG1UKkUPywxq/DLpOvdsBihB6hVcumcYQ93aLKlDsIs
+GD4ABdPS8pAO38LotAYeCx20p1OzoKaS/VJzfRJAeTI+BcwsF8vSUWaM+yfxI0OR
+gjQ49TtyJiaDrKksnwxGv4+E7iaaeEO0nySMDrzN7TobEroZNlts6GL7kiL0tLnY
+J+6smHyaHhzY8ZGBY0WVQzs4CE2rtCY9y5x7awmICQa6jpWTUPk3jkDLqOwlD2Fc
+psdyr8kVwQHSQEgFH6c80vzw7/QIECtdX6VQFq5o639iosxPquJWvm0ecvLyt/5p
+q5vi731Y8DoEC21mKcsCAwEAAaNZMFcwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB
+/wQFMAMBAf8wHQYDVR0OBBYEFI4QdSaRDUhv/0Z94g5yFiUuiLdpMBUGA1UdEQQO
+MAyCCmt1YmVybmV0ZXMwDQYJKoZIhvcNAQELBQADggEBACzVYJAS45PPNHURh2JY
+JX1rraLtcSo5n4mCW/hxNXtzB2R3ZHOSHg6avGrMxV8fZBvkAtBEiF33boE8sg5a
+8aXtEN4yo9YCaYsfW+kM6VCEGmUgynmwiyma0sInTJVuGvUl5nqXcPrIuoNMUkML
+t++rLBoCpclk7OUI04uvojzqshlCBb1DR9tpOK4++4PgOj+z9vt7x4w8LbXoBkoz
+38BrTJ2CsjmM1KfjeyiwgGVacxOXItcmzk74iC6tJ7jVmLVcZpG9dIopY9Y0ZND4
+d3f9f8gBZBsip4kx12aq2Ryw1X4eNhV6unNh+GTsa6QCJRtfOE+T867vdyOn6Lol
+ad8=
+-----END CERTIFICATE-----
+`
+
+func TestSetupProxyTransport(t *testing.T) { //nolint:funlen // test scaffolding.
+	t.Run("oidc auth provider gets a transport with TLS settings", func(t *testing.T) {
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte(testCACert), 0o600))
+
+		ctx := &Context{
+			Name: "oidc-context",
+			KubeContext: &api.Context{
+				Cluster:  "oidc-cluster",
+				AuthInfo: "oidc-user",
+			},
+			Cluster: &api.Cluster{
+				Server:               "https://127.0.0.1:6443",
+				CertificateAuthority: caFile,
+			},
+			AuthInfo: &api.AuthInfo{
+				AuthProvider: &api.AuthProviderConfig{
+					Name: "oidc",
+					Config: map[string]string{
+						"client-id":      "test-client",
+						"idp-issuer-url": "https://idp.example.com",
+					},
+				},
+			},
+		}
+
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+
+		// Previously the "oidc" auth provider made transport creation fail
+		// ("no Auth Provider found for name \"oidc\"") and the proxy silently
+		// fell back to the default transport without the cluster CA.
+		assert.NotNil(t, ctx.proxy.Transport,
+			"proxy should get a transport with the kubeconfig's TLS settings")
+	})
+
+	t.Run("valid config gets a transport", func(t *testing.T) {
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte(testCACert), 0o600))
+
+		ctx := &Context{
+			Name: "plain-context",
+			KubeContext: &api.Context{
+				Cluster:  "plain-cluster",
+				AuthInfo: "plain-user",
+			},
+			Cluster: &api.Cluster{
+				Server:               "https://127.0.0.1:6443",
+				CertificateAuthority: caFile,
+			},
+			AuthInfo: &api.AuthInfo{
+				Token: "test-token",
+			},
+		}
+
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+		assert.NotNil(t, ctx.proxy.Transport)
+	})
+
+	// RESTConfig() error branch: cert files referenced by the kubeconfig don't
+	// exist, so RESTConfig() fails before a transport is ever built.
+	t.Run("RESTConfig failure still sets up a proxy with default transport", func(t *testing.T) {
+		ctx := &Context{
+			Name: "broken-restconfig-context",
+			KubeContext: &api.Context{
+				Cluster:  "broken-cluster",
+				AuthInfo: "broken-user",
+			},
+			Cluster: &api.Cluster{
+				Server:               "https://127.0.0.1:6443",
+				CertificateAuthority: "/nonexistent/ca.crt",
+			},
+			AuthInfo: &api.AuthInfo{
+				ClientCertificate: "/nonexistent/client.crt",
+				ClientKey:         "/nonexistent/client.key",
+			},
+		}
+
+		// The error is logged (no longer silent) but the proxy still comes up
+		// with the default transport so existing setups keep working.
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+		assert.Nil(t, ctx.proxy.Transport)
+	})
+
+	// makeTransportFor() error branch: RESTConfig() succeeds (the CA data is
+	// stored as-is) but building the transport fails because the CA data isn't
+	// valid PEM.
+	t.Run("transport creation failure still sets up a proxy with default transport", func(t *testing.T) {
+		ctx := &Context{
+			Name: "broken-transport-context",
+			KubeContext: &api.Context{
+				Cluster:  "broken-cluster",
+				AuthInfo: "broken-user",
+			},
+			Cluster: &api.Cluster{
+				Server:                   "https://127.0.0.1:6443",
+				CertificateAuthorityData: []byte("not-valid-pem-data"),
+			},
+			AuthInfo: &api.AuthInfo{
+				Token: "test-token",
+			},
+		}
+
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+		assert.Nil(t, ctx.proxy.Transport)
+	})
+}

--- a/backend/pkg/kubeconfig/setupproxy_test.go
+++ b/backend/pkg/kubeconfig/setupproxy_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig //nolint:testpackage // tests inspect the unexported proxy transport.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// minimal valid self-signed CA certificate so transport creation succeeds.
+const testCACert = `-----BEGIN CERTIFICATE-----
+MIIC/jCCAeagAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl
+cm5ldGVzMB4XDTIyMDgyNjExMDQ1M1oXDTMyMDgyMzExMDQ1M1owFTETMBEGA1UE
+AxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANy7
+/dDC1WL7MsRXevgkTAy3pVG1UKkUPywxq/DLpOvdsBihB6hVcumcYQ93aLKlDsIs
+GD4ABdPS8pAO38LotAYeCx20p1OzoKaS/VJzfRJAeTI+BcwsF8vSUWaM+yfxI0OR
+gjQ49TtyJiaDrKksnwxGv4+E7iaaeEO0nySMDrzN7TobEroZNlts6GL7kiL0tLnY
+J+6smHyaHhzY8ZGBY0WVQzs4CE2rtCY9y5x7awmICQa6jpWTUPk3jkDLqOwlD2Fc
+psdyr8kVwQHSQEgFH6c80vzw7/QIECtdX6VQFq5o639iosxPquJWvm0ecvLyt/5p
+q5vi731Y8DoEC21mKcsCAwEAAaNZMFcwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB
+/wQFMAMBAf8wHQYDVR0OBBYEFI4QdSaRDUhv/0Z94g5yFiUuiLdpMBUGA1UdEQQO
+MAyCCmt1YmVybmV0ZXMwDQYJKoZIhvcNAQELBQADggEBACzVYJAS45PPNHURh2JY
+JX1rraLtcSo5n4mCW/hxNXtzB2R3ZHOSHg6avGrMxV8fZBvkAtBEiF33boE8sg5a
+8aXtEN4yo9YCaYsfW+kM6VCEGmUgynmwiyma0sInTJVuGvUl5nqXcPrIuoNMUkML
+t++rLBoCpclk7OUI04uvojzqshlCBb1DR9tpOK4++4PgOj+z9vt7x4w8LbXoBkoz
+38BrTJ2CsjmM1KfjeyiwgGVacxOXItcmzk74iC6tJ7jVmLVcZpG9dIopY9Y0ZND4
+d3f9f8gBZBsip4kx12aq2Ryw1X4eNhV6unNh+GTsa6QCJRtfOE+T867vdyOn6Lol
+ad8=
+-----END CERTIFICATE-----
+`
+
+// logEntry is a single logger.Log call captured by captureLogs.
+type logEntry struct {
+	level  uint
+	fields map[string]string
+	err    interface{}
+	msg    string
+}
+
+// captureLogs redirects logger.Log into the returned slice for the rest of the test.
+func captureLogs(t *testing.T) *[]logEntry {
+	t.Helper()
+
+	entries := &[]logEntry{}
+
+	original := logger.SetLogFunc(func(level uint, fields map[string]string, err interface{}, msg string) {
+		*entries = append(*entries, logEntry{level: level, fields: fields, err: err, msg: msg})
+	})
+
+	t.Cleanup(func() { logger.SetLogFunc(original) })
+
+	return entries
+}
+
+// assertErrorLogged checks that an error-level entry whose message contains want was
+// logged, naming the context it came from and carrying the underlying error.
+func assertErrorLogged(t *testing.T, entries []logEntry, contextName, want string) {
+	t.Helper()
+
+	for _, entry := range entries {
+		if entry.level != logger.LevelError || !strings.Contains(entry.msg, want) {
+			continue
+		}
+
+		assert.Equal(t, contextName, entry.fields[logFieldContext], "the failing context should be named")
+		assert.NotNil(t, entry.err, "the underlying error should be logged")
+
+		return
+	}
+
+	t.Errorf("no error-level log containing %q was written; got %v", want, entries)
+}
+
+func TestSetupProxyTransport(t *testing.T) { //nolint:funlen // test scaffolding.
+	t.Run("oidc auth provider gets a transport with TLS settings", func(t *testing.T) {
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte(testCACert), 0o600))
+
+		ctx := &Context{
+			Name: "oidc-context",
+			KubeContext: &api.Context{
+				Cluster:  "oidc-cluster",
+				AuthInfo: "oidc-user",
+			},
+			Cluster: &api.Cluster{
+				Server:               "https://127.0.0.1:6443",
+				CertificateAuthority: caFile,
+			},
+			AuthInfo: &api.AuthInfo{
+				AuthProvider: &api.AuthProviderConfig{
+					Name: "oidc",
+					Config: map[string]string{
+						"client-id":      "test-client",
+						"idp-issuer-url": "https://idp.example.com",
+					},
+				},
+			},
+		}
+
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+
+		// Previously the "oidc" auth provider made transport creation fail
+		// ("no Auth Provider found for name \"oidc\"") and the proxy silently
+		// fell back to the default transport without the cluster CA.
+		assert.NotNil(t, ctx.proxy.Transport,
+			"proxy should get a transport with the kubeconfig's TLS settings")
+	})
+
+	t.Run("valid config gets a transport", func(t *testing.T) {
+		caFile := filepath.Join(t.TempDir(), "ca.crt")
+		require.NoError(t, os.WriteFile(caFile, []byte(testCACert), 0o600))
+
+		ctx := &Context{
+			Name: "plain-context",
+			KubeContext: &api.Context{
+				Cluster:  "plain-cluster",
+				AuthInfo: "plain-user",
+			},
+			Cluster: &api.Cluster{
+				Server:               "https://127.0.0.1:6443",
+				CertificateAuthority: caFile,
+			},
+			AuthInfo: &api.AuthInfo{
+				Token: "test-token",
+			},
+		}
+
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+		assert.NotNil(t, ctx.proxy.Transport)
+	})
+
+	// RESTConfig() error branch: cert files referenced by the kubeconfig don't
+	// exist, so RESTConfig() fails before a transport is ever built.
+	t.Run("RESTConfig failure still sets up a proxy with default transport", func(t *testing.T) {
+		ctx := &Context{
+			Name: "broken-restconfig-context",
+			KubeContext: &api.Context{
+				Cluster:  "broken-cluster",
+				AuthInfo: "broken-user",
+			},
+			Cluster: &api.Cluster{
+				Server:               "https://127.0.0.1:6443",
+				CertificateAuthority: "/nonexistent/ca.crt",
+			},
+			AuthInfo: &api.AuthInfo{
+				ClientCertificate: "/nonexistent/client.crt",
+				ClientKey:         "/nonexistent/client.key",
+			},
+		}
+
+		entries := captureLogs(t)
+
+		// The error is logged (no longer silent) but the proxy still comes up
+		// with the default transport so existing setups keep working.
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+		assert.Nil(t, ctx.proxy.Transport)
+		assertErrorLogged(t, *entries, "broken-restconfig-context",
+			"couldn't get REST config for proxy transport")
+	})
+
+	// makeTransportFor() error branch: RESTConfig() succeeds (the CA data is
+	// stored as-is) but building the transport fails because the CA data isn't
+	// valid PEM.
+	t.Run("transport creation failure still sets up a proxy with default transport", func(t *testing.T) {
+		ctx := &Context{
+			Name: "broken-transport-context",
+			KubeContext: &api.Context{
+				Cluster:  "broken-cluster",
+				AuthInfo: "broken-user",
+			},
+			Cluster: &api.Cluster{
+				Server:                   "https://127.0.0.1:6443",
+				CertificateAuthorityData: []byte("not-valid-pem-data"),
+			},
+			AuthInfo: &api.AuthInfo{
+				Token: "test-token",
+			},
+		}
+
+		entries := captureLogs(t)
+
+		err := ctx.SetupProxy()
+		require.NoError(t, err)
+		require.NotNil(t, ctx.proxy)
+		assert.Nil(t, ctx.proxy.Transport)
+		assertErrorLogged(t, *entries, "broken-transport-context",
+			"couldn't create proxy transport")
+	})
+}


### PR DESCRIPTION
## Summary

SetupProxy() was silently swallowing errors from RESTConfig() and makeTransportFor(). When either failed, the proxy quietly fell back to http.DefaultTransport — no cluster CA, no client certs, no exec credentials — and nothing got logged. So users only found out later through confusing x509 errors at request time, with nothing in the logs pointing at the real cause.

This logs those failures at error level so a broken context shows up at setup time. The proxy still comes up on the default transport, so nothing that loads today stops loading — the only difference is the failure is loud now instead of silent.

While digging into it I found a bigger problem: every OIDC context was hitting this same fallback. client-go dropped the in-tree "oidc" auth provider, so any kubeconfig with auth-provider: oidc always failed transport creation and quietly lost its TLS settings, custom CA and all. Headlamp handles those tokens itself, so I strip the auth-provider from a config copy before building the transport and keep the rest of the TLS config. OIDC contexts get a proper transport with their CA back.

## Related Issue

Fixes #6429

## Changes

- backend/pkg/kubeconfig/kubeconfig.go: log transport setup errors instead of dropping them, and strip the auth-provider before building the transport so OIDC contexts keep their CA
- backend/pkg/kubeconfig/setupproxy_test.go: tests for the OIDC case, a valid config, and a broken config

## Steps to Test

1. Add a context to your kubeconfig with certificate-authority / client-certificate pointing to files that don't exist
2. Start Headlamp and load that context
3. Before this change the backend just logs "Proxy setup" with no error. After it, an error log shows the real cause (unreadable cert file) right at setup
4. For OIDC: load a kubeconfig with auth-provider: oidc and a custom idp-certificate-authority — the transport keeps the CA now instead of falling back to the default

## Screenshots (if applicable)

N/A — backend log/error handling change, nothing visual.

## Notes for the Reviewer

I went with log-and-continue instead of failing the context outright, so this doesn't change which clusters load — it just makes the failure visible. If you'd rather have it fail hard (context doesn't load at all when the transport can't be built), I'm happy to switch. I asked the same thing on Slack but figured opening the PR gives us something concrete to look at.
