### PR TITLE
frontend: plugins: reject on non-ok main.js response

### DIFF
--- a/frontend/src/plugin/fetchAndExecutePlugins.test.ts
+++ b/frontend/src/plugin/fetchAndExecutePlugins.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { fetchAndExecutePlugins } from './index';
+
+describe('fetchAndExecutePlugins — main.js response handling', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('rejects instead of treating a non-ok main.js response as plugin source', async () => {
+    const pluginMetadata = [{ path: 'plugins/broken-plugin', type: 'user', name: 'broken-plugin' }];
+
+    global.fetch = vi.fn((url: RequestInfo | URL) => {
+      const urlStr = String(url);
+
+      if (urlStr.endsWith('/plugins')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(pluginMetadata),
+        } as Response);
+      }
+
+      if (urlStr.includes('/main.js')) {
+        // Simulate the backend returning an error page instead of the file.
+        return Promise.resolve({
+          ok: false,
+          status: 502,
+          text: () => Promise.resolve('<html><body>502 Bad Gateway</body></html>'),
+        } as Response);
+      }
+
+      if (urlStr.includes('/package.json')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ name: 'broken-plugin', version: '1.0.0' }),
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch to ${urlStr}`));
+    }) as typeof fetch;
+
+    // Before the fix, this would resolve successfully with the HTML error
+    // page as the plugin's source, which then got executed as JavaScript.
+    // Now it should reject, so the caller (Plugins.tsx) can show a proper
+    // "failed to load plugins" error instead of a confusing SyntaxError.
+    await expect(
+      fetchAndExecutePlugins(
+        [],
+        () => {},
+        () => {}
+      )
+    ).rejects.toThrow(/Failed to fetch plugin main\.js/);
+  });
+});

--- a/frontend/src/plugin/index.ts
+++ b/frontend/src/plugin/index.ts
@@ -456,9 +456,14 @@ export async function fetchAndExecutePlugins(
 
   const sourcesPromise = Promise.all(
     pluginPaths.map(path =>
-      fetch(`${getAppUrl()}${path}/main.js`, { headers: new Headers(headers) }).then(resp =>
-        resp.text()
-      )
+      fetch(`${getAppUrl()}${path}/main.js`, { headers: new Headers(headers) }).then(resp => {
+        if (!resp.ok) {
+          throw new Error(
+            `Failed to fetch plugin main.js for ${path}: HTTP ${resp.status} ${resp.statusText}`
+          );
+        }
+        return resp.text();
+      })
     )
   );
 


### PR DESCRIPTION
## Summary

fetchAndExecutePlugins fetches each plugin's main.js and passes the response body straight to resp.text(), with no check that the request actually succeeded. If the backend returns an error response instead of the file (a 502 from a proxy, the server restarting mid-load, whatever), the error page's HTML gets treated as the plugin's source code and handed to runPlugin, which executes it via new Function(source). That throws a SyntaxError since HTML obviously isn't valid JS, and it escapes runPlugin uncaught because that call sits outside its try/catch.

So users just see a confusing SyntaxError that looks like a broken plugin, when the real issue is the server never returned the file in the first place.

This checks resp.ok before reading the body, same as the package.json fetch a few lines below already does, and rejects on failure instead of blindly executing whatever came back.

## Related Issue

Fixes #6454

## Changes

- frontend/src/plugin/index.ts: added a resp.ok check on the main.js fetch, rejecting on failure instead of passing the response through to resp.text()
- frontend/src/plugin/fetchAndExecutePlugins.test.ts: new test mocking a non-ok main.js response, asserting fetchAndExecutePlugins rejects instead of silently continuing with the error body as source

## Steps to Test

1. Point a plugin's main.js request at something that returns a non-200 (e.g. stick a proxy in front that 502s, or kill the plugin server mid-load)
2. Load Headlamp
3. Before this change: plugin fails with SyntaxError: Unexpected token '<'. After: the fetch rejects and gets caught by the existing plugin load error handling instead

## Screenshots (if applicable)

N/A — error handling change, nothing visual.

## Notes for the Reviewer

I only touched the main.js fetch, not the package.json one below it (that one already has its own resp.ok handling with different 404 logic, so I left it alone).
