### PR TITLE
frontend: Sidebar/ClusterBadge: Add Storybook stories

### DIFF
--- a/frontend/src/components/Sidebar/ClusterBadge.stories.tsx
+++ b/frontend/src/components/Sidebar/ClusterBadge.stories.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import ClusterBadge, { ClusterBadgeProps } from './ClusterBadge';
+
+export default {
+  title: 'Sidebar/ClusterBadge',
+  component: ClusterBadge,
+  argTypes: {
+    name: { control: 'text', description: 'Cluster display name.' },
+    accentColor: {
+      control: 'color',
+      description: 'Accent color for the circular icon border.',
+    },
+    icon: { control: 'text', description: 'Iconify icon shown inside the circle.' },
+  },
+} as Meta<typeof ClusterBadge>;
+
+const Template: StoryFn<ClusterBadgeProps> = args => <ClusterBadge {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  name: 'my-cluster',
+};
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  name: 'my-cluster',
+  icon: 'mdi:kubernetes',
+};
+
+export const WithAccentColor = Template.bind({});
+WithAccentColor.args = {
+  name: 'production',
+  icon: 'mdi:kubernetes',
+  accentColor: '#f44336',
+};
+
+export const LongName = Template.bind({});
+LongName.args = {
+  name: 'a-very-long-cluster-name-that-should-be-truncated-with-an-ellipsis',
+  icon: 'mdi:kubernetes',
+};

--- a/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.Default.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.Default.stories.storyshot
@@ -1,0 +1,13 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-172hjuw"
+    >
+      <span
+        class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+      >
+        my-cluster
+      </span>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.LongName.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.LongName.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-172hjuw"
+    >
+      <div
+        class="MuiBox-root css-iyhyxy"
+      />
+      <span
+        class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+      >
+        a-very-long-cluster-name-that-should-be-truncated-with-an-ellipsis
+      </span>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.WithAccentColor.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.WithAccentColor.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-172hjuw"
+    >
+      <div
+        class="MuiBox-root css-1txjpyk"
+      />
+      <span
+        class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+      >
+        production
+      </span>
+    </div>
+  </div>
+</body>

--- a/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.WithIcon.stories.storyshot
+++ b/frontend/src/components/Sidebar/__snapshots__/ClusterBadge.WithIcon.stories.storyshot
@@ -1,0 +1,16 @@
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-172hjuw"
+    >
+      <div
+        class="MuiBox-root css-iyhyxy"
+      />
+      <span
+        class="MuiTypography-root MuiTypography-caption css-chqac-MuiTypography-root"
+      >
+        my-cluster
+      </span>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## What this does

Adds Storybook stories for `Sidebar/ClusterBadge.tsx`, which previously had no story or test. In this repo stories double as snapshot tests (`storybook.test.tsx`), so this also gives the component snapshot coverage.

Four stories, all pure props-driven (no MSW/store needed):
- **Default** — basic cluster badge
- **WithIcon** — badge with an icon
- **WithAccentColor** — badge with a custom accent color
- **LongName** — long cluster name

The hand-written change is small (~58 lines in `ClusterBadge.stories.tsx`); the rest of the diff is auto-generated `.storyshot` files.

Full storyshot suite passes with zero drift.

Closes #6453

Part of the umbrella story-coverage effort (#931).