### PR TITLE
frontend: Fix Events table crash when event has no source field

### DIFF
--- a/frontend/src/components/common/ObjectEventList.tsx
+++ b/frontend/src/components/common/ObjectEventList.tsx
@@ -82,7 +82,7 @@ export default function ObjectEventList(props: ObjectEventListProps) {
           {
             label: t('From'),
             getter: item => {
-              return item.source.component;
+              return item.source?.component ?? '';
             },
           },
           {


### PR DESCRIPTION
## Summary

Events table crashes with TypeError when an event has no \source\ field (common with newer Kubernetes event APIs).

## Related Issue
Fixes #5823

## What changed
Added optional chaining to \item.source?.component\ in ObjectEventList.tsx's \From\ column getter.

## Testing done
- npm run frontend:test — 103 tests pass (19 files)
- npm run frontend:lint — clean

## Checklist
- [x] Lint/format passes
- [x] Linked issue referenced
- [x] No unrelated changes bundled in