### PR TITLE
headlamp-plugin: tsconfig: Migrate moduleResolution to bundler

### DIFF
--- a/plugins/headlamp-plugin/tsconfig.json
+++ b/plugins/headlamp-plugin/tsconfig.json
@@ -12,7 +12,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
This PR fixes the deprecated `moduleResolution=node10` warning in `plugins/headlamp-plugin/tsconfig.json` by migrating to `moduleResolution: bundler`, which is compatible with the existing `module: esnext` setting and stays consistent with `config/plugins-tsconfig.json`, already migrated in #6433.

## Related Issue
Fixes #6440

## Changes
- Updated `moduleResolution` from `"node"` (node10) to `"bundler"` in `plugins/headlamp-plugin/tsconfig.json`

## Steps to Test
1. Install TypeScript 6.0+ standalone without touching the pinned project version: `npx -p typescript@6.0.3 tsc --noEmit -p tsconfig.json`
2. Before the fix, this prints `TS5107: Option 'moduleResolution=node10' is deprecated...`
3. After the fix, the command exits cleanly with no warnings (exit code `0`)
4. Run `npm run build` under the pinned TypeScript 5.6.2 to confirm the actual build pipeline is unaffected

## Screenshots 
**Before fix** 
<img width="1528" height="198" alt="Screenshot from 2026-07-15 08-36-03" src="https://github.com/user-attachments/assets/5d201b25-9ba4-4039-a254-24feafefb2eb" />

**After fix** 
<img width="1497" height="61" alt="Screenshot from 2026-07-15 08-42-56" src="https://github.com/user-attachments/assets/84dbf3f7-40f9-4070-ba23-cd46d03048b3" />

## Notes for the Reviewer
- Scope limited to `plugins/headlamp-plugin/tsconfig.json` only, does not touch `config/plugins-tsconfig.json` (already covered in #6433)
- `bundler` was chosen over `node16`/`nodenext` because those require `module` to also be `node16`/`nodenext`, which would be a larger, unrelated change; `bundler` works directly with the existing `module: esnext` setting
- Verified with TypeScript 6.0.3 (via `npx`, not installed as a project dependency) since the pinned 5.6.2 does not emit this diagnostic
- Confirmed `npm run build` still succeeds under the pinned TypeScript 5.6.2, no regression to the actual build pipeline