### PR TITLE
frontend: ProjectDeleteButton: Add Storybook stories

### DIFF
--- a/frontend/src/components/project/ProjectDeleteButton.stories.tsx
+++ b/frontend/src/components/project/ProjectDeleteButton.stories.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { ProjectDefinition } from '../../redux/projectsSlice';
+import { API_BASE, TestContext } from '../../test';
+import { ProjectDeleteButton } from './ProjectDeleteButton';
+
+const mockProject: ProjectDefinition = {
+  id: 'test-project',
+  namespaces: ['ns1'],
+  clusters: [''],
+};
+
+const mockProjectNoMatch: ProjectDefinition = {
+  id: 'orphan-project',
+  namespaces: ['nonexistent'],
+  clusters: [''],
+};
+
+export default {
+  title: 'project/ProjectDeleteButton',
+  component: ProjectDeleteButton,
+  decorators: [
+    Story => (
+      <TestContext>
+        <Story />
+      </TestContext>
+    ),
+  ],
+  parameters: {
+    msw: {
+      handlers: {
+        base: null,
+        story: [
+          http.get(`${API_BASE}/api/v1/namespaces`, () =>
+            HttpResponse.json({
+              kind: 'NamespaceList',
+              apiVersion: 'v1',
+              items: [
+                {
+                  apiVersion: 'v1',
+                  kind: 'Namespace',
+                  metadata: {
+                    name: 'ns1',
+                    uid: 'ns-1',
+                  },
+                },
+              ],
+              metadata: {},
+            })
+          ),
+          http.post(`${API_BASE}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`, () =>
+            HttpResponse.json({
+              status: { allowed: true, reason: '' },
+            })
+          ),
+        ],
+      },
+    },
+  },
+} as Meta<typeof ProjectDeleteButton>;
+
+const Template: StoryFn<typeof ProjectDeleteButton> = args => <ProjectDeleteButton {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  project: mockProject,
+};
+
+export const NoNamespaces = Template.bind({});
+NoNamespaces.args = {
+  project: mockProjectNoMatch,
+};
+
+export const MenuStyle = Template.bind({});
+MenuStyle.args = {
+  project: mockProject,
+  buttonStyle: 'menu',
+};

--- a/frontend/src/components/project/__snapshots__/ProjectDeleteButton.Default.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectDeleteButton.Default.stories.storyshot
@@ -1,0 +1,15 @@
+<body>
+  <div>
+    <button
+      aria-label="Delete project"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-whz9ym-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>

--- a/frontend/src/components/project/__snapshots__/ProjectDeleteButton.MenuStyle.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectDeleteButton.MenuStyle.stories.storyshot
@@ -1,0 +1,25 @@
+<body>
+  <div>
+    <li
+      class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters css-1sgjfx9-MuiButtonBase-root-MuiMenuItem-root"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="MuiListItemIcon-root css-cveggr-MuiListItemIcon-root"
+      />
+      <div
+        class="MuiListItemText-root css-tlelie-MuiListItemText-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiListItemText-primary css-nqgwvn-MuiTypography-root"
+        >
+          Delete project
+        </span>
+      </div>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </li>
+  </div>
+</body>

--- a/frontend/src/components/project/__snapshots__/ProjectDeleteButton.NoNamespaces.stories.storyshot
+++ b/frontend/src/components/project/__snapshots__/ProjectDeleteButton.NoNamespaces.stories.storyshot
@@ -1,0 +1,3 @@
+<body>
+  <div />
+</body>


### PR DESCRIPTION
## Summary

This PR adds Storybook stories for the ProjectDeleteButton component to improve visual documentation and snapshot test coverage.

## Related Issue

Fixes #6504 

## Changes

- Added `frontend/src/components/project/ProjectDeleteButton.stories.tsx` with 3 stories:
  - `Default` — button visible as an icon button when matching namespaces exist
  - `NoNamespaces` — button hidden when no namespaces match (renders nothing)
  - `MenuStyle` — button rendered as a MenuItem when `buttonStyle="menu"`

## Steps to Test

1. Run `npm run frontend:test` to verify snapshot tests pass
2. Run `npm run frontend:storybook` and navigate to `project/ProjectDeleteButton`
3. Verify all 3 stories render correctly

## Screenshots (if applicable)


## Notes for the Reviewer

- Uses MSW to mock `Namespace.useList` (`GET /api/v1/namespaces`), following the pattern from `ProjectDetails.stories.tsx`
- `AuthVisible` is handled by the global base MSW handler — no additional mocking needed
- All 3 stories have full storyshots enabled (no play functions)