### PR TITLE
frontend: enforce vitest coverage thresholds

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -44,6 +44,12 @@ export default mergeConfig(
           'src/**/*.stories*.{js,jsx,ts,tsx}',
         ],
         include: ['src/**/*.{js,jsx,ts,tsx}'],
+        thresholds: {
+          statements: 63,
+          branches: 56,
+          functions: 59,
+          lines: 64,
+        },
       },
       restoreMocks: false,
       setupFiles: ['./src/setupTests.ts'],


### PR DESCRIPTION
## Summary
- enforce minimum frontend Vitest coverage thresholds in the shared config
- keep the thresholds aligned with the current suite baseline so existing CI starts failing only on real regression

## Linked Issue
Fixes #6485

## What Changed
- added global coverage thresholds for statements, branches, functions, and lines in `frontend/vitest.config.ts`
- left the existing frontend test command and workflow wiring unchanged so CI enforcement happens through the current Vitest invocation

## Verification
- `npm run frontend:lint` — passed
- `npm run frontend:tsc` — passed
- `npm run frontend:test` — passed
- `npm test` — passed
- `npm run lint` — failed: backend `golangci-lint` aborts before frontend linting because the installed linter binary was built with Go 1.25 while the repo targets Go 1.26.4

## Scope
- only `frontend/vitest.config.ts` was changed; unrelated files were not modified
