### PR TITLE
backend: externalproxy: Extract module and harden proxy headers

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -99,7 +99,8 @@ func (c *HeadlampConfig) proxyURLAllowlist() ([]externalproxy.AllowlistEntry, er
 		c.compiledProxyURLs = compiledProxyURLs
 	}
 
-	return c.compiledProxyURLs, nil
+	// Return a copy so callers cannot mutate the cached allowlist.
+	return append([]externalproxy.AllowlistEntry(nil), c.compiledProxyURLs...), nil
 }
 
 func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
@@ -43,7 +42,6 @@ import (
 	"time"
 
 	oidc "github.com/coreos/go-oidc/v3/oidc"
-	"github.com/gobwas/glob"
 	"github.com/google/uuid"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -51,6 +49,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory"
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/helm"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -79,49 +78,37 @@ import (
 type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
 	proxyURLMu        sync.Mutex
-	compiledProxyURLs []glob.Glob
+	compiledProxyURLs []externalproxy.AllowlistEntry
 	oidcStateReader   io.Reader
 }
 
-func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
-	compiledProxyURLs := make([]glob.Glob, 0, len(patterns))
-
-	for _, pattern := range patterns {
-		g, err := glob.Compile(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
-		}
-
-		compiledProxyURLs = append(compiledProxyURLs, g)
-	}
-
-	return compiledProxyURLs, nil
+func compileProxyURLPatterns(patterns []string) ([]externalproxy.AllowlistEntry, error) {
+	return externalproxy.CompileAllowlist(patterns)
 }
 
-func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
+func (c *HeadlampConfig) proxyURLAllowlist() ([]externalproxy.AllowlistEntry, error) {
 	c.proxyURLMu.Lock()
+	defer c.proxyURLMu.Unlock()
 
 	if c.compiledProxyURLs == nil && len(c.ProxyURLs) > 0 {
 		compiledProxyURLs, err := compileProxyURLPatterns(c.ProxyURLs)
 		if err != nil {
-			c.proxyURLMu.Unlock()
-
-			return false, err
+			return nil, err
 		}
 
 		c.compiledProxyURLs = compiledProxyURLs
 	}
 
-	compiledProxyURLs := c.compiledProxyURLs
-	c.proxyURLMu.Unlock()
+	return c.compiledProxyURLs, nil
+}
 
-	for _, g := range compiledProxyURLs {
-		if g.Match(proxyURL) {
-			return true, nil
-		}
+func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
+	allowlist, err := c.proxyURLAllowlist()
+	if err != nil {
+		return false, err
 	}
 
-	return false, nil
+	return externalproxy.MatchesAllowlist(proxyURL, allowlist), nil
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -146,16 +133,6 @@ const (
 	// serverIdleTimeout is the maximum time to wait for the next request on a keep-alive connection.
 	serverIdleTimeout = 120 * time.Second
 )
-
-// maxProxyResponseSize is the maximum size (in bytes) for proxied responses.
-//
-//nolint:gochecknoglobals // allow test override
-var maxProxyResponseSize int64 = 100 * 1024 * 1024
-
-// externalProxyTimeout is the maximum time to wait for a proxy response.
-//
-//nolint:gochecknoglobals // allow test override
-var externalProxyTimeout = 30 * time.Second
 
 const kubeConfigSource = "kubeconfig" // source for kubeconfig contexts
 
@@ -714,134 +691,17 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	config.handleClusterRequests(r)
 
-	r.HandleFunc("/externalproxy", func(w http.ResponseWriter, r *http.Request) {
-		proxyURL := r.Header.Get("proxy-to")
-		if proxyURL == "" && r.Header.Get("Forward-to") != "" {
-			proxyURL = r.Header.Get("Forward-to")
-		}
-
-		if proxyURL == "" {
-			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL},
-				errors.New("proxy URL is empty"), "proxy URL is empty")
-			http.Error(w, "proxy URL is empty", http.StatusBadRequest)
-
-			return
-		}
-
-		url, err := url.Parse(proxyURL)
+	externalProxyHandler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry {
+		allowlist, err := config.proxyURLAllowlist()
 		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL},
-				err, "The provided proxy URL is invalid")
-			http.Error(w, fmt.Sprintf("The provided proxy URL is invalid: %v", err), http.StatusBadRequest)
+			logger.Log(logger.LevelError, nil, err, "compiling proxy URL patterns")
 
-			return
+			return nil
 		}
 
-		isURLContainedInProxyURLs, err := config.proxyURLAllowed(url.String())
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL}, err, "compiling proxy URL patterns")
-			http.Error(w, "failed to compile proxy URL patterns", http.StatusInternalServerError)
-
-			return
-		}
-
-		if !isURLContainedInProxyURLs {
-			logger.Log(logger.LevelError, nil, err, "no allowed proxy url match, request denied")
-			http.Error(w, "no allowed proxy url match, request denied ", http.StatusBadRequest)
-
-			return
-		}
-
-		proxyCtx, cancel := context.WithTimeout(r.Context(), externalProxyTimeout)
-		defer cancel()
-
-		proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, proxyURL, r.Body) //nolint:gosec
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "creating request")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-
-			return
-		}
-
-		// We may want to filter some headers, otherwise we could just use a shallow copy
-		proxyReq.Header = make(http.Header)
-		for h, val := range r.Header {
-			proxyReq.Header[h] = val
-		}
-
-		// Disable caching
-		w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
-		w.Header().Set("Expires", time.Unix(0, 0).Format(http.TimeFormat))
-		w.Header().Set("Pragma", "no-cache")
-		w.Header().Set("X-Accel-Expires", "0")
-
-		client := http.Client{}
-
-		resp, err := client.Do(proxyReq) //nolint:gosec
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "making request")
-			http.Error(w, err.Error(), http.StatusBadGateway)
-
-			return
-		}
-
-		defer func() { _ = resp.Body.Close() }()
-
-		// Check that the server actually sent compressed data
-		var reader io.ReadCloser
-
-		switch resp.Header.Get("Content-Encoding") {
-		case "gzip":
-			reader, err = gzip.NewReader(resp.Body)
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "reading gzip response")
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-
-				return
-			}
-
-			defer func() { _ = reader.Close() }()
-		default:
-			reader = resp.Body
-		}
-
-		// Read the first chunk before committing the response so early upstream
-		// failures can still return a 502 instead of an empty success response.
-		firstChunk := make([]byte, 32*1024)
-
-		n, readErr := reader.Read(firstChunk)
-		if readErr != nil && !errors.Is(readErr, io.EOF) && n == 0 {
-			logger.Log(logger.LevelError, nil, readErr, "reading response")
-			http.Error(w, readErr.Error(), http.StatusBadGateway)
-
-			return
-		}
-
-		if contentType := resp.Header.Get("Content-Type"); contentType != "" {
-			w.Header().Set("Content-Type", contentType)
-		}
-
-		// Reject early if Content-Length exceeds the maximum allowed size.
-		if resp.ContentLength > maxProxyResponseSize {
-			logger.Log(logger.LevelError, nil, nil, "proxy response exceeded maximum allowed size (Content-Length)")
-			http.Error(w, "response too large", http.StatusBadGateway)
-
-			return
-		}
-
-		w.WriteHeader(resp.StatusCode)
-
-		// Stream the body, putting the already-read first chunk back in front of
-		// the reader so a single size limit covers the whole response. The limit
-		// prevents memory exhaustion and decompression bombs; if the length is
-		// unknown and the limit is reached, the response is truncated.
-		body := io.MultiReader(bytes.NewReader(firstChunk[:n]), reader)
-		if _, err := io.Copy(w, io.LimitReader(body, maxProxyResponseSize)); err != nil {
-			logger.Log(logger.LevelError, nil, err, "streaming response")
-
-			return
-		}
+		return allowlist
 	})
+	r.Handle("/externalproxy", externalProxyHandler)
 
 	// Configuration
 	r.HandleFunc("/config", config.getConfig).Methods("GET")

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -691,15 +691,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	config.handleClusterRequests(r)
 
-	externalProxyHandler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry {
-		allowlist, err := config.proxyURLAllowlist()
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "compiling proxy URL patterns")
-
-			return nil
-		}
-
-		return allowlist
+	externalProxyHandler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) {
+		return config.proxyURLAllowlist()
 	})
 	r.Handle("/externalproxy", externalProxyHandler)
 

