### PR TITLE
backend: k8cache: derive real API group/scope in cached auth error responses

### DIFF
--- a/backend/pkg/k8cache/authErrResp.go
+++ b/backend/pkg/k8cache/authErrResp.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/gorilla/mux"
 )
 
 // Details provides information about a specific resource kind.
@@ -74,6 +76,21 @@ func isDirectOrProxiedAPIResourceEndpoint(urlPath, group, resource string) bool 
 // this will returns directly without asking to K8's Server.
 func ReturnAuthErrorResponse(w http.ResponseWriter, r *http.Request, contextKey string) error {
 	last, kubeVerb := GetKindAndVerb(r)
+	group, namespace := GetGroupAndNamespace(r)
+
+	scope := "at the cluster scope"
+	if namespace != "" {
+		scope = fmt.Sprintf("in the namespace %q", namespace)
+	}
+
+	message := fmt.Sprintf("%s is forbidden: User \"system:serviceaccount:default:%s\" cannot ", last, contextKey) +
+		fmt.Sprintf("%s resource %q in API group %q %s", kubeVerb, last, group, scope)
+	if last == "" || kubeVerb == unknownVerb {
+		last = requestPathSubject(r)
+		kubeVerb = "access"
+		message = fmt.Sprintf("%s is forbidden: User \"system:serviceaccount:default:%s\" cannot ", last, contextKey) +
+			fmt.Sprintf("%s path %q %s", kubeVerb, last, scope)
+	}
 
 	// AuthErrorResponse will be the actual message which will be
 	// further transformed into JSON body for sending to the client.
@@ -81,9 +98,8 @@ func ReturnAuthErrorResponse(w http.ResponseWriter, r *http.Request, contextKey 
 		Kind:       "Status",
 		APIVersion: "v1",
 		MetaData:   Metadata{}, // In this case the Metadata will always be empty.
-		Message: fmt.Sprintf("%s is forbidden: User \"system:serviceaccount:default:%s\" cannot ", last, contextKey) +
-			fmt.Sprintf("%s resource \"%s\" in API group \"\" at the cluster scope", kubeVerb, last),
-		Reason: "Forbidden", // For this scenerio the reason should be forbidden.
+		Message:    message,
+		Reason:     "Forbidden", // For this scenario the reason should be forbidden.
 		Details: Details{
 			Kind: last,
 		},
@@ -101,6 +117,18 @@ func ReturnAuthErrorResponse(w http.ResponseWriter, r *http.Request, contextKey 
 	}
 
 	return nil
+}
+
+func requestPathSubject(r *http.Request) string {
+	if apiPath := strings.Trim(mux.Vars(r)["api"], "/"); apiPath != "" {
+		return apiPath
+	}
+
+	if path := strings.Trim(r.URL.Path, "/"); path != "" {
+		return path
+	}
+
+	return "request path"
 }
 
 // WriteResponseToClient returns UnAuthorized error response when the user Unauthorized

--- a/backend/pkg/k8cache/authErrResp_test.go
+++ b/backend/pkg/k8cache/authErrResp_test.go
@@ -16,10 +16,12 @@ package k8cache_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/stretchr/testify/assert"
 )
