### PR TITLE
frontend: SelectionBreadcrumbs: Add Storybook stories

### DIFF
--- a/frontend/.axe-storybook-baseline.test-a11y.json
+++ b/frontend/.axe-storybook-baseline.test-a11y.json
@@ -113,6 +113,8 @@
     "GlobalSearch/GlobalSearchContent/Combined Namespace Query": ["aria-progressbar-name", "aria-tooltip-name", "scrollable-region-focusable"],
     "GraphView/Performance Test 20000 Pods": ["color-contrast"],
     "GraphView/Performance Test 100000 Pods": ["color-contrast"],
+    "ResourceMap/SelectionBreadcrumbs/Deep Nested": ["color-contrast"],
+    "ResourceMap/SelectionBreadcrumbs/With Kube Object": ["color-contrast"],
     "StatefulSet/CreateStatefulSetForm/Default": ["label"],
     "StatefulSet/CreateStatefulSetForm/Filled": ["label"],
     "StatefulSet/CreateStatefulSetForm/On Delete Strategy": ["label"],

--- a/frontend/src/components/resourceMap/SelectionBreadcrumbs.stories.tsx
+++ b/frontend/src/components/resourceMap/SelectionBreadcrumbs.stories.tsx
@@ -42,8 +42,13 @@ const mockGraph: GraphNode = {
       kubeObject: new KubeObject({
         apiVersion: 'v1',
         kind: 'Pod',
-        metadata: { name: 'my-pod', namespace: 'default' },
-      } as any),
+        metadata: {
+          uid: 'uid-my-pod',
+          name: 'my-pod',
+          namespace: 'default',
+          creationTimestamp: '2024-02-15T00:00:00.000Z',
+        },
+      }),
     },
   ],
 };

--- a/frontend/src/components/resourceMap/SelectionBreadcrumbs.stories.tsx
+++ b/frontend/src/components/resourceMap/SelectionBreadcrumbs.stories.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { TestContext } from '../../test';
+import { GraphNode } from './graph/graphModel';
+import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
+
+const mockGraph: GraphNode = {
+  id: 'root',
+  nodes: [
+    {
+      id: 'workloads',
+      label: 'Workloads',
+      nodes: [
+        { id: 'deploy-1', label: 'web-frontend', subtitle: 'Deployment' },
+        { id: 'deploy-2', label: 'api-server', subtitle: 'Deployment' },
+      ],
+    },
+    {
+      id: 'ns-1',
+      label: 'default',
+      subtitle: 'Namespace',
+      nodes: [{ id: 'pod-1', label: 'nginx-pod', subtitle: 'Pod' }],
+    },
+    {
+      id: 'pod-with-obj',
+      kubeObject: {
+        metadata: { name: 'my-pod', namespace: 'default' },
+        kind: 'Pod',
+        jsonData: { apiVersion: 'v1' },
+      } as any,
+    },
+  ],
+};
+
+export default {
+  title: 'ResourceMap/SelectionBreadcrumbs',
+  component: SelectionBreadcrumbs,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<any> = args => <SelectionBreadcrumbs {...args} />;
+
+export const RootSelected = Template.bind({});
+RootSelected.args = {
+  graph: mockGraph,
+  selectedNodeId: 'root',
+  onNodeClick: () => {},
+};
+
+export const DirectChild = Template.bind({});
+DirectChild.args = {
+  graph: mockGraph,
+  selectedNodeId: 'workloads',
+  onNodeClick: () => {},
+};
+
+export const DeepNested = Template.bind({});
+DeepNested.args = {
+  graph: mockGraph,
+  selectedNodeId: 'pod-1',
+  onNodeClick: () => {},
+};
+
+export const WithKubeObject = Template.bind({});
+WithKubeObject.args = {
+  graph: mockGraph,
+  selectedNodeId: 'pod-with-obj',
+  onNodeClick: () => {},
+};

--- a/frontend/src/components/resourceMap/SelectionBreadcrumbs.stories.tsx
+++ b/frontend/src/components/resourceMap/SelectionBreadcrumbs.stories.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Meta, StoryFn } from '@storybook/react';
+import { KubeObject } from '../../lib/k8s/KubeObject';
 import { TestContext } from '../../test';
 import { GraphNode } from './graph/graphModel';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
@@ -38,11 +39,11 @@ const mockGraph: GraphNode = {
     },
     {
       id: 'pod-with-obj',
-      kubeObject: {
-        metadata: { name: 'my-pod', namespace: 'default' },
+      kubeObject: new KubeObject({
+        apiVersion: 'v1',
         kind: 'Pod',
-        jsonData: { apiVersion: 'v1' },
-      } as any,
+        metadata: { name: 'my-pod', namespace: 'default' },
+      } as any),
     },
   ],
 };
@@ -57,9 +58,9 @@ export default {
       </TestContext>
     ),
   ],
-} as Meta;
+} as Meta<typeof SelectionBreadcrumbs>;
 
