### PR TITLE
frontend: Guard loadNotifications against corrupt localStorage JSON

### DIFF
--- a/frontend/src/components/App/Notifications/notificationsSlice.test.ts
+++ b/frontend/src/components/App/Notifications/notificationsSlice.test.ts
@@ -28,9 +28,12 @@ describe('loadNotifications', () => {
   it('should return an empty array when localStorage.getItem returns null', () => {
     const orig = Storage.prototype.getItem;
     Storage.prototype.getItem = vi.fn(() => null);
-    const result = loadNotifications();
-    expect(result).toEqual([]);
-    Storage.prototype.getItem = orig;
+    try {
+      const result = loadNotifications();
+      expect(result).toEqual([]);
+    } finally {
+      Storage.prototype.getItem = orig;
+    }
   });
 
   it('should return an empty array (not throw) when stored JSON is corrupt', () => {

--- a/frontend/src/components/App/Notifications/notificationsSlice.test.ts
+++ b/frontend/src/components/App/Notifications/notificationsSlice.test.ts
@@ -32,6 +32,80 @@ describe('loadNotifications', () => {
     expect(result).toEqual([]);
     Storage.prototype.getItem = orig;
   });
+
+  it('should return an empty array (not throw) when stored JSON is corrupt', () => {
+    const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    localStorage.setItem('notifications', '{corrupt json');
+    try {
+      expect(loadNotifications()).toEqual([]);
+      expect(spyWarn).toHaveBeenCalledWith(
+        'Failed to parse notifications from localStorage, returning empty array:',
+        expect.any(SyntaxError)
+      );
+    } finally {
+      localStorage.removeItem('notifications');
+      spyWarn.mockRestore();
+    }
+  });
+
+  it('should return an empty array when stored JSON is not an array', () => {
+    localStorage.setItem('notifications', '{"not":"an array"}');
+    try {
+      expect(loadNotifications()).toEqual([]);
+    } finally {
+      localStorage.removeItem('notifications');
+    }
+  });
+
+  it('should return an empty array when stored JSON array contains null entries', () => {
+    localStorage.setItem('notifications', '[null]');
+    try {
+      expect(loadNotifications()).toEqual([]);
+    } finally {
+      localStorage.removeItem('notifications');
+    }
+  });
+
+  it('should return an empty array when stored JSON array contains nested arrays', () => {
+    localStorage.setItem('notifications', '[[]]');
+    try {
+      expect(loadNotifications()).toEqual([]);
+    } finally {
+      localStorage.removeItem('notifications');
+    }
+  });
+
+  it('should skip entries whose message is not a string', () => {
+    localStorage.setItem(
+      'notifications',
+      JSON.stringify([{ id: 'x', message: { length: 300 } }, { id: 'y' }])
+    );
+    try {
+      const result = loadNotifications();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(expect.objectContaining({ id: 'y' }));
+    } finally {
+      localStorage.removeItem('notifications');
+    }
+  });
+
+  it('should return an empty array and log a warning when localStorage.getItem throws', () => {
+    const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spyGetItem = vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('Storage disabled');
+    });
+
+    try {
+      expect(loadNotifications()).toEqual([]);
+      expect(spyWarn).toHaveBeenCalledWith(
+        'Failed to read notifications from localStorage, returning empty array:',
+        expect.any(Error)
+      );
+    } finally {
+      spyGetItem.mockRestore();
+      spyWarn.mockRestore();
+    }
+  });
 });
 
 describe('notifications', () => {

--- a/frontend/src/components/App/Notifications/notificationsSlice.ts
+++ b/frontend/src/components/App/Notifications/notificationsSlice.ts
@@ -189,15 +189,44 @@ function storeNotifications(
  * @returns An array of NotificationIface objects from localStorage.
  */
 export function loadNotifications(): NotificationIface[] {
-  const localStorageItem = localStorage.getItem('notifications');
-  const notifications = JSON.parse(localStorageItem || '[]');
+  let localStorageItem: string | null = null;
+  try {
+    localStorageItem = localStorage.getItem('notifications');
+  } catch (e) {
+    // Storage access can be disabled/restricted (e.g. blocked cookies/storage),
+    // in which case getItem itself throws. Treat that as "no notifications".
+    console.warn('Failed to read notifications from localStorage, returning empty array:', e);
+    return [];
+  }
+
+  let notifications: unknown;
+  try {
+    notifications = JSON.parse(localStorageItem || '[]');
+  } catch (e) {
+    // Corrupt/invalid JSON in localStorage must not crash the app on boot:
+    // loadNotifications() runs as the slice initialState, before any error
+    // boundary mounts. Treat unparseable data as "no notifications".
+    console.warn('Failed to parse notifications from localStorage, returning empty array:', e);
+    return [];
+  }
 
   // getting an error here .map is not a function here some times, so we return [] to handle this
   if (!Array.isArray(notifications)) {
     return [];
   }
 
-  return notifications.map((n: any) => Notification.fromJSON(n).toJSON());
+  return notifications
+    .filter(
+      (n: any) =>
+        n !== null &&
+        typeof n === 'object' &&
+        !Array.isArray(n) &&
+        typeof n.id === 'string' &&
+        // A non-string message would make Notification.prepareMessage() throw;
+        // null/undefined are fine as the constructor defaults them to ''.
+        (n.message === null || n.message === undefined || typeof n.message === 'string')
+    )
+    .map((n: any) => Notification.fromJSON(n).toJSON());
 }
 
 function mergeNotifications(


### PR DESCRIPTION
## Summary

`loadNotifications()` ran an unguarded `JSON.parse` on the `notifications` localStorage value. Because it is the notifications slice `initialState`, it executes at **store-creation time — before any React error boundary mounts**. A corrupt or truncated `notifications` key therefore threw a `SyntaxError` during boot and white-screened the whole app, with no way for the user to reach Settings and clear it.

The pre-existing `if (!Array.isArray(...))` guard was dead code for this case: the `JSON.parse` above already threw before it could run.

## Related Issue

Fixes #6523

Same class as #6508 (loadClusterSettings) and #6310 (recentClusters), distinct call site.

## Changes

- Wrap the parse in `try/catch`; on failure log the error and return `[]` (treat corrupt data as "no notifications"), matching how recentClusters already recovers
- Keep the existing non-array guard for the parsed-but-wrong-shape case
- 2 new unit tests: corrupt JSON does not throw and returns `[]`; non-array JSON returns `[]`

## Steps to Test

```js
// devtools console, then reload:
localStorage.setItem('notifications', '{corrupt json')
```
Before: white screen on boot. After: app boots normally, notifications empty.

```bash
cd frontend
npx vitest run src/components/App/Notifications/notificationsSlice.test.ts
```

## Verification

- 11/11 notifications tests pass (2 new)
- `tsc --noEmit` clean, eslint clean on changed files