@@ -125,6 +127,107 @@ func TestReturnAuthErrorResponse(t *testing.T) {
 	assert.Equal(t, 403, resp.Code)
 	assert.Contains(t, resp.Message, "is forbidden:")
 	assert.Equal(t, "Forbidden", resp.Reason)
+}
+
+func TestReturnAuthErrorResponseReflectsActualScope(t *testing.T) {
+	t.Run("resource paths", func(t *testing.T) {
+		testReturnAuthErrorResponseScope(t, []authErrorScopeTestCase{
+			{
+				name:              "Namespaced, non-core resource",
+				muxVars:           map[string]string{"api": "apis/apps/v1/namespaces/my-ns/deployments"},
+				expectedGroup:     "apps",
+				expectedNamespace: "my-ns",
+			},
+			{
+				name:              "Cluster-scoped, core resource",
+				muxVars:           map[string]string{"api": "api/v1/nodes"},
+				expectedGroup:     "",
+				expectedNamespace: "",
+			},
+		})
+	})
+
+	t.Run("non namespaced paths stay cluster scoped", func(t *testing.T) {
+		testReturnAuthErrorResponseScope(t, []authErrorScopeTestCase{
+			{
+				name:              "Namespace resource stays cluster scoped",
+				muxVars:           map[string]string{"api": "api/v1/namespaces/kube-system"},
+				expectedGroup:     "",
+				expectedNamespace: "",
+			},
+			{
+				name:              "Namespace subresource stays cluster scoped",
+				muxVars:           map[string]string{"api": "api/v1/namespaces/kube-system/status"},
+				expectedGroup:     "",
+				expectedNamespace: "",
+			},
+			{
+				name:              "Non resource endpoint does not fabricate namespace",
+				muxVars:           map[string]string{"api": "openapi/v2/namespaces/not-a-real-namespace"},
+				expectedGroup:     "",
+				expectedNamespace: "",
+				expectedPath:      true,
+			},
+		})
+	})
+}
+
+func TestReturnAuthErrorResponseUsesRequestPathForNonResourceEndpoints(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/", nil)
+	req = mux.SetURLVars(req, map[string]string{"api": "openapi/v2/namespaces/not-a-real-namespace"})
+
+	err := k8cache.ReturnAuthErrorResponse(rr, req, "test-context")
+	assert.NoError(t, err)
+
+	var resp k8cache.AuthErrResponse
+
+	err = json.Unmarshal(rr.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "openapi/v2/namespaces/not-a-real-namespace", resp.Details.Kind)
+	assert.Contains(t, resp.Message, "cannot access path")
+	assert.NotContains(t, resp.Message, "unknown resource \"\"")
+}
+
+type authErrorScopeTestCase struct {
+	name              string
+	muxVars           map[string]string
+	expectedGroup     string
+	expectedNamespace string
+	expectedPath      bool
+}
+
+func testReturnAuthErrorResponseScope(t *testing.T, tests []authErrorScopeTestCase) {
+	t.Helper()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), "GET", "/", nil)
+			req = mux.SetURLVars(req, tc.muxVars)
+
+			err := k8cache.ReturnAuthErrorResponse(rr, req, "test-context")
+			assert.NoError(t, err)
+
+			var resp k8cache.AuthErrResponse
+
+			err = json.Unmarshal(rr.Body.Bytes(), &resp)
+			assert.NoError(t, err)
+
+			if tc.expectedPath {
+				assert.Contains(t, resp.Message, "cannot access path")
+			} else {
+				assert.Contains(t, resp.Message, fmt.Sprintf("API group %q", tc.expectedGroup))
+			}
+
+			if tc.expectedNamespace != "" {
+				assert.Contains(t, resp.Message, fmt.Sprintf("in the namespace %q", tc.expectedNamespace))
+			} else {
+				assert.Contains(t, resp.Message, "at the cluster scope")
+			}
+		})
+	}
 }
 
 func TestWriteResponseToClient(t *testing.T) {

--- a/backend/pkg/k8cache/authorization.go
+++ b/backend/pkg/k8cache/authorization.go
@@ -522,6 +522,35 @@ func getResourceAttributes(r *http.Request) (*authorizationv1.ResourceAttributes
 	}, nil
 }
 
+// GetGroupAndNamespace extracts the API group and namespace (if any) from the incoming
+// request's "api" mux variable, so callers can describe the actual request scope instead
+// of assuming the core API group and cluster scope.
+func GetGroupAndNamespace(r *http.Request) (string, string) {
+	apiPath, ok := mux.Vars(r)["api"]
+	if !ok || apiPath == "" {
+		return "", ""
+	}
+
+	if request, ok := parseAPIResourceRequest(apiPath); ok {
+		return request.group, request.namespace
+	}
+
+	parts := strings.Split(strings.Trim(apiPath, "/"), "/")
+
+	switch parts[0] {
+	case "apis":
+		if len(parts) < 3 {
+			return "", ""
+		}
+
+		return parts[1], ""
+	case "api":
+		return "", ""
+	default:
+		return "", ""
+	}
+}
+
 // IsAllowed checks the user's permission to access the resource.
 // If the user is authorized and has permission to view the resources, it returns true.
 // Otherwise, it returns false if authorization fails.

--- a/backend/pkg/k8cache/authorization_test.go
+++ b/backend/pkg/k8cache/authorization_test.go
@@ -259,6 +259,109 @@ func runGetKindAndVerbTests(t *testing.T, tests []getKindAndVerbTestCase) {
 	}
 }
 
