### PR TITLE
app: plugin-manager: guard against malformed JSON in IPC handler

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -265,7 +265,15 @@ class PluginManagerEventListeners {
    */
   setupEventHandlers() {
     ipcMain.on('plugin-manager', async (event, data) => {
-      const eventData = JSON.parse(data) as Action;
+      let eventData: Action;
+
+      try {
+        eventData = JSON.parse(data) as Action;
+      } catch (error) {
+        console.error('plugin-manager: failed to parse event data as JSON:', error);
+        return;
+      }
+
       const { identifier, action } = eventData;
       const updateCache = (progress: ProgressResp) => {
         const percentage = this.convertProgressToPercentage(progress);


### PR DESCRIPTION
## Summary

The plugin-manager IPC handler parses the incoming event data with JSON.parse and no try/catch. Since the handler is async, a parse failure turns into an unhandled promise rejection in the Electron main process instead of a caught error — nothing tells the renderer that sent the message what went wrong.

In normal operation the frontend always sends well-formed JSON, so this doesn't fire during regular use. But an IPC handler shouldn't be able to take down the main process on bad input, and every other handler in this file already wraps its work in try/catch — this one was just missing the same guard.

This wraps the JSON.parse call in try/catch, logs the failure, and returns early instead of letting the exception escape uncaught.

## Related Issue

Fixes #6456

## Changes

- app/electron/main.ts: wrapped JSON.parse in the plugin-manager IPC handler in try/catch, logging and returning early on failure instead of letting it throw unhandled

## Steps to Test

1. Trigger the plugin-manager IPC channel with a non-JSON payload (e.g. from devtools: ipcRenderer.send('plugin-manager', 'not-json'))
2. Before this change: JSON.parse throws inside the async handler, which becomes an unhandled promise rejection in the main process
3. After this change: the error is caught, logged to the console, and the handler returns cleanly — no crash

## Screenshots (if applicable)

N/A — error handling change, nothing visual.

## Notes for the Reviewer

I didn't add an automated test for this one. main.ts pulls in electron, yargs, MCPClient and a handful of other modules with real side effects at import time, and nothing else in this codebase imports main.ts directly in a test — so mocking all of that just for this one handler felt like more risk than it was worth. Happy to add one if you'd rather have it, just let me know what approach you'd prefer.