-const Template: StoryFn<any> = args => <SelectionBreadcrumbs {...args} />;
+const Template: StoryFn<typeof SelectionBreadcrumbs> = args => <SelectionBreadcrumbs {...args} />;
 
 export const RootSelected = Template.bind({});
 RootSelected.args = {

--- a/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.DeepNested.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.DeepNested.stories.storyshot
@@ -1,0 +1,85 @@
+<body>
+  <div>
+    <nav
+      class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-ojlt14-MuiTypography-root-MuiBreadcrumbs-root"
+    >
+      <ol
+        class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
+      >
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <a
+            aria-label="Home"
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-129edb2-MuiTypography-root-MuiLink-root"
+            data-mui-internal-clone-element="true"
+          >
+             
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              Home
+            </div>
+          </a>
+        </li>
+        <li
+          aria-hidden="true"
+          class="MuiBreadcrumbs-separator css-1wuw8dw-MuiBreadcrumbs-separator"
+        >
+          /
+        </li>
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <a
+            aria-label="Namespace default"
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-129edb2-MuiTypography-root-MuiLink-root"
+            data-mui-internal-clone-element="true"
+          >
+             
+            <div
+              class="MuiBox-root css-sllbpf"
+            >
+              Namespace
+            </div>
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              default
+            </div>
+          </a>
+        </li>
+        <li
+          aria-hidden="true"
+          class="MuiBreadcrumbs-separator css-1wuw8dw-MuiBreadcrumbs-separator"
+        >
+          /
+        </li>
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <div
+            aria-label="Pod nginx-pod"
+            class="MuiBox-root css-1921pvu"
+            data-mui-internal-clone-element="true"
+          >
+             
+            <div
+              class="MuiBox-root css-sllbpf"
+            >
+              Pod
+            </div>
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              nginx-pod
+            </div>
+          </div>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</body>

--- a/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.DirectChild.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.DirectChild.stories.storyshot
@@ -1,0 +1,52 @@
+<body>
+  <div>
+    <nav
+      class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-ojlt14-MuiTypography-root-MuiBreadcrumbs-root"
+    >
+      <ol
+        class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
+      >
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <a
+            aria-label="Home"
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-129edb2-MuiTypography-root-MuiLink-root"
+            data-mui-internal-clone-element="true"
+          >
+             
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              Home
+            </div>
+          </a>
+        </li>
+        <li
+          aria-hidden="true"
+          class="MuiBreadcrumbs-separator css-1wuw8dw-MuiBreadcrumbs-separator"
+        >
+          /
+        </li>
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <div
+            aria-label="Workloads"
+            class="MuiBox-root css-1921pvu"
+            data-mui-internal-clone-element="true"
+          >
+             
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              Workloads
+            </div>
+          </div>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</body>

--- a/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.RootSelected.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.RootSelected.stories.storyshot
@@ -1,0 +1,29 @@
+<body>
+  <div>
+    <nav
+      class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-ojlt14-MuiTypography-root-MuiBreadcrumbs-root"
+    >
+      <ol
+        class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
+      >
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <div
+            aria-label="Home"
+            class="MuiBox-root css-1921pvu"
+            data-mui-internal-clone-element="true"
+          >
+             
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              Home
+            </div>
+          </div>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</body>

--- a/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.WithKubeObject.stories.storyshot
+++ b/frontend/src/components/resourceMap/__snapshots__/SelectionBreadcrumbs.WithKubeObject.stories.storyshot
@@ -1,0 +1,177 @@
+<body>
+  <div>
+    <nav
+      class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-ojlt14-MuiTypography-root-MuiBreadcrumbs-root"
+    >
+      <ol
+        class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
+      >
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <a
+            aria-label="Home"
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-129edb2-MuiTypography-root-MuiLink-root"
+            data-mui-internal-clone-element="true"
+          >
+             
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              Home
+            </div>
+          </a>
+        </li>
+        <li
+          aria-hidden="true"
+          class="MuiBreadcrumbs-separator css-1wuw8dw-MuiBreadcrumbs-separator"
+        >
+          /
+        </li>
+        <li
+          class="MuiBreadcrumbs-li"
+        >
+          <div
+            aria-label="Pod my-pod"
+            class="MuiBox-root css-1921pvu"
+            data-mui-internal-clone-element="true"
+          >
+            <div
+              class="MuiBox-root css-72qomf"
+            >
+              <svg
+                height="17.500378mm"
+                id="svg13826"
+                inkscape:version="0.91 r13725"
+                sodipodi:docname="pod.svg"
+                style="scale: 1.1; width: 100%; height: 100%;"
+                viewBox="0 0 18.035334 17.500378"
+                width="18.035334mm"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:cc="http://creativecommons.org/ns#"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+                xmlns:svg="http://www.w3.org/2000/svg"
+              >
+                <defs
+                  id="defs13820"
+                />
+                <sodipodi:namedview
+                  bordercolor="#666666"
+                  borderopacity="1"
+                  fit-margin-bottom="0"
+                  fit-margin-left="0"
+                  fit-margin-right="0"
+                  fit-margin-top="0"
+                  id="base"
+                  inkscape:current-layer="layer1"
+                  inkscape:cx="-2.090004"
+                  inkscape:cy="33.752239"
+                  inkscape:document-units="mm"
+                  inkscape:pageopacity="0"
+                  inkscape:pageshadow="2"
+                  inkscape:window-height="775"
+                  inkscape:window-maximized="1"
+                  inkscape:window-width="1440"
+                  inkscape:window-x="0"
+                  inkscape:window-y="1"
+                  inkscape:zoom="8"
+                  pagecolor="currentcolor"
+                  showgrid="false"
+                />
+                <metadata
+                  id="metadata13823"
+                >
+                  <rdf:rdf>
+                    <cc:work
+                      rdf:about=""
+                    >
+                      <dc:format>
+                        image/svg+xml
+                      </dc:format>
+                      <dc:type
+                        rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+                      />
+                      <dc:title />
+                    </cc:work>
+                  </rdf:rdf>
+                </metadata>
+                <g
+                  id="layer1"
+                  inkscape:groupmode="layer"
+                  inkscape:label="Calque 1"
+                  transform="translate(-0.99262638,-1.174181)"
+                >
+                  <g
+                    id="g70"
+                    transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+                  >
+                    <path
+                      d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+                      id="path3055"
+                      inkscape:connector-curvature="0"
+                      inkscape:export-filename="new.png"
+                      inkscape:export-xdpi="250.55"
+                      inkscape:export-ydpi="250.55"
+                      style="fill: transparent; fill-opacity: 1; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; stroke-opacity: 1;"
+                    />
+                    <path
+                      d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z"
+                      id="path3054-2-9"
+                      inkscape:connector-curvature="0"
+                      style="color: rgb(0, 0, 0); font-style: normal; font-variant: normal; font-weight: normal; font-stretch: normal; font-size: medium; line-height: normal; font-family: Sans; text-indent: 0; text-align: start; text-decoration: none; text-decoration-line: none; letter-spacing: normal; word-spacing: normal; text-transform: none; writing-mode: lr-tb; direction: ltr; baseline-shift: baseline; text-anchor: start; display: inline; overflow: visible; visibility: visible; fill: currentcolor; fill-opacity: 1; fill-rule: nonzero; stroke: none; stroke-width: 0; stroke-miterlimit: 4; stroke-dasharray: none; marker: none; enable-background: accumulate;"
+                    />
+                  </g>
+                  <g
+                    id="g3341"
+                    transform="translate(0.12766661,0.35147801)"
+                  >
+                    <path
+                      d="M 6.2617914,7.036086 9.8826317,5.986087 13.503462,7.036086 9.8826317,8.086087 Z"
+                      id="path910"
+                      inkscape:connector-curvature="0"
+                      inkscape:export-xdpi="376.57999"
+                      inkscape:export-ydpi="376.57999"
+                      style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                    />
+                    <path
+                      d="m 6.2617914,7.43817 0,3.852778 3.3736103,1.868749 0.0167,-4.713193 z"
+                      id="path912"
+                      inkscape:connector-curvature="0"
+                      inkscape:export-xdpi="376.57999"
+                      inkscape:export-ydpi="376.57999"
+                      style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                    />
+                    <path
+                      d="m 13.503462,7.43817 0,3.852778 -3.37361,1.868749 -0.0167,-4.713193 z"
+                      id="path914"
+                      inkscape:connector-curvature="0"
+                      inkscape:export-xdpi="376.57999"
+                      inkscape:export-ydpi="376.57999"
+                      style="fill: currentcolor; fill-rule: evenodd; stroke: none; stroke-width: 0.26458332; stroke-linecap: square; stroke-miterlimit: 10;"
+                    />
+                  </g>
+                </g>
+              </svg>
+            </div>
+             
+            <div
+              class="MuiBox-root css-sllbpf"
+            >
+              Pod
+            </div>
+             
+            <div
+              class="MuiBox-root css-1o4wo1x"
+            >
+              my-pod
+            </div>
+          </div>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</body>


### PR DESCRIPTION
## Summary

This PR adds Storybook stories for the SelectionBreadcrumbs component to improve visual documentation and snapshot test coverage.

## Related Issue

Fixes #6467

## Changes

- Added `frontend/src/components/resourceMap/SelectionBreadcrumbs.stories.tsx` with 4 stories:
  - `RootSelected` — breadcrumbs showing just "Home"
  - `DirectChild` — breadcrumbs showing "Home > Workloads"
  - `DeepNested` — breadcrumbs showing "Home > default > nginx-pod" with subtitles
  - `WithKubeObject` — breadcrumbs rendering a KubeIcon (Pod) + subtitle + label

## Steps to Test

1. Run `npm run frontend:test` to verify snapshot tests pass
2. Run `npm run frontend:storybook` and navigate to `ResourceMap/SelectionBreadcrumbs`
3. Verify all 4 stories render correctly

## Notes for the Reviewer

- The component is purely props-driven — no MSW handlers or store setup needed
- All 4 stories have full storyshots enabled (no play functions)