### PR TITLE
backend: k8cache: watch discovered list-watch resources

### DIFF
--- a/backend/pkg/k8cache/cacheInvalidation.go
+++ b/backend/pkg/k8cache/cacheInvalidation.go
@@ -115,8 +115,8 @@ func SkipWebSocket(r *http.Request, next http.Handler, w http.ResponseWriter) bo
 	return false
 }
 
-// returnGVRList returns list+watch GroupVersionResources filtered to an allowlisted set of
-// API resource names (e.g. pods, deployments) used for cache invalidation watchers.
+// returnGVRList returns discovered GroupVersionResources that support both list and watch.
+// Subresources and explicitly skipped noisy kinds are excluded from cache invalidation watchers.
 func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
 	skipKinds := map[string]bool{
 		"Lease": true,
@@ -146,37 +146,7 @@ func returnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVer
 		}
 	}
 
-	filtered := filterImportantResources(gvrList)
-
-	return filtered
-}
-
-// filterImportantResources filters the provided list of GroupVersionResources to
-// include only those that are deemed important for caching and watching.
-func filterImportantResources(gvrList []schema.GroupVersionResource) []schema.GroupVersionResource {
-	allowed := map[string]struct{}{
-		"pods":         {},
-		"services":     {},
-		"deployments":  {},
-		"replicasets":  {},
-		"statefulsets": {},
-		"daemonsets":   {},
-		"nodes":        {},
-		"configmaps":   {},
-		"secrets":      {},
-		"jobs":         {},
-		"cronjobs":     {},
-	}
-
-	filtered := make([]schema.GroupVersionResource, 0, len(allowed))
-
-	for _, gvr := range gvrList {
-		if _, ok := allowed[gvr.Resource]; ok {
-			filtered = append(filtered, gvr)
-		}
-	}
-
-	return filtered
+	return gvrList
 }
 
 // Corrected CheckForChanges.

--- a/backend/pkg/k8cache/cacheInvalidation_internal_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_internal_test.go
@@ -21,70 +21,121 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestReturnGVRList(t *testing.T) {
-	apiResourceLists := []*metav1.APIResourceList{
-		{
-			GroupVersion: "v1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:  "pods",
-					Kind:  "Pod",
-					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
-				},
-				{
-					Name:  "events",
-					Kind:  "Event", // skipped: Kind in skipKinds
-					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
-				},
-				{
-					Name:  "pods/status", // skipped: name contains "/"
-					Kind:  "Pod",
-					Verbs: metav1.Verbs{"get", "patch", "update"},
-				},
+func testAPIResourceLists() []*metav1.APIResourceList {
+	return []*metav1.APIResourceList{
+		coreResources(),
+		appsResources(),
+		ingressResources(),
+		namespaceResources(),
+		leaseResources(),
+		invalidGroupVersionResources(),
+	}
+}
+
+func coreResources() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:  "pods",
+				Kind:  "Pod",
+				Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
-		},
-		{
-			GroupVersion: "apps/v1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:  "deployments",
-					Kind:  "Deployment",
-					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
-				},
-				{
-					Name:  "replicasets",
-					Kind:  "ReplicaSet",
-					Verbs: metav1.Verbs{"create", "delete", "get", "patch", "update"}, // skipped: missing list and watch
-				},
+			{
+				Name:  "events",
+				Kind:  "Event", // skipped: Kind in skipKinds
+				Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
-		},
-		{
-			GroupVersion: "coordination.k8s.io/v1",
-			APIResources: []metav1.APIResource{
-				{
-					Name:  "leases",
-					Kind:  "Lease", // skipped: Kind in skipKinds
-					Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
-				},
-			},
-		},
-		{
-			GroupVersion: "invalid/group/version", // skipped: ParseGroupVersion fails
-			APIResources: []metav1.APIResource{
-				{
-					Name:  "foos",
-					Kind:  "Foo",
-					Verbs: metav1.Verbs{"list", "watch"},
-				},
+			{
+				Name:  "pods/status", // skipped: name contains "/"
+				Kind:  "Pod",
+				Verbs: metav1.Verbs{"get", "patch", "update"},
 			},
 		},
 	}
+}
 
