### PR TITLE
app: validate resolved path in open-plugin-folder before opening it

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -51,6 +51,7 @@ import {
   defaultUserPluginsDir,
   getMatchingExtraFiles,
   getPluginBinDirectories,
+  isPathWithinDirectory,
   PluginManager,
 } from './plugin-management';
 import {
@@ -1801,21 +1802,44 @@ function startElectron() {
         event: IpcMainEvent,
         pluginInfo: { folderName: string; type: 'development' | 'user' | 'shipped' }
       ) => {
-        let folderPath: string | null = null;
+        // The IPC payload comes from the renderer and isn't trusted.
+        if (!pluginInfo || typeof pluginInfo.folderName !== 'string') {
+          return;
+        }
+
+        let baseDir: string | null = null;
 
         if (pluginInfo.type === 'user') {
-          folderPath = path.join(defaultUserPluginsDir(), pluginInfo.folderName);
+          baseDir = defaultUserPluginsDir();
         } else if (pluginInfo.type === 'development') {
-          folderPath = path.join(defaultPluginsDir(), pluginInfo.folderName);
+          baseDir = defaultPluginsDir();
         } else if (pluginInfo.type === 'shipped') {
-          folderPath = path.join(process.resourcesPath, '.plugins', pluginInfo.folderName);
+          baseDir = path.join(process.resourcesPath, '.plugins');
         }
 
-        if (folderPath) {
-          shell.openPath(folderPath).catch((err: Error) => {
-            console.error('Failed to open plugin folder:', err);
-          });
+        if (!baseDir) {
+          return;
         }
+
+        const folderPath = path.join(baseDir, pluginInfo.folderName);
+
+        // pluginInfo.folderName comes from the renderer and isn't trusted, so
+        // make sure the resolved path still lives inside the expected plugin
+        // directory before opening it. Without this, a folderName like
+        // "../../../../etc" would resolve outside baseDir entirely, and
+        // shell.openPath would open (or, for a file, launch) whatever it lands on.
+        if (!isPathWithinDirectory(baseDir, folderPath)) {
+          console.error(`Refusing to open plugin folder outside of ${baseDir}: ${folderPath}`);
+          return;
+        }
+
+        // shell.openPath resolves with an error message string on failure
+        // rather than rejecting, so check the resolved value.
+        shell.openPath(folderPath).then((errMsg: string) => {
+          if (errMsg) {
+            console.error('Failed to open plugin folder:', errMsg);
+          }
+        });
       }
     );
 

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -57,6 +57,8 @@ import {
   defaultUserPluginsDir,
   getMatchingExtraFiles,
   getPluginBinDirectories,
+  isExistingDirectory,
+  isPathWithinDirectory,
   PluginManager,
   setAppConfigDirName,
 } from './plugin-management';
@@ -1818,21 +1820,53 @@ function startElectron() {
         event: IpcMainEvent,
         pluginInfo: { folderName: string; type: 'development' | 'user' | 'shipped' }
       ) => {
-        let folderPath: string | null = null;
+        // The IPC payload comes from the renderer and isn't trusted.
+        if (!pluginInfo || typeof pluginInfo.folderName !== 'string') {
+          return;
+        }
+
+        let baseDir: string | null = null;
 
         if (pluginInfo.type === 'user') {
-          folderPath = path.join(defaultUserPluginsDir(), pluginInfo.folderName);
+          baseDir = defaultUserPluginsDir();
         } else if (pluginInfo.type === 'development') {
-          folderPath = path.join(defaultPluginsDir(), pluginInfo.folderName);
+          baseDir = defaultPluginsDir();
         } else if (pluginInfo.type === 'shipped') {
-          folderPath = path.join(process.resourcesPath, '.plugins', pluginInfo.folderName);
+          baseDir = path.join(process.resourcesPath, '.plugins');
         }
 
-        if (folderPath) {
-          shell.openPath(folderPath).catch((err: Error) => {
-            console.error('Failed to open plugin folder:', err);
-          });
+        if (!baseDir) {
+          return;
         }
+
+        const folderPath = path.join(baseDir, pluginInfo.folderName);
+
+        // pluginInfo.folderName comes from the renderer and isn't trusted, so
+        // make sure the resolved path still lives inside the expected plugin
+        // directory before opening it. Without this, a folderName like
+        // "../../../../etc" would resolve outside baseDir entirely, and
+        // shell.openPath would open (or, for a file, launch) whatever it lands on.
+        if (!isPathWithinDirectory(baseDir, folderPath)) {
+          console.error(`Refusing to open plugin folder outside of ${baseDir}: ${folderPath}`);
+          return;
+        }
+
+        // Staying inside the plugins directory is not enough: a folderName like
+        // "some-plugin/bin/tool.exe" resolves to a file in there, and
+        // shell.openPath launches a file with its OS handler instead of showing
+        // it. This channel opens folders, so refuse anything else.
+        if (!isExistingDirectory(folderPath)) {
+          console.error(`Refusing to open plugin path that is not a directory: ${folderPath}`);
+          return;
+        }
+
+        // shell.openPath resolves with an error message string on failure
+        // rather than rejecting, so check the resolved value.
+        shell.openPath(folderPath).then((errMsg: string) => {
+          if (errMsg) {
+            console.error('Failed to open plugin folder:', errMsg);
+          }
+        });
       }
     );
 

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -27,8 +27,7 @@ import os from 'os';
 import path from 'path';
 import * as tar from 'tar';
 import { describe, expect, it, vi } from 'vitest';
-import { PluginManager } from './plugin-management';
-import { getExtraFiles } from './plugin-management';
+import { getExtraFiles, isPathWithinDirectory, PluginManager } from './plugin-management';
 
 const TEST_DATA_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-data');
 const PLUGIN_DEST_BASE_DIR = path.join(os.tmpdir(), 'headlamp-test-plugins');
@@ -671,4 +670,36 @@ describe('TLS error detection', () => {
       }
     }
   }, 30000);
