### PR TITLE
app: Fix zoom persistence when switching panes

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -32,7 +32,6 @@ import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import find_process from 'find-process';
 import * as fsPromises from 'fs/promises';
 import * as net from 'net';
-import fs from 'node:fs';
 import { userInfo } from 'node:os';
 import { promisify } from 'node:util';
 import { platform } from 'os';
@@ -69,6 +68,13 @@ import {
   setTrayIconEnabled,
 } from './tray';
 import windowSize from './windowSize';
+import {
+  clampZoom,
+  DEFAULT_ZOOM_FACTOR,
+  flushZoomFactorSave,
+  loadZoomFactor,
+  saveZoomFactor,
+} from './zoom';
 
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
@@ -1390,40 +1396,66 @@ function killProcess(pid: number) {
 }
 
 const ZOOM_FILE_PATH = path.join(app.getPath('userData'), 'headlamp-config.json');
-let cachedZoom: number = 1.0;
+let cachedZoom: number = DEFAULT_ZOOM_FACTOR;
 
-function saveZoomFactor(factor: number) {
-  try {
-    fs.writeFileSync(ZOOM_FILE_PATH, JSON.stringify({ zoomFactor: factor }), 'utf-8');
-  } catch (err) {
-    console.error('Failed to save zoom factor:', err);
+function applyZoom(source = 'unknown', forceRefresh = false) {
+  if (!mainWindow?.webContents) {
+    return;
   }
+
+  const wc = mainWindow.webContents;
+  // The window may be mid-close (e.g. deferred scheduleApplyZoom callbacks);
+  // setZoomFactor on a destroyed WebContents throws.
+  if (wc.isDestroyed()) {
+    return;
+  }
+
+  const needsRefresh =
+    forceRefresh ||
+    source.includes('route') ||
+    source.includes('navigate') ||
+    source.includes('focus') ||
+    source.includes('show');
+
+  // Electron can report the correct zoomFactor while newly rendered SPA content
+  // still paints at 100%; nudge then restore to force a repaint.
+  if (needsRefresh && cachedZoom !== DEFAULT_ZOOM_FACTOR) {
+    let nudge = clampZoom(cachedZoom + 0.001);
+    if (nudge === cachedZoom) {
+      nudge = clampZoom(cachedZoom - 0.001);
+    }
+    wc.setZoomFactor(nudge);
+  }
+  wc.setZoomFactor(cachedZoom);
 }
 
-async function loadZoomFactor(): Promise<number> {
-  try {
-    const content = await fsPromises.readFile(ZOOM_FILE_PATH, 'utf-8');
-    const { zoomFactor = 1.0 } = JSON.parse(content);
-    return typeof zoomFactor === 'number' ? zoomFactor : 1.0;
-  } catch (err) {
-    console.error('Failed to load zoom factor, defaulting to 1.0:', err);
-    return 1.0;
-  }
-}
+function scheduleApplyZoom(source: string, forceRefresh = false) {
+  applyZoom(source, forceRefresh);
+  setImmediate(() => {
+    applyZoom(`${source}:deferred`, forceRefresh);
 
-// The zoom factor should respect the fixed limits set by Electron.
-function clampZoom(factor: number) {
-  return Math.min(5.0, Math.max(0.25, factor));
+    // Re-grab webContents: the window may have closed since scheduling.
+    const wc = mainWindow?.webContents;
+    if (!wc || wc.isDestroyed()) {
+      return;
+    }
+
+    wc.executeJavaScript(
+      'new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+    )
+      .then(() => applyZoom(`${source}:after-paint`, forceRefresh))
+      .catch(() => {});
+  });
 }
 
 function setZoom(factor: number) {
-  cachedZoom = factor;
-  mainWindow?.webContents.setZoomFactor(cachedZoom);
+  cachedZoom = clampZoom(factor);
+  applyZoom('setZoom');
+  saveZoomFactor(ZOOM_FILE_PATH, cachedZoom);
 }
 
 function adjustZoom(delta: number) {
-  const newZoom = clampZoom(cachedZoom + delta);
-  setZoom(newZoom);
+  setZoom(cachedZoom + delta);
 }
 
 function startElectron() {
@@ -1601,6 +1633,9 @@ function startElectron() {
       },
     });
 
+    cachedZoom = await loadZoomFactor(ZOOM_FILE_PATH);
+    applyZoom('createWindow:load');
+
     // Load the frontend
     mainWindow.loadURL(startUrl);
 
@@ -1629,15 +1664,44 @@ function startElectron() {
       }
     });
 
-    mainWindow.webContents.on('did-finish-load', async () => {
-      const startZoom = await loadZoomFactor();
-      if (startZoom !== 1.0) {
-        setZoom(startZoom);
-      }
-
+    mainWindow.webContents.on('did-finish-load', () => {
+      scheduleApplyZoom('did-finish-load');
       // Inject the backend port into the window object
       mainWindow?.webContents.executeJavaScript(`window.headlampBackendPort = ${actualPort};`);
     });
+
+    mainWindow.webContents.on('did-frame-finish-load', (_event, isMainFrame) => {
+      if (isMainFrame) {
+        scheduleApplyZoom('did-frame-finish-load');
+      }
+    });
+
+    // React Router navigates in-page without a full reload (issue #3948).
+    mainWindow.webContents.on('did-navigate-in-page', () => {
+      scheduleApplyZoom('did-navigate-in-page');
+    });
+
+    mainWindow.webContents.on('zoom-changed', () => {
+      // The event signals the intent to zoom, so the new factor may not be
+      // applied yet; read it on the next tick to capture the applied value.
+      setImmediate(() => {
+        const wc = mainWindow?.webContents;
+        if (!wc || wc.isDestroyed()) {
+          return;
+        }
+
+        const actual = wc.getZoomFactor();
+        if (Math.abs(actual - cachedZoom) > 0.001) {
+          cachedZoom = clampZoom(actual);
+          saveZoomFactor(ZOOM_FILE_PATH, cachedZoom);
+          scheduleApplyZoom('zoom-changed:correct', true);
+        }
+      });
+    });
+
+    // Electron can visually reset zoom after SPA navigation or when the window regains focus.
+    mainWindow.on('focus', () => scheduleApplyZoom('focus'));
+    mainWindow.on('show', () => scheduleApplyZoom('show'));
 
     mainWindow.webContents.on('dom-ready', () => {
       const defaultMenu = getDefaultAppMenu();
@@ -1775,6 +1839,14 @@ function startElectron() {
       }
     });
 
+    // createWindow() can run more than once (e.g. macOS 'activate'), so only
+    // register once to avoid duplicate zoom applies per route change.
+    if (ipcMain.listenerCount('route-changed') === 0) {
+      ipcMain.on('route-changed', () => {
+        scheduleApplyZoom('route-changed', true);
+      });
+    }
+
     ipcMain.on('request-backend-token', () => {
       mainWindow?.webContents.send('backend-token', backendToken);
     });
@@ -1909,9 +1981,10 @@ function startElectron() {
 
   app.once('before-quit', async () => {
     isQuitting = true;
+    // Persist any zoom change still waiting on the debounced save.
+    flushZoomFactorSave();
     cleanupHeadlampTray();
     hasTray = false;
-    saveZoomFactor(cachedZoom);
     i18n.off('languageChanged');
     if (mainWindow) {
       mainWindow.removeAllListeners('close');

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -32,7 +32,6 @@ import { IpcMainEvent, MenuItemConstructorOptions } from 'electron/main';
 import find_process from 'find-process';
 import * as fsPromises from 'fs/promises';
 import * as net from 'net';
-import fs from 'node:fs';
 import { userInfo } from 'node:os';
 import { promisify } from 'node:util';
 import { platform } from 'os';
@@ -76,6 +75,13 @@ import {
   setTrayIconEnabled,
 } from './tray';
 import windowSize from './windowSize';
+import {
+  clampZoom,
+  DEFAULT_ZOOM_FACTOR,
+  flushZoomFactorSave,
+  loadZoomFactor,
+  saveZoomFactor,
+} from './zoom';
 
 if (process.env.APPIMAGE) {
   app.commandLine.appendSwitch('disable-setuid-sandbox');
@@ -1409,41 +1415,75 @@ function killProcess(pid: number) {
 }
 
 const ZOOM_FILE_PATH = path.join(app.getPath('userData'), 'headlamp-config.json');
-let cachedZoom: number = 1.0;
+let cachedZoom: number = DEFAULT_ZOOM_FACTOR;
 
-function saveZoomFactor(factor: number) {
-  try {
-    fs.writeFileSync(ZOOM_FILE_PATH, JSON.stringify({ zoomFactor: factor }), 'utf-8');
-  } catch (err) {
-    console.error('Failed to save zoom factor:', err);
+function applyZoom(forceRefresh = false) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
   }
+
+  const wc = mainWindow.webContents;
+  // The window may be mid-close (e.g. deferred scheduleApplyZoom callbacks);
+  // setZoomFactor on a destroyed WebContents throws.
+  if (!wc || wc.isDestroyed()) {
+    return;
+  }
+
+  // Chromium's renderer process skips re-calculating layout and re-scaling
+  // newly painted DOM elements if it believes the zoom factor is already set
+  // to cachedZoom (e.g. on in-page SPA navigation or window focus/restore).
+  // Nudging the zoomFactor slightly (±0.001) forces Chromium to recognize
+  // a factor change and re-layout/repaint the page, then we immediately restore
+  // it to the target cachedZoom.
+  if (forceRefresh && cachedZoom !== DEFAULT_ZOOM_FACTOR) {
+    let nudge = clampZoom(cachedZoom + 0.001);
+    if (nudge === cachedZoom) {
+      nudge = clampZoom(cachedZoom - 0.001);
+    }
+    wc.setZoomFactor(nudge);
+  }
+  wc.setZoomFactor(cachedZoom);
 }
 
-async function loadZoomFactor(): Promise<number> {
-  try {
-    const content = await fsPromises.readFile(ZOOM_FILE_PATH, 'utf-8');
-    const { zoomFactor = 1.0 } = JSON.parse(content);
-    return typeof zoomFactor === 'number' ? zoomFactor : 1.0;
-  } catch (err) {
-    console.error('Failed to load zoom factor, defaulting to 1.0:', err);
-    return 1.0;
-  }
-}
+function scheduleApplyZoom(forceRefresh = false) {
+  applyZoom(forceRefresh);
+  setImmediate(() => {
+    applyZoom(forceRefresh);
 
-// The zoom factor should respect the fixed limits set by Electron.
-function clampZoom(factor: number) {
-  return Math.min(5.0, Math.max(0.25, factor));
+    // Re-grab webContents: the window may have closed since scheduling.
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      return;
+    }
+    const wc = mainWindow.webContents;
+    if (!wc || wc.isDestroyed()) {
+      return;
+    }
+
+    wc.executeJavaScript(
+      'new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+    )
+      .then(() => applyZoom(forceRefresh))
+      .catch(() => {});
+  });
 }
 
 function setZoom(factor: number) {
-  cachedZoom = factor;
-  mainWindow?.webContents.setZoomFactor(cachedZoom);
+  cachedZoom = clampZoom(factor);
+  applyZoom(false);
+  saveZoomFactor(ZOOM_FILE_PATH, cachedZoom);
 }
 
 function adjustZoom(delta: number) {
-  const newZoom = clampZoom(cachedZoom + delta);
-  setZoom(newZoom);
+  setZoom(cachedZoom + delta);
 }
+
+// React Router in the frontend renderer sends 'route-changed' after rendering
+// and painting a new route; re-apply zoom with forceRefresh to ensure the new view
+// is rendered at the correct scale. Registered outside createWindow so it is not
+// re-attached multiple times when the window is reopened (e.g. on macOS activate).
+ipcMain.on('route-changed', () => {
+  scheduleApplyZoom(true);
+});
 
 function startElectron() {
   console.info('App starting...');
@@ -1610,6 +1650,15 @@ function startElectron() {
     const withMargin = await isWSL();
     const { width, height } = windowSize(screen.getPrimaryDisplay().workAreaSize, withMargin);
 
+    // Flush any pending debounced zoom save before reading so reopening the
+    // window immediately after a zoom change reads the latest factor.
+    flushZoomFactorSave();
+
+    // Load before constructing the window so no await sits between window
+    // creation and the 'closed' handler; closing during the read would
+    // otherwise leave a destroyed window that later loadURL/menu calls throw on.
+    cachedZoom = await loadZoomFactor(ZOOM_FILE_PATH);
+
     mainWindow = new BrowserWindow({
       width,
       height,
@@ -1619,6 +1668,8 @@ function startElectron() {
         preload: `${__dirname}/preload.js`,
       },
     });
+
+    applyZoom();
 
     // Load the frontend
     mainWindow.loadURL(startUrl);
@@ -1648,15 +1699,34 @@ function startElectron() {
       }
     });
 
-    mainWindow.webContents.on('did-finish-load', async () => {
-      const startZoom = await loadZoomFactor();
-      if (startZoom !== 1.0) {
-        setZoom(startZoom);
-      }
-
+    mainWindow.webContents.on('did-finish-load', () => {
+      scheduleApplyZoom(true);
       // Inject the backend port into the window object
       mainWindow?.webContents.executeJavaScript(`window.headlampBackendPort = ${actualPort};`);
     });
+
+    mainWindow.webContents.on('did-frame-finish-load', (_event, isMainFrame) => {
+      if (isMainFrame) {
+        scheduleApplyZoom(true);
+      }
+    });
+
+    mainWindow.webContents.on('zoom-changed', (_event, zoomDirection) => {
+      if (!mainWindow || mainWindow.isDestroyed()) {
+        return;
+      }
+      const wc = mainWindow.webContents;
+      if (!wc || wc.isDestroyed()) {
+        return;
+      }
+
+      const delta = zoomDirection === 'in' ? 0.1 : -0.1;
+      adjustZoom(delta);
+    });
+
+    // Electron can visually reset zoom after SPA navigation or when the window regains focus.
+    mainWindow.on('focus', () => scheduleApplyZoom(true));
+    mainWindow.on('show', () => scheduleApplyZoom(true));
 
     mainWindow.webContents.on('dom-ready', () => {
       const defaultMenu = getDefaultAppMenu();
@@ -1935,9 +2005,10 @@ function startElectron() {
 
   app.once('before-quit', async () => {
     isQuitting = true;
+    // Persist any zoom change still waiting on the debounced save.
+    flushZoomFactorSave();
     cleanupHeadlampTray();
     hasTray = false;
-    saveZoomFactor(cachedZoom);
     i18n.off('languageChanged');
     if (mainWindow) {
       mainWindow.removeAllListeners('close');

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -47,6 +47,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'request-tray-icon',
       'set-tray-icon',
       'cluster-changed',
+      'route-changed',
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -48,6 +48,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
       'request-tray-icon',
       'set-tray-icon',
       'cluster-changed',
+      'route-changed',
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);

--- a/app/electron/zoom.test.ts
+++ b/app/electron/zoom.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clampZoom,
+  DEFAULT_ZOOM_FACTOR,
+  flushZoomFactorSave,
+  loadZoomFactor,
+  saveZoomFactor,
+} from './zoom';
+
+function tmpPath(): string {
+  return path.join(os.tmpdir(), `zoom-test-${Date.now()}-${Math.random()}.json`);
+}
+
+describe('zoom load/save', () => {
+  let filePath: string;
+
+  beforeEach(() => {
+    filePath = tmpPath();
+    try {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  afterEach(() => {
+    try {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('clamps zoom factor to Electron limits', () => {
+    expect(clampZoom(0)).toBe(0.25);
+    expect(clampZoom(3)).toBe(3);
+    expect(clampZoom(10)).toBe(5);
+  });
+
+  it('returns default zoom factor for non-finite numbers', () => {
+    expect(clampZoom(NaN)).toBe(DEFAULT_ZOOM_FACTOR);
+    expect(clampZoom(Infinity)).toBe(DEFAULT_ZOOM_FACTOR);
+    expect(clampZoom(-Infinity)).toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('saves and loads the zoom factor', async () => {
+    saveZoomFactor(filePath, 0.7);
+    flushZoomFactorSave();
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(0.7);
+  });
+
+  it('saves the clamped zoom factor when the value is out of range', async () => {
+    saveZoomFactor(filePath, 10);
+    flushZoomFactorSave();
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(5);
+  });
+
+  it('debounces rapid saves into one write of the latest value', async () => {
+    vi.useFakeTimers();
+    const writeSpy = vi.spyOn(fs, 'writeFileSync');
+
+    try {
+      saveZoomFactor(filePath, 0.5);
+      saveZoomFactor(filePath, 0.6);
+      saveZoomFactor(filePath, 0.7);
+      expect(writeSpy).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      writeSpy.mockRestore();
+      vi.useRealTimers();
+    }
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(0.7);
+  });
+
+  it('flushZoomFactorSave writes a pending value immediately', async () => {
+    saveZoomFactor(filePath, 0.8);
+    // No timers elapse; flush must persist the pending value.
+    flushZoomFactorSave();
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(0.8);
+  });
+
+  it('flushZoomFactorSave is a no-op with nothing pending', () => {
+    const writeSpy = vi.spyOn(fs, 'writeFileSync');
+
+    try {
+      flushZoomFactorSave();
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('loads the default zoom factor when the file is missing', async () => {
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('loads the default zoom factor when the saved value is invalid', async () => {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: '0.7' }), 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('clamps the loaded zoom factor', async () => {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: 10 }), 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(5);
+  });
+
+  it('loads the default zoom factor when the file contains corrupted JSON', async () => {
+    fs.writeFileSync(filePath, '{ "zoomFactor": ', 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+
+  it('loads the default zoom factor when the saved value is null', async () => {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: null }), 'utf-8');
+
+    await expect(loadZoomFactor(filePath)).resolves.toBe(DEFAULT_ZOOM_FACTOR);
+  });
+});

--- a/app/electron/zoom.ts
+++ b/app/electron/zoom.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fsPromises from 'fs/promises';
+import fs from 'node:fs';
+
+export const DEFAULT_ZOOM_FACTOR = 1.0;
+
+// The zoom factor should respect the fixed limits set by Electron.
+export function clampZoom(factor: number) {
+  if (!Number.isFinite(factor)) {
+    return DEFAULT_ZOOM_FACTOR;
+  }
+  return Math.min(5.0, Math.max(0.25, factor));
+}
+
+const SAVE_DEBOUNCE_MS = 250;
+
+let saveTimer: NodeJS.Timeout | null = null;
+let pendingSave: { filePath: string; factor: number } | null = null;
+
+function writeZoomFactor(filePath: string, factor: number) {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify({ zoomFactor: clampZoom(factor) }), 'utf-8');
+  } catch (err) {
+    console.error('Failed to save zoom factor:', err);
+  }
+}
+
+/**
+ * Persists the zoom factor, debounced: rapid zoom gestures coalesce into one
+ * write of the latest value so the main process isn't blocked by disk I/O on
+ * every step. Call {@link flushZoomFactorSave} before quitting so a pending
+ * value isn't lost (see issue #3948).
+ */
+export function saveZoomFactor(filePath: string, factor: number) {
+  pendingSave = { filePath, factor };
+
+  if (saveTimer !== null) {
+    clearTimeout(saveTimer);
+  }
+
+  saveTimer = setTimeout(() => {
+    saveTimer = null;
+
+    if (pendingSave) {
+      const { filePath, factor } = pendingSave;
+      pendingSave = null;
+      writeZoomFactor(filePath, factor);
+    }
+  }, SAVE_DEBOUNCE_MS);
+}
+
+/** Writes any pending zoom factor immediately. Call before the app quits. */
+export function flushZoomFactorSave() {
+  if (saveTimer !== null) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+
+  if (pendingSave) {
+    const { filePath, factor } = pendingSave;
+    pendingSave = null;
+    writeZoomFactor(filePath, factor);
+  }
+}
+
+export async function loadZoomFactor(filePath: string): Promise<number> {
+  try {
+    const content = await fsPromises.readFile(filePath, 'utf-8');
+    const { zoomFactor = DEFAULT_ZOOM_FACTOR } = JSON.parse(content);
+    return typeof zoomFactor === 'number' ? clampZoom(zoomFactor) : DEFAULT_ZOOM_FACTOR;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.error(`Failed to load zoom factor, defaulting to ${DEFAULT_ZOOM_FACTOR}:`, err);
+    }
+    return DEFAULT_ZOOM_FACTOR;
+  }
+}

--- a/frontend/src/components/App/AppContainer.test.tsx
+++ b/frontend/src/components/App/AppContainer.test.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { isValidRedirectPath } from './AppContainer';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, useHistory } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as isElectronModule from '../../helpers/isElectron';
+import { isValidRedirectPath, RouteZoomSync } from './AppContainer';
 
 describe('isValidRedirectPath', () => {
   it('should allow safe internal paths', () => {
@@ -89,5 +94,217 @@ describe('isValidRedirectPath', () => {
     expect(isValidRedirectPath('/a')).toBe(true);
     expect(isValidRedirectPath('javascript')).toBe(true);
     expect(isValidRedirectPath('data')).toBe(true);
+  });
+});
+
+function NavigationHarness({ onNavigate }: { onNavigate?: (nav: (path: string) => void) => void }) {
+  const history = useHistory();
+  React.useEffect(() => {
+    onNavigate?.((path: string) => history.push(path));
+  }, [history, onNavigate]);
+  return <RouteZoomSync />;
+}
+
+describe('RouteZoomSync', () => {
+  let originalDesktopApi: any;
+  let rafCallbacks: { [id: number]: FrameRequestCallback } = {};
+  let nextRafId = 1;
+
+  function runNextFrame() {
+    const ids = Object.keys(rafCallbacks).map(Number);
+    if (ids.length > 0) {
+      const firstId = ids[0];
+      const cb = rafCallbacks[firstId];
+      delete rafCallbacks[firstId];
+      cb(performance.now());
+    }
+  }
+
+  function flushFrames() {
+    let loops = 0;
+    while (Object.keys(rafCallbacks).length > 0 && loops < 50) {
+      runNextFrame();
+      loops++;
+    }
+  }
+
+  beforeEach(() => {
+    originalDesktopApi = window.desktopApi;
+    rafCallbacks = {};
+    nextRafId = 1;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+      const id = nextRafId++;
+      rafCallbacks[id] = cb;
+      return id;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      delete rafCallbacks[id];
+    });
+  });
+
+  afterEach(() => {
+    window.desktopApi = originalDesktopApi;
+    vi.restoreAllMocks();
+  });
+
+  it('should not request animation frames or send route-changed when not in Electron', () => {
+    vi.spyOn(isElectronModule, 'isElectron').mockReturnValue(false);
+    const sendSpy = vi.fn();
+    window.desktopApi = { send: sendSpy } as any;
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <RouteZoomSync />
+      </MemoryRouter>
+    );
+
+    flushFrames();
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it('should not request animation frames when desktopApi is missing', () => {
+    vi.spyOn(isElectronModule, 'isElectron').mockReturnValue(true);
+    delete (window as any).desktopApi;
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <RouteZoomSync />
+      </MemoryRouter>
+    );
+
+    flushFrames();
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it('should send route-changed after double requestAnimationFrame on mount', () => {
+    vi.spyOn(isElectronModule, 'isElectron').mockReturnValue(true);
+    const sendSpy = vi.fn();
+    window.desktopApi = { send: sendSpy } as any;
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <RouteZoomSync />
+      </MemoryRouter>
+    );
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(Object.keys(rafCallbacks)).toHaveLength(1);
+
+    // First frame resolves, schedules inner frame
+    runNextFrame();
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(Object.keys(rafCallbacks)).toHaveLength(1);
+
+    // Second frame resolves, sends route-changed
+    runNextFrame();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy).toHaveBeenCalledWith('route-changed');
+  });
+
+  it('should send route-changed after route transitions', () => {
+    vi.spyOn(isElectronModule, 'isElectron').mockReturnValue(true);
+    const sendSpy = vi.fn();
+    window.desktopApi = { send: sendSpy } as any;
+
+    let navigate: (path: string) => void = () => {};
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <NavigationHarness
+          onNavigate={n => {
+            navigate = n;
+          }}
+        />
+      </MemoryRouter>
+    );
+
+    flushFrames();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      navigate('/namespaces/default/pods');
+    });
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+
+    flushFrames();
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    expect(sendSpy).toHaveBeenLastCalledWith('route-changed');
+  });
+
+  it('should cancel outer frame on unmount to suppress stale sends', () => {
+    vi.spyOn(isElectronModule, 'isElectron').mockReturnValue(true);
+    const sendSpy = vi.fn();
+    window.desktopApi = { send: sendSpy } as any;
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <RouteZoomSync />
+      </MemoryRouter>
+    );
+
+    unmount();
+    flushFrames();
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('should cancel inner frame on unmount to suppress stale sends', () => {
+    vi.spyOn(isElectronModule, 'isElectron').mockReturnValue(true);
+    const sendSpy = vi.fn();
+    window.desktopApi = { send: sendSpy } as any;
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <RouteZoomSync />
+      </MemoryRouter>
+    );
+
+    runNextFrame(); // Outer frame executed, inner frame scheduled
+    unmount();
+    flushFrames();
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('should cancel pending frames and suppress stale sends on rapid route changes', () => {
+    vi.spyOn(isElectronModule, 'isElectron').mockReturnValue(true);
+    const sendSpy = vi.fn();
+    window.desktopApi = { send: sendSpy } as any;
+
+    let navigate: (path: string) => void = () => {};
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <NavigationHarness
+          onNavigate={n => {
+            navigate = n;
+          }}
+        />
+      </MemoryRouter>
+    );
+
+    // Initial mount schedules outer frame
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    // Rapidly navigate to a new route before first frame resolves
+    act(() => {
+      navigate('/route-1');
+    });
+
+    // Run 1 frame (resolves outer frame for /route-1, schedules inner frame)
+    runNextFrame();
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    // Rapidly navigate to another route before inner frame resolves
+    act(() => {
+      navigate('/route-2');
+    });
+
+    // Outer & inner frames for /route-1 were cancelled when navigating to /route-2
+    // Now flush all remaining frames for /route-2
+    flushFrames();
+
+    // Exactly 1 call should have been made (for /route-2 only, initial and /route-1 suppressed)
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy).toHaveBeenCalledWith('route-changed');
   });
 });

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -125,6 +125,33 @@ const QueryParamRedirect = () => {
 
   return null;
 };
+
+/** Notify Electron main process after React paints a new route (issue #3948). */
+function RouteZoomSync() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isElectron() || !window.desktopApi) {
+      return;
+    }
+
+    const route = `${location.pathname}${location.search}${location.hash}`;
+    let innerFrame = 0;
+    const outerFrame = requestAnimationFrame(() => {
+      innerFrame = requestAnimationFrame(() => {
+        window.desktopApi?.send('route-changed', route);
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(outerFrame);
+      cancelAnimationFrame(innerFrame);
+    };
+  }, [location.pathname, location.search, location.hash]);
+
+  return null;
+}
+
 const Router = ({ children }: React.PropsWithChildren<{}>) =>
   isElectron() ? (
     <HashRouter>{children}</HashRouter>
@@ -156,6 +183,7 @@ export default function AppContainer() {
       />
       <Router>
         <PreviousRouteProvider>
+          <RouteZoomSync />
           <MonacoEditorLoaderInitializer>
             <Plugins />
             <Layout />

--- a/frontend/src/components/App/AppContainer.tsx
+++ b/frontend/src/components/App/AppContainer.tsx
@@ -125,6 +125,42 @@ const QueryParamRedirect = () => {
 
   return null;
 };
+
+/**
+ * Notify Electron main process after React renders and paints a new route (issue #3948).
+ *
+ * Electron's WebContents 'did-navigate-in-page' event fires immediately when
+ * the URL hash changes, before React has committed the new route components
+ * to the DOM. As a result, applying zoom on 'did-navigate-in-page' can miss
+ * the newly mounted DOM elements, causing them to paint at default 100% scale.
+ * RouteZoomSync waits for double-requestAnimationFrame after location changes
+ * to ensure React has fully rendered and painted the new route before notifying
+ * Electron to enforce the cached zoom factor.
+ */
+export function RouteZoomSync() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isElectron() || !window.desktopApi) {
+      return;
+    }
+
+    let innerFrame = 0;
+    const outerFrame = requestAnimationFrame(() => {
+      innerFrame = requestAnimationFrame(() => {
+        window.desktopApi?.send('route-changed');
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(outerFrame);
+      cancelAnimationFrame(innerFrame);
+    };
+  }, [location.pathname, location.search, location.hash]);
+
+  return null;
+}
+
 const Router = ({ children }: React.PropsWithChildren<{}>) =>
   isElectron() ? (
     <HashRouter>{children}</HashRouter>
@@ -156,6 +192,7 @@ export default function AppContainer() {
       />
       <Router>
         <PreviousRouteProvider>
+          <RouteZoomSync />
           <MonacoEditorLoaderInitializer>
             <Plugins />
             <Layout />


### PR DESCRIPTION
## Summary

Fix zoom persistence in the Electron app when navigating between panes (SPA navigation), switching windows, or regaining focus.

## Related Issue

Fixes #3948

## Changes

- Save zoom immediately on zoom in/out/reset (not only on quit)
- Re-apply cached zoom after SPA navigation, window focus, and route changes
- RouteZoomSync notifies main process after React paints a new route
- zoom.ts helper with 12 unit tests

## Steps to Test

1. Open the app and navigate between different views/panes — zoom level persists
2. Zoom in/out, switch away from the app window, switch back — zoom is not reset
3. Quit and relaunch — zoom level is restored from disk

## Notes for the Reviewer

- Zoom is saved immediately via IPC on every change, not only on app quit
- SPA navigation (HashRouter) triggers re-application of the cached zoom level
- Focus/blur events also trigger re-application
- RouteZoomSync component in AppContainer bridges React Router changes to the Electron main process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zoom preferences are now saved and restored between app sessions.
  * Zoom settings remain consistent when navigating between routes, loading pages, or refocusing the app.
  * Zoom values are validated and kept within supported limits.

* **Bug Fixes**
  * Improved handling of missing or invalid saved zoom settings.
  * Ensured the latest zoom preference is saved before the app closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->