### PR TITLE
docs: clarify generated API docs are checked in

### DIFF
--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -62,9 +62,11 @@ API documentation for TypeScript is done with [typedoc](https://typedoc.org/) an
 npm run docs
 ```
 
-The API output markdown is generated in docs/development/api and is not
-committed to Git, but is shown on the website at
-[headlamp/latest/development/api](https://headlamp.dev/docs/latest/development/api/)
+The API output markdown is generated in `docs/development/api/`, committed to
+Git, and shown on the website at
+[headlamp/latest/development/api](https://headlamp.dev/docs/latest/development/api/).
+When API changes affect the generated output, run `npm run docs` and include
+the resulting `docs/development/api/` updates in the same change for review.
 
 ## Storybook
 


### PR DESCRIPTION
## Summary

This PR updates the frontend development guide so it no longer claims generated API docs are untracked.

## Related Issue

Fixes #6491

## Changes

- Updated `docs/development/frontend.md` to state that `docs/development/api/` is committed to Git
- Documented that contributors should run `npm run docs` and include generated API doc diffs when API changes affect the output

## Steps to Test

1. Open `docs/development/frontend.md`.
2. Confirm the API documentation section says `docs/development/api/` is committed to Git.
3. Run `git ls-files docs/development/api | wc -l` and verify the repository tracks generated API docs.
4. Run `npm run docs` when API changes affect the generated output and review the resulting `docs/development/api/` diff.

## Screenshots (if applicable)

Not applicable.

## Notes for the Reviewer

- Scope is limited to contributor documentation.
- I ran the frontend contributor checks plus `npm run docs`; `typedoc` currently emits many warnings and generates a large-format churn in `docs/development/api/`, so those generated artifacts were not included in this scoped docs fix.

## Verification
- `npm run docs` — passed
- `npm run frontend:lint` — passed
- `npm run frontend:tsc` — passed
- `npm run frontend:test` — passed

## Scope
- Only `docs/development/frontend.md` was changed; no unrelated repository files were included.