--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
@@ -43,7 +42,6 @@ import (
 	"time"
 
 	oidc "github.com/coreos/go-oidc/v3/oidc"
-	"github.com/gobwas/glob"
 	"github.com/google/uuid"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -51,6 +49,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory"
 	cfg "github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/helm"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -80,49 +79,38 @@ import (
 type HeadlampConfig struct {
 	*headlampconfig.HeadlampConfig
 	proxyURLMu        sync.Mutex
-	compiledProxyURLs []glob.Glob
+	compiledProxyURLs []externalproxy.AllowlistEntry
 	oidcStateReader   io.Reader
 }
 
-func compileProxyURLPatterns(patterns []string) ([]glob.Glob, error) {
-	compiledProxyURLs := make([]glob.Glob, 0, len(patterns))
-
-	for _, pattern := range patterns {
-		g, err := glob.Compile(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
-		}
-
-		compiledProxyURLs = append(compiledProxyURLs, g)
-	}
-
-	return compiledProxyURLs, nil
+func compileProxyURLPatterns(patterns []string) ([]externalproxy.AllowlistEntry, error) {
+	return externalproxy.CompileAllowlist(patterns)
 }
 
-func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
+func (c *HeadlampConfig) proxyURLAllowlist() ([]externalproxy.AllowlistEntry, error) {
 	c.proxyURLMu.Lock()
+	defer c.proxyURLMu.Unlock()
 
 	if c.compiledProxyURLs == nil && len(c.ProxyURLs) > 0 {
 		compiledProxyURLs, err := compileProxyURLPatterns(c.ProxyURLs)
 		if err != nil {
-			c.proxyURLMu.Unlock()
-
-			return false, err
+			return nil, err
 		}
 
 		c.compiledProxyURLs = compiledProxyURLs
 	}
 
-	compiledProxyURLs := c.compiledProxyURLs
-	c.proxyURLMu.Unlock()
+	// Return a copy so callers cannot mutate the cached allowlist.
+	return append([]externalproxy.AllowlistEntry(nil), c.compiledProxyURLs...), nil
+}
 
-	for _, g := range compiledProxyURLs {
-		if g.Match(proxyURL) {
-			return true, nil
-		}
+func (c *HeadlampConfig) proxyURLAllowed(proxyURL string) (bool, error) {
+	allowlist, err := c.proxyURLAllowlist()
+	if err != nil {
+		return false, err
 	}
 
-	return false, nil
+	return externalproxy.MatchesAllowlist(proxyURL, allowlist), nil
 }
 
 const DrainNodeCacheTTL = 20 // seconds
@@ -149,16 +137,6 @@ const (
 	// serviceAccountNamespacePath contains the namespace of an in-cluster pod.
 	serviceAccountNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 )
-
-// maxProxyResponseSize is the maximum size (in bytes) for proxied responses.
-//
-//nolint:gochecknoglobals // allow test override
-var maxProxyResponseSize int64 = 100 * 1024 * 1024
-
-// externalProxyTimeout is the maximum time to wait for a proxy response.
-//
-//nolint:gochecknoglobals // allow test override
-var externalProxyTimeout = 30 * time.Second
 
 const kubeConfigSource = "kubeconfig" // source for kubeconfig contexts
 
@@ -834,133 +812,8 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 
 	config.handleClusterRequests(r)
 
-	externalProxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxyURL := r.Header.Get("proxy-to")
-		if proxyURL == "" && r.Header.Get("Forward-to") != "" {
-			proxyURL = r.Header.Get("Forward-to")
-		}
-
-		if proxyURL == "" {
-			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL},
-				errors.New("proxy URL is empty"), "proxy URL is empty")
-			http.Error(w, "proxy URL is empty", http.StatusBadRequest)
-
-			return
-		}
-
-		url, err := url.Parse(proxyURL)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL},
-				err, "The provided proxy URL is invalid")
-			http.Error(w, fmt.Sprintf("The provided proxy URL is invalid: %v", err), http.StatusBadRequest)
-
-			return
-		}
-
-		isURLContainedInProxyURLs, err := config.proxyURLAllowed(url.String())
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL}, err, "compiling proxy URL patterns")
-			http.Error(w, "failed to compile proxy URL patterns", http.StatusInternalServerError)
-
-			return
-		}
-
-		if !isURLContainedInProxyURLs {
-			logger.Log(logger.LevelError, nil, err, "no allowed proxy url match, request denied")
-			http.Error(w, "no allowed proxy url match, request denied ", http.StatusBadRequest)
-
-			return
-		}
-
-		proxyCtx, cancel := context.WithTimeout(r.Context(), externalProxyTimeout)
-		defer cancel()
-
-		proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, proxyURL, r.Body) //nolint:gosec
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "creating request")
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-
-			return
-		}
-
-		// We may want to filter some headers, otherwise we could just use a shallow copy
-		proxyReq.Header = make(http.Header)
-		for h, val := range r.Header {
-			proxyReq.Header[h] = val
-		}
-
-		// Disable caching
-		w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
-		w.Header().Set("Expires", time.Unix(0, 0).Format(http.TimeFormat))
-		w.Header().Set("Pragma", "no-cache")
-		w.Header().Set("X-Accel-Expires", "0")
-
-		client := http.Client{}
-
-		resp, err := client.Do(proxyReq) //nolint:gosec
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "making request")
-			http.Error(w, err.Error(), http.StatusBadGateway)
-
-			return
-		}
-
-		defer func() { _ = resp.Body.Close() }()
-
-		// Check that the server actually sent compressed data
-		var reader io.ReadCloser
-
-		switch resp.Header.Get("Content-Encoding") {
-		case "gzip":
-			reader, err = gzip.NewReader(resp.Body)
-			if err != nil {
-				logger.Log(logger.LevelError, nil, err, "reading gzip response")
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-
-				return
-			}
-
-			defer func() { _ = reader.Close() }()
-		default:
-			reader = resp.Body
-		}
-
-		// Read the first chunk before committing the response so early upstream
-		// failures can still return a 502 instead of an empty success response.
-		firstChunk := make([]byte, 32*1024)
-
-		n, readErr := reader.Read(firstChunk)
-		if readErr != nil && !errors.Is(readErr, io.EOF) && n == 0 {
-			logger.Log(logger.LevelError, nil, readErr, "reading response")
-			http.Error(w, readErr.Error(), http.StatusBadGateway)
-
-			return
-		}
-
-		if contentType := resp.Header.Get("Content-Type"); contentType != "" {
-			w.Header().Set("Content-Type", contentType)
-		}
-
-		// Reject early if Content-Length exceeds the maximum allowed size.
-		if resp.ContentLength > maxProxyResponseSize {
-			logger.Log(logger.LevelError, nil, nil, "proxy response exceeded maximum allowed size (Content-Length)")
-			http.Error(w, "response too large", http.StatusBadGateway)
-
-			return
-		}
-
-		w.WriteHeader(resp.StatusCode)
-
-		// Stream the body, putting the already-read first chunk back in front of
-		// the reader so a single size limit covers the whole response. The limit
-		// prevents memory exhaustion and decompression bombs; if the length is
-		// unknown and the limit is reached, the response is truncated.
-		body := io.MultiReader(bytes.NewReader(firstChunk[:n]), reader)
-		if _, err := io.Copy(w, io.LimitReader(body, maxProxyResponseSize)); err != nil {
-			logger.Log(logger.LevelError, nil, err, "streaming response")
-
-			return
-		}
+	externalProxyHandler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) {
+		return config.proxyURLAllowlist()
 	})
 	r.Handle("/externalproxy", auth.NewBackendTokenMiddleware(config.UseInCluster)(externalProxyHandler))
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -712,7 +712,7 @@ func newLargeBodyUpstream(t *testing.T, size int) *httptest.Server {
 	}))
 }
 
-func newExternalProxyHandler(t *testing.T, upstream string) http.Handler {
+func newExternalProxyHandler(t *testing.T, upstream string, customize ...func(*externalproxy.Handler)) http.Handler {
 	t.Helper()
 
 	upstreamURL, err := url.Parse(upstream)
@@ -720,16 +720,23 @@ func newExternalProxyHandler(t *testing.T, upstream string) http.Handler {
 		t.Fatal(err)
 	}
 
-	return createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{upstreamURL.String()},
-				KubeConfigStore: kubeconfig.NewContextStore(),
-			},
-			Cache: cache.New[interface{}](),
-		},
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) {
+		return allowlist, nil
 	})