-	expected := []schema.GroupVersionResource{
+func appsResources() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "apps/v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:  "deployments",
+				Kind:  "Deployment",
+				Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+			},
+			{
+				Name:  "replicasets",
+				Kind:  "ReplicaSet",
+				Verbs: metav1.Verbs{"create", "delete", "get", "patch", "update"}, // skipped: missing list and watch
+			},
+		},
+	}
+}
+
+func ingressResources() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "networking.k8s.io/v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:  "ingresses",
+				Kind:  "Ingress",
+				Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+			},
+		},
+	}
+}
+
+func namespaceResources() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:  "namespaces",
+				Kind:  "Namespace",
+				Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+			},
+		},
+	}
+}
+
+func leaseResources() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "coordination.k8s.io/v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:  "leases",
+				Kind:  "Lease", // skipped: Kind in skipKinds
+				Verbs: metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"},
+			},
+		},
+	}
+}
+
+func invalidGroupVersionResources() *metav1.APIResourceList {
+	return &metav1.APIResourceList{
+		GroupVersion: "invalid/group/version", // skipped: ParseGroupVersion fails
+		APIResources: []metav1.APIResource{
+			{
+				Name:  "foos",
+				Kind:  "Foo",
+				Verbs: metav1.Verbs{"list", "watch"},
+			},
+		},
+	}
+}
+
+func expectedGVRList() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
 		{Group: "", Version: "v1", Resource: "pods"},
 		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+		{Group: "", Version: "v1", Resource: "namespaces"},
 	}
+}
 
-	result := returnGVRList(apiResourceLists)
-	assert.ElementsMatch(t, expected, result)
+func TestReturnGVRList(t *testing.T) {
+	result := returnGVRList(testAPIResourceLists())
+
+	assert.ElementsMatch(t, expectedGVRList(), result)
 }

--- a/backend/pkg/k8cache/cacheInvalidation_test.go
+++ b/backend/pkg/k8cache/cacheInvalidation_test.go
@@ -735,86 +735,7 @@ func TestHandleNonGETCacheInvalidation_PostOnResourceNamedVersion(t *testing.T) 
 	assert.NotContains(t, cachedValue, "stale")
 }
 
