### PR TITLE
frontend: OauthPopup: Fix stale closures on auth completion

### DIFF
--- a/frontend/src/components/oidcauth/OauthPopup.test.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.test.tsx
@@ -147,6 +147,7 @@ describe('OauthPopup', () => {
     } as unknown as Window;
 
     vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
     const initialOnCode = vi.fn();
 
     const { rerender } = render(
@@ -173,6 +174,11 @@ describe('OauthPopup', () => {
         Open Auth Popup
       </OauthPopup>
     );
+
+    const storageListener = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'storage'
+    )?.[1];
+    expect(storageListener).toBeTypeOf('function');
 
     localStorage.setItem(AUTH_STATUS_KEY, 'code=oauth-code');
     window.dispatchEvent(new StorageEvent('storage'));

--- a/frontend/src/components/oidcauth/OauthPopup.test.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.test.tsx
@@ -138,4 +138,92 @@ describe('OauthPopup', () => {
     );
     expect(popupWindow.close).toHaveBeenCalled();
   });
+
+  it('uses the latest onCode callback when the component re-renders and auth completes', () => {
+    const popupWindow = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+    const initialOnCode = vi.fn();
+
+    const { rerender } = render(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={initialOnCode}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+    const newOnCode = vi.fn();
+    rerender(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={newOnCode}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    localStorage.setItem(AUTH_STATUS_KEY, 'code=oauth-code');
+    window.dispatchEvent(new StorageEvent('storage'));
+
+    expect(initialOnCode).not.toHaveBeenCalled();
+    expect(newOnCode).toHaveBeenCalledWith('code=oauth-code');
+  });
+
+  it('uses the latest onClose callback when the component re-renders and the popup is closed manually', () => {
+    const popupListeners: Record<string, () => void> = {};
+    const popupWindow = {
+      addEventListener: vi.fn((eventName: string, listener: () => void) => {
+        popupListeners[eventName] = listener;
+      }),
+      removeEventListener: vi.fn(),
+      close: vi.fn(),
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+    const initialOnClose = vi.fn();
+
+    const { rerender } = render(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={vi.fn()}
+        onClose={initialOnClose}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+    const newOnClose = vi.fn();
+    rerender(
+      <OauthPopup
+        button={Button}
+        url="https://example.com/auth"
+        title="Auth Popup"
+        onCode={vi.fn()}
+        onClose={newOnClose}
+      >
+        Open Auth Popup
+      </OauthPopup>
+    );
+
+    popupListeners.beforeunload?.();
+
+    expect(initialOnClose).not.toHaveBeenCalled();
+    expect(newOnClose).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -43,7 +43,7 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
   const beforeUnloadListenerRef = React.useRef<(() => void) | null>(null);
   const latestProps = React.useRef(props);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     latestProps.current = props;
   }, [props]);
 

--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -41,6 +41,11 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
   const externalWindowRef = React.useRef<Window | null>(null);
   const storageListenerRef = React.useRef<(() => void) | null>(null);
   const beforeUnloadListenerRef = React.useRef<(() => void) | null>(null);
+  const latestProps = React.useRef(props);
+
+  React.useEffect(() => {
+    latestProps.current = props;
+  }, [props]);
 
   const cleanupPopup = React.useCallback(
     (closeWindow = false) => {
@@ -80,7 +85,7 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
   }, [cleanupPopup]);
 
   const createPopup = () => {
-    const { url, title, width, height, onCode } = { ...defaultOauthPopupProps, ...props };
+    const { url, title, width, height } = { ...defaultOauthPopupProps, ...props };
     const left = window.screenX + ((window.outerWidth - width) as number) / 2;
     const top = window.screenY + ((window.outerHeight - height) as number) / 2.5;
 
@@ -93,7 +98,7 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
       try {
         const authStatus = localStorage.getItem(AUTH_STATUS_KEY);
         if (authStatus) {
-          onCode(authStatus);
+          latestProps.current.onCode(authStatus);
           localStorage.removeItem(AUTH_STATUS_KEY);
           cleanupPopup(true);
         }
@@ -111,8 +116,8 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
         const beforeUnloadListener = () => {
           cleanupPopup();
           externalWindowRef.current = null;
-          if (!!props.onClose) {
-            props.onClose();
+          if (!!latestProps.current.onClose) {
+            latestProps.current.onClose();
           }
         };
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where the login popup was using outdated information if the main page refreshed while the popup was still open.

## Related Issue

Fixes #6480  

## Changes

- Fixed a bug in `OauthPopup.tsx` where the popup would get "stuck" using the original functions it was given when it first opened.
- Added a `latestProps` tracker so the popup always knows about the newest updates from the main page and uses the most up-to-date versions of the `onCode` and `onClose` functions.

## Steps to Test

1. Click the login button to open the OAuth popup window.
2. Complete the login process inside the popup.
3. Make sure the popup closes automatically and the main Headlamp app logs you in successfully without getting stuck.

## Screenshots (if applicable)

N/A - This is a behind-the-scenes logic fix, so nothing looks different on the screen.

## Notes for the Reviewer

I removed `onCode` from the shortcut list at the top of the function to prevent a linter error, since we are now explicitly calling `latestProps.current.onCode` instead!


