### PR TITLE
backend: server: Route --version output through structured logger

### DIFF
--- a/backend/cmd/server.go
+++ b/backend/cmd/server.go
@@ -59,7 +59,9 @@ func main() {
 	logger.Init(conf.LogLevel)
 
 	if conf.Version {
-		fmt.Printf("%s %s (%s/%s)\n", kubeconfig.AppName, kubeconfig.Version, runtime.GOOS, runtime.GOARCH)
+		logger.Log(logger.LevelInfo, nil, nil,
+			fmt.Sprintf("%s %s (%s/%s)", kubeconfig.AppName, kubeconfig.Version, runtime.GOOS, runtime.GOARCH))
+
 		return
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes a missed spot from #6224's structured-logging cleanup: `backend/cmd/server.go` still called `fmt.Printf` directly for `--version` output, bypassing the configured log level and structured format that every other backend log line now uses.

## Related Issue

Fixes #6497

## Changes

- Replaced the direct `fmt.Printf` call in `backend/cmd/server.go`'s `--version` handling with `logger.Log(logger.LevelInfo, nil, nil, fmt.Sprintf(...))`, matching the exact call pattern already used throughout `backend/cmd/headlamp.go` since #6224.

## Steps to Test

1. Build the backend: `cd backend && go build -o headlamp-server ./cmd`
2. Run `./headlamp-server --version` — output now appears as a structured JSON log line on stderr (`level`, `source`, `line`, `time`, `message` fields) instead of raw text on stdout.
3. Run `HEADLAMP_CONFIG_LOG_LEVEL=warn ./headlamp-server --version` — expect no output, since the `info`-level line is now correctly suppressed like every other `logger.Log(logger.LevelInfo, ...)` call.
4. `npm run backend:format` / `npm run backend:lint:fix` — clean, 0 issues.
5. `go test -p 1 ./...` — all packages pass, no regressions.

## Screenshots (if applicable)

N/A — CLI/log output change, no UI.

## Notes for the Reviewer

- Single-line, single-file change; no new imports needed (`fmt`, `runtime`, `kubeconfig`, `logger` were already imported in `server.go`).
- Considered reusing `kubeconfig.buildUserAgent()` (same format string) but it's unexported and serves a different purpose (HTTP `User-Agent` header) — kept this independent to avoid a coincidental coupling.