### PR TITLE
frontend: test: Fix mocker namespace interpolation

### DIFF
--- a/frontend/src/test/mocker.test.ts
+++ b/frontend/src/test/mocker.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { vi } from 'vitest';
+
+// Breaks mocker → KubeObject → util → node → KubeObject circular dep at module-load time.
+vi.mock('../lib/k8s/KubeObject', () => {
+  class KubeObject {
+    metadata: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+    }
+  }
+  return { KubeObject };
+});
+
+// node.ts imports the k8s barrel, re-triggering the same cycle.
+vi.mock('../lib/k8s', () => ({}));
+
+import { generateK8sResourceList } from './mocker';
+
+const baseMeta = { uid: '', creationTimestamp: '' };
+
+describe('generateK8sResourceList', () => {
+  it('interpolates {{i}} in namespace', () => {
+    const list = generateK8sResourceList({
+      kind: 'Pod',
+      apiVersion: 'v1',
+      metadata: { ...baseMeta, name: 'pod-{{i}}', namespace: 'ns-{{i}}' },
+    });
+
+    expect(list[0].metadata.namespace).toBe('ns-0');
+    expect(list[1].metadata.namespace).toBe('ns-1');
+    expect(list[2].metadata.namespace).toBe('ns-2');
+    expect(list[3].metadata.namespace).toBe('ns-3');
+    expect(list[4].metadata.namespace).toBe('ns-4');
+  });
+
+  it('does not leave literal {{i}} in namespace', () => {
+    const list = generateK8sResourceList({
+      kind: 'Pod',
+      apiVersion: 'v1',
+      metadata: { ...baseMeta, name: 'pod', namespace: 'ns-{{i}}' },
+    });
+
+    list.forEach(item => {
+      expect(item.metadata.namespace).not.toContain('{{i}}');
+    });
+  });
+
+  it('interpolates {{i}} in name', () => {
+    const list = generateK8sResourceList({
+      kind: 'Pod',
+      apiVersion: 'v1',
+      metadata: { ...baseMeta, name: 'pod-{{i}}' },
+    });
+
+    expect(list[0].metadata.name).toBe('pod-0');
+    expect(list[1].metadata.name).toBe('pod-1');
+  });
+
+  it('respects numResults', () => {
+    const list = generateK8sResourceList(
+      { kind: 'Pod', apiVersion: 'v1', metadata: { ...baseMeta, name: 'pod' } },
+      { numResults: 2 }
+    );
+
+    expect(list).toHaveLength(2);
+  });
+});

--- a/frontend/src/test/mocker.ts
+++ b/frontend/src/test/mocker.ts
@@ -62,7 +62,7 @@ export function generateK8sResourceList<
     }
 
     if (json.metadata.namespace !== undefined) {
-      json.metadata.namespace.replace('{{i}}', i.toString());
+      json.metadata.namespace = json.metadata.namespace.replace('{{i}}', i.toString());
       if (!json.metadata.namespace) {
         json.metadata.namespace = 'my-namespace';
       }


### PR DESCRIPTION
## Summary

This PR fixes a silent bug in `generateK8sResourceList` where `{{i}}` placeholders
in `metadata.namespace` were never replaced, and adds unit tests for the function
to prevent regressions.

## Related Issue

Fixes #6474

## Changes

- Fixed `frontend/src/test/mocker.ts`: assigned the `.replace()` result back so
  `{{i}}` in `metadata.namespace` is actually interpolated
- Added `frontend/src/test/mocker.test.ts`: 4 unit tests covering `{{i}}`
  interpolation in `metadata.name`, `{{i}}` interpolation in `metadata.namespace`,
  absence of literal `{{i}}` in output, and the `numResults` option

## Steps to Test

1. `cd frontend && npx vitest run src/test/mocker.test.ts`
2. Confirm all 4 tests pass
3. Optionally call `generateK8sResourceList` with `namespace: 'ns-{{i}}'` in any
   existing test and verify items now get distinct namespaces (`ns-0`, `ns-1`, …)
   instead of the literal `ns-{{i}}`

## Notes for the Reviewer

- The test file requires two `vi.mock` calls at the top to break a
  `mocker → KubeObject → util → node → KubeObject` circular import; without them
  `class Node extends KubeObject` evaluates while `KubeObject` is still `undefined`.
- No functional changes to any component or runtime path — only the shared test
  helper is affected.