+
+	for _, fn := range customize {
+		fn(handler)
+	}
+
+	router := mux.NewRouter()
+	router.Handle("/externalproxy", handler)
+
+	return router
 }
 
 func TestExternalProxyForwarding(t *testing.T) {
@@ -801,11 +808,6 @@ func TestExternalProxyStreamsLargeBody(t *testing.T) {
 }
 
 func TestExternalProxyTimeout(t *testing.T) {
-	originalLimit := externalproxy.Timeout
-	externalproxy.Timeout = 50 * time.Millisecond
-
-	t.Cleanup(func() { externalproxy.Timeout = originalLimit })
-
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond) // Block longer than the timeout
 		w.WriteHeader(http.StatusOK)
@@ -813,27 +815,14 @@ func TestExternalProxyTimeout(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.Timeout = 50 * time.Millisecond
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -4018,12 +4007,9 @@ func TestHostValidationMiddleware(t *testing.T) {
 }
 
 func TestExternalProxyOversizeResponse(t *testing.T) {
-	originalLimit := externalproxy.MaxResponseSize
-	externalproxy.MaxResponseSize = 64 // 64 bytes
+	const maxSize int64 = 64
 
-	t.Cleanup(func() { externalproxy.MaxResponseSize = originalLimit })
-
-	oversizeBody := strings.Repeat("X", int(externalproxy.MaxResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(maxSize)+1)
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", strconv.Itoa(len(oversizeBody)))
@@ -4032,27 +4018,14 @@ func TestExternalProxyOversizeResponse(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.MaxResponseSize = maxSize
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -4062,12 +4035,9 @@ func TestExternalProxyOversizeResponse(t *testing.T) {
 }
 
 func TestExternalProxyOversizeResponseUnknownLength(t *testing.T) {
-	originalLimit := externalproxy.MaxResponseSize
-	externalproxy.MaxResponseSize = 64
+	const maxSize int64 = 64
 
-	t.Cleanup(func() { externalproxy.MaxResponseSize = originalLimit })
-
-	oversizeBody := strings.Repeat("X", int(externalproxy.MaxResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(maxSize)+1)
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Transfer-Encoding", "chunked")
@@ -4077,42 +4047,26 @@ func TestExternalProxyOversizeResponseUnknownLength(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.MaxResponseSize = maxSize
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, int(externalproxy.MaxResponseSize), rr.Body.Len())
+	assert.Equal(t, int(maxSize), rr.Body.Len())
 }
 
 func TestExternalProxyOversizeResponseGzip(t *testing.T) {
-	originalLimit := externalproxy.MaxResponseSize
-	externalproxy.MaxResponseSize = 64
+	const maxSize int64 = 64
 
-	t.Cleanup(func() { externalproxy.MaxResponseSize = originalLimit })
-
-	oversizeBody := strings.Repeat("X", int(externalproxy.MaxResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(maxSize)+1)
 
 	var buf bytes.Buffer
 
@@ -4131,31 +4085,18 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.MaxResponseSize = maxSize
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, int(externalproxy.MaxResponseSize), rr.Body.Len())
+	assert.Equal(t, int(maxSize), rr.Body.Len())
 }

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	inventorymetadata "github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -800,10 +801,10 @@ func TestExternalProxyStreamsLargeBody(t *testing.T) {
 }
 
 func TestExternalProxyTimeout(t *testing.T) {
-	originalLimit := externalProxyTimeout
-	externalProxyTimeout = 50 * time.Millisecond
+	originalLimit := externalproxy.Timeout
+	externalproxy.Timeout = 50 * time.Millisecond
 
-	t.Cleanup(func() { externalProxyTimeout = originalLimit })
+	t.Cleanup(func() { externalproxy.Timeout = originalLimit })
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond) // Block longer than the timeout
@@ -838,7 +839,7 @@ func TestExternalProxyTimeout(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "context deadline exceeded")
+	assert.Contains(t, rr.Body.String(), "external proxy request failed")
 }
 
 func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
@@ -4017,12 +4018,12 @@ func TestHostValidationMiddleware(t *testing.T) {
 }
 
 func TestExternalProxyOversizeResponse(t *testing.T) {
-	originalLimit := maxProxyResponseSize
-	maxProxyResponseSize = 64 // 64 bytes
+	originalLimit := externalproxy.MaxResponseSize
+	externalproxy.MaxResponseSize = 64 // 64 bytes
 
-	t.Cleanup(func() { maxProxyResponseSize = originalLimit })
+	t.Cleanup(func() { externalproxy.MaxResponseSize = originalLimit })
 
-	oversizeBody := strings.Repeat("X", int(maxProxyResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(externalproxy.MaxResponseSize)+1)
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", strconv.Itoa(len(oversizeBody)))
@@ -4061,12 +4062,12 @@ func TestExternalProxyOversizeResponse(t *testing.T) {
 }
 
 func TestExternalProxyOversizeResponseUnknownLength(t *testing.T) {
-	originalLimit := maxProxyResponseSize
-	maxProxyResponseSize = 64
+	originalLimit := externalproxy.MaxResponseSize
+	externalproxy.MaxResponseSize = 64
 
-	t.Cleanup(func() { maxProxyResponseSize = originalLimit })
+	t.Cleanup(func() { externalproxy.MaxResponseSize = originalLimit })
 
-	oversizeBody := strings.Repeat("X", int(maxProxyResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(externalproxy.MaxResponseSize)+1)
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Transfer-Encoding", "chunked")
@@ -4102,16 +4103,16 @@ func TestExternalProxyOversizeResponseUnknownLength(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
+	assert.Equal(t, int(externalproxy.MaxResponseSize), rr.Body.Len())
 }
 
 func TestExternalProxyOversizeResponseGzip(t *testing.T) {
-	originalLimit := maxProxyResponseSize
-	maxProxyResponseSize = 64
+	originalLimit := externalproxy.MaxResponseSize
+	externalproxy.MaxResponseSize = 64
 
-	t.Cleanup(func() { maxProxyResponseSize = originalLimit })
+	t.Cleanup(func() { externalproxy.MaxResponseSize = originalLimit })
 
-	oversizeBody := strings.Repeat("X", int(maxProxyResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(externalproxy.MaxResponseSize)+1)
 
 	var buf bytes.Buffer
 
@@ -4156,5 +4157,5 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
+	assert.Equal(t, int(externalproxy.MaxResponseSize), rr.Body.Len())
 }

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -698,12 +698,11 @@ func TestProxyURLAllowlistReturnsCopy(t *testing.T) {
 	allowlist, err := config.proxyURLAllowlist()
 	require.NoError(t, err)
 	require.Len(t, allowlist, 1)
+	require.Len(t, config.compiledProxyURLs, 1)
 
-	originalLen := len(config.compiledProxyURLs)
-	_ = append(allowlist, allowlist[0])
-
-	assert.Equal(t, originalLen, len(config.compiledProxyURLs),
-		"mutating the returned allowlist must not change the cached slice")
+	// Returned slice must not share backing storage with the cache.
+	assert.False(t, &allowlist[0] == &config.compiledProxyURLs[0],
+		"proxyURLAllowlist must return a copy, not the cached slice")
 }
 
 func newLargeBodyUpstream(t *testing.T, size int) *httptest.Server {

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -686,6 +686,26 @@ func TestProxyURLAllowedCompilesConfiguredProxyURLs(t *testing.T) {
 	assert.NotEmpty(t, config.compiledProxyURLs)
 }
 
+func TestProxyURLAllowlistReturnsCopy(t *testing.T) {
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				ProxyURLs: []string{"https://example.com/*"},
+			},
+		},
+	}
+
+	allowlist, err := config.proxyURLAllowlist()
+	require.NoError(t, err)
+	require.Len(t, allowlist, 1)
+
+	originalLen := len(config.compiledProxyURLs)
+	_ = append(allowlist, allowlist[0])
+
+	assert.Equal(t, originalLen, len(config.compiledProxyURLs),
+		"mutating the returned allowlist must not change the cached slice")
+}
+
 func newLargeBodyUpstream(t *testing.T, size int) *httptest.Server {
 	t.Helper()
 

--- a/backend/cmd/headlamp_test.go
+++ b/backend/cmd/headlamp_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
 	inventorymetadata "github.com/kubernetes-sigs/headlamp/backend/pkg/clusterinventory/metadata"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/k8cache"
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
@@ -903,6 +904,25 @@ func TestProxyURLAllowedCompilesConfiguredProxyURLs(t *testing.T) {
 	assert.NotEmpty(t, config.compiledProxyURLs)
 }
 
+func TestProxyURLAllowlistReturnsCopy(t *testing.T) {
+	config := &HeadlampConfig{
+		HeadlampConfig: &headlampconfig.HeadlampConfig{
+			HeadlampCFG: &headlampconfig.HeadlampCFG{
+				ProxyURLs: []string{"https://example.com/*"},
+			},
+		},
+	}
+
+	allowlist, err := config.proxyURLAllowlist()
+	require.NoError(t, err)
+	require.Len(t, allowlist, 1)
+	require.Len(t, config.compiledProxyURLs, 1)
+
+	// Returned slice must not share backing storage with the cache.
+	assert.False(t, &allowlist[0] == &config.compiledProxyURLs[0],
+		"proxyURLAllowlist must return a copy, not the cached slice")
+}
+
 func newLargeBodyUpstream(t *testing.T, size int) *httptest.Server {
 	t.Helper()
 
@@ -929,7 +949,7 @@ func newLargeBodyUpstream(t *testing.T, size int) *httptest.Server {
 	}))
 }
 
-func newExternalProxyHandler(t *testing.T, upstream string) http.Handler {
+func newExternalProxyHandler(t *testing.T, upstream string, customize ...func(*externalproxy.Handler)) http.Handler {
 	t.Helper()
 
 	upstreamURL, err := url.Parse(upstream)
@@ -937,16 +957,23 @@ func newExternalProxyHandler(t *testing.T, upstream string) http.Handler {
 		t.Fatal(err)
 	}
 
-	return createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{upstreamURL.String()},
-				KubeConfigStore: kubeconfig.NewContextStore(),
-			},
-			Cache: cache.New[interface{}](),
-		},
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) {
+		return allowlist, nil
 	})
+
+	for _, fn := range customize {
+		fn(handler)
+	}
+
+	router := mux.NewRouter()
+	router.Handle("/externalproxy", handler)
+
+	return router
 }
 
 func TestExternalProxyForwarding(t *testing.T) {
@@ -1027,11 +1054,6 @@ func TestExternalProxyStreamsLargeBody(t *testing.T) {
 }
 
 func TestExternalProxyTimeout(t *testing.T) {
-	originalLimit := externalProxyTimeout
-	externalProxyTimeout = 50 * time.Millisecond
-
-	t.Cleanup(func() { externalProxyTimeout = originalLimit })
-
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond) // Block longer than the timeout
 		w.WriteHeader(http.StatusOK)
@@ -1039,33 +1061,20 @@ func TestExternalProxyTimeout(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.Timeout = 50 * time.Millisecond
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadGateway, rr.Code)
-	assert.Contains(t, rr.Body.String(), "context deadline exceeded")
+	assert.Contains(t, rr.Body.String(), "external proxy request failed")
 }
 
 func TestDrainAndCordonNode(t *testing.T) { //nolint:funlen
@@ -4443,12 +4452,9 @@ func TestHostValidationMiddleware(t *testing.T) {
 }
 
 func TestExternalProxyOversizeResponse(t *testing.T) {
-	originalLimit := maxProxyResponseSize
-	maxProxyResponseSize = 64 // 64 bytes
+	const maxSize int64 = 64
 
-	t.Cleanup(func() { maxProxyResponseSize = originalLimit })
-
-	oversizeBody := strings.Repeat("X", int(maxProxyResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(maxSize)+1)
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", strconv.Itoa(len(oversizeBody)))
@@ -4457,27 +4463,14 @@ func TestExternalProxyOversizeResponse(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.MaxResponseSize = maxSize
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -4487,12 +4480,9 @@ func TestExternalProxyOversizeResponse(t *testing.T) {
 }
 
 func TestExternalProxyOversizeResponseUnknownLength(t *testing.T) {
-	originalLimit := maxProxyResponseSize
-	maxProxyResponseSize = 64
+	const maxSize int64 = 64
 
-	t.Cleanup(func() { maxProxyResponseSize = originalLimit })
-
-	oversizeBody := strings.Repeat("X", int(maxProxyResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(maxSize)+1)
 
 	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Transfer-Encoding", "chunked")
@@ -4502,42 +4492,26 @@ func TestExternalProxyOversizeResponseUnknownLength(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.MaxResponseSize = maxSize
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
+	assert.Equal(t, int(maxSize), rr.Body.Len())
 }
 
 func TestExternalProxyOversizeResponseGzip(t *testing.T) {
-	originalLimit := maxProxyResponseSize
-	maxProxyResponseSize = 64
+	const maxSize int64 = 64
 
-	t.Cleanup(func() { maxProxyResponseSize = originalLimit })
-
-	oversizeBody := strings.Repeat("X", int(maxProxyResponseSize)+1)
+	oversizeBody := strings.Repeat("X", int(maxSize)+1)
 
 	var buf bytes.Buffer
 
@@ -4556,31 +4530,18 @@ func TestExternalProxyOversizeResponseGzip(t *testing.T) {
 	}))
 	defer proxyServer.Close()
 
-	proxyURL, err := url.Parse(proxyServer.URL)
-	require.NoError(t, err)
-
-	cache := cache.New[interface{}]()
-	kubeConfigStore := kubeconfig.NewContextStore()
-
-	handler := createHeadlampHandler(context.Background(), &HeadlampConfig{
-		HeadlampConfig: &headlampconfig.HeadlampConfig{
-			HeadlampCFG: &headlampconfig.HeadlampCFG{
-				UseInCluster:    false,
-				ProxyURLs:       []string{proxyURL.String()},
-				KubeConfigStore: kubeConfigStore,
-			},
-			Cache: cache,
-		},
+	handler := newExternalProxyHandler(t, proxyServer.URL, func(h *externalproxy.Handler) {
+		h.MaxResponseSize = maxSize
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "/externalproxy", nil)
 	require.NoError(t, err)
 
-	req.Header.Set("proxy-to", proxyURL.String())
+	req.Header.Set("proxy-to", proxyServer.URL)
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, int(maxProxyResponseSize), rr.Body.Len())
+	assert.Equal(t, int(maxSize), rr.Body.Len())
 }

--- a/backend/pkg/externalproxy/allowlist.go
+++ b/backend/pkg/externalproxy/allowlist.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"fmt"
+
+	"github.com/gobwas/glob"
+)
+
+// AllowlistEntry is a compiled ProxyURLs pattern.
+type AllowlistEntry struct {
+	Pattern string
+	Matcher glob.Glob
+}
+
+// CompileAllowlist compiles ProxyURLs glob patterns used by /externalproxy.
+func CompileAllowlist(patterns []string) ([]AllowlistEntry, error) {
+	entries := make([]AllowlistEntry, 0, len(patterns))
+
+	for _, pattern := range patterns {
+		matcher, err := glob.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("compiling proxy URL pattern %q: %w", pattern, err)
+		}
+
+		entries = append(entries, AllowlistEntry{
+			Pattern: pattern,
+			Matcher: matcher,
+		})
+	}
+
+	return entries, nil
+}
+
+// MatchesAllowlist reports whether proxyURL matches any allowlist entry.
+func MatchesAllowlist(proxyURL string, allowlist []AllowlistEntry) bool {
+	for _, entry := range allowlist {
+		if entry.Matcher.Match(proxyURL) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/backend/pkg/externalproxy/client.go
+++ b/backend/pkg/externalproxy/client.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type allowlistContextKey struct{}
+
+const maxRedirects = 10
+
+func newTransport() http.RoundTripper {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{
+			DisableCompression: true,
+		}
+	}
+
+	transport := defaultTransport.Clone()
+	transport.DisableCompression = true
+
+	return transport
+}
+
+// NewHTTPClient returns an HTTP client that follows redirects only when the
+// redirect target matches the allowlist stored in the request context.
+func NewHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: newTransport(),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
+
+			allowlist, ok := req.Context().Value(allowlistContextKey{}).([]AllowlistEntry)
+			if !ok || len(allowlist) == 0 {
+				return http.ErrUseLastResponse
+			}
+
+			if err := validateProxyURL(req.URL); err != nil {
+				return fmt.Errorf("redirect target is invalid: %w", err)
+			}
+
+			if !MatchesAllowlist(req.URL.String(), allowlist) {
+				return fmt.Errorf("redirect target not in allowlist")
+			}
+
+			return nil
+		},
+	}
+}

--- a/backend/pkg/externalproxy/client.go
+++ b/backend/pkg/externalproxy/client.go
@@ -54,6 +54,10 @@ func NewHTTPClient() *http.Client {
 				return http.ErrUseLastResponse
 			}
 
+			if err := validateProxyURL(req.URL); err != nil {
+				return fmt.Errorf("redirect target is invalid: %w", err)
+			}
+
 			if !MatchesAllowlist(req.URL.String(), allowlist) {
 				return fmt.Errorf("redirect target not in allowlist")
 			}

--- a/backend/pkg/externalproxy/client.go
+++ b/backend/pkg/externalproxy/client.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type allowlistContextKey struct{}
+
+const maxRedirects = 10
+
+func newTransport() http.RoundTripper {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{
+			DisableCompression: true,
+		}
+	}
+
+	transport := defaultTransport.Clone()
+	transport.DisableCompression = true
+
+	return transport
+}
+
+// NewHTTPClient returns an HTTP client that follows redirects only when the
+// redirect target matches the allowlist stored in the request context.
+func NewHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: newTransport(),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
+
+			allowlist, ok := req.Context().Value(allowlistContextKey{}).([]AllowlistEntry)
+			if !ok || len(allowlist) == 0 {
+				return http.ErrUseLastResponse
+			}
+
+			if !MatchesAllowlist(req.URL.String(), allowlist) {
+				return fmt.Errorf("redirect target not in allowlist")
+			}
+
+			return nil
+		},
+	}
+}

--- a/backend/pkg/externalproxy/doc.go
+++ b/backend/pkg/externalproxy/doc.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package externalproxy implements Headlamp's /externalproxy HTTP endpoint.
+//
+// # How to use
+//
+// Configure allowlisted upstream URL patterns with the server ProxyURLs flag
+// (comma-separated globs). The frontend (or any client) then calls:
+//
+//	GET /externalproxy
+//	proxy-to: https://allowed.example.com/path
+//
+// The Forward-to header is still accepted as a legacy alias for proxy-to.
+//
+// # Security behavior
+//
+// Credential and hop-by-hop headers are stripped before the request is
+// forwarded. Redirects are followed only when the new URL still matches the
+// ProxyURLs allowlist. Client-facing error bodies are generic so upstream
+// URLs are not leaked.
+//
+// # Compatibility
+//
+// The public route remains /externalproxy. Existing clients that set proxy-to
+// or Forward-to continue to work. Responses no longer forward Authorization,
+// Cookie, or Headlamp-internal headers to upstream services.
+package externalproxy

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -179,10 +179,10 @@ func (h *Handler) allowlist() ([]AllowlistEntry, error) {
 }
 
 func writeAllowlistDenied(w http.ResponseWriter, targetURL *url.URL) {
-	denyErr := errors.New("no allowed proxy url match, request denied")
+	denyErr := errors.New("No allowed proxy URL match, request denied")
 	logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
-		denyErr, "no allowed proxy url match, request denied")
-	http.Error(w, "no allowed proxy url match, request denied", http.StatusBadRequest)
+		denyErr, "No allowed proxy URL match, request denied")
+	http.Error(w, "No allowed proxy URL match, request denied", http.StatusBadRequest)
 }
 
 func redactURLForLog(targetURL *url.URL) string {

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -266,7 +266,9 @@ func (h *Handler) proxyRequest(
 
 	proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, targetURL.String(), r.Body) //nolint:gosec
 	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "creating request")
