### PR TITLE
frontend: ingress: fix stale cachedRules by invalidating on resourceVersion change

### DIFF
--- a/frontend/src/lib/k8s/ingress.test.ts
+++ b/frontend/src/lib/k8s/ingress.test.ts
@@ -245,5 +245,27 @@ describe('Ingress class', () => {
       // Rules object should be reused from cache (same identity)
       expect(rules1).toBe(rules2);
     });
+
+    it('skips caching when resourceVersion is undefined', () => {
+      const data = JSON.parse(JSON.stringify(mockIngressData));
+      delete data.metadata.resourceVersion;
+      const ingress = new Ingress(data);
+      const rules1 = ingress.getRules();
+      const rules2 = ingress.getRules();
+      // Without a resourceVersion to key the cache, rules should be recomputed.
+      expect(rules1).not.toBe(rules2);
+    });
+    it('recomputes cached rules when resourceVersion changes', () => {
+      const data = JSON.parse(JSON.stringify(mockIngressData));
+      const ingress = new Ingress(data);
+      const rules1 = ingress.getRules();
+      // Simulate a watch/update that mutates the existing instance's jsonData.
+      ingress.jsonData.spec.rules = [{ host: 'updated.example.com' }];
+      ingress.jsonData.metadata.resourceVersion = '999999';
+      const rules2 = ingress.getRules();
+      expect(rules1).not.toBe(rules2);
+      expect(rules2).toHaveLength(1);
+      expect(rules2[0].host).toBe('updated.example.com');
+    });
   });
 });

--- a/frontend/src/lib/k8s/ingress.ts
+++ b/frontend/src/lib/k8s/ingress.ts
@@ -131,6 +131,7 @@ class Ingress extends KubeObject<KubeIngress> {
 
   // Normalized, cached rules.
   private cachedRules: IngressRule[] = [];
+  private cachedResourceVersion?: string;
 
   get spec(): KubeIngress['spec'] {
     return this.jsonData.spec;
@@ -149,7 +150,11 @@ class Ingress extends KubeObject<KubeIngress> {
   }
 
   getRules(): IngressRule[] {
-    if (this.cachedRules.length > 0) {
+    const currentResourceVersion = this.jsonData.metadata?.resourceVersion;
+    if (
+      currentResourceVersion !== undefined &&
+      this.cachedResourceVersion === currentResourceVersion
+    ) {
       return this.cachedRules;
     }
 
@@ -191,6 +196,7 @@ class Ingress extends KubeObject<KubeIngress> {
     });
 
     this.cachedRules = rules;
+    this.cachedResourceVersion = currentResourceVersion;
     return rules;
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes stale ingress rules being returned by `getRules()` by invalidating
the cache when `resourceVersion` changes.

## Related Issue
Fixes #6499

## Changes
- Added `cachedResourceVersion` private field to the `Ingress` class
- Updated `getRules()` to compare current `metadata.resourceVersion` against the
  cached version before returning cached rules
- Cache is now recomputed and `cachedResourceVersion` is updated whenever the
  Ingress resource changes in the cluster
- Added unit tests to verify cache invalidation logic when `resourceVersion` changes

## Steps to Test
1. Deploy an Ingress resource to your cluster
2. Open Headlamp and navigate to the Ingress detail page
3. Note the rules displayed
4. Update the Ingress resource (e.g. add or remove a rule)
5. Observe that Headlamp now reflects the updated rules without requiring a full
   page refresh
6. Run unit tests via `npm test frontend/src/lib/k8s/ingress.test.ts` to ensure all tests pass

## Screenshots (if applicable)

## Notes for the Reviewer
- If `metadata.resourceVersion` is `undefined` the cache is skipped entirely and
  rules are always recomputed  safe fallback, no crash risk
- Affected files are `frontend/src/lib/k8s/ingress.ts` and its corresponding test file `frontend/src/lib/k8s/ingress.test.ts`
