### PR TITLE
frontend: SimpleTable: Fix pagination bug

### DIFF
--- a/frontend/src/components/common/SimpleTable.test.tsx
+++ b/frontend/src/components/common/SimpleTable.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@mui/material/styles';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { createMuiTheme } from '../../lib/themes';
+import { TestContext } from '../../test';
+import SimpleTable from './SimpleTable';
+
+const theme = createMuiTheme({ name: 'light', base: 'light' });
+
+describe('SimpleTable Component', () => {
+  it('correctly handles page boundaries and prevents empty pages', async () => {
+    const columns = [{ label: 'Name', datum: 'name' }];
+    const data = Array.from({ length: 10 }, (_, i) => ({ name: `Item ${i + 1}` }));
+
+    render(
+      <ThemeProvider theme={theme}>
+        <TestContext>
+          <SimpleTable columns={columns} data={data} page={1} rowsPerPage={[10]} />
+        </TestContext>
+      </ThemeProvider>
+    );
+
+    // If it corrected the page to 0, we should see "Item 1".
+    expect(await screen.findByText('Item 1')).toBeInTheDocument();
+    expect(await screen.findByText('Item 10')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/SimpleTable.test.tsx
+++ b/frontend/src/components/common/SimpleTable.test.tsx
@@ -16,11 +16,17 @@
 
 import { ThemeProvider } from '@mui/material/styles';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createMuiTheme } from '../../lib/themes';
 import { TestContext } from '../../test';
 import SimpleTable from './SimpleTable';
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('|')[1] || key,
+    i18n: { language: 'en' },
+  }),
+}));
 const theme = createMuiTheme({ name: 'light', base: 'light' });
 
 describe('SimpleTable Component', () => {

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -342,6 +342,7 @@ export default function SimpleTable(props: SimpleTableProps) {
     }
 
     if (
+      filterFunction &&
       (filteredData?.length === 0 || (filteredData?.length ?? 0) <= page * rowsPerPage) &&
       page !== 0
     ) {

--- a/frontend/src/components/common/SimpleTable.tsx
+++ b/frontend/src/components/common/SimpleTable.tsx
@@ -214,8 +214,8 @@ export default function SimpleTable(props: SimpleTableProps) {
       return;
     }
 
-    if (displayData && page * rowsPerPage > displayData.length) {
-      setPage(Math.floor(displayData.length / rowsPerPage));
+    if (displayData && page * rowsPerPage >= displayData.length) {
+      setPage(Math.max(0, Math.floor((displayData.length - 1) / rowsPerPage)));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page, displayData, rowsPerPage]);
@@ -342,7 +342,7 @@ export default function SimpleTable(props: SimpleTableProps) {
     }
 
     if (
-      (filteredData?.length === 0 || (filteredData?.length ?? 0) < page * rowsPerPage) &&
+      (filteredData?.length === 0 || (filteredData?.length ?? 0) <= page * rowsPerPage) &&
       page !== 0
     ) {
       setPage(0);


### PR DESCRIPTION
## Summary

Fixes a bug in  SimpleTable  where navigating to an empty page occurs when the total number of items is an exact multiple of the page size (e.g. exactly 10 items, viewing the second page).


## Related Issue

Fixes #6476

## Changes

- Updated page validation check in SimpleTable.tsx from  >  to  >=  to capture exact boundary alignments.
- Corrected the fallback page index calculation in SimpleTable.tsx to compute the maximum valid page index using Math.max(0, Math.floor((displayData.length - 1) / rowsPerPage)) .
- Updated the filtered data reset check in SimpleTable.tsx from  <  to  <=  to return the page index to  0  when filters matching exactly  page * rowsPerPage  items are applied.
- Added a new regression unit test in SimpleTable.test.tsx to verify correct page correction at page boundaries.