+		// Omit the raw error: it can embed the upstream URL (path/query).
+		logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
+			nil, "creating request")
 		http.Error(w, "external proxy request failed", http.StatusInternalServerError)
 
 		return
@@ -283,7 +285,9 @@ func (h *Handler) proxyRequest(
 			_ = resp.Body.Close()
 		}
 
-		logger.Log(logger.LevelError, nil, err, "making request")
+		// Omit the raw error: net/http errors include the full request URL.
+		logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
+			nil, "making request")
 		http.Error(w, "external proxy request failed", http.StatusBadGateway)
 
 		return

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -278,6 +278,11 @@ func (h *Handler) proxyRequest(
 
 	resp, err := h.client().Do(proxyReq) //nolint:gosec
 	if err != nil {
+		// CheckRedirect can return both a non-nil response and an error; close the body to avoid leaks.
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+
 		logger.Log(logger.LevelError, nil, err, "making request")
 		http.Error(w, "external proxy request failed", http.StatusBadGateway)
 

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -179,7 +179,7 @@ func (h *Handler) allowlist() ([]AllowlistEntry, error) {
 }
 
 func writeAllowlistDenied(w http.ResponseWriter, targetURL *url.URL) {
-	denyErr := errors.New("No allowed proxy URL match, request denied")
+	denyErr := errors.New("no allowed proxy URL match, request denied")
 	logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
 		denyErr, "No allowed proxy URL match, request denied")
 	http.Error(w, "No allowed proxy URL match, request denied", http.StatusBadRequest)

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -36,6 +36,8 @@ const (
 	DefaultMaxResponseSize int64 = 100 * 1024 * 1024
 )
 
+var errEmptyProxyURL = errors.New("proxy URL is empty")
+
 // Timeout and MaxResponseSize are package defaults that tests may override.
 //
 //nolint:gochecknoglobals // allow test override
@@ -94,92 +96,64 @@ func (h *Handler) client() *http.Client {
 	return NewHTTPClient()
 }
 
-// ServeHTTP implements http.Handler for /externalproxy.
-func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func targetURLFromRequest(r *http.Request) (*url.URL, error) {
 	proxyURL := r.Header.Get("proxy-to")
 	if proxyURL == "" && r.Header.Get("Forward-to") != "" {
 		proxyURL = r.Header.Get("Forward-to")
 	}
 
 	if proxyURL == "" {
-		logger.Log(logger.LevelError, nil, errors.New("proxy URL is empty"), "proxy URL is empty")
+		return nil, errEmptyProxyURL
+	}
+
+	return url.Parse(proxyURL)
+}
+
+func writeTargetURLError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, errEmptyProxyURL) {
+		logger.Log(logger.LevelError, nil, err, "proxy URL is empty")
 		http.Error(w, "proxy URL is empty", http.StatusBadRequest)
 
 		return
 	}
 
-	targetURL, err := url.Parse(proxyURL)
-	if err != nil {
-		logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL}, err, "The provided proxy URL is invalid")
-		http.Error(w, "The provided proxy URL is invalid", http.StatusBadRequest)
+	logger.Log(logger.LevelError, map[string]string{"proxyURL": r.Header.Get("proxy-to")},
+		err, "The provided proxy URL is invalid")
+	http.Error(w, "The provided proxy URL is invalid", http.StatusBadRequest)
+}
 
-		return
+func (h *Handler) allowlist() []AllowlistEntry {
+	if h.GetAllowlist == nil {
+		return nil
 	}
 
-	allowlist := []AllowlistEntry{}
-	if h.GetAllowlist != nil {
-		allowlist = h.GetAllowlist()
-	}
+	return h.GetAllowlist()
+}
 
-	if !MatchesAllowlist(targetURL.String(), allowlist) {
-		denyErr := errors.New("no allowed proxy url match, request denied")
-		logger.Log(logger.LevelError, map[string]string{"proxyURL": targetURL.Redacted()},
-			denyErr, "no allowed proxy url match, request denied")
-		http.Error(w, "no allowed proxy url match, request denied", http.StatusBadRequest)
+func writeAllowlistDenied(w http.ResponseWriter, targetURL *url.URL) {
+	denyErr := errors.New("no allowed proxy url match, request denied")
+	logger.Log(logger.LevelError, map[string]string{"proxyURL": targetURL.Redacted()},
+		denyErr, "no allowed proxy url match, request denied")
+	http.Error(w, "no allowed proxy url match, request denied", http.StatusBadRequest)
+}
 
-		return
-	}
-
-	proxyCtx := context.WithValue(r.Context(), allowlistContextKey{}, allowlist)
-	proxyCtx, cancel := context.WithTimeout(proxyCtx, h.timeout())
-	defer cancel()
-
-	proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, proxyURL, r.Body) //nolint:gosec
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "creating request")
-		http.Error(w, "external proxy request failed", http.StatusInternalServerError)
-
-		return
-	}
-
-	proxyReq.Header = make(http.Header)
-	CopyFilteredHeaders(proxyReq.Header, r.Header)
-
-	// Disable caching
+func setNoCacheHeaders(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
 	w.Header().Set("Expires", time.Unix(0, 0).Format(http.TimeFormat))
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("X-Accel-Expires", "0")
+}
 
-	resp, err := h.client().Do(proxyReq) //nolint:gosec
-	if err != nil {
-		logger.Log(logger.LevelError, nil, err, "making request")
-		http.Error(w, "external proxy request failed", http.StatusBadGateway)
-
-		return
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	var reader io.ReadCloser
-
+func responseReader(resp *http.Response) (io.ReadCloser, error) {
 	switch resp.Header.Get("Content-Encoding") {
 	case "gzip":
-		reader, err = gzip.NewReader(resp.Body)
-		if err != nil {
-			logger.Log(logger.LevelError, nil, err, "reading gzip response")
-			http.Error(w, "external proxy request failed", http.StatusInternalServerError)
-
-			return
-		}
-
-		defer func() { _ = reader.Close() }()
+		return gzip.NewReader(resp.Body)
 	default:
-		reader = resp.Body
+		return resp.Body, nil
 	}
+}
 
-	// Read the first chunk before committing the response so early upstream
-	// failures can still return a 502 instead of an empty success response.
+func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response, reader io.Reader, maxSize int64) {
 	firstChunk := make([]byte, 32*1024)
 
 	n, readErr := reader.Read(firstChunk)
@@ -194,9 +168,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", contentType)
 	}
 
