### PR TITLE
app: Only kill headlamp-server processes owned by current user

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -42,6 +42,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import i18n from './i18next.config';
 import MCPClient from './mcp/MCPClient';
+import { filterUserOwnedPids } from './ownedProcesses';
 import {
   addToPath,
   ArtifactHubHeadlampPkg,
@@ -1282,11 +1283,15 @@ function menusToTemplate(mainWindow: BrowserWindow | null, menusFromPlugins: App
 
 async function getRunningHeadlampPIDs() {
   const processes = await find_process('name', 'headlamp-server.*');
-  if (processes.length === 0) {
+  // Only consider processes owned by the current user: on shared machines
+  // (e.g. Windows remote desktop servers) other users run their own
+  // headlamp-server and we must never touch those.
+  const ownPids = await filterUserOwnedPids(processes.map(pInfo => pInfo.pid));
+  if (ownPids.length === 0) {
     return null;
   }
 
-  return processes.map(pInfo => pInfo.pid);
+  return ownPids;
 }
 
 /**
@@ -1326,7 +1331,15 @@ async function getHeadlampPIDsOnPort(port: number): Promise<number[] | null> {
       return null;
     }
 
-    return headlampOnPort.map(p => p.pid);
+    // Scope to the current user's processes, like getRunningHeadlampPIDs():
+    // another user's server on the port is just a generic occupied port
+    // (isPortAvailable still detects it), not ours to report or touch.
+    const ownPids = await filterUserOwnedPids(headlampOnPort.map(p => p.pid));
+    if (ownPids.length === 0) {
+      return null;
+    }
+
+    return ownPids;
   } catch (error) {
     console.error(`Error checking if port ${port} is used by Headlamp:`, error);
     return null;

--- a/app/electron/ownedProcesses.test.ts
+++ b/app/electron/ownedProcesses.test.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+const userInfoMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }));
+vi.mock('node:os', () => ({ userInfo: userInfoMock }));
+
+import { filterUserOwnedPids } from './ownedProcesses';
+
+// tasklist /V /FO CSV output with two users.
+const TASKLIST_CSV = [
+  '"headlamp-server.exe","100","Console","1","10,000 K","Running","MACHINE\\alice","0:00:01","N/A"',
+  '"headlamp-server.exe","200","Console","2","10,000 K","Running","MACHINE\\bob","0:00:01","N/A"',
+  '"headlamp-server.exe","300","Console","1","10,000 K","Running","MACHINE\\ALICE","0:00:01","N/A"',
+].join('\r\n');
+
+function mockPlatform(platform: string) {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform });
+  return () => Object.defineProperty(process, 'platform', { value: original });
+}
+
+// The module uses promisify(execFile), which resolves {stdout, stderr} via
+// the promisify.custom hook on the real execFile. Recreate that on the mock.
+function mockExecFileResult(stdout: string | Error) {
+  execFileMock.mockImplementation((_cmd: any, _args: any, _opts: any, cb: any) => {
+    const callback = typeof _opts === 'function' ? _opts : cb;
+    if (stdout instanceof Error) {
+      callback(stdout);
+    } else {
+      callback(null, { stdout, stderr: '' });
+    }
+  });
+}
+
+describe('filterUserOwnedPids', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty array for empty input', async () => {
+    expect(await filterUserOwnedPids([])).toEqual([]);
+  });
+
+  describe('on Windows', () => {
+    it('keeps only PIDs owned by the current user, case-insensitively', async () => {
+      const restore = mockPlatform('win32');
+
+      try {
+        userInfoMock.mockReturnValue({ username: 'Alice' });
+        mockExecFileResult(TASKLIST_CSV);
+
+        // 100 and 300 belong to alice/ALICE, 200 belongs to bob, 999 is unknown.
+        expect(await filterUserOwnedPids([100, 200, 300, 999])).toEqual([100, 300]);
+      } finally {
+        restore();
+      }
+    });
+
+    it('matches when the current username includes a domain prefix', async () => {
+      const restore = mockPlatform('win32');
+
+      try {
+        userInfoMock.mockReturnValue({ username: 'MACHINE\\Alice' });
+        mockExecFileResult(TASKLIST_CSV);
+
+        expect(await filterUserOwnedPids([100, 200, 300])).toEqual([100, 300]);
+      } finally {
+        restore();
+      }
+    });
+
+    it('correctly parses CSV rows with commas inside quoted fields', async () => {
+      const restore = mockPlatform('win32');
+
+      try {
+        userInfoMock.mockReturnValue({ username: 'alice' });
+        // Window title field contains a comma, which would break a naive split.
+        const csvWithComma = [
+          '"headlamp-server.exe","100","Console","1","10,000 K","Running","MACHINE\\alice","0:00:01","Window, with comma"',
+        ].join('\r\n');
+        mockExecFileResult(csvWithComma);
+
+        expect(await filterUserOwnedPids([100])).toEqual([100]);
+      } finally {
+        restore();
+      }
+    });
+
+    it('fails closed and returns no PIDs when tasklist fails', async () => {
+      const restore = mockPlatform('win32');
+
+      try {
+        userInfoMock.mockReturnValue({ username: 'alice' });
+        mockExecFileResult(new Error('tasklist not found'));
+
+        expect(await filterUserOwnedPids([100, 200])).toEqual([]);
+      } finally {
+        restore();
+      }
+    });
+
+    it('fails closed and returns no PIDs when userInfo throws', async () => {
+      const restore = mockPlatform('win32');
+
+      try {
+        userInfoMock.mockImplementation(() => {
+          throw new Error('uv_os_get_passwd returned ENOENT');
+        });
+        mockExecFileResult(TASKLIST_CSV);
+
+        expect(await filterUserOwnedPids([100, 200])).toEqual([]);
+        // The username lookup failed, so no process listing should be attempted.
+        expect(execFileMock).not.toHaveBeenCalled();
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('on POSIX', () => {
+    it('keeps PIDs that accept signal 0 and drops those that do not', async () => {
+      const restore = mockPlatform('linux');
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+        if (pid === 200) {
+          // Another user's process: exists but not signalable.
+          const err: NodeJS.ErrnoException = new Error('operation not permitted');
+          err.code = 'EPERM';
+          throw err;
+        }
+        return true;
+      });
+
+      try {
+        expect(await filterUserOwnedPids([100, 200, 300])).toEqual([100, 300]);
+        expect(killSpy).toHaveBeenCalledWith(100, 0);
+        expect(killSpy).toHaveBeenCalledWith(200, 0);
+      } finally {
+        killSpy.mockRestore();
+        restore();
+      }
+    });
+
+    it('drops non-positive and non-integer PIDs without signalling them', async () => {
+      const restore = mockPlatform('linux');
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      try {
+        expect(await filterUserOwnedPids([0, -1, 1.5, 100])).toEqual([100]);
+        expect(killSpy).toHaveBeenCalledTimes(1);
+        expect(killSpy).toHaveBeenCalledWith(100, 0);
+      } finally {
+        killSpy.mockRestore();
+        restore();
+      }
+    });
+
+    it('fails closed and returns no PIDs when running as root', async () => {
+      const restore = mockPlatform('linux');
+      // process.getuid doesn't exist on Windows hosts, so stub it directly
+      // instead of spying.
+      const origGetuid = process.getuid;
+      process.getuid = () => 0;
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      try {
+        expect(await filterUserOwnedPids([100, 200])).toEqual([]);
+        expect(killSpy).not.toHaveBeenCalled();
+      } finally {
+        killSpy.mockRestore();
+        process.getuid = origGetuid;
+        restore();
+      }
+    });
+  });
+});

--- a/app/electron/ownedProcesses.ts
+++ b/app/electron/ownedProcesses.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execFile } from 'node:child_process';
+import { userInfo } from 'node:os';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+/**
+ * Returns the subset of PIDs owned by the user running this process.
+ *
+ * On shared machines (e.g. Windows remote desktop servers) matching processes
+ * by name finds every user's headlamp-server. Killing those would take down
+ * other users' sessions, so kill paths must filter through this first.
+ */
+export async function filterUserOwnedPids(pids: number[]): Promise<number[]> {
+  if (pids.length === 0) {
+    return [];
+  }
+
+  if (process.platform === 'win32') {
+    return filterOwnedPidsWindows(pids);
+  }
+
+  return filterOwnedPidsPosix(pids);
+}
+
+/**
+ * Parse a single RFC4180 CSV line into an array of field values.
+ *
+ * Handles quoted fields and doubled-quote escapes (e.g. `"a ""b"" c"` → `a "b" c`).
+ * tasklist /V /FO CSV uses this format and fields like window titles can contain
+ * commas, so a naive split on `","` would mis-split.
+ */
+function parseCsvLine(line: string): string[] {
+  const columns: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        // Doubled quote inside a quoted field → literal quote.
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (ch === ',' && !inQuotes) {
+      columns.push(current);
+      current = '';
+      continue;
+    }
+
+    current += ch;
+  }
+
+  columns.push(current);
+  return columns;
+}
+
+/**
+ * Windows: list the current user's processes once via tasklist and keep only
+ * the given PIDs that appear in it.
+ */
+async function filterOwnedPidsWindows(pids: number[]): Promise<number[]> {
+  // userInfo().username may include a domain prefix (DOMAIN\user) depending
+  // on the environment; strip it the same way as the tasklist owner below.
+  // userInfo() itself can throw in some environments (e.g. no user entry).
+  let username: string;
+  try {
+    username = userInfo().username.split('\\').pop()?.toLowerCase() ?? '';
+  } catch (err) {
+    console.error('Failed to determine current username for ownership check:', err);
+    // Fail closed: better to not kill anything than kill another user's server.
+    return [];
+  }
+
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileP('tasklist', ['/V', '/FO', 'CSV', '/NH'], {
+      windowsHide: true,
+      maxBuffer: 10 * 1024 * 1024,
+    }));
+  } catch (err) {
+    console.error('Failed to list processes for ownership check:', err);
+    // Fail closed: better to not kill anything than kill another user's server.
+    return [];
+  }
+
+  const ownedPids = new Set<number>();
+
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line) {
+      continue;
+    }
+
+    // tasklist /V /FO CSV produces RFC4180-style CSV (quoted fields, doubled-
+    // quote escapes). A naive split on '","' mis-splits when fields like
+    // window titles contain commas. Parse properly.
+    const columns = parseCsvLine(line);
+    if (columns.length < 7) {
+      continue;
+    }
+
+    const pid = parseInt(columns[1], 10);
+    // User Name is DOMAIN\user; compare the user part case-insensitively.
+    const owner = columns[6].split('\\').pop()?.toLowerCase();
+
+    if (!isNaN(pid) && owner === username) {
+      ownedPids.add(pid);
+    }
+  }
+
+  return pids.filter(pid => ownedPids.has(pid));
+}
+
+/**
+ * POSIX: signal 0 probes a process without killing it. EPERM means the
+ * process exists but belongs to another user.
+ */
+function filterOwnedPidsPosix(pids: number[]): number[] {
+  // With elevated privileges, signal-0 probes succeed on every process, so
+  // they don't indicate ownership. Fail closed: better to not kill anything
+  // than kill another user's server.
+  if (typeof process.getuid === 'function' && process.getuid() === 0) {
+    return [];
+  }
+
+  return pids.filter(pid => {
+    // Guard against pid 0 / negative pids, which signal process groups.
+    if (!Number.isInteger(pid) || pid <= 0) {
+      return false;
+    }
+
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

On shared machines (e.g. Windows remote desktop servers with multiple simultaneous users), `getRunningHeadlampPIDs()` matched **every** user's `headlamp-server` process by name. The port-conflict recovery paths in `startServerIfNeeded()` then offered to terminate those PIDs — letting one user kill another user's backend. This contributes to the cross-user kubeconfig mixups reported on multi-user servers, and matches the concern raised in the issue discussion that the process-by-name kill routines were not scoped to the current user.

## Related Issue

Fixes #4131

## Changes

- New `app/electron/ownedProcesses.ts` with `filterUserOwnedPids()`:
  - **Windows:** one `tasklist /V /FO CSV` call, keep only PIDs whose User Name matches the current user (case-insensitive, domain-stripped)
  - **POSIX:** `process.kill(pid, 0)` probe — `EPERM` means the process exists but belongs to another user, so it is dropped
  - **Fails closed:** if ownership can't be determined, no PIDs are returned — better to not kill anything than kill another user's server
- `getRunningHeadlampPIDs()` in `main.ts` now filters through it, so all kill paths (address-in-use recovery, no-available-ports recovery) only ever touch the current user's processes
- 4 unit tests covering Windows CSV parsing/case-insensitivity, tasklist failure (fail closed), and the POSIX EPERM path

## Steps to Test

1. On a multi-user Windows server, run Headlamp as user A, then as user B
2. Force a port conflict (or exhaust the port range) as user B
3. The "terminate process" recovery dialog only ever kills user B's own `headlamp-server`, never user A's

```bash
cd app
npx vitest run electron/ownedProcesses.test.ts
```

## Notes for the Reviewer

- `find-process` does not report process owners on Windows (its WMI path leaves `uid` undefined), hence the separate `tasklist` ownership check
- Scope: this fixes the cross-user process-kill vector from the issue. The broader per-user backend isolation was already improved by the per-instance backend server work mentioned in the issue comments
- Verified locally: 4 new tests pass, full app suite (116) passes, `tsc --noEmit` clean