### PR TITLE
backend: Add unit tests for pkg/headlampconfig

### DIFF
--- a/backend/pkg/headlampconfig/headlampconfig_test.go
+++ b/backend/pkg/headlampconfig/headlampconfig_test.go
@@ -1,0 +1,211 @@
+package headlampconfig_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubMultiplexer is a minimal WebSocketMultiplexer implementation for tests.
+type stubMultiplexer struct {
+	called bool
+}
+
+func (s *stubMultiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Request) {
+	s.called = true
+}
+
+// Compile-time check that the stub satisfies the interface.
+var _ headlampconfig.WebSocketMultiplexer = (*stubMultiplexer)(nil)
+
+// stubContextStore is a resource-free ContextStore for tests. The real
+// NewContextStore starts a cache cleanup goroutine with no Close method, which
+// would leak until the test process exits; the tests here never call store
+// methods, so a no-op stub avoids that.
+type stubContextStore struct{}
+
+func (stubContextStore) AddContext(*kubeconfig.Context) error           { return nil }
+func (stubContextStore) GetContexts() ([]*kubeconfig.Context, error)    { return nil, nil }
+func (stubContextStore) GetContext(string) (*kubeconfig.Context, error) { return nil, nil }
+func (stubContextStore) RemoveContext(string) error                     { return nil }
+func (stubContextStore) AddContextWithKeyAndTTL(*kubeconfig.Context, string, time.Duration) error {
+	return nil
+}
+func (stubContextStore) UpdateTTL(string, time.Duration) error        { return nil }
+func (stubContextStore) AddListener(kubeconfig.ContextChangeListener) {}
+func (stubContextStore) GetContextKeys() ([]string, error)            { return nil, nil }
+
+// Compile-time check that the stub satisfies the interface.
+var _ kubeconfig.ContextStore = stubContextStore{}
+
+func TestHeadlampCFGZeroValues(t *testing.T) {
+	cfg := headlampconfig.HeadlampCFG{}
+
+	assert.False(t, cfg.UseInCluster)
+	assert.False(t, cfg.DevMode)
+	assert.False(t, cfg.Insecure)
+	assert.False(t, cfg.EnableHelm)
+	assert.False(t, cfg.EnableDynamicClusters)
+	assert.False(t, cfg.UnsafeUseServiceAccountToken)
+	assert.Equal(t, uint(0), cfg.Port)
+	assert.Equal(t, 0, cfg.SessionTTL)
+	assert.Empty(t, cfg.AppName)
+	assert.Empty(t, cfg.BaseURL)
+	assert.Empty(t, cfg.ProxyURLs)
+	assert.Nil(t, cfg.KubeConfigStore)
+	assert.Nil(t, cfg.Telemetry)
+	assert.Nil(t, cfg.Metrics)
+	assert.Equal(t, time.Duration(0), cfg.ClusterInventoryRootReconcileInterval)
+	assert.Equal(t, time.Duration(0), cfg.ClusterInventoryNoCRDCacheTTL)
+}
+
+func TestHeadlampConfigZeroValues(t *testing.T) {
+	cfg := headlampconfig.HeadlampConfig{}
+
+	assert.Nil(t, cfg.HeadlampCFG)
+	assert.Nil(t, cfg.Cache)
+	assert.Nil(t, cfg.Multiplexer)
+	assert.Nil(t, cfg.TelemetryHandler)
+	assert.Nil(t, cfg.ServerCtx)
+	assert.False(t, cfg.OidcUseAccessToken)
+	assert.False(t, cfg.OidcSkipTLSVerify)
+	assert.False(t, cfg.OidcUsePKCE)
+	assert.False(t, cfg.ProxyAuthEnabled)
+	assert.Empty(t, cfg.OidcClientID)
+	assert.Empty(t, cfg.OidcScopes)
+}
+
+// Accessing an embedded field through a nil *HeadlampCFG panics; callers must
+// always populate the embedded struct. This documents that requirement.
+func TestHeadlampConfigNilEmbeddedPanics(t *testing.T) {
+	cfg := headlampconfig.HeadlampConfig{}
+
+	assert.Panics(t, func() {
+		_ = cfg.Port
+	})
+}
+
+// newTestCFG builds a HeadlampCFG with every field populated (a superset of
+// what buildHeadlampCFG in server.go sets), acting as a constructibility and
+// field-name guard.
+func newTestCFG(store kubeconfig.ContextStore) *headlampconfig.HeadlampCFG {
+	return &headlampconfig.HeadlampCFG{ //nolint:gosec // test fixture, not real credentials
+		AppName:                               "Headlamp",
+		UseInCluster:                          true,
+		InClusterContextName:                  "main",
+		ListenAddr:                            "localhost",
+		Port:                                  4466,
+		DevMode:                               true,
+		Insecure:                              true,
+		EnableHelm:                            true,
+		EnableDynamicClusters:                 true,
+		AllowKubeconfigChanges:                true,
+		WatchPluginsChanges:                   true,
+		CacheEnabled:                          true,
+		KubeConfigPath:                        "/tmp/kubeconfig",
+		KubeConfigDir:                         "/tmp/kubeconfigs",
+		SkippedKubeContexts:                   "skip-me",
+		StaticDir:                             "static",
+		PluginDir:                             "plugins",
+		UserPluginDir:                         "user-plugins",
+		StaticPluginDir:                       "static-plugins",
+		KubeConfigStore:                       store,
+		Telemetry:                             nil,
+		Metrics:                               nil,
+		BaseURL:                               "/headlamp",
+		ProxyURLs:                             []string{"https://example.com"},
+		TLSCertPath:                           "/tls/cert.pem",
+		TLSKeyPath:                            "/tls/key.pem",
+		SessionTTL:                            3600,
+		PodDebugImage:                         "busybox",
+		NodeShellImage:                        "alpine",
+		NodeShellNamespace:                    "kube-system",
+		OidcUseCookie:                         true,
+		DefaultLightTheme:                     "light",
+		DefaultDarkTheme:                      "dark",
+		ForceTheme:                            "light",
+		UnsafeUseServiceAccountToken:          true,
+		ServiceAccountTokenPath:               "/var/run/token",
+		EnableClusterInventory:                true,
+		ClusterInventoryProviderFile:          "providers.yaml",
+		ClusterInventoryLabelSelector:         "app=headlamp",
+		ClusterInventoryNamespaces:            "team-a,team-b",
+		ClusterInventoryRootReconcileInterval: 5 * time.Minute,
+		ClusterInventoryNoCRDCacheTTL:         time.Minute,
+	}
+}
+
+// TestHeadlampConfigConstruction verifies struct constructibility, promoted
+// embedded field access, and interface delegation on HeadlampConfig.
+func TestHeadlampConfigConstruction(t *testing.T) {
+	store := stubContextStore{}
+	c := cache.New[interface{}]()
+	mux := &stubMultiplexer{}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	cfg := &headlampconfig.HeadlampConfig{
+		HeadlampCFG:               newTestCFG(store),
+		OidcClientID:              "client-id",
+		OidcValidatorClientID:     "validator-client-id",
+		OidcClientSecret:          "test-value",
+		OidcIdpIssuerURL:          "https://idp.example.com",
+		OidcCallbackURL:           "https://headlamp.example.com/oidc-callback",
+		OidcValidatorIdpIssuerURL: "https://validator.example.com",
+		OidcUseAccessToken:        true,
+		OidcSkipTLSVerify:         true,
+		OidcCACert:                "ca-cert",
+		OidcUsePKCE:               true,
+		OidcScopes:                []string{"openid", "profile", "email"},
+		Cache:                     c,
+		Multiplexer:               mux,
+		TelemetryConfig:           config.Config{},
+		TelemetryHandler:          nil,
+		MeUsernamePaths:           "username",
+		MeEmailPaths:              "email",
+		MeGroupsPaths:             "groups",
+		MeUserInfoURL:             "https://idp.example.com/userinfo",
+		ProxyAuthEnabled:          true,
+		ProxyAuthUsernameHeader:   "X-User",
+		ProxyAuthGroupHeader:      "X-Groups",
+		ProxyAuthEmailHeader:      "X-Email",
+		ProxyAuthTokenHeader:      "X-Token",
+		ServerCtx:                 nil,
+	}
+
+	// Embedded fields are reachable directly on HeadlampConfig.
+	assert.Equal(t, uint(4466), cfg.Port)
+	assert.Equal(t, "/headlamp", cfg.BaseURL)
+	assert.True(t, cfg.UseInCluster)
+	assert.Equal(t, []string{"https://example.com"}, cfg.ProxyURLs)
+
+	// Interface fields work through the config.
+	require.NotNil(t, cfg.Multiplexer)
+	cfg.Multiplexer.HandleClientWebSocket(nil, nil)
+	assert.True(t, mux.called)
+
+	require.NotNil(t, cfg.KubeConfigStore)
+	require.NotNil(t, cfg.Cache)
+	assert.Equal(t, []string{"openid", "profile", "email"}, cfg.OidcScopes)
+}
+
+// Go's embedded-pointer semantics mean that a write to a promoted field on the
+// outer struct (HeadlampConfig) reaches the shared *HeadlampCFG directly.
+// Verify this guarantee so field access patterns remain obvious to future readers.
+func TestHeadlampConfigEmbeddedMutation(t *testing.T) {
+	inner := &headlampconfig.HeadlampCFG{}
+	cfg := headlampconfig.HeadlampConfig{HeadlampCFG: inner}
+
+	cfg.BaseURL = "/base"
+	cfg.Port = 8080
+
+	assert.Equal(t, "/base", inner.BaseURL)
+	assert.Equal(t, uint(8080), inner.Port)
+}

