### PR TITLE
backend: watcher: Watch and reload referenced kubeconfig credential files

### DIFF
--- a/backend/cmd/headlamp.go
+++ b/backend/cmd/headlamp.go
@@ -624,8 +624,6 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 			pluginEventChan,
 			config.Cache,
 		)
-		// in-cluster mode is unlikely to want reloading kubeconfig.
-		go kubeconfig.LoadAndWatchFiles(ctx, config.KubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig, skipFunc)
 	}
 
 	// In-cluster
@@ -653,6 +651,11 @@ func createHeadlampHandler(ctx context.Context, config *HeadlampConfig) http.Han
 	err := kubeconfig.LoadAndStoreKubeConfigs(config.KubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig, skipFunc)
 	if err != nil {
 		logger.Log(logger.LevelError, nil, err, "loading kubeconfig")
+	}
+
+	// in-cluster mode is unlikely to want reloading kubeconfig.
+	if !config.UseInCluster {
+		go kubeconfig.LoadAndWatchFiles(ctx, config.KubeConfigStore, kubeConfigPath, kubeconfig.KubeConfig, skipFunc)
 	}
 
 	// Prometheus metrics endpoint

--- a/backend/pkg/kubeconfig/watcher.go
+++ b/backend/pkg/kubeconfig/watcher.go
@@ -17,8 +17,10 @@ const watchInterval = 10 * time.Second
 // logFieldPath is the structured-log field name for filesystem paths.
 const logFieldPath = "path"
 
-// LoadAndWatchFiles loads kubeconfig files and watches them for changes.
+// LoadAndWatchFiles watches kubeconfig files (and any referenced credential files) and reloads contexts on changes.
 // It runs until the provided context is cancelled.
