### PR TITLE
frontend: ClusterSettings: Handle invalid json and add unit test

### DIFF
--- a/frontend/src/helpers/clusterSettings.test.ts
+++ b/frontend/src/helpers/clusterSettings.test.ts
@@ -118,16 +118,37 @@ describe('clusterSettings', () => {
       expect(loadClusterSettings('prod.extra')).toEqual({});
     });
 
-    it('returns empty object and logs console error when the stored payload is not valid JSON', () => {
+    it('returns empty object and logs console warning when the stored payload is not valid JSON', () => {
       localStorage.setItem('cluster_settings.prod', '{not json');
 
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const result = loadClusterSettings('prod');
 
       expect(result).toEqual({});
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('returns empty object and logs console warning when the stored payload is not an object', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Test null
+      localStorage.setItem('cluster_settings.prod', 'null');
+      expect(loadClusterSettings('prod')).toEqual({});
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+
+      // Test array
+      localStorage.setItem('cluster_settings.prod', '[1, 2, 3]');
+      expect(loadClusterSettings('prod')).toEqual({});
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+
+      // Test string
+      localStorage.setItem('cluster_settings.prod', '"some string"');
+      expect(loadClusterSettings('prod')).toEqual({});
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(3);
+
+      consoleWarnSpy.mockRestore();
     });
   });
 });

--- a/frontend/src/helpers/clusterSettings.test.ts
+++ b/frontend/src/helpers/clusterSettings.test.ts
@@ -118,13 +118,16 @@ describe('clusterSettings', () => {
       expect(loadClusterSettings('prod.extra')).toEqual({});
     });
 
-    // Documents current behaviour: corrupted localStorage payloads surface as
-    // a parse error rather than silently falling back to {}. A future change
-    // could add defensive recovery; this test should be updated alongside it.
-    it('throws when the stored payload is not valid JSON', () => {
+    it('returns empty object and logs console error when the stored payload is not valid JSON', () => {
       localStorage.setItem('cluster_settings.prod', '{not json');
 
-      expect(() => loadClusterSettings('prod')).toThrow(SyntaxError);
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = loadClusterSettings('prod');
+
+      expect(result).toEqual({});
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/frontend/src/helpers/clusterSettings.ts
+++ b/frontend/src/helpers/clusterSettings.ts
@@ -68,6 +68,11 @@ export function loadClusterSettings(clusterName: string): ClusterSettings {
   if (!clusterName) {
     return {};
   }
-  const settings = JSON.parse(localStorage.getItem(`cluster_settings.${clusterName}`) || '{}');
-  return settings;
+  try {
+    const settings = JSON.parse(localStorage.getItem(`cluster_settings.${clusterName}`) || '{}');
+    return settings;
+  } catch (err) {
+    console.error(`Error parsing cluster settings for ${clusterName}:`, err);
+    return {};
+  }
 }

--- a/frontend/src/helpers/clusterSettings.ts
+++ b/frontend/src/helpers/clusterSettings.ts
@@ -69,10 +69,15 @@ export function loadClusterSettings(clusterName: string): ClusterSettings {
     return {};
   }
   try {
-    const settings = JSON.parse(localStorage.getItem(`cluster_settings.${clusterName}`) || '{}');
-    return settings;
-  } catch (err) {
-    console.error(`Error parsing cluster settings for ${clusterName}:`, err);
-    return {};
+    const raw = localStorage.getItem(`cluster_settings.${clusterName}`) || '{}';
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      console.warn(`cluster_settings.${clusterName} is not an object, falling back to {}.`);
+      return {};
+    }
+    return parsed as ClusterSettings;
+  } catch (error) {
+    console.warn(`Failed to parse cluster_settings.${clusterName}, falling back to {}:`, error);
   }
+  return {};
 }


### PR DESCRIPTION
## Summary

Wrap JSON parsing in `loadClusterSettings` with a try-catch block to prevent the Headlamp React UI rendering path from crashing if `localStorage` contains invalid or corrupted JSON.


## Related Issue

Fixes #6508

## Changes

- Modified clusterSettings.ts in clusterSettings.ts to safely handle JSON parsing exceptions.
- Added unit tests in clusterSettings.test.ts to verify correct loading, storing, and fallback parsing behavior.