+});
+
+describe('isPathWithinDirectory', () => {
+  const baseDir = path.join(os.tmpdir(), 'headlamp-plugins-test-base');
+
+  it('allows a normal plugin folder name', () => {
+    const target = path.join(baseDir, 'headlamp-my-plugin');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(true);
+  });
+
+  it('allows a nested subdirectory', () => {
+    const target = path.join(baseDir, 'sub', 'plugin');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(true);
+  });
+
+  it('allows a folder name that starts with ..', () => {
+    const target = path.join(baseDir, '..foo');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(true);
+  });
+
+  it('rejects a folder name that traverses outside the base directory', () => {
+    const target = path.join(baseDir, '..', '..', '..', 'etc');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(false);
+  });
+
+  it('rejects the base directory itself', () => {
+    expect(isPathWithinDirectory(baseDir, baseDir)).toBe(false);
+  });
+
+  it('rejects an unrelated absolute path', () => {
+    expect(isPathWithinDirectory(baseDir, '/etc/passwd')).toBe(false);
+  });
 });

--- a/app/electron/plugin-management.test.ts
+++ b/app/electron/plugin-management.test.ts
@@ -33,6 +33,8 @@ import {
   defaultPluginsDir,
   defaultUserPluginsDir,
   getExtraFiles,
+  isExistingDirectory,
+  isPathWithinDirectory,
   PluginManager,
   setAppConfigDirName,
 } from './plugin-management';
@@ -750,4 +752,69 @@ describe('TLS error detection', () => {
       }
     }
   }, 30000);