-	maxSize := h.maxResponseSize()
-
-	// Reject early if Content-Length exceeds the maximum allowed size.
 	if resp.ContentLength > maxSize {
 		logger.Log(logger.LevelError, nil, nil, "proxy response exceeded maximum allowed size (Content-Length)")
 		http.Error(w, "response too large", http.StatusBadGateway)
@@ -204,7 +175,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Prevent unexpected or unfollowed redirects from being returned.
 	if resp.StatusCode >= 300 && resp.StatusCode <= 399 && resp.StatusCode != http.StatusNotModified {
 		logger.Log(logger.LevelError, nil, nil, "proxy response returned an unexpected or unfollowed redirect")
 		http.Error(w, "external proxy request failed: unexpected redirect", http.StatusBadGateway)
@@ -217,7 +187,73 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body := io.MultiReader(bytes.NewReader(firstChunk[:n]), reader)
 	if _, err := io.Copy(w, io.LimitReader(body, maxSize)); err != nil {
 		logger.Log(logger.LevelError, nil, err, "streaming response")
+	}
+}
+
+func (h *Handler) proxyRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	targetURL *url.URL,
+	allowlist []AllowlistEntry,
+) {
+	proxyCtx := context.WithValue(r.Context(), allowlistContextKey{}, allowlist)
+
+	proxyCtx, cancel := context.WithTimeout(proxyCtx, h.timeout())
+
+	defer cancel()
+
+	proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, targetURL.String(), r.Body) //nolint:gosec
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "creating request")
+		http.Error(w, "external proxy request failed", http.StatusInternalServerError)
 
 		return
 	}