--- a/backend/pkg/headlampconfig/headlampconfig_test.go
+++ b/backend/pkg/headlampconfig/headlampconfig_test.go
@@ -1,0 +1,186 @@
+package headlampconfig_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/cache"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/config"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/headlampconfig"
+	"github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubMultiplexer is a minimal WebSocketMultiplexer implementation for tests.
+type stubMultiplexer struct {
+	called bool
+}
+
+func (s *stubMultiplexer) HandleClientWebSocket(w http.ResponseWriter, r *http.Request) {
+	s.called = true
+}
+
+// Compile-time check that the stub satisfies the interface.
+var _ headlampconfig.WebSocketMultiplexer = (*stubMultiplexer)(nil)
+
+func TestHeadlampCFGZeroValues(t *testing.T) {
+	cfg := headlampconfig.HeadlampCFG{}
+
+	assert.False(t, cfg.UseInCluster)
+	assert.False(t, cfg.DevMode)
+	assert.False(t, cfg.Insecure)
+	assert.False(t, cfg.EnableHelm)
+	assert.False(t, cfg.EnableDynamicClusters)
+	assert.False(t, cfg.UnsafeUseServiceAccountToken)
+	assert.Equal(t, uint(0), cfg.Port)
+	assert.Equal(t, 0, cfg.SessionTTL)
+	assert.Empty(t, cfg.BaseURL)
+	assert.Empty(t, cfg.ProxyURLs)
+	assert.Nil(t, cfg.KubeConfigStore)
+	assert.Nil(t, cfg.Telemetry)
+	assert.Nil(t, cfg.Metrics)
+	assert.Equal(t, time.Duration(0), cfg.ClusterInventoryRootReconcileInterval)
+	assert.Equal(t, time.Duration(0), cfg.ClusterInventoryNoCRDCacheTTL)
+}
+
+func TestHeadlampConfigZeroValues(t *testing.T) {
+	cfg := headlampconfig.HeadlampConfig{}
+
+	assert.Nil(t, cfg.HeadlampCFG)
+	assert.Nil(t, cfg.Cache)
+	assert.Nil(t, cfg.Multiplexer)
+	assert.Nil(t, cfg.TelemetryHandler)
+	assert.Nil(t, cfg.ServerCtx)
+	assert.False(t, cfg.OidcUseAccessToken)
+	assert.False(t, cfg.OidcSkipTLSVerify)
+	assert.False(t, cfg.OidcUsePKCE)
+	assert.False(t, cfg.ProxyAuthEnabled)
+	assert.Empty(t, cfg.OidcClientID)
+	assert.Empty(t, cfg.OidcScopes)
+}
+
+// Accessing an embedded field through a nil *HeadlampCFG panics; callers must
+// always populate the embedded struct. This documents that requirement.
+func TestHeadlampConfigNilEmbeddedPanics(t *testing.T) {
+	cfg := headlampconfig.HeadlampConfig{}
+
+	assert.Panics(t, func() {
+		_ = cfg.Port
+	})
+}
+
+// newTestCFG builds a HeadlampCFG with every field populated (a superset of
+// what buildHeadlampCFG in server.go sets), so renames or type changes of any
+// field break this test.
+func newTestCFG(store kubeconfig.ContextStore) *headlampconfig.HeadlampCFG {
+	return &headlampconfig.HeadlampCFG{ //nolint:gosec // test fixture, not real credentials
+		UseInCluster:                          true,
+		InClusterContextName:                  "main",
+		ListenAddr:                            "localhost",
+		Port:                                  4466,
+		DevMode:                               true,
+		Insecure:                              true,
+		EnableHelm:                            true,
+		EnableDynamicClusters:                 true,
+		AllowKubeconfigChanges:                true,
+		WatchPluginsChanges:                   true,
+		CacheEnabled:                          true,
+		KubeConfigPath:                        "/tmp/kubeconfig",
+		SkippedKubeContexts:                   "skip-me",
+		StaticDir:                             "static",
+		PluginDir:                             "plugins",
+		UserPluginDir:                         "user-plugins",
+		StaticPluginDir:                       "static-plugins",
+		KubeConfigStore:                       store,
+		Telemetry:                             nil,
+		Metrics:                               nil,
+		BaseURL:                               "/headlamp",
+		ProxyURLs:                             []string{"https://example.com"},
+		TLSCertPath:                           "/tls/cert.pem",
+		TLSKeyPath:                            "/tls/key.pem",
+		SessionTTL:                            3600,
+		PodDebugImage:                         "busybox",
+		NodeShellImage:                        "alpine",
+		NodeShellNamespace:                    "kube-system",
+		OidcUseCookie:                         true,
+		DefaultLightTheme:                     "light",
+		DefaultDarkTheme:                      "dark",
+		ForceTheme:                            "light",
+		UnsafeUseServiceAccountToken:          true,
+		ServiceAccountTokenPath:               "/var/run/token",
+		EnableClusterInventory:                true,
+		ClusterInventoryProviderFile:          "providers.yaml",
+		ClusterInventoryLabelSelector:         "app=headlamp",
+		ClusterInventoryRootReconcileInterval: 5 * time.Minute,
+		ClusterInventoryNoCRDCacheTTL:         time.Minute,
+	}
+}
+
+// Mirrors how server.go builds the config (buildHeadlampCFG + createHeadlampConfig),
+// guarding against accidental field renames or type changes.
+func TestHeadlampConfigConstruction(t *testing.T) {
+	store := kubeconfig.NewContextStore()
+	c := cache.New[interface{}]()
+	mux := &stubMultiplexer{}
+
+	t.Cleanup(func() { _ = c.Close() })
+
+	cfg := &headlampconfig.HeadlampConfig{
+		HeadlampCFG:               newTestCFG(store),
+		OidcClientID:              "client-id",
+		OidcValidatorClientID:     "validator-client-id",
+		OidcClientSecret:          "test-value",
+		OidcIdpIssuerURL:          "https://idp.example.com",
+		OidcCallbackURL:           "https://headlamp.example.com/oidc-callback",
+		OidcValidatorIdpIssuerURL: "https://validator.example.com",
+		OidcUseAccessToken:        true,
+		OidcSkipTLSVerify:         true,
+		OidcCACert:                "ca-cert",
+		OidcUsePKCE:               true,
+		OidcScopes:                []string{"openid", "profile", "email"},
+		Cache:                     c,
+		Multiplexer:               mux,
+		TelemetryConfig:           config.Config{},
+		TelemetryHandler:          nil,
+		MeUsernamePaths:           "username",
+		MeEmailPaths:              "email",
+		MeGroupsPaths:             "groups",
+		MeUserInfoURL:             "https://idp.example.com/userinfo",
+		ProxyAuthEnabled:          true,
+		ProxyAuthUsernameHeader:   "X-User",
+		ProxyAuthGroupHeader:      "X-Groups",
+		ProxyAuthEmailHeader:      "X-Email",
+		ProxyAuthTokenHeader:      "X-Token",
+		ServerCtx:                 nil,
+	}
+
+	// Embedded fields are reachable directly on HeadlampConfig.
+	assert.Equal(t, uint(4466), cfg.Port)
+	assert.Equal(t, "/headlamp", cfg.BaseURL)
+	assert.True(t, cfg.UseInCluster)
+	assert.Equal(t, []string{"https://example.com"}, cfg.ProxyURLs)
+
+	// Interface fields work through the config.
+	require.NotNil(t, cfg.Multiplexer)
+	cfg.Multiplexer.HandleClientWebSocket(nil, nil)
+	assert.True(t, mux.called)
+
+	require.NotNil(t, cfg.KubeConfigStore)
+	require.NotNil(t, cfg.Cache)
+	assert.Equal(t, []string{"openid", "profile", "email"}, cfg.OidcScopes)
+}
+
+// Mutating an embedded field through the outer struct writes to the shared
+// *HeadlampCFG, matching how createHeadlampConfig assigns fields after construction.
+func TestHeadlampConfigEmbeddedMutation(t *testing.T) {
+	inner := &headlampconfig.HeadlampCFG{}
+	cfg := headlampconfig.HeadlampConfig{HeadlampCFG: inner}
+
+	cfg.BaseURL = "/base"
+	cfg.Port = 8080
+
+	assert.Equal(t, "/base", inner.BaseURL)
+	assert.Equal(t, uint(8080), inner.Port)
+}