+});
+
+describe('isPathWithinDirectory', () => {
+  const baseDir = path.join(os.tmpdir(), 'headlamp-plugins-test-base');
+
+  it('allows a normal plugin folder name', () => {
+    const target = path.join(baseDir, 'headlamp-my-plugin');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(true);
+  });
+
+  it('allows a nested subdirectory', () => {
+    const target = path.join(baseDir, 'sub', 'plugin');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(true);
+  });
+
+  it('allows a folder name that starts with ..', () => {
+    const target = path.join(baseDir, '..foo');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(true);
+  });
+
+  it('rejects a folder name that traverses outside the base directory', () => {
+    const target = path.join(baseDir, '..', '..', '..', 'etc');
+    expect(isPathWithinDirectory(baseDir, target)).toBe(false);
+  });
+
+  it('rejects the base directory itself', () => {
+    expect(isPathWithinDirectory(baseDir, baseDir)).toBe(false);
+  });
+
+  it('rejects an unrelated absolute path', () => {
+    expect(isPathWithinDirectory(baseDir, '/etc/passwd')).toBe(false);
+  });
+});
+
+// Containment is not enough on its own: a name can resolve to a file inside the
+// plugins directory, and shell.openPath launches a file rather than showing it.
+describe('isExistingDirectory', () => {
+  const baseDir = getUniqueTestDir(TEST_DATA_BASE_DIR, 'is-existing-directory');
+
+  afterEach(() => {
+    if (fs.existsSync(baseDir)) {
+      fs.rmSync(baseDir, { recursive: true });
+    }
+  });
+
+  it('accepts a directory', () => {
+    const pluginDir = path.join(baseDir, 'headlamp-my-plugin');
+    fs.mkdirSync(pluginDir, { recursive: true });
+
+    expect(isExistingDirectory(pluginDir)).toBe(true);
+  });
+
+  it('rejects a file', () => {
+    const binDir = path.join(baseDir, 'headlamp-my-plugin', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+
+    const binary = path.join(binDir, 'tool');
+    fs.writeFileSync(binary, 'binary');
+
+    expect(isExistingDirectory(binary)).toBe(false);
+  });
+
+  it('rejects a path that does not exist', () => {
+    expect(isExistingDirectory(path.join(baseDir, 'missing'))).toBe(false);
+  });
 });

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -1086,6 +1086,27 @@ export function defaultUserPluginsDir() {
 }
 
 /**
+ * Reports whether targetPath resolves to a location strictly inside baseDir.
+ *
+ * Used to validate renderer-supplied path segments (e.g. a plugin folder
+ * name) before they're used in filesystem operations, so a value like
+ * "../../../../etc" can't escape the intended directory.
+ *
+ * @param baseDir - The directory targetPath is expected to stay within.
+ * @param targetPath - The resolved path to check.
+ * @returns {boolean} True if targetPath is a strict subpath of baseDir.
+ */
+export function isPathWithinDirectory(baseDir: string, targetPath: string): boolean {
+  const relative = path.relative(baseDir, targetPath);
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+/**
  * Checks if a given folder is a valid plugin bin folder.
  *
  * @param {string} folder - The path to the folder to check. Should not include /bin in the path.

--- a/app/electron/plugin-management.ts
+++ b/app/electron/plugin-management.ts
@@ -1120,6 +1120,46 @@ export function defaultKubeConfigsDir(): string {
 }
 
 /**
+ * Reports whether targetPath resolves to a location strictly inside baseDir.
+ *
+ * Used to validate renderer-supplied path segments (e.g. a plugin folder
+ * name) before they're used in filesystem operations, so a value like
+ * "../../../../etc" can't escape the intended directory.
+ *
+ * @param baseDir - The directory targetPath is expected to stay within.
+ * @param targetPath - The resolved path to check.
+ * @returns {boolean} True if targetPath is a strict subpath of baseDir.
+ */
+export function isPathWithinDirectory(baseDir: string, targetPath: string): boolean {
+  const relative = path.relative(baseDir, targetPath);
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+/**
+ * Reports whether targetPath is an existing directory.
+ *
+ * Used before handing a path to shell.openPath, which opens a directory in the
+ * file manager but launches a file with its OS handler. Plugin directories hold
+ * binaries as well as sources, so "open this plugin's folder" has to refuse
+ * anything that is not a folder.
+ *
+ * @param targetPath - The path to check.
+ * @returns {boolean} True if targetPath exists and is a directory.
+ */
+export function isExistingDirectory(targetPath: string): boolean {
+  try {
+    return fs.statSync(targetPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks if a given folder is a valid plugin bin folder.
  *
  * @param {string} folder - The path to the folder to check. Should not include /bin in the path.


### PR DESCRIPTION
## Summary

The open-plugin-folder IPC handler joined the renderer-supplied folderName onto the plugins base directory and passed the result straight to shell.openPath, with no check that the joined path actually stayed inside that directory. A folderName like "../../../../etc" resolves outside the plugins folder entirely, and shell.openPath doesn't just browse directories - given a file path it opens that file with the OS's default handler, so this could end up launching something rather than just showing the wrong folder.

Added isPathWithinDirectory() in plugin-management.ts and used it to reject any resolved path that escapes the expected base directory before calling shell.openPath, logging the attempt instead.

## Related Issue

Fixes #6472

## Changes

- app/electron/plugin-management.ts: added isPathWithinDirectory(), a small helper that checks a resolved path stays inside a base directory
- app/electron/main.ts: use isPathWithinDirectory() in the open-plugin-folder handler, refusing shell.openPath if the resolved path escapes the plugins directory
- app/electron/plugin-management.test.ts: tests for isPathWithinDirectory covering a normal plugin folder, a nested subdirectory, a traversal attempt, the base directory itself, and an unrelated absolute path

## Steps to Test

1. Trigger the open-plugin-folder IPC channel with folderName set to something like ../../../../etc and a valid type (e.g. user)
2. Before this change, the handler joins the path and calls shell.openPath on whatever it resolves to, even outside the plugins folder
3. After this change, it logs "Refusing to open plugin folder outside of ..." and shell.openPath never gets called
4. A normal plugin folderName still opens fine like before

## Screenshots (if applicable)

N/A, this is a main-process validation change with nothing visual to show.

## Notes for the Reviewer

I pulled the check out into plugin-management.ts instead of leaving it inline in main.ts since that file already has test coverage, and nothing else in the codebase imports main.ts directly in a test (would mean mocking electron, yargs, dotenv, etc for basically no benefit).
