### PR TITLE
frontend: handle manual closure of cross-origin Oauth popup

### DIFF
--- a/frontend/src/components/oidcauth/OauthPopup.test.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.test.tsx
@@ -138,4 +138,59 @@ describe('OauthPopup', () => {
     );
     expect(popupWindow.close).toHaveBeenCalled();
   });
+
+  it('uses fallback interval to detect popup closure when addEventListener throws', async () => {
+    try {
+      let isClosed = false;
+      const popupWindow = {
+        addEventListener: vi.fn(() => {
+          throw new Error(
+            'SecurityError: Blocked a frame with origin from accessing a cross-origin frame.'
+          );
+        }),
+        removeEventListener: vi.fn(),
+        close: vi.fn(),
+        get closed() {
+          return isClosed;
+        },
+      } as unknown as Window;
+
+      vi.spyOn(window, 'open').mockReturnValue(popupWindow);
+      const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+      const onClose = vi.fn();
+
+      render(
+        <OauthPopup
+          button={Button}
+          url="https://example.com/auth"
+          title="Auth Popup"
+          onCode={vi.fn()}
+          onClose={onClose}
+        >
+          Open Auth Popup
+        </OauthPopup>
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open Auth Popup' }));
+
+      const storageListener = addEventListenerSpy.mock.calls.find(
+        ([eventName]) => eventName === 'storage'
+      )?.[1];
+
+      // Wait a bit, shouldn't trigger onClose yet
+      await new Promise(r => setTimeout(r, 100));
+      expect(onClose).not.toHaveBeenCalled();
+
+      // Simulate user closing the window
+      isClosed = true;
+
+      // Wait for the next 500ms interval to tick
+      await new Promise(r => setTimeout(r, 600));
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', storageListener);
+      expect(onClose).toHaveBeenCalled();
+    } finally {
+    }
+  });
 });

--- a/frontend/src/components/oidcauth/OauthPopup.tsx
+++ b/frontend/src/components/oidcauth/OauthPopup.tsx
@@ -41,6 +41,7 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
   const externalWindowRef = React.useRef<Window | null>(null);
   const storageListenerRef = React.useRef<(() => void) | null>(null);
   const beforeUnloadListenerRef = React.useRef<(() => void) | null>(null);
+  const popupCheckIntervalRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
 
   const cleanupPopup = React.useCallback(
     (closeWindow = false) => {
@@ -58,6 +59,11 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
           console.error('Error occurred while removing beforeunload event listener', e);
         }
         beforeUnloadListenerRef.current = null;
+      }
+
+      if (popupCheckIntervalRef.current) {
+        clearInterval(popupCheckIntervalRef.current);
+        popupCheckIntervalRef.current = null;
       }
 
       if (closeWindow && popupWindow) {
@@ -107,19 +113,31 @@ const OauthPopup: React.FC<OauthPopupProps> = props => {
     window.addEventListener('storage', storageListener);
 
     if (externalWindowRef.current) {
-      try {
-        const beforeUnloadListener = () => {
-          cleanupPopup();
-          externalWindowRef.current = null;
-          if (!!props.onClose) {
-            props.onClose();
-          }
-        };
+      const beforeUnloadListener = () => {
+        cleanupPopup();
+        externalWindowRef.current = null;
+        if (!!props.onClose) {
+          props.onClose();
+        }
+      };
 
+      try {
         externalWindowRef.current.addEventListener('beforeunload', beforeUnloadListener, false);
         beforeUnloadListenerRef.current = beforeUnloadListener;
       } catch (e) {
-        console.error('Error occurred while adding beforeunload event listener');
+        console.error('Error occurred while adding beforeunload event listener', e);
+
+        // Fallback for cross-origin popups where addEventListener fails
+        popupCheckIntervalRef.current = setInterval(() => {
+          if (!externalWindowRef.current) {
+            if (popupCheckIntervalRef.current) clearInterval(popupCheckIntervalRef.current);
+          }
+          // Check if the user manually closed the popup window
+          else if (externalWindowRef.current.closed) {
+            if (popupCheckIntervalRef.current) clearInterval(popupCheckIntervalRef.current);
+            beforeUnloadListener();
+          }
+        }, 500);
       }
     }
   };


### PR DESCRIPTION
## Summary

This PR fixes an issue where the app doesn't realize when a user manually closes the OAuth login popup window, which leaves the main app waiting forever.

## Related Issue

Fixes #6489

## Changes

- Updated `OauthPopup.tsx` to handle when cross-origin popup windows are closed.
- Added a fallback check using `setInterval` that looks at the window's `.closed` status every 500ms if the browser blocks the standard event listener.

## Steps to Test

1. Start Headlamp with OIDC authentication enabled.
2. Click the login button to open the popup.
3. Manually close the popup window by clicking the 'X'.
4. Notice that the main app successfully detects that you closed the window and stops waiting.

## Screenshots (if applicable)

*(N/A - Background logic fix)*

## Notes for the Reviewer

- The 500ms interval polling is only initialized if the initial `addEventListener` fails, ensuring we don't waste resources polling on same-origin popups.
