### PR TITLE
frontend: Backlink: Remove redundant useffect hook

### DIFF
--- a/frontend/src/components/common/BackLink/BackLink.tsx
+++ b/frontend/src/components/common/BackLink/BackLink.tsx
@@ -17,7 +17,6 @@
 import { Icon } from '@iconify/react';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -30,9 +29,6 @@ export default function BackLink(props: BackLinkProps) {
   const { to: backLink = '' } = props;
   const { t } = useTranslation();
   const history = useHistory();
-
-  // We only want to update when the backLink changes (not the history).
-  React.useEffect(() => {}, [backLink]);
 
   return (
     <Button


### PR DESCRIPTION
## Summary

This PR removes a redundant empty  useEffect  hook in the  BackLink  component.

## Related Issue

Fixes #6478

## Changes

Removed the dead React.useEffect(() => {}, [backLink]); hook from `BackLink.tsx`.