+
+	proxyReq.Header = make(http.Header)
+	CopyFilteredHeaders(proxyReq.Header, r.Header)
+	setNoCacheHeaders(w)
+
+	resp, err := h.client().Do(proxyReq) //nolint:gosec
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "making request")
+		http.Error(w, "external proxy request failed", http.StatusBadGateway)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	reader, err := responseReader(resp)
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "reading gzip response")
+		http.Error(w, "external proxy request failed", http.StatusInternalServerError)
+
+		return
+	}
+
+	if reader != resp.Body {
+		defer func() { _ = reader.Close() }()
+	}
+
+	writeUpstreamResponse(w, resp, reader, h.maxResponseSize())
+}
+
+// ServeHTTP implements http.Handler for /externalproxy.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	targetURL, err := targetURLFromRequest(r)
+	if err != nil {
+		writeTargetURLError(w, r, err)
+
+		return
+	}
+
+	allowlist := h.allowlist()
+	if !MatchesAllowlist(targetURL.String(), allowlist) {
+		writeAllowlistDenied(w, targetURL)
+
+		return
+	}
+
+	h.proxyRequest(w, r, targetURL, allowlist)
 }

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -55,7 +55,7 @@ var (
 // that does not disclose upstream URLs.
 type Handler struct {
 	// GetAllowlist returns the current ProxyURLs allowlist.
-	GetAllowlist func() []AllowlistEntry
+	GetAllowlist func() ([]AllowlistEntry, error)
 	// Timeout overrides DefaultTimeout when non-zero.
 	Timeout time.Duration
 	// MaxResponseSize overrides DefaultMaxResponseSize when non-zero.
@@ -65,7 +65,7 @@ type Handler struct {
 }
 
 // NewHandler constructs a Handler with a shared redirect-aware HTTP client.
-func NewHandler(getAllowlist func() []AllowlistEntry) *Handler {
+func NewHandler(getAllowlist func() ([]AllowlistEntry, error)) *Handler {
 	return &Handler{
 		GetAllowlist: getAllowlist,
 		Client:       NewHTTPClient(),
@@ -122,9 +122,9 @@ func writeTargetURLError(w http.ResponseWriter, r *http.Request, err error) {
 	http.Error(w, "The provided proxy URL is invalid", http.StatusBadRequest)
 }
 
-func (h *Handler) allowlist() []AllowlistEntry {
+func (h *Handler) allowlist() ([]AllowlistEntry, error) {
 	if h.GetAllowlist == nil {
-		return nil
+		return nil, nil
 	}
 
 	return h.GetAllowlist()
@@ -132,9 +132,23 @@ func (h *Handler) allowlist() []AllowlistEntry {
 
 func writeAllowlistDenied(w http.ResponseWriter, targetURL *url.URL) {
 	denyErr := errors.New("no allowed proxy url match, request denied")
-	logger.Log(logger.LevelError, map[string]string{"proxyURL": targetURL.Redacted()},
+	logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
 		denyErr, "no allowed proxy url match, request denied")
 	http.Error(w, "no allowed proxy url match, request denied", http.StatusBadRequest)
+}
+
+func redactURLForLog(targetURL *url.URL) string {
+	if targetURL == nil {
+		return ""
+	}
+
+	redacted := *targetURL
+	redacted.Path = ""
+	redacted.RawPath = ""
+	redacted.RawQuery = ""
+	redacted.Fragment = ""
+
+	return redacted.Redacted()
 }
 
 func setNoCacheHeaders(w http.ResponseWriter) {
@@ -248,7 +262,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	allowlist := h.allowlist()
+	allowlist, err := h.allowlist()
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "compiling proxy URL patterns")
+		http.Error(w, "failed to compile proxy URL patterns", http.StatusInternalServerError)
+
+		return
+	}
+
 	if !MatchesAllowlist(targetURL.String(), allowlist) {
 		writeAllowlistDenied(w, targetURL)
 

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -36,7 +36,10 @@ const (
 	DefaultMaxResponseSize int64 = 100 * 1024 * 1024
 )
 
-var errEmptyProxyURL = errors.New("proxy URL is empty")
+var (
+	errEmptyProxyURL   = errors.New("proxy URL is empty")
+	errInvalidProxyURL = errors.New("invalid proxy URL")
+)
 
 // Timeout and MaxResponseSize are package defaults that tests may override.
 //
@@ -106,7 +109,50 @@ func targetURLFromRequest(r *http.Request) (*url.URL, error) {
 		return nil, errEmptyProxyURL
 	}
 
-	return url.Parse(proxyURL)
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateProxyURL(parsed); err != nil {
+		return nil, err
+	}
+
+	return parsed, nil
+}
+
+func validateProxyURL(targetURL *url.URL) error {
+	if targetURL.Scheme != "http" && targetURL.Scheme != "https" {
+		return errInvalidProxyURL
+	}
+
+	if targetURL.Host == "" {
+		return errInvalidProxyURL
+	}
+
+	if targetURL.User != nil {
+		return errInvalidProxyURL
+	}
+
+	return nil
+}
+
+func proxyURLHeaderForLog(r *http.Request) string {
+	proxyURL := r.Header.Get("proxy-to")
+	if proxyURL == "" {
+		proxyURL = r.Header.Get("Forward-to")
+	}
+
+	if proxyURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return "[invalid]"
+	}
+
+	return redactURLForLog(parsed)
 }
 
 func writeTargetURLError(w http.ResponseWriter, r *http.Request, err error) {
@@ -117,7 +163,7 @@ func writeTargetURLError(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 
-	logger.Log(logger.LevelError, map[string]string{"proxyURL": r.Header.Get("proxy-to")},
+	logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURLHeaderForLog(r)},
 		err, "The provided proxy URL is invalid")
 	http.Error(w, "The provided proxy URL is invalid", http.StatusBadRequest)
 }

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+const (
+	// DefaultTimeout is the maximum time to wait for a proxy response.
+	DefaultTimeout = 30 * time.Second
+	// DefaultMaxResponseSize is the maximum size (in bytes) for proxied responses.
+	DefaultMaxResponseSize int64 = 100 * 1024 * 1024
+)
+
+// Timeout and MaxResponseSize are package defaults that tests may override.
+//
+//nolint:gochecknoglobals // allow test override
+var (
+	Timeout         = DefaultTimeout
+	MaxResponseSize = DefaultMaxResponseSize
+)
+
+// Handler proxies browser requests to allowlisted external URLs.
+//
+// The target URL is taken from the proxy-to header (or Forward-to for
+// compatibility). Sensitive and hop-by-hop headers are stripped before the
+// request is forwarded. Redirects are followed only when the new target is
+// still on the allowlist; otherwise the proxy returns 502 with a generic body
+// that does not disclose upstream URLs.
+type Handler struct {
+	// GetAllowlist returns the current ProxyURLs allowlist.
+	GetAllowlist func() []AllowlistEntry
+	// Timeout overrides DefaultTimeout when non-zero.
+	Timeout time.Duration
+	// MaxResponseSize overrides DefaultMaxResponseSize when non-zero.
+	MaxResponseSize int64
+	// Client is the HTTP client used for upstream requests.
+	Client *http.Client
+}
+
+// NewHandler constructs a Handler with a shared redirect-aware HTTP client.
+func NewHandler(getAllowlist func() []AllowlistEntry) *Handler {
+	return &Handler{
+		GetAllowlist: getAllowlist,
+		Client:       NewHTTPClient(),
+	}
+}
+
+func (h *Handler) timeout() time.Duration {
+	if h.Timeout > 0 {
+		return h.Timeout
+	}
+
+	return Timeout
+}
+
+func (h *Handler) maxResponseSize() int64 {
+	if h.MaxResponseSize > 0 {
+		return h.MaxResponseSize
+	}
+
+	return MaxResponseSize
+}
+
+func (h *Handler) client() *http.Client {
+	if h.Client != nil {
+		return h.Client
+	}
+
+	return NewHTTPClient()
+}
+
+// ServeHTTP implements http.Handler for /externalproxy.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	proxyURL := r.Header.Get("proxy-to")
+	if proxyURL == "" && r.Header.Get("Forward-to") != "" {
+		proxyURL = r.Header.Get("Forward-to")
+	}
+
+	if proxyURL == "" {
+		logger.Log(logger.LevelError, nil, errors.New("proxy URL is empty"), "proxy URL is empty")
+		http.Error(w, "proxy URL is empty", http.StatusBadRequest)
+
+		return
+	}
+
+	targetURL, err := url.Parse(proxyURL)
+	if err != nil {
+		logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURL}, err, "The provided proxy URL is invalid")
+		http.Error(w, "The provided proxy URL is invalid", http.StatusBadRequest)
+
+		return
+	}
+
+	allowlist := []AllowlistEntry{}
+	if h.GetAllowlist != nil {
+		allowlist = h.GetAllowlist()
+	}
+
+	if !MatchesAllowlist(targetURL.String(), allowlist) {
+		denyErr := errors.New("no allowed proxy url match, request denied")
+		logger.Log(logger.LevelError, map[string]string{"proxyURL": targetURL.Redacted()},
+			denyErr, "no allowed proxy url match, request denied")
+		http.Error(w, "no allowed proxy url match, request denied", http.StatusBadRequest)
+
+		return
+	}
+
+	proxyCtx := context.WithValue(r.Context(), allowlistContextKey{}, allowlist)
+	proxyCtx, cancel := context.WithTimeout(proxyCtx, h.timeout())
+	defer cancel()
+
+	proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, proxyURL, r.Body) //nolint:gosec
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "creating request")
+		http.Error(w, "external proxy request failed", http.StatusInternalServerError)
+
+		return
+	}
+
+	proxyReq.Header = make(http.Header)
+	CopyFilteredHeaders(proxyReq.Header, r.Header)
+
+	// Disable caching
+	w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
+	w.Header().Set("Expires", time.Unix(0, 0).Format(http.TimeFormat))
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("X-Accel-Expires", "0")
+
+	resp, err := h.client().Do(proxyReq) //nolint:gosec
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "making request")
+		http.Error(w, "external proxy request failed", http.StatusBadGateway)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var reader io.ReadCloser
+
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		reader, err = gzip.NewReader(resp.Body)
+		if err != nil {
+			logger.Log(logger.LevelError, nil, err, "reading gzip response")
+			http.Error(w, "external proxy request failed", http.StatusInternalServerError)
+
+			return
+		}
+
+		defer func() { _ = reader.Close() }()
+	default:
+		reader = resp.Body
+	}
+
+	// Read the first chunk before committing the response so early upstream
+	// failures can still return a 502 instead of an empty success response.
+	firstChunk := make([]byte, 32*1024)
+
+	n, readErr := reader.Read(firstChunk)
+	if readErr != nil && !errors.Is(readErr, io.EOF) && n == 0 {
+		logger.Log(logger.LevelError, nil, readErr, "reading response")
+		http.Error(w, "external proxy request failed", http.StatusBadGateway)
+
+		return
+	}
+
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+
+	maxSize := h.maxResponseSize()
+
+	// Reject early if Content-Length exceeds the maximum allowed size.
+	if resp.ContentLength > maxSize {
+		logger.Log(logger.LevelError, nil, nil, "proxy response exceeded maximum allowed size (Content-Length)")
+		http.Error(w, "response too large", http.StatusBadGateway)
+
+		return
+	}
+
+	// Prevent unexpected or unfollowed redirects from being returned.
+	if resp.StatusCode >= 300 && resp.StatusCode <= 399 && resp.StatusCode != http.StatusNotModified {
+		logger.Log(logger.LevelError, nil, nil, "proxy response returned an unexpected or unfollowed redirect")
+		http.Error(w, "external proxy request failed: unexpected redirect", http.StatusBadGateway)
+
+		return
+	}
+
+	w.WriteHeader(resp.StatusCode)
+
+	body := io.MultiReader(bytes.NewReader(firstChunk[:n]), reader)
+	if _, err := io.Copy(w, io.LimitReader(body, maxSize)); err != nil {
+		logger.Log(logger.LevelError, nil, err, "streaming response")
+
+		return
+	}
+}

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -111,7 +111,9 @@ func targetURLFromRequest(r *http.Request) (*url.URL, error) {
 
 	parsed, err := url.Parse(proxyURL)
 	if err != nil {
-		return nil, err
+		// url.Parse errors embed the raw input; return a generic error so
+		// logs do not leak potentially sensitive proxy-to values.
+		return nil, errInvalidProxyURL
 	}
 
 	if err := validateProxyURL(parsed); err != nil {

--- a/backend/pkg/externalproxy/handler.go
+++ b/backend/pkg/externalproxy/handler.go
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
+)
+
+const (
+	// DefaultTimeout is the maximum time to wait for a proxy response.
+	DefaultTimeout = 30 * time.Second
+	// DefaultMaxResponseSize is the maximum size (in bytes) for proxied responses.
+	DefaultMaxResponseSize int64 = 100 * 1024 * 1024
+)
+
+var (
+	errEmptyProxyURL   = errors.New("proxy URL is empty")
+	errInvalidProxyURL = errors.New("invalid proxy URL")
+)
+
+// Timeout and MaxResponseSize are package defaults that tests may override.
+//
+//nolint:gochecknoglobals // allow test override
+var (
+	Timeout         = DefaultTimeout
+	MaxResponseSize = DefaultMaxResponseSize
+)
+
+// Handler proxies browser requests to allowlisted external URLs.
+//
+// The target URL is taken from the proxy-to header (or Forward-to for
+// compatibility). Sensitive and hop-by-hop headers are stripped before the
+// request is forwarded. Redirects are followed only when the new target is
+// still on the allowlist; otherwise the proxy returns 502 with a generic body
+// that does not disclose upstream URLs.
+type Handler struct {
+	// GetAllowlist returns the current ProxyURLs allowlist.
+	GetAllowlist func() ([]AllowlistEntry, error)
+	// Timeout overrides DefaultTimeout when non-zero.
+	Timeout time.Duration
+	// MaxResponseSize overrides DefaultMaxResponseSize when non-zero.
+	MaxResponseSize int64
+	// Client is the HTTP client used for upstream requests.
+	Client *http.Client
+}
+
+// NewHandler constructs a Handler with a shared redirect-aware HTTP client.
+func NewHandler(getAllowlist func() ([]AllowlistEntry, error)) *Handler {
+	return &Handler{
+		GetAllowlist: getAllowlist,
+		Client:       NewHTTPClient(),
+	}
+}
+
+func (h *Handler) timeout() time.Duration {
+	if h.Timeout > 0 {
+		return h.Timeout
+	}
+
+	return Timeout
+}
+
+func (h *Handler) maxResponseSize() int64 {
+	if h.MaxResponseSize > 0 {
+		return h.MaxResponseSize
+	}
+
+	return MaxResponseSize
+}
+
+func (h *Handler) client() *http.Client {
+	if h.Client != nil {
+		return h.Client
+	}
+
+	return NewHTTPClient()
+}
+
+func targetURLFromRequest(r *http.Request) (*url.URL, error) {
+	proxyURL := r.Header.Get("proxy-to")
+	if proxyURL == "" && r.Header.Get("Forward-to") != "" {
+		proxyURL = r.Header.Get("Forward-to")
+	}
+
+	if proxyURL == "" {
+		return nil, errEmptyProxyURL
+	}
+
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		// url.Parse errors embed the raw input; return a generic error so
+		// logs do not leak potentially sensitive proxy-to values.
+		return nil, errInvalidProxyURL
+	}
+
+	if err := validateProxyURL(parsed); err != nil {
+		return nil, err
+	}
+
+	return parsed, nil
+}
+
+func validateProxyURL(targetURL *url.URL) error {
+	if targetURL.Scheme != "http" && targetURL.Scheme != "https" {
+		return errInvalidProxyURL
+	}
+
+	if targetURL.Host == "" {
+		return errInvalidProxyURL
+	}
+
+	if targetURL.User != nil {
+		return errInvalidProxyURL
+	}
+
+	return nil
+}
+
+func proxyURLHeaderForLog(r *http.Request) string {
+	proxyURL := r.Header.Get("proxy-to")
+	if proxyURL == "" {
+		proxyURL = r.Header.Get("Forward-to")
+	}
+
+	if proxyURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return "[invalid]"
+	}
+
+	return redactURLForLog(parsed)
+}
+
+func writeTargetURLError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, errEmptyProxyURL) {
+		logger.Log(logger.LevelError, nil, err, "proxy URL is empty")
+		http.Error(w, "proxy URL is empty", http.StatusBadRequest)
+
+		return
+	}
+
+	logger.Log(logger.LevelError, map[string]string{"proxyURL": proxyURLHeaderForLog(r)},
+		err, "The provided proxy URL is invalid")
+	http.Error(w, "The provided proxy URL is invalid", http.StatusBadRequest)
+}
+
+func (h *Handler) allowlist() ([]AllowlistEntry, error) {
+	if h.GetAllowlist == nil {
+		return nil, nil
+	}
+
+	return h.GetAllowlist()
+}
+
+func writeAllowlistDenied(w http.ResponseWriter, targetURL *url.URL) {
+	denyErr := errors.New("no allowed proxy URL match, request denied")
+	logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
+		denyErr, "No allowed proxy URL match, request denied")
+	http.Error(w, "No allowed proxy URL match, request denied", http.StatusBadRequest)
+}
+
+func redactURLForLog(targetURL *url.URL) string {
+	if targetURL == nil {
+		return ""
+	}
+
+	redacted := *targetURL
+	redacted.User = nil
+	redacted.Path = ""
+	redacted.RawPath = ""
+	redacted.RawQuery = ""
+	redacted.Fragment = ""
+
+	return redacted.Redacted()
+}
+
+func setNoCacheHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
+	w.Header().Set("Expires", time.Unix(0, 0).Format(http.TimeFormat))
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("X-Accel-Expires", "0")
+}
+
+func responseReader(resp *http.Response) (io.ReadCloser, error) {
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		return gzip.NewReader(resp.Body)
+	default:
+		return resp.Body, nil
+	}
+}
+
+func writeUpstreamResponse(w http.ResponseWriter, resp *http.Response, reader io.Reader, maxSize int64) {
+	firstChunk := make([]byte, 32*1024)
+
+	n, readErr := reader.Read(firstChunk)
+	if readErr != nil && !errors.Is(readErr, io.EOF) && n == 0 {
+		logger.Log(logger.LevelError, nil, readErr, "reading response")
+		http.Error(w, "external proxy request failed", http.StatusBadGateway)
+
+		return
+	}
+
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+
+	if resp.ContentLength > maxSize {
+		logger.Log(logger.LevelError, nil, nil, "proxy response exceeded maximum allowed size (Content-Length)")
+		http.Error(w, "response too large", http.StatusBadGateway)
+
+		return
+	}
+
+	if resp.StatusCode >= 300 && resp.StatusCode <= 399 && resp.StatusCode != http.StatusNotModified {
+		logger.Log(logger.LevelError, nil, nil, "proxy response returned an unexpected or unfollowed redirect")
+		http.Error(w, "external proxy request failed: unexpected redirect", http.StatusBadGateway)
+
+		return
+	}
+
+	w.WriteHeader(resp.StatusCode)
+
+	body := io.MultiReader(bytes.NewReader(firstChunk[:n]), reader)
+	if _, err := io.Copy(w, io.LimitReader(body, maxSize)); err != nil {
+		logger.Log(logger.LevelError, nil, err, "streaming response")
+	}
+}
+
+func (h *Handler) proxyRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	targetURL *url.URL,
+	allowlist []AllowlistEntry,
+) {
+	proxyCtx := context.WithValue(r.Context(), allowlistContextKey{}, allowlist)
+
+	proxyCtx, cancel := context.WithTimeout(proxyCtx, h.timeout())
+
+	defer cancel()
+
+	proxyReq, err := http.NewRequestWithContext(proxyCtx, r.Method, targetURL.String(), r.Body) //nolint:gosec
+	if err != nil {
+		// Omit the raw error: it can embed the upstream URL (path/query).
+		logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
+			nil, "creating request")
+		http.Error(w, "external proxy request failed", http.StatusInternalServerError)
+
+		return
+	}
+
+	proxyReq.Header = make(http.Header)
+	CopyFilteredHeaders(proxyReq.Header, r.Header)
+	setNoCacheHeaders(w)
+
+	resp, err := h.client().Do(proxyReq) //nolint:gosec
+	if err != nil {
+		// CheckRedirect can return both a non-nil response and an error; close the body to avoid leaks.
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+
+		// Omit the raw error: net/http errors include the full request URL.
+		logger.Log(logger.LevelError, map[string]string{"proxyURL": redactURLForLog(targetURL)},
+			nil, "making request")
+		http.Error(w, "external proxy request failed", http.StatusBadGateway)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	reader, err := responseReader(resp)
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "reading gzip response")
+		http.Error(w, "external proxy request failed", http.StatusInternalServerError)
+
+		return
+	}
+
+	if reader != resp.Body {
+		defer func() { _ = reader.Close() }()
+	}
+
+	writeUpstreamResponse(w, resp, reader, h.maxResponseSize())
+}
+
+// ServeHTTP implements http.Handler for /externalproxy.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	targetURL, err := targetURLFromRequest(r)
+	if err != nil {
+		writeTargetURLError(w, r, err)
+
+		return
+	}
+
+	allowlist, err := h.allowlist()
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "compiling proxy URL patterns")
+		http.Error(w, "failed to compile proxy URL patterns", http.StatusInternalServerError)
+
+		return
+	}
+
+	if !MatchesAllowlist(targetURL.String(), allowlist) {
+		writeAllowlistDenied(w, targetURL)
+
+		return
+	}
+
+	h.proxyRequest(w, r, targetURL, allowlist)
+}