### PR DESCRIPTION
## Summary

Add unit tests for `backend/pkg/headlampconfig`, which previously had 0% test coverage despite being the central config package consumed across the backend.

## Related Issue

Fixes #6074

## Changes

- New `backend/pkg/headlampconfig/headlampconfig_test.go` with 5 tests:
  - Zero-value sanity checks for `HeadlampCFG` and `HeadlampConfig` fields
  - Documents that accessing an embedded field through a nil `*HeadlampCFG` panics
  - Compile-time and runtime `WebSocketMultiplexer` interface compliance via a stub
  - Full construction test mirroring `buildHeadlampCFG` + `createHeadlampConfig` in `server.go` (regression guard against field renames/type changes)
  - Embedded-pointer mutation semantics (writes through outer struct reach the shared `*HeadlampCFG`)

## Steps to Test

```bash
cd backend
go test ./pkg/headlampconfig/...
```

## Notes for the Reviewer

- Tests are in an external `headlampconfig_test` package (per `testpackage` linter)
- Verified locally: `go test` passes, `go vet` clean, `golangci-lint run` (v2.12.2, repo config) reports 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for configuration behavior, including default values, embedded settings, interface integration, and mutation propagation.
  * Added WebSocket multiplexer test coverage and validation.
  * Added a complete configuration fixture for testing all supported settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->