### PR TITLE
frontend: EventsLifetimeInfo: Add Storybook stories

### DIFF
--- a/frontend/src/components/common/EventsLifetimeInfo.stories.tsx
+++ b/frontend/src/components/common/EventsLifetimeInfo.stories.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, StoryFn } from '@storybook/react';
+import EventsLifetimeInfo from './EventsLifetimeInfo';
+
+export default {
+  title: 'common/EventsLifetimeInfo',
+  component: EventsLifetimeInfo,
+} as Meta;
+
+const Template: StoryFn = () => <EventsLifetimeInfo />;
+
+export const Default = Template.bind({});

--- a/frontend/src/components/common/__snapshots__/EventsLifetimeInfo.Default.stories.storyshot
+++ b/frontend/src/components/common/__snapshots__/EventsLifetimeInfo.Default.stories.storyshot
@@ -1,0 +1,15 @@
+<body>
+  <div>
+    <button
+      aria-label="Events lifetime information"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-ai5t7w-MuiButtonBase-root-MuiIconButton-root"
+      data-mui-internal-clone-element="true"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</body>


### PR DESCRIPTION
Adds a Storybook story for the `EventsLifetimeInfo` component (`frontend/src/components/common/EventsLifetimeInfo.tsx`), which had none. In this repo stories double as snapshot tests via `frontend/src/storybook.test.tsx`, so this gives the component snapshot coverage.

It is a small, purely presentational component (a `LightTooltip` wrapping an info `IconButton`) with no props, so a single `Default` story is sufficient. No MSW handlers or Redux store are needed.

The diff is small: the hand-written change is the ~26-line story file; the rest is one generated `.storyshot` snapshot. Full storyshot suite passes (642) with zero drift.

Closes #6506

Part of the umbrella effort to add stories for uncovered components (#931).