--- a/backend/pkg/externalproxy/handler_internal_test.go
+++ b/backend/pkg/externalproxy/handler_internal_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactURLForLogClearsUserinfo(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := url.Parse("https://secret-token@evil.example.com/path?token=abc")
+	require.NoError(t, err)
+
+	redacted := redactURLForLog(parsed)
+	assert.NotContains(t, redacted, "secret-token")
+	assert.NotContains(t, redacted, "token=abc")
+	assert.Contains(t, redacted, "evil.example.com")
+}

--- a/backend/pkg/externalproxy/handler_test.go
+++ b/backend/pkg/externalproxy/handler_test.go
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerFiltersSensitiveHeaders(t *testing.T) {
+	var mu sync.Mutex
+
+	var received http.Header
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		received = r.Header.Clone()
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", upstream.URL)
+	req.Header.Set("Authorization", "Bearer sensitive")
+	req.Header.Set("Cookie", "session=1")
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", "secret")
+	req.Header.Set("X-Custom-Preserve", "keep")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "keep", received.Get("X-Custom-Preserve"))
+	assert.Empty(t, received.Get("Authorization"))
+	assert.Empty(t, received.Get("Cookie"))
+	assert.Empty(t, received.Get("X-HEADLAMP_BACKEND-TOKEN"))
+	assert.Empty(t, received.Get("proxy-to"))
+}
+
+func TestHandlerBlocksDisallowedRedirect(t *testing.T) {
+	var mu sync.Mutex
+
+	disallowedHit := false
+
+	disallowed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		disallowedHit = true
+		mu.Unlock()
+	}))
+	defer disallowed.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, disallowed.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", upstream.URL)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Body.String(), "external proxy request failed")
+	assert.NotContains(t, rr.Body.String(), disallowed.URL)
+
+	mu.Lock()
+	assert.False(t, disallowedHit)
+	mu.Unlock()
+}
+
+func TestHandlerFollowsAllowedRedirect(t *testing.T) {
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("final"))
+	}))
+	defer final.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstream.URL + "*", final.URL + "*"})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", upstream.URL)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "final", rr.Body.String())
+}
+
+func TestHandlerReturnsInternalErrorOnAllowlistCompileFailure(t *testing.T) {
+	compileErr := errors.New("compile failed")
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) {
+		return nil, compileErr
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", "https://example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "failed to compile proxy URL patterns")
+}
+
+func TestHandlerRejectsURLWithUserinfo(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	allowlist, err := externalproxy.CompileAllowlist([]string{"https://allowed.example.com*"})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", "https://allowed.example.com@evil.example.com/")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "The provided proxy URL is invalid")
+}
+
+func TestHandlerRejectsNonHTTPScheme(t *testing.T) {
+	allowlist, err := externalproxy.CompileAllowlist([]string{"file://*"})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", "file:///etc/passwd")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "The provided proxy URL is invalid")
+}
+
+func TestHandlerRejectsMalformedURL(t *testing.T) {
+	allowlist, err := externalproxy.CompileAllowlist([]string{"https://*"})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	// Unclosed IPv6 bracket makes url.Parse fail and embed the raw input in err.
+	req.Header.Set("proxy-to", "https://[::1/secret-token")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "The provided proxy URL is invalid")
+	assert.NotContains(t, rr.Body.String(), "secret-token")
+}

--- a/backend/pkg/externalproxy/handler_test.go
+++ b/backend/pkg/externalproxy/handler_test.go
@@ -193,3 +193,21 @@ func TestHandlerRejectsNonHTTPScheme(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "The provided proxy URL is invalid")
 }
+
+func TestHandlerRejectsMalformedURL(t *testing.T) {
+	allowlist, err := externalproxy.CompileAllowlist([]string{"https://*"})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	// Unclosed IPv6 bracket makes url.Parse fail and embed the raw input in err.
+	req.Header.Set("proxy-to", "https://[::1/secret-token")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "The provided proxy URL is invalid")
+	assert.NotContains(t, rr.Body.String(), "secret-token")
+}

--- a/backend/pkg/externalproxy/handler_test.go
+++ b/backend/pkg/externalproxy/handler_test.go
@@ -156,3 +156,40 @@ func TestHandlerReturnsInternalErrorOnAllowlistCompileFailure(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t, rr.Body.String(), "failed to compile proxy URL patterns")
 }
+
+func TestHandlerRejectsURLWithUserinfo(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	allowlist, err := externalproxy.CompileAllowlist([]string{"https://allowed.example.com*"})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", "https://allowed.example.com@evil.example.com/")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "The provided proxy URL is invalid")
+}
+
+func TestHandlerRejectsNonHTTPScheme(t *testing.T) {
+	allowlist, err := externalproxy.CompileAllowlist([]string{"file://*"})
+	require.NoError(t, err)
+
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", "file:///etc/passwd")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "The provided proxy URL is invalid")
+}

--- a/backend/pkg/externalproxy/handler_test.go
+++ b/backend/pkg/externalproxy/handler_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package externalproxy
+package externalproxy_test
 
 import (
 	"context"
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +34,7 @@ func TestHandlerFiltersSensitiveHeaders(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		received = r.Header.Clone()
+
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	}))
@@ -41,10 +43,10 @@ func TestHandlerFiltersSensitiveHeaders(t *testing.T) {
 	upstreamURL, err := url.Parse(upstream.URL)
 	require.NoError(t, err)
 
-	allowlist, err := CompileAllowlist([]string{upstreamURL.String()})
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
 	require.NoError(t, err)
 
-	handler := NewHandler(func() []AllowlistEntry { return allowlist })
+	handler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry { return allowlist })
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
 	req.Header.Set("proxy-to", upstream.URL)
@@ -84,10 +86,10 @@ func TestHandlerBlocksDisallowedRedirect(t *testing.T) {
 	upstreamURL, err := url.Parse(upstream.URL)
 	require.NoError(t, err)
 
-	allowlist, err := CompileAllowlist([]string{upstreamURL.String()})
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
 	require.NoError(t, err)
 
-	handler := NewHandler(func() []AllowlistEntry { return allowlist })
+	handler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry { return allowlist })
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
 	req.Header.Set("proxy-to", upstream.URL)
@@ -116,10 +118,10 @@ func TestHandlerFollowsAllowedRedirect(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	allowlist, err := CompileAllowlist([]string{upstream.URL + "*", final.URL + "*"})
+	allowlist, err := externalproxy.CompileAllowlist([]string{upstream.URL + "*", final.URL + "*"})
 	require.NoError(t, err)
 
-	handler := NewHandler(func() []AllowlistEntry { return allowlist })
+	handler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry { return allowlist })
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
 	req.Header.Set("proxy-to", upstream.URL)

--- a/backend/pkg/externalproxy/handler_test.go
+++ b/backend/pkg/externalproxy/handler_test.go
@@ -18,6 +18,7 @@ package externalproxy_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -30,10 +31,14 @@ import (
 )
 
 func TestHandlerFiltersSensitiveHeaders(t *testing.T) {
+	var mu sync.Mutex
+
 	var received http.Header
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		received = r.Header.Clone()
+		mu.Unlock()
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
@@ -46,7 +51,7 @@ func TestHandlerFiltersSensitiveHeaders(t *testing.T) {
 	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
 	require.NoError(t, err)
 
-	handler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry { return allowlist })
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
 	req.Header.Set("proxy-to", upstream.URL)
@@ -57,6 +62,9 @@ func TestHandlerFiltersSensitiveHeaders(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+
+	mu.Lock()
+	defer mu.Unlock()
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "keep", received.Get("X-Custom-Preserve"))
@@ -89,7 +97,7 @@ func TestHandlerBlocksDisallowedRedirect(t *testing.T) {
 	allowlist, err := externalproxy.CompileAllowlist([]string{upstreamURL.String()})
 	require.NoError(t, err)
 
-	handler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry { return allowlist })
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
 	req.Header.Set("proxy-to", upstream.URL)
@@ -121,7 +129,7 @@ func TestHandlerFollowsAllowedRedirect(t *testing.T) {
 	allowlist, err := externalproxy.CompileAllowlist([]string{upstream.URL + "*", final.URL + "*"})
 	require.NoError(t, err)
 
-	handler := externalproxy.NewHandler(func() []externalproxy.AllowlistEntry { return allowlist })
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) { return allowlist, nil })
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
 	req.Header.Set("proxy-to", upstream.URL)
