### PR TITLE
frontend: Auth: Add rel=noopener noreferrer to external link

### DIFF
--- a/frontend/src/components/account/Auth.test.tsx
+++ b/frontend/src/components/account/Auth.test.tsx
@@ -146,6 +146,7 @@ describe('PureAuthToken', () => {
 
     const link = screen.getByRole('link', { name: /service account token/i });
     expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('shows error snackbar when showError is true', () => {

--- a/frontend/src/components/account/Auth.tsx
+++ b/frontend/src/components/account/Auth.tsx
@@ -157,6 +157,7 @@ export function PureAuthToken({
                 <Link
                   style={{ cursor: 'pointer', marginLeft: '0.4rem' }}
                   target="_blank"
+                  rel="noopener noreferrer"
                   href="https://headlamp.dev/docs/latest/installation/#create-a-service-account-token"
                 >
                   service account token


### PR DESCRIPTION
## Summary
Add rel="noopener noreferrer" to the external documentation link in the Auth dialog to prevent reverse tabnabbing.

## Related Issue
Fixes #6359

## Changes
- Added rel="noopener noreferrer" to the service account token docs <Link> in Auth.tsx
- Added test assertion to verify the attribute

## Steps to Test
1. cd frontend && npx vitest run src/components/account/Auth.test.tsx
2. All 14 tests should pass

## Checklist
- [x] Tests added/updated
- [x] No unrelated changes bundled in
- [x] Only 2 files touched, +2 lines