-var filterImportantResourcesTests = []struct {
-	name  string
-	input []schema.GroupVersionResource
-	want  []schema.GroupVersionResource
-}{
-	{
-		name:  "empty input",
-		input: nil,
-		want:  []schema.GroupVersionResource{},
-	},
-	{
-		name: "keeps allowed resources and drops others",
-		input: []schema.GroupVersionResource{
-			{Group: "", Version: "v1", Resource: "pods"},
-			{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
-			{Group: "apps", Version: "v1", Resource: "deployments"},
-			{Group: "", Version: "v1", Resource: "namespaces"},
-		},
-		want: []schema.GroupVersionResource{
-			{Group: "", Version: "v1", Resource: "pods"},
-			{Group: "apps", Version: "v1", Resource: "deployments"},
-		},
-	},
-	{
-		name: "preserves group and version fields",
-		input: []schema.GroupVersionResource{
-			{Group: "batch", Version: "v1", Resource: "jobs"},
-			{Group: "batch", Version: "v1", Resource: "cronjobs"},
-		},
-		want: []schema.GroupVersionResource{
-			{Group: "batch", Version: "v1", Resource: "jobs"},
-			{Group: "batch", Version: "v1", Resource: "cronjobs"},
-		},
-	},
-	{
-		name: "keeps all allowlisted resource kinds",
-		input: []schema.GroupVersionResource{
-			{Group: "", Version: "v1", Resource: "pods"},
-			{Group: "", Version: "v1", Resource: "services"},
-			{Group: "apps", Version: "v1", Resource: "deployments"},
-			{Group: "apps", Version: "v1", Resource: "replicasets"},
-			{Group: "apps", Version: "v1", Resource: "statefulsets"},
-			{Group: "apps", Version: "v1", Resource: "daemonsets"},
-			{Group: "", Version: "v1", Resource: "nodes"},
-			{Group: "", Version: "v1", Resource: "configmaps"},
-			{Group: "", Version: "v1", Resource: "secrets"},
-			{Group: "batch", Version: "v1", Resource: "jobs"},
-			{Group: "batch", Version: "v1", Resource: "cronjobs"},
-		},
-		want: []schema.GroupVersionResource{
-			{Group: "", Version: "v1", Resource: "pods"},
-			{Group: "", Version: "v1", Resource: "services"},
-			{Group: "apps", Version: "v1", Resource: "deployments"},
-			{Group: "apps", Version: "v1", Resource: "replicasets"},
-			{Group: "apps", Version: "v1", Resource: "statefulsets"},
-			{Group: "apps", Version: "v1", Resource: "daemonsets"},
-			{Group: "", Version: "v1", Resource: "nodes"},
-			{Group: "", Version: "v1", Resource: "configmaps"},
-			{Group: "", Version: "v1", Resource: "secrets"},
-			{Group: "batch", Version: "v1", Resource: "jobs"},
-			{Group: "batch", Version: "v1", Resource: "cronjobs"},
-		},
-	},
-}
-
-func TestFilterImportantResources(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range filterImportantResourcesTests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := k8cache.ExportedFilterImportantResources(tt.input)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
+func TestReturnGVRList_UsesDiscoveredListWatchResources(t *testing.T) {
 	t.Parallel()
 
 	apiResourceLists := []*metav1.APIResourceList{
@@ -822,6 +743,11 @@ func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
 			GroupVersion: "v1",
 			APIResources: []metav1.APIResource{
 				{Name: "pods", Kind: "Pod", Verbs: []string{"list", "watch", "get"}},
+			},
+		},
+		{
+			GroupVersion: "networking.k8s.io/v1",
+			APIResources: []metav1.APIResource{
 				{Name: "ingresses", Kind: "Ingress", Verbs: []string{"list", "watch", "get"}},
 			},
 		},
@@ -829,7 +755,14 @@ func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
 			GroupVersion: "apps/v1",
 			APIResources: []metav1.APIResource{
 				{Name: "deployments", Kind: "Deployment", Verbs: []string{"list", "watch", "get"}},
+				{Name: "replicasets", Kind: "ReplicaSet", Verbs: []string{"list", "watch", "get"}},
 				{Name: "deployments/scale", Kind: "Scale", Verbs: []string{"get", "update"}},
+			},
+		},
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "namespaces", Kind: "Namespace", Verbs: []string{"list", "watch", "get"}},
 			},
 		},
 		{
@@ -844,7 +777,10 @@ func TestReturnGVRList_FiltersImportantResources(t *testing.T) {
 
 	want := []schema.GroupVersionResource{
 		{Group: "", Version: "v1", Resource: "pods"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "apps", Version: "v1", Resource: "replicasets"},
+		{Group: "", Version: "v1", Resource: "namespaces"},
 	}
 
 	assert.Equal(t, want, got)

--- a/backend/pkg/k8cache/export_test.go
+++ b/backend/pkg/k8cache/export_test.go
@@ -162,11 +162,6 @@ func ExportedRedactCacheKey(key string) string {
 	return redactCacheKey(key)
 }
 
-// ExportedFilterImportantResources exposes filterImportantResources for testing.
-func ExportedFilterImportantResources(gvrList []schema.GroupVersionResource) []schema.GroupVersionResource {
-	return filterImportantResources(gvrList)
-}
-
 // ExportedReturnGVRList exposes returnGVRList for testing.
 func ExportedReturnGVRList(apiResourceLists []*metav1.APIResourceList) []schema.GroupVersionResource {
 	return returnGVRList(apiResourceLists)


### PR DESCRIPTION
## Summary
- expand k8cache watcher setup to keep all discovered resources that support both `list` and `watch`
- remove the static watcher allowlist that excluded common resources such as `Ingress` and `Namespace`
- update k8cache tests to cover the broader discovery-based watcher selection

## Related Issue

Fixes #6457

## Changes

- Updated `returnGVRList` to return discovered list+watch-capable resources after the existing subresource and noisy-kind exclusions
- Removed the now-obsolete `filterImportantResources` helper and its test-only export
- Replaced allowlist-based tests with discovery-based coverage for `ingresses`, `namespaces`, and `replicasets`

## Steps to Test

1. Run `npm run backend:format`.
2. Run `npm run backend:build`.
3. Run `npm run backend:test`.
4. Run `npm test`.
5. Run `npm run backend:start` and confirm the backend starts.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

- Scope is limited to backend cache invalidation watcher discovery and its tests.
- `npm run lint` currently fails in this repository because `backend:lint` builds `golangci-lint` with Go 1.25 while the repo targets Go 1.26.4.

