### PR TITLE
backend: cmd: Cap request body size on JSON API endpoints

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -152,6 +152,12 @@ const (
 //nolint:gochecknoglobals // allow test override
 var maxProxyResponseSize int64 = 100 * 1024 * 1024
 
+// maxRequestBodySize bounds a JSON request body accepted by Headlamp's own API
+// endpoints, so an oversized body is rejected instead of being read fully into
+// memory. It does not apply to the cluster proxy, which forwards arbitrary
+// Kubernetes payloads.
+const maxRequestBodySize int64 = 1 * 1024 * 1024
+
 // externalProxyTimeout is the maximum time to wait for a proxy response.
 //
 //nolint:gochecknoglobals // allow test override
@@ -1785,6 +1791,38 @@ func (c *HeadlampConfig) handleError(w http.ResponseWriter, ctx context.Context,
 	http.Error(w, err.Error(), status)
 }
 
+// limitRequestBody caps r.Body so that decoding a request larger than
+// maxRequestBodySize fails instead of buffering the whole body into memory.
+func limitRequestBody(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+}
+
+// bodyDecodeStatus returns the HTTP status for a request-body decode error:
+// 413 when the body exceeded maxRequestBodySize, 400 for any other decode
+// failure such as malformed JSON.
+func bodyDecodeStatus(err error) int {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		return http.StatusRequestEntityTooLarge
+	}
+
+	return http.StatusBadRequest
+}
+
+// writeDecodeError responds to a request-body decode failure: an oversized body
+// gets 413 with the underlying "request body too large" message, any other
+// decode error gets 400 with badRequestMsg.
+func writeDecodeError(w http.ResponseWriter, err error, badRequestMsg string) {
+	status := bodyDecodeStatus(err)
+
+	msg := badRequestMsg
+	if status == http.StatusRequestEntityTooLarge {
+		msg = err.Error()
+	}
+
+	http.Error(w, msg, status)
+}
+
 func clusterRequestHandler(c *HeadlampConfig) http.Handler { //nolint:funlen
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -2184,11 +2222,13 @@ func (c *HeadlampConfig) addCluster(w http.ResponseWriter, r *http.Request) { //
 		return
 	}
 
+	limitRequestBody(w, r)
+
 	clusterReq, err := decodeClusterRequest(r)
 	if err != nil {
 		c.TelemetryHandler.RecordError(span, err, "failed to decode cluster request")
 		c.TelemetryHandler.RecordErrorCount(ctx, attribute.String("error.type", "decode error"))
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), bodyDecodeStatus(err))
 
 		return
 	}
@@ -2599,9 +2639,11 @@ func (c *HeadlampConfig) renameCluster(w http.ResponseWriter, r *http.Request) {
 	c.TelemetryHandler.RecordRequestCount(ctx, r, attribute.String("cluster", clusterName))
 
 	// Parse request and validate
+	limitRequestBody(w, r)
+
 	var reqBody RenameClusterRequest
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-		c.handleError(w, ctx, span, err, "failed to decode request body", http.StatusBadRequest)
+		c.handleError(w, ctx, span, err, "failed to decode request body", bodyDecodeStatus(err))
 		return
 	}
 
@@ -2801,13 +2843,15 @@ func (c *HeadlampConfig) handleNodeDrain(w http.ResponseWriter, r *http.Request)
 
 	defer span.End()
 
+	limitRequestBody(w, r)
+
 	var drainPayload struct {
 		Cluster  string `json:"cluster"`
 		NodeName string `json:"nodeName"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&drainPayload); err != nil {
-		c.handleError(w, ctx, span, err, "decoding payload", http.StatusBadRequest)
+		c.handleError(w, ctx, span, err, "decoding payload", bodyDecodeStatus(err))
 
 		return
 	}
@@ -3035,12 +3079,14 @@ func (c *HeadlampConfig) handleNodeDrainStatus(w http.ResponseWriter, r *http.Re
 func (c *HeadlampConfig) handleSetToken(w http.ResponseWriter, r *http.Request) {
 	cluster := mux.Vars(r)["clusterName"]
 
+	limitRequestBody(w, r)
+
 	var req struct {
 		Token string `json:"token"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		writeDecodeError(w, err, "Invalid JSON")
 		return
 	}
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -4158,3 +4158,30 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
 }
+
+func TestRequestBodySizeLimit(t *testing.T) {
+	cfg := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				KubeConfigStore: kubeconfig.NewContextStore(),
+			},
+			Cache:            cache.New[interface{}](),
+			TelemetryConfig:  GetDefaultTestTelemetryConfig(),
+			TelemetryHandler: &telemetry.RequestHandler{},
+		},
+	}
+
+	// A body larger than maxRequestBodySize, made of valid JSON so only the size
+	// limit (not JSON validity) can reject it.
+	huge := strings.Repeat("A", int(maxRequestBodySize)+1)
+	body := fmt.Sprintf(`{"cluster":"c","nodeName":"%s"}`, huge)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/drain-node",
+		strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	cfg.handleNodeDrain(rr, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	assert.Contains(t, rr.Body.String(), "too large")
+}

--- a/backend/cmd/stateless.go
+++ b/backend/cmd/stateless.go
@@ -169,12 +169,14 @@ func (c *HeadlampConfig) parseKubeConfig(w http.ResponseWriter, r *http.Request)
 	var kubeconfigReq KubeconfigRequest
 
 	// Decode the JSON request body into the kubeconfigReq variable
+	limitRequestBody(w, r)
+
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&kubeconfigReq); err != nil {
 		// Handle the error, return a bad request response
 		logger.Log(logger.LevelError, nil, err, "decoding config")
 
-		http.Error(w, "Invalid JSON request body", http.StatusBadRequest)
+		writeDecodeError(w, err, "Invalid JSON request body")
 
 		return
 	}


### PR DESCRIPTION
## Summary

Headlamp's own JSON API endpoints decoded the request body with json.NewDecoder(r.Body) and no size limit, so a client holding a valid backend token could send a multi-gigabyte body that gets buffered fully into memory before the JSON is even looked at, exhausting the server's memory and dragging down everyone else on the same instance. This adds a maxRequestBodySize limit and a small limitRequestBody helper that wraps the body with http.MaxBytesReader, so an oversized body gets rejected instead of read in full. It's the same idea as the memory-bounding already done for proxied responses in /externalproxy, just on the request side.

## Related Issue

Fixes #6484

## Changes

- backend/cmd/headlamp.go: added maxRequestBodySize and a limitRequestBody helper, and applied it to addCluster, renameCluster, handleNodeDrain and handleSetToken before they decode the body
- backend/cmd/stateless.go: same for parseKubeConfig
- Left the cluster proxy alone on purpose, since it has to forward arbitrary Kubernetes payloads like large manifests
- backend/cmd/headlamp_test.go: added a test that sends an oversized but valid JSON body and checks it's rejected rather than decoded

## Steps to Test

1. Send a POST to /drain-node (or any of the endpoints above) with a valid backend token and a body bigger than 1 MiB, e.g. a huge string in one of the JSON fields
2. Before this change the server decodes the whole thing; after it, the request is rejected with "http: request body too large"
3. A normal small request still works exactly as before

## Screenshots (if applicable)

N/A — backend request handling, nothing visual.

## Notes for the Reviewer

I set the limit at 1 MiB, which is plenty for these endpoints (even a kubeconfig with ~150 contexts fits comfortably), but happy to bump it if you'd rather have more headroom for parseKubeConfig multi-file uploads. Also kept it scoped to the JSON endpoints rather than a global middleware, since a blanket limit would break the cluster proxy forwarding large manifests.