+func TestGetGroupAndNamespaceResourcePaths(t *testing.T) {
+	testGetGroupAndNamespaceCases(t, []groupAndNamespaceTestCase{
+		{
+			name:              "Core API, cluster scope",
+			muxVars:           map[string]string{"api": "api/v1/pods"},
+			expectedGroup:     "",
+			expectedNamespace: "",
+		},
+		{
+			name:              "Core API, namespaced",
+			muxVars:           map[string]string{"api": "api/v1/namespaces/ns/pods"},
+			expectedGroup:     "",
+			expectedNamespace: "ns",
+		},
+		{
+			name:              "Named API group, cluster scope",
+			muxVars:           map[string]string{"api": "apis/apps/v1/deployments"},
+			expectedGroup:     "apps",
+			expectedNamespace: "",
+		},
+		{
+			name:              "Named API group, namespaced",
+			muxVars:           map[string]string{"api": "apis/apps/v1/namespaces/ns/deployments"},
+			expectedGroup:     "apps",
+			expectedNamespace: "ns",
+		},
+		{
+			name:              "Leading slash is ignored",
+			muxVars:           map[string]string{"api": "/apis/apps/v1/namespaces/ns/deployments"},
+			expectedGroup:     "apps",
+			expectedNamespace: "ns",
+		},
+	})
+}
+
+func TestGetGroupAndNamespaceClusterScopedAndInvalidPaths(t *testing.T) {
+	testGetGroupAndNamespaceCases(t, []groupAndNamespaceTestCase{
+		{
+			name:              "Core API version-only path",
+			muxVars:           map[string]string{"api": "api/v1"},
+			expectedGroup:     "",
+			expectedNamespace: "",
+		},
+		{
+			name:              "Named API version-only path",
+			muxVars:           map[string]string{"api": "apis/apps/v1"},
+			expectedGroup:     "apps",
+			expectedNamespace: "",
+		},
+		{
+			name:              "Namespace resource stays cluster scoped",
+			muxVars:           map[string]string{"api": "api/v1/namespaces/kube-system"},
+			expectedGroup:     "",
+			expectedNamespace: "",
+		},
+		{
+			name:              "Namespace subresource stays cluster scoped",
+			muxVars:           map[string]string{"api": "api/v1/namespaces/kube-system/status"},
+			expectedGroup:     "",
+			expectedNamespace: "",
+		},
+		{
+			name:              "Non resource endpoint",
+			muxVars:           map[string]string{"api": "openapi/v2/namespaces/not-a-real-namespace"},
+			expectedGroup:     "",
+			expectedNamespace: "",
+		},
+		{
+			name:              "No mux vars",
+			muxVars:           map[string]string{},
+			expectedGroup:     "",
+			expectedNamespace: "",
+		},
+		{
+			name:              "Empty api var",
+			muxVars:           map[string]string{"api": ""},
+			expectedGroup:     "",
+			expectedNamespace: "",
+		},
+	})
+}
+
+type groupAndNamespaceTestCase struct {
+	name              string
+	muxVars           map[string]string
+	expectedGroup     string
+	expectedNamespace string
+}
+
+func testGetGroupAndNamespaceCases(t *testing.T, tests []groupAndNamespaceTestCase) {
+	t.Helper()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req = mux.SetURLVars(req, tc.muxVars)
+			group, namespace := k8cache.GetGroupAndNamespace(req)
+			assert.Equal(t, tc.expectedGroup, group)
+			assert.Equal(t, tc.expectedNamespace, namespace)
+		})
+	}
+}
+
 func TestIsAllowed(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- Cached (locally synthesized) 403 responses from `k8cache` always claimed API group `""` (core) and "the cluster scope", even when the actual request targeted a named API group (e.g. `apps`, `batch`) and/or a specific namespace.
- This gave operators debugging RBAC/permission problems an inaccurate description of the request that was actually denied.

## Linked Issue
Fixes #6459

## What Changed
- Added `GetGroupAndNamespace` in `backend/pkg/k8cache/authorization.go`, which parses the API group and namespace from the request's `api` mux variable (handles both `api/v1/...` and `apis/<group>/<version>/...` paths, with or without a `namespaces/<ns>` segment).
- Updated `ReturnAuthErrorResponse` in `backend/pkg/k8cache/authErrResp.go` to use the parsed group/namespace instead of hardcoding `""` and "the cluster scope".
- Added unit tests for `GetGroupAndNamespace` covering core/named API groups, cluster-scoped/namespaced paths, missing mux vars, and empty `api` var.
- Added a test asserting `ReturnAuthErrorResponse` reflects the actual group/namespace for a namespaced non-core resource and a cluster-scoped core resource.

## Verification
- `npm run backend:format` — passed (no diff)
- `go test ./pkg/k8cache/...` (from `backend/`) — passed
- `go test ./...` (from `backend/`, full backend suite) — passed
- `go vet ./pkg/k8cache/...` (from `backend/`) — passed
- `npm run backend:lint` — not run: the pinned `golangci-lint v2.12.2` binary was built with Go 1.25 and refuses to run against this module's Go 1.26 toolchain requirement (`can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.4)`), a pre-existing local toolchain/lint-version mismatch unrelated to this change. `go vet` was run instead as the closest feasible local check.

## Scope
- Only `backend/pkg/k8cache/authErrResp.go`, `backend/pkg/k8cache/authErrResp_test.go`, `backend/pkg/k8cache/authorization.go`, and `backend/pkg/k8cache/authorization_test.go` were changed; no unrelated files were touched.