@@ -131,4 +139,20 @@ func TestHandlerFollowsAllowedRedirect(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "final", rr.Body.String())
+}
+
+func TestHandlerReturnsInternalErrorOnAllowlistCompileFailure(t *testing.T) {
+	compileErr := errors.New("compile failed")
+	handler := externalproxy.NewHandler(func() ([]externalproxy.AllowlistEntry, error) {
+		return nil, compileErr
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", "https://example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "failed to compile proxy URL patterns")
 }

--- a/backend/pkg/externalproxy/handler_test.go
+++ b/backend/pkg/externalproxy/handler_test.go
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerFiltersSensitiveHeaders(t *testing.T) {
+	var received http.Header
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+
+	allowlist, err := CompileAllowlist([]string{upstreamURL.String()})
+	require.NoError(t, err)
+
+	handler := NewHandler(func() []AllowlistEntry { return allowlist })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", upstream.URL)
+	req.Header.Set("Authorization", "Bearer sensitive")
+	req.Header.Set("Cookie", "session=1")
+	req.Header.Set("X-HEADLAMP_BACKEND-TOKEN", "secret")
+	req.Header.Set("X-Custom-Preserve", "keep")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "keep", received.Get("X-Custom-Preserve"))
+	assert.Empty(t, received.Get("Authorization"))
+	assert.Empty(t, received.Get("Cookie"))
+	assert.Empty(t, received.Get("X-HEADLAMP_BACKEND-TOKEN"))
+	assert.Empty(t, received.Get("proxy-to"))
+}
+
+func TestHandlerBlocksDisallowedRedirect(t *testing.T) {
+	var mu sync.Mutex
+
+	disallowedHit := false
+
+	disallowed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		disallowedHit = true
+		mu.Unlock()
+	}))
+	defer disallowed.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, disallowed.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+
+	allowlist, err := CompileAllowlist([]string{upstreamURL.String()})
+	require.NoError(t, err)
+
+	handler := NewHandler(func() []AllowlistEntry { return allowlist })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", upstream.URL)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadGateway, rr.Code)
+	assert.Contains(t, rr.Body.String(), "external proxy request failed")
+	assert.NotContains(t, rr.Body.String(), disallowed.URL)
+
+	mu.Lock()
+	assert.False(t, disallowedHit)
+	mu.Unlock()
+}
+
+func TestHandlerFollowsAllowedRedirect(t *testing.T) {
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("final"))
+	}))
+	defer final.Close()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+
+	allowlist, err := CompileAllowlist([]string{upstream.URL + "*", final.URL + "*"})
+	require.NoError(t, err)
+
+	handler := NewHandler(func() []AllowlistEntry { return allowlist })
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/externalproxy", nil)
+	req.Header.Set("proxy-to", upstream.URL)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "final", rr.Body.String())
+}

--- a/backend/pkg/externalproxy/headers.go
+++ b/backend/pkg/externalproxy/headers.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ShouldFilterRequestHeader reports whether a browser request header must not be
+// forwarded to an external proxy target.
+//
+// Filtered headers include credentials, Headlamp-internal routing headers
+// (both X-Headlamp-* and X-HEADLAMP_* forms), and hop-by-hop protocol headers.
+func ShouldFilterRequestHeader(headerName string) bool {
+	hLower := strings.ToLower(headerName)
+
+	if hLower == "authorization" ||
+		hLower == "cookie" ||
+		hLower == "accept-encoding" ||
+		hLower == "proxy-authorization" ||
+		strings.HasPrefix(hLower, "x-headlamp-") ||
+		strings.HasPrefix(hLower, "x-headlamp_") {
+		return true
+	}
+
+	switch hLower {
+	case "connection",
+		"forward-to",
+		"keep-alive",
+		"proxy-connection",
+		"proxy-to",
+		"te",
+		"trailer",
+		"transfer-encoding",
+		"upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+// ConnectionHeaderTokens returns lowercased header names listed in Connection.
+func ConnectionHeaderTokens(headers http.Header) map[string]struct{} {
+	tokens := map[string]struct{}{}
+
+	for _, headerValue := range headers.Values("Connection") {
+		for _, token := range strings.Split(headerValue, ",") {
+			token = strings.ToLower(strings.TrimSpace(token))
+			if token != "" {
+				tokens[token] = struct{}{}
+			}
+		}
+	}
+
+	return tokens
+}
+
+// CopyFilteredHeaders copies non-sensitive request headers into dst.
+func CopyFilteredHeaders(dst http.Header, src http.Header) {
+	connectionTokens := ConnectionHeaderTokens(src)
+
+	for name, values := range src {
+		if ShouldFilterRequestHeader(name) {
+			continue
+		}
+
+		if _, ok := connectionTokens[strings.ToLower(name)]; ok {
+			continue
+		}
+
+		dst[name] = values
+	}
+}

--- a/backend/pkg/externalproxy/headers_test.go
+++ b/backend/pkg/externalproxy/headers_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldFilterRequestHeader(t *testing.T) {
+	t.Parallel()
+
+	filtered := []string{
+		"Authorization",
+		"Cookie",
+		"Proxy-Authorization",
+		"X-Headlamp-Backend-Token",
+		"X-HEADLAMP_BACKEND-TOKEN",
+		"proxy-to",
+		"Forward-to",
+		"Connection",
+		"Upgrade",
+		"Accept-Encoding",
+	}
+
+	for _, header := range filtered {
+		assert.Truef(t, externalproxy.ShouldFilterRequestHeader(header), "expected %s to be filtered", header)
+	}
+
+	assert.False(t, externalproxy.ShouldFilterRequestHeader("X-Custom-Preserve"))
+}
+
+func TestCopyFilteredHeaders(t *testing.T) {
+	t.Parallel()
+
+	src := http.Header{}
+	src.Set("proxy-to", "https://example.com")
+	src.Set("Authorization", "Bearer secret")
+	src.Set("Cookie", "a=b")
+	src.Set("X-Headlamp-Custom", "secret")
+	src.Set("X-HEADLAMP_BACKEND-TOKEN", "secret")
+	src.Set("Connection", "Upgrade, X-Connection-Only")
+	src.Set("Upgrade", "websocket")
+	src.Set("X-Connection-Only", "drop-me")
+	src.Set("X-Custom-Preserve", "keep")
+
+	dst := http.Header{}
+	externalproxy.CopyFilteredHeaders(dst, src)
+
+	assert.Equal(t, "keep", dst.Get("X-Custom-Preserve"))
+	assert.Empty(t, dst.Get("Authorization"))
+	assert.Empty(t, dst.Get("Cookie"))
+	assert.Empty(t, dst.Get("proxy-to"))
+	assert.Empty(t, dst.Get("X-Headlamp-Custom"))
+	assert.Empty(t, dst.Get("X-HEADLAMP_BACKEND-TOKEN"))
+	assert.Empty(t, dst.Get("Upgrade"))
+	assert.Empty(t, dst.Get("X-Connection-Only"))
+}

--- a/backend/pkg/externalproxy/headers_test.go
+++ b/backend/pkg/externalproxy/headers_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package externalproxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldFilterRequestHeader(t *testing.T) {
+	t.Parallel()
+
+	filtered := []string{
+		"Authorization",
+		"Cookie",
+		"Proxy-Authorization",
+		"X-Headlamp-Backend-Token",
+		"X-HEADLAMP_BACKEND-TOKEN",
+		"proxy-to",
+		"Forward-to",
+		"Connection",
+		"Upgrade",
+		"Accept-Encoding",
+	}
+
+	for _, header := range filtered {
+		assert.Truef(t, ShouldFilterRequestHeader(header), "expected %s to be filtered", header)
+	}
+
+	assert.False(t, ShouldFilterRequestHeader("X-Custom-Preserve"))
+}
+
+func TestCopyFilteredHeaders(t *testing.T) {
+	t.Parallel()
+
+	src := http.Header{}
+	src.Set("proxy-to", "https://example.com")
+	src.Set("Authorization", "Bearer secret")
+	src.Set("Cookie", "a=b")
+	src.Set("X-Headlamp-Custom", "secret")
+	src.Set("X-HEADLAMP_BACKEND-TOKEN", "secret")
+	src.Set("Connection", "Upgrade, X-Connection-Only")
+	src.Set("Upgrade", "websocket")
+	src.Set("X-Connection-Only", "drop-me")
+	src.Set("X-Custom-Preserve", "keep")
+
+	dst := http.Header{}
+	CopyFilteredHeaders(dst, src)
+
+	assert.Equal(t, "keep", dst.Get("X-Custom-Preserve"))
+	assert.Empty(t, dst.Get("Authorization"))
+	assert.Empty(t, dst.Get("Cookie"))
+	assert.Empty(t, dst.Get("proxy-to"))
+	assert.Empty(t, dst.Get("X-Headlamp-Custom"))
+	assert.Empty(t, dst.Get("X-HEADLAMP_BACKEND-TOKEN"))
+	assert.Empty(t, dst.Get("Upgrade"))
+	assert.Empty(t, dst.Get("X-Connection-Only"))
+}

--- a/backend/pkg/externalproxy/headers_test.go
+++ b/backend/pkg/externalproxy/headers_test.go
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package externalproxy
+package externalproxy_test
 
 import (
 	"net/http"
 	"testing"
 
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/externalproxy"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,10 +41,10 @@ func TestShouldFilterRequestHeader(t *testing.T) {
 	}
 
 	for _, header := range filtered {
-		assert.Truef(t, ShouldFilterRequestHeader(header), "expected %s to be filtered", header)
+		assert.Truef(t, externalproxy.ShouldFilterRequestHeader(header), "expected %s to be filtered", header)
 	}
 
-	assert.False(t, ShouldFilterRequestHeader("X-Custom-Preserve"))
+	assert.False(t, externalproxy.ShouldFilterRequestHeader("X-Custom-Preserve"))
 }
 
 func TestCopyFilteredHeaders(t *testing.T) {
@@ -61,7 +62,7 @@ func TestCopyFilteredHeaders(t *testing.T) {
 	src.Set("X-Custom-Preserve", "keep")
 
 	dst := http.Header{}
-	CopyFilteredHeaders(dst, src)
+	externalproxy.CopyFilteredHeaders(dst, src)
 
 	assert.Equal(t, "keep", dst.Get("X-Custom-Preserve"))
 	assert.Empty(t, dst.Get("Authorization"))


### PR DESCRIPTION
## Summary
- Extract `/externalproxy` from `backend/cmd/headlamp.go` into `backend/pkg/externalproxy` (requested by @illume on #5680).
- Harden the proxy: strip sensitive/hop-by-hop headers and follow redirects only when the target stays on the ProxyURLs allowlist.
- Continues the security work from #5680 — thanks @ayushmaan-16. Includes review fixes (generic error bodies so upstream URLs aren’t leaked; filter both `X-Headlamp-*` and `X-HEADLAMP_*`).

## How users use this
1. Start Headlamp with allowlisted upstreams, e.g. `--proxy-urls="https://artifacthub.io/*"`.
2. Clients call `GET /externalproxy` with header `proxy-to: <allowlisted-url>` (legacy `Forward-to` still works).
3. Headlamp proxies the request after stripping credentials / internal headers.

## Backwards compatibility
- Route remains `/externalproxy`.
- `proxy-to` / `Forward-to` still work for allowlisted URLs.
- Breaking only for anyone relying on forwarding `Authorization` / `Cookie` / Headlamp-internal headers to upstream (that was insecure and is intentionally stopped).

## Test plan
- [x] `go test ./pkg/externalproxy/`
- [x] `go test ./cmd/ -run "ExternalProxy|ProxyURL"`
- [x] Manual: `go run ./cmd --proxy-urls="https://artifacthub.io/*"` then:

```bash
curl -i "http://localhost:4466/externalproxy" \
  -H "proxy-to: https://artifacthub.io/api/v1/packages/search?ts_query_web=helm" \
  -H "Authorization: Bearer should-not-leak" \
  -H "Cookie: session=should-not-leak"

<img width="1025" height="272" alt="image" src="https://github.com/user-attachments/assets/8ee2963a-57dd-46f1-baac-6c4555811c0c" />
