### PR TITLE
frontend: EditButton: Show edit button when user has patch permission

### DIFF
--- a/frontend/src/components/common/Resource/EditButton.test.tsx
+++ b/frontend/src/components/common/Resource/EditButton.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TestContext } from '../../../test';
+import EditButton from './EditButton';
+
+function mockItem(updateAllowed: boolean, patchAllowed: boolean) {
+  return {
+    _class: () => ({
+      apiName: 'namespaces',
+      apiVersion: 'v1',
+    }),
+    getName: () => 'test-ns',
+    getNamespace: () => '',
+    getAuthorization: vi.fn((verb: string) =>
+      Promise.resolve({
+        status: {
+          allowed: verb === 'update' ? updateAllowed : patchAllowed,
+          reason: verb === 'update' && !updateAllowed ? 'Forbidden' : 'Forbidden',
+        },
+      })
+    ),
+    metadata: {
+      name: 'test-ns',
+      uid: 'test-uid',
+    },
+    kind: 'Namespace',
+    cluster: 'test-cluster',
+    jsonData: { apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'test-ns' } },
+    getEditableObject: () => ({
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name: 'test-ns' },
+    }),
+    patchUpdate: vi.fn(),
+  } as any;
+}
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TestContext>{ui}</TestContext>
+    </QueryClientProvider>
+  );
+}
+
+describe('EditButton', () => {
+  it('shows edit button when user has update permission', async () => {
+    renderWithProviders(<EditButton item={mockItem(true, false)} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows edit button when user has patch permission (but not update)', async () => {
+    renderWithProviders(<EditButton item={mockItem(false, true)} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows edit button when user has both update and patch', async () => {
+    renderWithProviders(<EditButton item={mockItem(true, true)} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    });
+  });
+
+  it('does not show edit button when user has neither update nor patch', async () => {
+    renderWithProviders(<EditButton item={mockItem(false, false)} />);
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/common/Resource/EditButton.tsx
+++ b/frontend/src/components/common/Resource/EditButton.tsx
@@ -15,12 +15,13 @@
  */
 
 import { Icon } from '@iconify/react';
+import { useQuery } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { KubeObject } from '../../../lib/k8s/KubeObject';
+import { KubeObject, KubeObjectClass } from '../../../lib/k8s/KubeObject';
 import { KubeObjectInterface } from '../../../lib/k8s/KubeObject';
 import { normalizeBaselineForPatch } from '../../../lib/k8s/patchUtils';
 import { CallbackActionOptions, clusterAction } from '../../../redux/clusterActionSlice';
@@ -32,7 +33,6 @@ import {
 import { AppDispatch } from '../../../redux/stores/store';
 import { Activity } from '../../activity/Activity';
 import ActionButton, { ButtonStyle } from '../ActionButton';
-import AuthVisible from './AuthVisible';
 import EditorDialog from './EditorDialog';
 import { fetchLatestKubeObject } from './fetchLatestKubeObject';
 import ViewButton from './ViewButton';
@@ -126,22 +126,47 @@ export default function EditButton(props: EditButtonProps) {
     return null;
   }
 
+  const itemClass: KubeObjectClass | null = (item as any)?._class?.() ?? item;
+  const itemName = (item as any)?.getName?.();
+
+  const { data: authData } = useQuery({
+    enabled: !!item,
+    queryKey: ['authEdit', itemName, itemClass?.apiName, itemClass?.apiVersion],
+    queryFn: async () => {
+      try {
+        const [update, patch] = await Promise.all([
+          item!.getAuthorization('update', {}, (item as any).cluster),
+          item!.getAuthorization('patch', {}, (item as any).cluster),
+        ]);
+        return { allowed: update?.status?.allowed || patch?.status?.allowed };
+      } catch (e: any) {
+        console.error(`Error while getting authorization for edit button in ${item}:`, e);
+        setIsReadOnly(true);
+        return { allowed: false };
+      }
+    },
+  });
+
+  React.useEffect(() => {
+    if (authData !== undefined) {
+      setIsReadOnly(!authData.allowed);
+    }
+  }, [authData]);
+
   if (isReadOnly) {
     return <ViewButton item={item} />;
   }
 
+  if (!authData) {
+    return null;
+  }
+
+  if (!authData.allowed) {
+    return null;
+  }
+
   return (
-    <AuthVisible
-      item={item}
-      authVerb="update"
-      onError={(err: Error) => {
-        console.error(`Error while getting authorization for edit button in ${item}:`, err);
-        setIsReadOnly(true);
-      }}
-      onAuthResult={({ allowed }) => {
-        setIsReadOnly(!allowed);
-      }}
-    >
+    <>
       <ActionButton
         description={t('translation|Edit')}
         buttonStyle={buttonStyle}
@@ -219,6 +244,6 @@ export default function EditButton(props: EditButtonProps) {
         }}
         icon="mdi:pencil"
       />
-    </AuthVisible>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
When a user has \patch\ verb on namespaces but not \update\, the edit pencil was hidden because EditButton only checked for \update\ permission.

## Related Issue
Fixes #4882

## What changed
- Modified EditButton.tsx to check both \update\ and \patch\ verbs using a single useQuery with Promise.all
- Removed the single-verb AuthVisible wrapper in favor of a combined auth check
- Added EditButton.test.tsx with 4 tests covering all verb combinations

## Why this approach
Patch-only RBAC is a valid and commonly used least-privilege setup. The existing AuthVisible component only supports a single verb, so the simplest correct fix was to check both verbs directly in EditButton.

## Testing done
- npm run frontend:test — 76 tests pass (14 test files)
- npm run frontend:lint — clean
- All 4 new EditButton tests pass, including the critical case: user with \patch\ but no \update\ now sees the edit button