### PR TITLE
backend: kubeconfig: Add test for missing context removal

### DIFF
--- a/backend/pkg/kubeconfig/file_test.go
+++ b/backend/pkg/kubeconfig/file_test.go
@@ -238,3 +238,25 @@ func TestRemoveContextFromFile(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestRemoveContextFromFile_NonExistentContext(t *testing.T) {
+	data, err := os.ReadFile("./test_data/kubeconfig1")
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	err = os.WriteFile("./test_data/config_copy_nonexistent", data, 0o600) //nolint:gosec
+	require.NoError(t, err)
+
+	defer os.Remove("./test_data/config_copy_nonexistent")
+	defer os.Remove("./test_data/config_copy_nonexistent.lock")
+
+	err = kubeconfig.RemoveContextFromFile("non-existent-context", "./test_data/config_copy_nonexistent")
+	assert.Error(t, err)
+	assert.Equal(t, "context not found in kubeconfig", err.Error())
+}
+
+func TestRemoveContextFromFile_EmptyPath(t *testing.T) {
+	err := kubeconfig.RemoveContextFromFile("some-context", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "kubeconfig path is empty")
+}

--- a/backend/pkg/kubeconfig/file_test.go
+++ b/backend/pkg/kubeconfig/file_test.go
@@ -249,6 +249,7 @@ func TestRemoveContextFromFile_NonExistentContext(t *testing.T) {
 
 	t.Cleanup(func() {
 		require.NoError(t, os.Remove("./test_data/config_copy_nonexistent"))
+
 		if err := os.Remove("./test_data/config_copy_nonexistent.lock"); err != nil && !errors.Is(err, os.ErrNotExist) {
 			require.NoError(t, err)
 		}

--- a/backend/pkg/kubeconfig/file_test.go
+++ b/backend/pkg/kubeconfig/file_test.go
@@ -247,16 +247,18 @@ func TestRemoveContextFromFile_NonExistentContext(t *testing.T) {
 	err = os.WriteFile("./test_data/config_copy_nonexistent", data, 0o600) //nolint:gosec
 	require.NoError(t, err)
 
-	defer os.Remove("./test_data/config_copy_nonexistent")
-	defer os.Remove("./test_data/config_copy_nonexistent.lock")
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove("./test_data/config_copy_nonexistent"))
+		if err := os.Remove("./test_data/config_copy_nonexistent.lock"); err != nil && !errors.Is(err, os.ErrNotExist) {
+			require.NoError(t, err)
+		}
+	})
 
 	err = kubeconfig.RemoveContextFromFile("non-existent-context", "./test_data/config_copy_nonexistent")
-	assert.Error(t, err)
-	assert.Equal(t, "context not found in kubeconfig", err.Error())
+	require.ErrorContains(t, err, "context not found in kubeconfig")
 }
 
 func TestRemoveContextFromFile_EmptyPath(t *testing.T) {
 	err := kubeconfig.RemoveContextFromFile("some-context", "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "kubeconfig path is empty")
+	require.ErrorContains(t, err, "kubeconfig path is empty")
 }


### PR DESCRIPTION
**Summary:**
Added backend tests to `kubeconfig` to improve test coverage and ensure robust error handling for edge cases in `RemoveContextFromFile`.

**Changes:**
- Added `TestRemoveContextFromFile_NonExistentContext` to verify the error returned when removing a context that does not exist in the kubeconfig file.
- Added `TestRemoveContextFromFile_EmptyPath` to verify that lock acquisition correctly fails and handles empty path strings.

**Steps to Test:**
1. Navigate to the backend directory: `cd backend`
2. Run the tests for the kubeconfig package: `npm run backend:test`
3. Verify that all tests pass and coverage is maintained or increased.

**Screenshots:**
*(Not applicable for backend test additions)*

**Notes for the Reviewer:**
These tests are small, strictly backward compatible, and improve the reliability of the `kubeconfig` file operations by explicitly covering previously untested error branches. No changes were made to the public API or existing logic.