### PR TITLE
frontend: useKubeObjectList: Replace ts-ignore with Object.assign return

### DIFF
--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.test.tsx
@@ -923,6 +923,42 @@ describe('useKubeObjectList', () => {
     expect(spy.mock.calls[3][0].connections.length).toBe(1);
     expect(spy.mock.calls[3][0].connections[0].cluster).toBe('cluster-1');
   });
+
+  it('should report pending while endpoint discovery is in progress', () => {
+    // Never resolve so useEndpoints stays probing (multiple apiInfo → async discovery).
+    mockClusterFetch.mockReturnValue(new Promise(() => {}));
+
+    const multiEndpointClass = class {
+      static apiVersion = 'v1';
+      static apiName = 'pods';
+      static apiEndpoint = {
+        apiInfo: [
+          { group: '', resource: 'pods', version: 'v1' },
+          { group: 'apps', resource: 'pods', version: 'v1' },
+        ],
+      };
+      constructor(public jsonData: any) {}
+    } as any;
+
+    const { result } = renderHook(
+      () =>
+        useKubeObjectList({
+          kubeObjectClass: multiEndpointClass,
+          requests: [{ cluster: 'default', namespaces: ['a'] }],
+        }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+
+    expect(result.current.status).toBe('pending');
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isFetching).toBe(true);
+    expect(result.current.isSuccess).toBe(false);
+  });
 });
 
 describe('useWatchKubeObjectLists (Multiplexer)', () => {

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -701,7 +701,7 @@ export function useKubeObjectList<K extends KubeObject>({
     setPaginationError(null);
   }, [paginationInputKey]);
 
-  const errors = [...query.errors.filter(it => it !== null), paginationError].filter(
+  const queryErrors = [...query.errors.filter(it => it !== null), paginationError].filter(
     it => it !== null
   );
 
@@ -848,22 +848,37 @@ export function useKubeObjectList<K extends KubeObject>({
     refetchInterval,
   ]);
 
-  // @ts-ignore - TS compiler gets confused with iterators
-  return {
-    items: endpointError ? [] : query.items,
-    errors: endpointError ? [endpointError] : errors.length > 0 ? errors : null,
-    error: endpointError ?? paginationError ?? query.errors.find(it => it !== null) ?? null,
+  // useEndpoints returns undefined endpoint (no error) while probing multiple API versions.
+  // With no list queries yet, useQueries would otherwise report success + empty data.
+  const isEndpointPending = !endpoint && !endpointError;
+  const items = endpointError ? [] : query.items;
+  const error =
+    endpointError ?? paginationError ?? query.errors.find(it => it !== null) ?? null;
+  const errors = endpointError ? [endpointError] : queryErrors.length > 0 ? queryErrors : null;
+  const isLoading = isEndpointPending || query.isLoading;
+  const isFetching = isEndpointPending || query.isFetching;
+  const isSuccess = !isEndpointPending && query.isSuccess && !endpointError;
+  const status: 'error' | 'pending' | 'success' =
+    endpointError || query.isError || !!paginationError
+      ? 'error'
+      : isLoading
+      ? 'pending'
+      : 'success';
+
+  // Object.assign creates a tuple+object intersection without @ts-ignore (same pattern as useKubeObject).
+  return Object.assign([items, error] as [Array<K> | null, ApiError | null], {
+    data: endpointError || isEndpointPending ? null : query.data,
+    items,
+    errors,
+    error,
     clusterResults: query.clusterResults,
-    isError: query.isError || !!paginationError,
-    isLoading: query.isLoading,
-    isFetching: query.isFetching,
-    isSuccess: query.isSuccess,
+    isError: query.isError || !!endpointError || !!paginationError,
+    isLoading,
+    isFetching,
+    isSuccess,
+    status,
     hasMore: query.hasMore,
     remainingItemCount: query.remainingItemCount,
     loadMore: query.hasMore ? loadMore : undefined,
-    *[Symbol.iterator](): ArrayIterator<ApiError | K[] | null> {
-      yield query.items;
-      yield endpointError ?? paginationError ?? query.errors.find(it => it !== null) ?? null;
-    },
-  };
+  });
 }

--- a/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
+++ b/frontend/src/lib/k8s/api/v2/useKubeObjectList.ts
@@ -852,8 +852,7 @@ export function useKubeObjectList<K extends KubeObject>({
   // With no list queries yet, useQueries would otherwise report success + empty data.
   const isEndpointPending = !endpoint && !endpointError;
   const items = endpointError ? [] : query.items;
-  const error =
-    endpointError ?? paginationError ?? query.errors.find(it => it !== null) ?? null;
+  const error = endpointError ?? paginationError ?? query.errors.find(it => it !== null) ?? null;
   const errors = endpointError ? [endpointError] : queryErrors.length > 0 ? queryErrors : null;
   const isLoading = isEndpointPending || query.isLoading;
   const isFetching = isEndpointPending || query.isFetching;


### PR DESCRIPTION
### Summary
Replace the @ts-ignore on useKubeObjectList’s return with an Object.assign tuple+object intersection, matching the approach used for useKubeObject in #5061.

### Related Issue
Follow-up to #5061 (leftover @ts-ignore in useKubeObjectList.ts; that PR covers hooks.ts / KubeObject.ts / graphLayout.tsx only).

### Changes
Removed custom *[Symbol.iterator] + @ts-ignore
Return Object.assign([items, error], { … }) so callers can still destructure or use .items / .error / etc.
Filled typed data and status fields that the ignore had been hiding
### Steps to Test
cd frontend
npx vitest run src/lib/k8s/api/v2/useKubeObjectList.test.tsx (19 tests)
npx tsc --noEmit — no errors in useKubeObjectList.ts
Optional: run the app and open a resource list page (Pods/Deployments) to confirm lists still load
### Notes for the Reviewer
Same pattern as #5061’s useKubeObject fix; does not touch files in that PR
Happy to wait on / coordinate with #5061 if preferred

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior while API endpoint discovery is still in progress.
  * Prevented incomplete object data from appearing before endpoint resolution.
  * Endpoint discovery errors are now reflected in the overall error state.

* **Tests**
  * Added coverage for unresolved endpoints remaining in a pending/loading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->