### PR TITLE
backend: helm: Clarify repository lock retry timing

### DIFF
--- a/backend/pkg/helm/repository.go
+++ b/backend/pkg/helm/repository.go
@@ -97,6 +97,7 @@ func lockRepositoryFile(lockCtx context.Context, repositoryConfig string) (bool,
 
 	fileLock := flock.New(lockPath)
 
+	// The context bounds the total wait; this duration controls how often the lock is retried.
 	locked, err := fileLock.TryLockContext(lockCtx, time.Second)
 
 	return locked, fileLock, err


### PR DESCRIPTION
## Summary

Clarifies the Helm repository lock timing semantics so the one-second retry
cadence is not mistaken for the total acquisition timeout.

## Related Issue

Relates to #5629

## Changes

- Documented that the context bounds the total lock wait.
- Clarified that the `TryLockContext` duration controls retry frequency.

## Steps to Test

1. Run `npm run backend:test`.
2. Run `npm run backend:lint`.

## Screenshots

Not applicable for this backend-only documentation change.

## Notes for the Reviewer

This intentionally does not change lock behavior. The existing context keeps
the total wait at 30 seconds, while the one-second argument is the retry
cadence. Using 30 seconds as the retry cadence could prevent another attempt
before the context expires.
