### PR TITLE
backend: logger: Add tests for log function and SetLogFunc reset

### DIFF
--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -207,6 +207,9 @@ func captureLog(t *testing.T, level uint, str map[string]string, err interface{}
 //
 //nolint:funlen // table-driven test, splitting hurts readability
 func TestDefaultLogFunc(t *testing.T) {
+	origLogFunc := logger.SetLogFunc(nil)
+	t.Cleanup(func() { logger.SetLogFunc(origLogFunc) })
+
 	tests := []struct {
 		name     string
 		level    uint

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -208,6 +208,7 @@ func captureLog(t *testing.T, level uint, str map[string]string, err interface{}
 //nolint:funlen // table-driven test, splitting hurts readability
 func TestDefaultLogFunc(t *testing.T) {
 	origLogFunc := logger.SetLogFunc(nil)
+
 	t.Cleanup(func() { logger.SetLogFunc(origLogFunc) })
 
 	tests := []struct {

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package logger_test
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +39,9 @@ func MockLog(level uint, str map[string]string, err interface{}, msg string) {
 }
 
 func TestLog(t *testing.T) {
-	t.Parallel()
+	// Note: no t.Parallel() here (or in any test in this package): the tests
+	// mutate process-wide state (logger.SetLogFunc, zerolog.SetGlobalLevel,
+	// zlog.Logger and capturedLogs), so they must run serially.
 
 	// Replace the actual logging function with the mock one
 	originalLogFunc := logger.SetLogFunc(MockLog)
@@ -168,4 +174,138 @@ func TestEmptyOrMissingEnvDefaultsToInfo(t *testing.T) {
 			t.Fatalf("expected info when env missing")
 		}
 	})
+}
+
+// captureLog redirects the global zerolog logger into a buffer, calls
+// logger.Log with the default (real) log function, and returns the output.
+func captureLog(t *testing.T, level uint, str map[string]string, err interface{}, msg string) string {
+	t.Helper()
+
+	origLevel := zerolog.GlobalLevel()
+
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+
+	origLogger := zlog.Logger
+
+	t.Cleanup(func() {
+		zlog.Logger = origLogger
+
+		zerolog.SetGlobalLevel(origLevel)
+	})
+
+	var buf bytes.Buffer
+
+	zlog.Logger = zerolog.New(&buf)
+
+	logger.Log(level, str, err, msg)
+
+	return buf.String()
+}
+
+// Exercises the real log function: levels, string fields, source/line and
+// every error type branch ([]error, int, string, error, interface{}).
+//
+//nolint:funlen // table-driven test, splitting hurts readability
+func TestDefaultLogFunc(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    uint
+		str      map[string]string
+		err      interface{}
+		msg      string
+		expected []string
+	}{
+		{
+			name:     "info with fields and no error",
+			level:    logger.LevelInfo,
+			str:      map[string]string{"key": "value"},
+			msg:      "info msg",
+			expected: []string{`"level":"info"`, `"key":"value"`, `"source":`, `"line":`, `"message":"info msg"`},
+		},
+		{
+			name:     "warn level",
+			level:    logger.LevelWarn,
+			msg:      "warn msg",
+			expected: []string{`"level":"warn"`, `"message":"warn msg"`},
+		},
+		{
+			name:     "unknown level defaults to info",
+			level:    42,
+			msg:      "default msg",
+			expected: []string{`"level":"info"`, `"message":"default msg"`},
+		},
+		{
+			name:     "error interface",
+			level:    logger.LevelError,
+			err:      errors.New("boom"),
+			msg:      "error msg",
+			expected: []string{`"level":"error"`, `"error":"boom"`, `"message":"error msg"`},
+		},
+		{
+			name:     "error slice",
+			level:    logger.LevelError,
+			err:      []error{errors.New("first"), errors.New("second")},
+			msg:      "multi error",
+			expected: []string{`"error":["first","second"]`, `"message":"multi error"`},
+		},
+		{
+			name:     "int error code",
+			level:    logger.LevelError,
+			err:      404,
+			msg:      "int error",
+			expected: []string{`"error":404`, `"message":"int error"`},
+		},
+		{
+			name:     "string error",
+			level:    logger.LevelError,
+			err:      "string failure",
+			msg:      "string error",
+			expected: []string{`"error":"string failure"`, `"message":"string error"`},
+		},
+		{
+			name:     "generic interface error",
+			level:    logger.LevelError,
+			err:      struct{ Code int }{Code: 7},
+			msg:      "generic error",
+			expected: []string{`"error":{"Code":7}`, `"message":"generic error"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureLog(t, tt.level, tt.str, tt.err, tt.msg)
+
+			for _, want := range tt.expected {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected output to contain %s, got: %s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// SetLogFunc(nil) restores the default log function.
+func TestSetLogFuncNilRestoresDefault(t *testing.T) {
+	orig := logger.SetLogFunc(MockLog)
+
+	t.Cleanup(func() {
+		logger.SetLogFunc(orig)
+	})
+
+	returned := logger.SetLogFunc(nil)
+	if returned == nil {
+		t.Fatal("expected previous log function to be returned")
+	}
+
+	// The default function is active again: output goes to zerolog, not MockLog.
+	capturedLogs = nil
+	out := captureLog(t, logger.LevelInfo, nil, nil, "after reset")
+
+	if len(capturedLogs) != 0 {
+		t.Errorf("mock should not capture after reset, got: %v", capturedLogs)
+	}
+
+	if !strings.Contains(out, `"message":"after reset"`) {
+		t.Errorf("expected default log output, got: %s", out)
+	}
 }

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -182,16 +183,15 @@ func captureLog(t *testing.T, level uint, str map[string]string, err interface{}
 	t.Helper()
 
 	origLevel := zerolog.GlobalLevel()
-
-	zerolog.SetGlobalLevel(zerolog.TraceLevel)
-
 	origLogger := zlog.Logger
 
-	t.Cleanup(func() {
+	defer func() {
 		zlog.Logger = origLogger
 
 		zerolog.SetGlobalLevel(origLevel)
-	})
+	}()
+
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
 
 	var buf bytes.Buffer
 
@@ -299,6 +299,11 @@ func TestSetLogFuncNilRestoresDefault(t *testing.T) {
 	returned := logger.SetLogFunc(nil)
 	if returned == nil {
 		t.Fatal("expected previous log function to be returned")
+	}
+
+	// SetLogFunc must return the *previous* function, i.e. exactly MockLog.
+	if reflect.ValueOf(returned).Pointer() != reflect.ValueOf(logger.LogFunc(MockLog)).Pointer() {
+		t.Fatal("expected SetLogFunc to return MockLog as the previous log function")
 	}
 
 	// The default function is active again: output goes to zerolog, not MockLog.

--- a/backend/pkg/logger/logger_test.go
+++ b/backend/pkg/logger/logger_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package logger_test
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kubernetes-sigs/headlamp/backend/pkg/logger"
 	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +40,9 @@ func MockLog(level uint, str map[string]string, err interface{}, msg string) {
 }
 
 func TestLog(t *testing.T) {
-	t.Parallel()
+	// Note: no t.Parallel() here (or in any test in this package): the tests
+	// mutate process-wide state (logger.SetLogFunc, zerolog.SetGlobalLevel,
+	// zlog.Logger and capturedLogs), so they must run serially.
 
 	// Replace the actual logging function with the mock one
 	originalLogFunc := logger.SetLogFunc(MockLog)
@@ -168,4 +175,146 @@ func TestEmptyOrMissingEnvDefaultsToInfo(t *testing.T) {
 			t.Fatalf("expected info when env missing")
 		}
 	})
+}
+
+// captureLog redirects the global zerolog logger into a buffer, calls
+// logger.Log with the default (real) log function, and returns the output.
+func captureLog(t *testing.T, level uint, str map[string]string, err interface{}, msg string) string {
+	t.Helper()
+
+	origLevel := zerolog.GlobalLevel()
+	origLogger := zlog.Logger
+
+	defer func() {
+		zlog.Logger = origLogger
+
+		zerolog.SetGlobalLevel(origLevel)
+	}()
+
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+
+	var buf bytes.Buffer
+
+	zlog.Logger = zerolog.New(&buf)
+
+	logger.Log(level, str, err, msg)
+
+	return buf.String()
+}
+
+// Exercises the real log function: levels, string fields, source/line and
+// every error type branch ([]error, int, string, error, interface{}).
+//
+//nolint:funlen // table-driven test, splitting hurts readability
+func TestDefaultLogFunc(t *testing.T) {
+	origLogFunc := logger.SetLogFunc(nil)
+
+	t.Cleanup(func() { logger.SetLogFunc(origLogFunc) })
+
+	tests := []struct {
+		name     string
+		level    uint
+		str      map[string]string
+		err      interface{}
+		msg      string
+		expected []string
+	}{
+		{
+			name:     "info with fields and no error",
+			level:    logger.LevelInfo,
+			str:      map[string]string{"key": "value"},
+			msg:      "info msg",
+			expected: []string{`"level":"info"`, `"key":"value"`, `"source":`, `"line":`, `"message":"info msg"`},
+		},
+		{
+			name:     "warn level",
+			level:    logger.LevelWarn,
+			msg:      "warn msg",
+			expected: []string{`"level":"warn"`, `"message":"warn msg"`},
+		},
+		{
+			name:     "unknown level defaults to info",
+			level:    42,
+			msg:      "default msg",
+			expected: []string{`"level":"info"`, `"message":"default msg"`},
+		},
+		{
+			name:     "error interface",
+			level:    logger.LevelError,
+			err:      errors.New("boom"),
+			msg:      "error msg",
+			expected: []string{`"level":"error"`, `"error":"boom"`, `"message":"error msg"`},
+		},
+		{
+			name:     "error slice",
+			level:    logger.LevelError,
+			err:      []error{errors.New("first"), errors.New("second")},
+			msg:      "multi error",
+			expected: []string{`"error":["first","second"]`, `"message":"multi error"`},
+		},
+		{
+			name:     "int error code",
+			level:    logger.LevelError,
+			err:      404,
+			msg:      "int error",
+			expected: []string{`"error":404`, `"message":"int error"`},
+		},
+		{
+			name:     "string error",
+			level:    logger.LevelError,
+			err:      "string failure",
+			msg:      "string error",
+			expected: []string{`"error":"string failure"`, `"message":"string error"`},
+		},
+		{
+			name:     "generic interface error",
+			level:    logger.LevelError,
+			err:      struct{ Code int }{Code: 7},
+			msg:      "generic error",
+			expected: []string{`"error":{"Code":7}`, `"message":"generic error"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureLog(t, tt.level, tt.str, tt.err, tt.msg)
+
+			for _, want := range tt.expected {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected output to contain %s, got: %s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// SetLogFunc(nil) restores the default log function.
+func TestSetLogFuncNilRestoresDefault(t *testing.T) {
+	orig := logger.SetLogFunc(MockLog)
+
+	t.Cleanup(func() {
+		logger.SetLogFunc(orig)
+	})
+
+	returned := logger.SetLogFunc(nil)
+	if returned == nil {
+		t.Fatal("expected previous log function to be returned")
+	}
+
+	// SetLogFunc must return the *previous* function, i.e. exactly MockLog.
+	if reflect.ValueOf(returned).Pointer() != reflect.ValueOf(logger.LogFunc(MockLog)).Pointer() {
+		t.Fatal("expected SetLogFunc to return MockLog as the previous log function")
+	}
+
+	// The default function is active again: output goes to zerolog, not MockLog.
+	capturedLogs = nil
+	out := captureLog(t, logger.LevelInfo, nil, nil, "after reset")
+
+	if len(capturedLogs) != 0 {
+		t.Errorf("mock should not capture after reset, got: %v", capturedLogs)
+	}
+
+	if !strings.Contains(out, `"message":"after reset"`) {
+		t.Errorf("expected default log output, got: %s", out)
+	}
 }


### PR DESCRIPTION
## Summary

Add unit tests for the untested paths in `backend/pkg/logger`, raising package coverage from 50% to 100% of statements.

## Related Issue

Fixes #6059

## Changes

- `TestDefaultLogFunc` — exercises the real (default) `log` function by redirecting the global zerolog logger into a buffer:
  - info/warn levels and the unknown-level → info default
  - string fields and source/line caller info
  - every error type branch: `error`, `[]error`, `int`, `string`, generic `interface{}`
- `TestSetLogFuncNilRestoresDefault` — `SetLogFunc(nil)` restores the default log function (previously uncovered branch)
- `captureLog` helper — swaps `zlog.Logger` for a buffer with cleanup, so assertions run against real zerolog JSON output

`Init()` was already fully covered by existing tests; this PR closes the remaining gaps called out in the issue (`log` at 0%, `SetLogFunc` at 85.7%).

## Steps to Test

```bash
cd backend
go test ./pkg/logger/... -cover
```

Coverage output:

```text
ok  github.com/kubernetes-sigs/headlamp/backend/pkg/logger  coverage: 100.0% of statements
```

## Notes for the Reviewer

- Tests stay in the existing external `logger_test` package
- Verified locally: `go test` passes, `go vet` clean, `golangci-lint run` (v2.12.2, repo config) reports 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded logging coverage across severity levels, fields, source metadata, and supported error types.
  * Added validation that restoring the default logging behavior works correctly.
  * Improved test isolation when capturing and verifying log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->