### PR TITLE
frontend: streamingApi:  websocket memory leak on component unmount

### DIFF
--- a/frontend/src/lib/k8s/api/v1/streamingApi.ts
+++ b/frontend/src/lib/k8s/api/v1/streamingApi.ts
@@ -344,6 +344,10 @@ export function stream<T>(url: string, cb: StreamResultsCb<T>, args: StreamArgs)
     if (connectCb) connectCb();
     try {
       connection = await connectStream(url, cb, onFail, isJson, additionalProtocols, cluster);
+
+      if (isCancelled) {
+        connection.close();
+      }
     } catch (error) {
       console.error('Error connecting stream:', error);
       onFail();


### PR DESCRIPTION

This adds a quick check to make sure we aren't leaving connections open by accident. If a user clicks away while the app is still trying to connect, we now immediately close the socket as soon as it connects, rather than leaving it running in the background.

## Summary

This PR fixes a bug where background connections (WebSockets) were getting left open forever if a user navigated away from a page too quickly. 

## Related Issue



## Changes

- Updated `streamingApi.ts` to double-check if a stream was cancelled right after it finishes connecting. If it was cancelled, we close the socket immediately.

## Steps to Test

1. Start up the app locally.
2. Open your browser's Developer Tools and go to the **Network** tab (filter by "WS" to see WebSockets).
3. Try to view a Pod's logs or open a Terminal.
4. Before the terminal or logs fully load, quickly click away to a different page.
5. Check the Network tab: You should see the WebSocket connection close immediately, instead of staying open and running in the background forever.

## Screenshots (if applicable)

*(No screenshots needed, this is just a background logic fix!)*

## Notes for the Reviewer

- Because the connection process takes a little bit of time, clicking away from the page early was missing the "close connection" command. This just adds a check at the very end of the connection process to make sure the user hasn't already left the page. Tests are passing locally!