+//
+//nolint:funlen
 func LoadAndWatchFiles(
 	ctx context.Context,
 	kubeConfigStore ContextStore,
@@ -42,8 +44,16 @@ func LoadAndWatchFiles(
 
 	kubeConfigPaths := splitKubeConfigPath(paths)
 
+	getDesiredPaths := func() []string {
+		desired := append([]string{}, kubeConfigPaths...)
+		credPaths := getReferencedCredentialPaths(kubeConfigStore)
+		desired = append(desired, credPaths...)
+
+		return desired
+	}
+
 	// add files to watcher
-	addFilesToWatcher(watcher, kubeConfigPaths)
+	updateWatcherPaths(watcher, getDesiredPaths())
 
 	for {
 		select {
@@ -52,9 +62,13 @@ func LoadAndWatchFiles(
 
 			return
 		case <-ticker.C:
-			if len(watcher.WatchList()) != len(kubeConfigPaths) {
-				logger.Log(logger.LevelInfo, nil, nil, "watcher: re-adding missing files")
-				addFilesToWatcher(watcher, kubeConfigPaths)
+			desired := getDesiredPaths()
+			beforeWatchList := watcher.WatchList()
+			updateWatcherPaths(watcher, desired)
+			afterWatchList := watcher.WatchList()
+
+			if hasWatchListChanged(beforeWatchList, afterWatchList) {
+				logger.Log(logger.LevelInfo, nil, nil, "watcher: watchlist updated, reloading contexts")
 
 				err := LoadAndStoreKubeConfigs(kubeConfigStore, paths, source, ignoreFunc)
 				if err != nil {
@@ -63,17 +77,16 @@ func LoadAndWatchFiles(
 			}
 
 		case event := <-watcher.Events:
-			triggers := []fsnotify.Op{fsnotify.Create, fsnotify.Write, fsnotify.Remove, fsnotify.Rename}
-			for _, trigger := range triggers {
-				if event.Op.Has(trigger) {
-					logger.Log(logger.LevelInfo, map[string]string{"event": event.Name},
-						nil, "watcher: kubeconfig file changed, reloading contexts")
+			if isEventTrigger(event.Op) {
+				logger.Log(logger.LevelInfo, map[string]string{"event": event.Name},
+					nil, "watcher: file changed, reloading contexts")
 
-					err := syncContexts(kubeConfigStore, paths, source, ignoreFunc)
-					if err != nil {
-						logger.Log(logger.LevelError, nil, err, "watcher: error synchronizing contexts")
-					}
+				err := syncContexts(kubeConfigStore, paths, source, ignoreFunc)
+				if err != nil {
+					logger.Log(logger.LevelError, nil, err, "watcher: error synchronizing contexts")
 				}
+
+				updateWatcherPaths(watcher, getDesiredPaths())
 			}
 
 		case err := <-watcher.Errors:
@@ -82,43 +95,31 @@ func LoadAndWatchFiles(
 	}
 }
 
-func addFilesToWatcher(watcher *fsnotify.Watcher, paths []string) {
-	for _, path := range paths {
-		// if path is relative, make it absolute
-		if !filepath.IsAbs(path) {
-			absPath, err := filepath.Abs(path)
-			if err != nil {
-				logger.Log(logger.LevelError, map[string]string{logFieldPath: path},
-					err, "getting absolute path")
+// hasWatchListChanged checks if the watch list of paths has changed between before and after states.
+func hasWatchListChanged(before, after []string) bool {
+	if len(before) != len(after) {
+		return true
+	}
 
-				continue
-			}
-
-			path = absPath
-		}
-
-		// check if path exists
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			logger.Log(logger.LevelError, map[string]string{logFieldPath: path},
-				err, "Path does not exist")
-
-			continue
-		}
-
-		// check if path is already being watched
-		// if it is, continue
-		filesBeingWatched := watcher.WatchList()
-		if slices.Contains(filesBeingWatched, path) {
-			continue
-		}
-
-		// if it isn't, add it to the watcher
-		err := watcher.Add(path)
-		if err != nil {
-			logger.Log(logger.LevelError, map[string]string{logFieldPath: path},
-				err, "adding path to watcher")
+	for _, path := range before {
+		if !slices.Contains(after, path) {
+			return true
 		}
 	}
+
+	return false
+}
+
+// isEventTrigger returns true if the fsnotify operation is one of the triggers we care about.
+func isEventTrigger(op fsnotify.Op) bool {
+	triggers := []fsnotify.Op{fsnotify.Create, fsnotify.Write, fsnotify.Remove, fsnotify.Rename}
+	for _, trigger := range triggers {
+		if op.Has(trigger) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // syncContexts synchronizes the contexts in the store with the ones in the kubeconfig files.
@@ -168,4 +169,116 @@ func syncContexts(kubeConfigStore ContextStore, paths string, source int, ignore
 	}
 
 	return nil
+}
+
+// getReferencedCredentialPaths retrieves absolute paths of all external credential/certificate files
+// referenced in KubeConfig type contexts in the store.
+func getReferencedCredentialPaths(kubeConfigStore ContextStore) []string {
+	contexts, err := kubeConfigStore.GetContexts()
+	if err != nil {
+		logger.Log(logger.LevelError, nil, err, "watcher: error getting contexts to extract credential paths")
+		return nil
+	}
+
+	var paths []string
+
+	for _, ctx := range contexts {
+		if ctx.Source != KubeConfig || ctx.AuthInfo == nil {
+			continue
+		}
+
+		for _, relPath := range []string{ctx.AuthInfo.ClientCertificate, ctx.AuthInfo.ClientKey, ctx.AuthInfo.TokenFile} {
+			if relPath == "" {
+				continue
+			}
+
+			absPath := relPath
+			if !filepath.IsAbs(relPath) && ctx.KubeConfigPath != "" {
+				absPath = filepath.Join(filepath.Dir(ctx.KubeConfigPath), relPath)
+			}
+
+			absPath, err = filepath.Abs(absPath)
+			if err != nil {
+				continue
+			}
+
+			if !slices.Contains(paths, absPath) {
+				paths = append(paths, absPath)
+			}
+		}
+	}
+
+	return paths
+}
+
+// normalizePaths converts relative paths to absolute and de-duplicates them.
+func normalizePaths(desiredPaths []string) []string {
+	normalizedDesired := make([]string, 0, len(desiredPaths))
+
+	seen := make(map[string]struct{}, len(desiredPaths))
+	for _, p := range desiredPaths {
+		if p == "" {
+			continue
+		}
+
+		absPath := p
+		if !filepath.IsAbs(p) {
+			var err error
+
+			absPath, err = filepath.Abs(p)
+			if err != nil {
+				logger.Log(logger.LevelError, map[string]string{logFieldPath: p}, err, "getting absolute path")
+				continue
+			}
+		}
+
+		if _, ok := seen[absPath]; ok {
+			continue
+		}
+
+		seen[absPath] = struct{}{}
+		normalizedDesired = append(normalizedDesired, absPath)
+	}
+
+	return normalizedDesired
+}
+
+// updateWatcherPaths registers desired paths to be watched and deregisters stale ones.
+func updateWatcherPaths(watcher *fsnotify.Watcher, desiredPaths []string) {
+	desiredPaths = normalizePaths(desiredPaths)
+
+	// Remove any path that is no longer desired (diff against actual watcher state)
+	for _, path := range watcher.WatchList() {
+		if !slices.Contains(desiredPaths, path) {
+			if err := watcher.Remove(path); err != nil {
+				logger.Log(logger.LevelError, map[string]string{logFieldPath: path}, err, "removing path from watcher")
+			}
+		}
+	}
+
+	for _, absPath := range desiredPaths {
+		if _, err := os.Stat(absPath); err != nil {
+			// If the file no longer exists (or is otherwise unreadable), ensure we don't keep a stale watch.
+			if slices.Contains(watcher.WatchList(), absPath) {
+				_ = watcher.Remove(absPath)
+			}
+
+			if os.IsNotExist(err) {
+				logger.Log(logger.LevelError, map[string]string{logFieldPath: absPath}, err, "Path does not exist")
+			} else {
+				logger.Log(logger.LevelError, map[string]string{logFieldPath: absPath}, err, "stat path")
+			}
+
+			continue
+		}
+
+		filesBeingWatched := watcher.WatchList()
+		if !slices.Contains(filesBeingWatched, absPath) {
+			err := watcher.Add(absPath)
+			if err != nil {
+				logger.Log(logger.LevelError, map[string]string{logFieldPath: absPath}, err, "adding path to watcher")
+				continue
+			}
+		}
+	}
 }

--- a/backend/pkg/kubeconfig/watcher_test.go
+++ b/backend/pkg/kubeconfig/watcher_test.go
@@ -3,6 +3,7 @@ package kubeconfig_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -31,6 +32,10 @@ func TestWatchAndLoadFiles(t *testing.T) {
 
 	kubeConfigStore := kubeconfig.NewContextStore()
 
+	// Perform initial load as done by the Headlamp server
+	err := kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, path, kubeconfig.KubeConfig, nil)
+	require.NoError(t, err)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Ensure the watcher goroutine is stopped when the test ends
 
@@ -38,9 +43,6 @@ func TestWatchAndLoadFiles(t *testing.T) {
 
 	// Test adding a context
 	t.Run("Add context", func(t *testing.T) {
-		// Sleep to ensure watcher is ready
-		time.Sleep(2 * time.Second)
-
 		// Read existing config
 		config, err := clientcmd.LoadFromFile("./test_data/kubeconfig1")
 		require.NoError(t, err)
@@ -51,21 +53,21 @@ func TestWatchAndLoadFiles(t *testing.T) {
 			AuthInfo: "docker-desktop", // reuse existing auth
 		}
 
-		// Write back to file
-		err = clientcmd.WriteToFile(*config, "./test_data/kubeconfig1")
-		require.NoError(t, err)
-
-		// Wait for context to be added
+		// Periodically rewrite file until watcher detects event
 		found := false
 
-		for i := 0; i < 20; i++ {
+		for i := 0; i < 30; i++ {
+			err = clientcmd.WriteToFile(*config, "./test_data/kubeconfig1")
+			require.NoError(t, err)
+
 			context, err := kubeConfigStore.GetContext("random-cluster-4")
 			if err == nil && context != nil {
 				found = true
+
 				break
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 		}
 
 		require.True(t, found, "Context should have been added")
@@ -115,4 +117,137 @@ func TestWatchAndLoadFiles(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}()
+}
+
+//nolint:funlen
+func TestWatchAndLoadReferencedCredentialFiles(t *testing.T) {
+	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {
+		t.Skip("skipping integration test")
+	}
+
+	// Create a temp directory for the test files
+	tempDir, err := os.MkdirTemp("", "headlamp-watcher-test")
+	require.NoError(t, err)
+
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create a mock token file
+	tokenPath := filepath.Join(tempDir, "token")
+	err = os.WriteFile(tokenPath, []byte("initial-token"), 0o600)
+	require.NoError(t, err)
+
+	// Create a mock kubeconfig referencing the token file
+	kubeconfigPath := filepath.Join(tempDir, "kubeconfig")
+	config := clientcmdapi.NewConfig()
+	config.Clusters["test-cluster"] = &clientcmdapi.Cluster{
+		Server: "https://127.0.0.1:6443",
+	}
+	config.AuthInfos["test-user"] = &clientcmdapi.AuthInfo{
+		TokenFile: tokenPath,
+	}
+	config.Contexts["test-context"] = &clientcmdapi.Context{
+		Cluster:  "test-cluster",
+		AuthInfo: "test-user",
+	}
+	config.CurrentContext = "test-context"
+
+	err = clientcmd.WriteToFile(*config, kubeconfigPath)
+	require.NoError(t, err)
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+
+	// Perform initial load as done by the Headlamp server
+	err = kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, kubeconfigPath, kubeconfig.KubeConfig, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go kubeconfig.LoadAndWatchFiles(ctx, kubeConfigStore, kubeconfigPath, kubeconfig.KubeConfig, nil)
+
+	// Verify context exists
+	_, err = kubeConfigStore.GetContext("test-context")
+	require.NoError(t, err)
+
+	// Add listener to track notifications
+	reloadChan := make(chan struct{}, 10)
+
+	kubeConfigStore.AddListener(func() {
+		select {
+		case reloadChan <- struct{}{}:
+		default:
+		}
+	})
+
+	// Modify the referenced token file with retry sync until reload triggers
+	reloaded := false
+
+	for i := 0; i < 30; i++ {
+		err = os.WriteFile(tokenPath, []byte("updated-token"), 0o600)
+		require.NoError(t, err)
+
+		select {
+		case <-reloadChan:
+			reloaded = true
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		if reloaded {
+			break
+		}
+	}
+
+	require.True(t, reloaded, "Timeout waiting for watcher to trigger reload on credential file change")
+}
+
+func TestRemoveContextWithSharedCluster(t *testing.T) {
+	if os.Getenv("HEADLAMP_RUN_INTEGRATION_TESTS") != "true" {
+		t.Skip("skipping integration test")
+	}
+
+	tempDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tempDir, "kubeconfig")
+	config := clientcmdapi.NewConfig()
+	config.Clusters["shared-cluster"] = &clientcmdapi.Cluster{Server: "https://127.0.0.1:6443"}
+	config.AuthInfos["user-1"] = &clientcmdapi.AuthInfo{Token: "token-1"}
+	config.AuthInfos["user-2"] = &clientcmdapi.AuthInfo{Token: "token-2"}
+	config.Contexts["ctx-1"] = &clientcmdapi.Context{Cluster: "shared-cluster", AuthInfo: "user-1"}
+	config.Contexts["ctx-2"] = &clientcmdapi.Context{Cluster: "shared-cluster", AuthInfo: "user-2"}
+
+	require.NoError(t, clientcmd.WriteToFile(*config, kubeconfigPath))
+
+	kubeConfigStore := kubeconfig.NewContextStore()
+	require.NoError(t, kubeconfig.LoadAndStoreKubeConfigs(kubeConfigStore, kubeconfigPath, kubeconfig.KubeConfig, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go kubeconfig.LoadAndWatchFiles(ctx, kubeConfigStore, kubeconfigPath, kubeconfig.KubeConfig, nil)
+
+	_, err1 := kubeConfigStore.GetContext("ctx-1")
+	_, err2 := kubeConfigStore.GetContext("ctx-2")
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+
+	delete(config.Contexts, "ctx-1")
+
+	removed := false
+
+	for i := 0; i < 30; i++ {
+		require.NoError(t, clientcmd.WriteToFile(*config, kubeconfigPath))
+
+		if _, err := kubeConfigStore.GetContext("ctx-1"); err != nil {
+			removed = true
+
+			break
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	require.True(t, removed, "ctx-1 should have been removed by watcher")
+
+	_, err := kubeConfigStore.GetContext("ctx-2")
+	require.NoError(t, err, "ctx-2 should still exist in store")
 }


### PR DESCRIPTION
## Summary

This PR adds a feature to watch and reload external credential/certificate files (e.g. client certificates, client keys, and token files) referenced inside Kubeconfig contexts. When these referenced files are updated or rotated by external helpers/tools, the watcher automatically detects the change, reloads the context configurations, and invalidates cached HTTP transport reverse proxies.

## Related Issue

Fixes #6374 

## Changes

- **Added `getReferencedCredentialPaths` in `backend/pkg/kubeconfig/watcher.go`:** Iterates through loaded contexts and extracts absolute file paths to `ClientCertificate`, `ClientKey`, and `TokenFile` fields.
- **Added `updateWatcherPaths` in `backend/pkg/kubeconfig/watcher.go`:** Manages the active fsnotify watch list dynamically by registering new credential file paths and deregistering stale ones when config changes.
- **Refactored `LoadAndWatchFiles` in `backend/pkg/kubeconfig/watcher.go`:** Updates the watch loop to monitor both the main kubeconfig files and any referenced credential files.
- **Added Integration Test in `backend/pkg/kubeconfig/watcher_test.go`:** Created `TestWatchAndLoadReferencedCredentialFiles` to verify that updating a referenced token file dynamically triggers a context store reload.

## Steps to Test

1. Enable integration tests and run the kubeconfig package test suite:
   ```bash
    go test -v ./pkg/kubeconfig/...
   ```
2. Verify that the new TestWatchAndLoadReferencedCredentialFiles test passes successfully.

## Screenshots (if applicable)


## Notes for the Reviewer

- The implementation dynamically removes watched paths from `fsnotify` as soon as they are no longer referenced in the active kubeconfig, avoiding file descriptor leaks.
- Standard linter bypass comments (`//nolint:funlen`) were used for the long watch and test function blocks, keeping the linter output completely clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kubeconfig changes are now detected reliably when referenced credential files, such as tokens, are updated.
  * Watchers stay synchronized as kubeconfig contexts and credential paths change, including when contexts are removed.
  * In-cluster deployments no longer start unnecessary kubeconfig monitoring.
  * Initial kubeconfig loading and watcher readiness are handled more promptly.
  * Configurations sharing cluster information continue working correctly when individual contexts change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->